### PR TITLE
Unconditionally include "config.h"

### DIFF
--- a/dune/grid/common/GeometryHelpers.cpp
+++ b/dune/grid/common/GeometryHelpers.cpp
@@ -34,7 +34,7 @@ You should have received a copy of the GNU General Public License
 along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if HAVE_CONFIG_H
+
 #include "config.h"
-#endif
+
 #include "GeometryHelpers.hpp"

--- a/dune/grid/common/GridPartitioning.cpp
+++ b/dune/grid/common/GridPartitioning.cpp
@@ -33,9 +33,9 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if HAVE_CONFIG_H
+
 #include "config.h"
-#endif
+
 #include "GridPartitioning.hpp"
 #include <dune/grid/CpGrid.hpp>
 #include <stack>

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -33,9 +33,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if HAVE_CONFIG_H
 #include "config.h"
-#endif
+
 #include <fstream>
 #include "../CpGrid.hpp"
 #include <opm/core/utility/parameters/ParameterGroup.hpp>

--- a/dune/grid/cpgrid/readEclipseFormat.cpp
+++ b/dune/grid/cpgrid/readEclipseFormat.cpp
@@ -34,9 +34,8 @@
 */
 
 
-#if HAVE_CONFIG_H
 #include "config.h"
-#endif
+
 #include <fstream>
 #include "../CpGrid.hpp"
 #include <opm/core/io/eclipse/EclipseGridParser.hpp>

--- a/dune/grid/cpgrid/readSintefLegacyFormat.cpp
+++ b/dune/grid/cpgrid/readSintefLegacyFormat.cpp
@@ -33,9 +33,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if HAVE_CONFIG_H
 #include "config.h"
-#endif
 
 #include <fstream>
 #include <vector>

--- a/dune/grid/cpgrid/writeSintefLegacyFormat.cpp
+++ b/dune/grid/cpgrid/writeSintefLegacyFormat.cpp
@@ -34,9 +34,7 @@
 */
 
 
-#if HAVE_CONFIG_H
 #include "config.h"
-#endif
 
 #include <fstream>
 #include <vector>

--- a/examples/grdecl2vtu.cpp
+++ b/examples/grdecl2vtu.cpp
@@ -18,9 +18,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if HAVE_CONFIG_H
 #include "config.h"
-#endif
 
 #include <iostream>
 #include <dune/grid/io/file/vtk/vtkwriter.hh>

--- a/tests/not-unit/check_grid_normals.cpp
+++ b/tests/not-unit/check_grid_normals.cpp
@@ -34,10 +34,8 @@
 */
 
 
-
-#if HAVE_CONFIG_H
 #include "config.h"
-#endif
+
 #include <dune/common/mpihelper.hh>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <dune/grid/CpGrid.hpp>

--- a/tests/not-unit/mapper_test.cpp
+++ b/tests/not-unit/mapper_test.cpp
@@ -13,9 +13,8 @@
  *                                                                           *
  *   This program is distributed WITHOUT ANY WARRANTY.                       *
  *****************************************************************************/
-#if HAVE_CONFIG_H
+
 #include "config.h"
-#endif
 
 #include <algorithm>
 #include <iostream>

--- a/tests/not-unit/partition_test.cpp
+++ b/tests/not-unit/partition_test.cpp
@@ -33,9 +33,9 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if HAVE_CONFIG_H
+
 #include "config.h"
-#endif
+
 #include <dune/common/mpihelper.hh>
 #include <dune/grid/common/GridPartitioning.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>


### PR DESCRIPTION
Our build system no longer defines HAVE_CONFIG_H, so the construct

  #if HAVE_CONFIG_H
  #include "config.h"
  #endif

leads to not including "config.h" at all.
