### PR TITLE
fix the collective communication object which is returned by CpGrid::comm()

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -153,7 +153,9 @@ namespace Dune
 	typedef cpgrid::IdSet<CpGrid> LocalIdSet;
 
 	/// \brief The type of the collective communication.
-	typedef Dune::CollectiveCommunication<CpGrid> CollectiveCommunication;
+
+    typedef Dune::MPIHelper::MPICommunicator MPICommunicator;
+    typedef Dune::CollectiveCommunication<MPICommunicator> CollectiveCommunication;
     };
 
 
@@ -194,8 +196,9 @@ namespace Dune
 	/// Default constructor
 	CpGrid()
 	    : index_set_(*this),
-        use_unique_boundary_ids_(false),
-        idSet_( *this )
+          use_unique_boundary_ids_(false),
+          idSet_( *this ),
+          ccobj_(Dune::MPIHelper::getCommunicator())
 	{
 	}
 


### PR DESCRIPTION
If I'm not mistaken, then Dune expects that the template argument to
the collective communication is type of the communicator returned by
Dune::MPIHelper::getCommunication(). I used this as an argument to a
method of mine and CpGrid made the compiler bail out. This patch fixes
the issue.
