### PR TITLE
Link dependencies after the project libraries

### DIFF
--- a/dune/grid/test/Makefile.am
+++ b/dune/grid/test/Makefile.am
@@ -12,9 +12,8 @@ AM_LDFLAGS  += $(ALL_PKG_LDFLAGS) $(DUNEMPILDFLAGS) $(OPM_BOOST_LDFLAGS)
 # the tree that should be built before this one,
 # but if you do not run make from the top you may
 # run into trouble. Recursive make considered harmful...
-LDADD = $(ALL_PKG_LIBS)  $(DUNE_LIBS) $(DUNEMPILIBS) $(BOOST_SYSTEM_LIB) \
-         ../cpgrid/libcpgrid.la         \
-         ../common/libgrid.la
+LDADD = ../cpgrid/libcpgrid.la ../common/libgrid.la \
+        $(ALL_PKG_LIBS)  $(DUNE_LIBS) $(DUNEMPILIBS) $(BOOST_SYSTEM_LIB)
 
 cpgrid_test_SOURCES = cpgrid_test.cpp
 


### PR DESCRIPTION
The tests link the dependencies first and then dune-cornerpoint; this probably works on modern distributions due to some DT_NEEDED field in the library.
