### PR TITLE
ignore unknown command line arguments

### DIFF
--- a/configure
+++ b/configure
@@ -270,7 +270,6 @@ for a in "$ENVVARS"; do
   [ -n "$a" ] && FILTERED_ENVVARS="$FILTERED_ENVVARS \"${a/\"/\\\"}\""
 done
 ENVVARS="$FILTERED_ENVVARS"
-echo "HALLO: $ENVVARS"
 
 # pass everything on to CMake
 CMDLINE="env ${ENVVARS} ${CMAKE_COMMAND} \"${srcdir}\" \"-DCMAKE_INSTALL_PREFIX=$prefix\" -DCMAKE_BUILD_TYPE=${buildtype}${pch_use}${silent_rules}${debug_loc} ${FEATURES}"


### PR DESCRIPTION
I did as Atgeirr requested and tried to compile the release branch of all modules using openSUSE 12.2 and using dunecontrol. I had some issues with the configure script (patch attached) and much more serious issues because my CMake refuses variable names which contain a '-'. On the latter issue I gave up after half a day. Does anyone have an idea how to fix this? the issue probably does not occur if you only compile opm-core, because I suspect that cmake ignores everything before the last '-', and the macros are only invoked once in this case...

NB: Although I picked dune-cornerpoint as the target repo, this patch should be applied to all CMake enabled OPM modules.
