### PR TITLE
Changed std::tr1 occurences to boost.

### DIFF
--- a/dune/grid/cpgrid/readEclipseFormat.cpp
+++ b/dune/grid/cpgrid/readEclipseFormat.cpp
@@ -131,8 +131,8 @@ namespace Dune
             double maxz_bot = -1e100;
             for (int i = 0; i < g.dims[0]; ++i) {
                 for (int j = 0; j < g.dims[1]; ++j) {
-                    std::tr1::array<double, 8> cellz_bot = inspector.cellZvals(i, j, 0);
-                    std::tr1::array<double, 8> cellz_top = inspector.cellZvals(i, j, g.dims[2] - 1);
+                    boost::array<double, 8> cellz_bot = inspector.cellZvals(i, j, 0);
+                    boost::array<double, 8> cellz_top = inspector.cellZvals(i, j, g.dims[2] - 1);
                     for (int dd = 0; dd < 4; ++dd) {
                         minz_top = std::min(cellz_top[dd+4], minz_top);
                         maxz_bot = std::max(cellz_bot[dd], maxz_bot);

--- a/examples/grdecl2vtu.cpp
+++ b/examples/grdecl2vtu.cpp
@@ -59,7 +59,7 @@ void condWriteDoubleField(std::vector<double> & fieldvector,
         fieldvector.resize(global_cell.size());
 
 	Opm::EclipseGridInspector insp(eclParser);
-        std::tr1::array<int, 3> dims = insp.gridSize();
+        boost::array<int, 3> dims = insp.gridSize();
         int num_global_cells = dims[0]*dims[1]*dims[2];
         if (int(eclVector.size()) != num_global_cells) {
             THROW(fieldname << " field must have the same size as the "
@@ -86,7 +86,7 @@ void condWriteIntegerField(std::vector<double> & fieldvector,
         fieldvector.resize(global_cell.size());
 
 	Opm::EclipseGridInspector insp(eclParser);
-        std::tr1::array<int, 3> dims = insp.gridSize();
+        boost::array<int, 3> dims = insp.gridSize();
         int num_global_cells = dims[0]*dims[1]*dims[2];
         if (int(eclVector.size()) != num_global_cells) {
             THROW(fieldname << " field must have the same size as the "


### PR DESCRIPTION
std::tr1 might not be supported by all compilers and will eventually
be dropped by others. Using boost instead makes this more
portable.

Pull requests for the other modules will follow shortly.
