### PR TITLE
Removes unnecessary GridType template parameter from Geometry.

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -103,10 +103,10 @@ namespace Dune
 	{
 	    /// \brief The type of the geometry associated with the entity.
 	    /// IMPORTANT: Codim<codim>::Geometry == Geometry<dim-codim,dimw>
- 	    typedef cpgrid::Geometry<3-cd, 3, Grid> Geometry;
+ 	    typedef cpgrid::Geometry<3-cd, 3> Geometry;
 	    //typedef Dune::Geometry<3-cd, 3, CpGrid, cpgrid::Geometry> Geometry;
 	    /// \brief The type of the local geometry associated with the entity.
- 	    typedef cpgrid::Geometry<3-cd, 3, Grid> LocalGeometry;
+ 	    typedef cpgrid::Geometry<3-cd, 3> LocalGeometry;
 	    //typedef Dune::Geometry<3-cd, 3, CpGrid, cpgrid::Geometry> LocalGeometry;
 	    /// \brief The type of the entity.
 	    typedef cpgrid::Entity<cd, CpGrid> Entity;
@@ -754,7 +754,7 @@ namespace Dune
 
 	// Return the geometry vector corresponding to the given codim.
 	template <int codim>
-	const cpgrid::EntityVariable< cpgrid::Geometry<3 - codim, 3, CpGrid>, codim>& geomVector() const
+	const cpgrid::EntityVariable< cpgrid::Geometry<3 - codim, 3>, codim>& geomVector() const
 	{
 	    return geometry_.geomVector<codim>();
 	}

--- a/dune/grid/cpgrid/DefaultGeometryPolicy.hpp
+++ b/dune/grid/cpgrid/DefaultGeometryPolicy.hpp
@@ -64,9 +64,9 @@ namespace Dune
 	    /// @brief
 	    /// @todo Doc me
 	    /// @param
-	    DefaultGeometryPolicy(const EntityVariable<cpgrid::Geometry<3, 3, GridType>, 0>& cell_geom,
-				  const EntityVariable<cpgrid::Geometry<2, 3, GridType>, 1>& face_geom,
-				  const EntityVariable<cpgrid::Geometry<0, 3, GridType>, 3>& point_geom)
+	    DefaultGeometryPolicy(const EntityVariable<cpgrid::Geometry<3, 3>, 0>& cell_geom,
+				  const EntityVariable<cpgrid::Geometry<2, 3>, 1>& face_geom,
+				  const EntityVariable<cpgrid::Geometry<0, 3>, 3>& point_geom)
 		: cell_geom_(cell_geom), face_geom_(face_geom), point_geom_(point_geom)
 	    {
 	    }
@@ -77,7 +77,7 @@ namespace Dune
 	    /// @param
 	    /// @return
 	    template <int codim>
-	    const EntityVariable<cpgrid::Geometry<3 - codim, 3, GridType>, codim>& geomVector() const
+	    const EntityVariable<cpgrid::Geometry<3 - codim, 3>, codim>& geomVector() const
 	    {
 		static_assert(codim != 2, "");
 		typedef typename boost::mpl::if_c<codim == 0, GetCellGeom, 
@@ -88,9 +88,9 @@ namespace Dune
 	    friend struct GetCellGeom;
 	    friend struct GetFaceGeom;
 	    friend struct GetPointGeom;
-	    EntityVariable<cpgrid::Geometry<3, 3, GridType>, 0> cell_geom_;
-	    EntityVariable<cpgrid::Geometry<2, 3, GridType>, 1> face_geom_;
-	    EntityVariable<cpgrid::Geometry<0, 3, GridType>, 3> point_geom_;
+	    EntityVariable<cpgrid::Geometry<3, 3>, 0> cell_geom_;
+	    EntityVariable<cpgrid::Geometry<2, 3>, 1> face_geom_;
+	    EntityVariable<cpgrid::Geometry<0, 3>, 3> point_geom_;
 	};
 
 	/// @brief
@@ -104,7 +104,7 @@ namespace Dune
 	    /// @param
 	    /// @return
 	    template <class GridType>
-	    static const EntityVariable<cpgrid::Geometry<3, 3, GridType>, 0>&
+	    static const EntityVariable<cpgrid::Geometry<3, 3>, 0>&
 	    value(const DefaultGeometryPolicy<GridType>& geom)
 	    {
 		return geom.cell_geom_;
@@ -121,7 +121,7 @@ namespace Dune
 	    /// @param
 	    /// @return
 	    template <class GridType>
-	    static const EntityVariable<cpgrid::Geometry<2, 3, GridType>, 1>&
+	    static const EntityVariable<cpgrid::Geometry<2, 3>, 1>&
 	    value(const DefaultGeometryPolicy<GridType>& geom)
 	    {
 		return geom.face_geom_;
@@ -138,7 +138,7 @@ namespace Dune
 	    /// @param
 	    /// @return 
 	    template <class GridType>
-	    static const EntityVariable<cpgrid::Geometry<0, 3, GridType>, 3>&
+	    static const EntityVariable<cpgrid::Geometry<0, 3>, 3>&
 	    value(const DefaultGeometryPolicy<GridType>& geom)
 	    {
 		return geom.point_geom_;

--- a/dune/grid/cpgrid/Geometry.hpp
+++ b/dune/grid/cpgrid/Geometry.hpp
@@ -55,7 +55,7 @@ namespace Dune
         /// constant (vertex) or trilinear (cell) mappings.
 	/// For intersections, we use the singular geometry type
         /// (None), and provide no mappings.
-	template <int mydim, int cdim, class GridImp> // GridImp arg never used
+	template <int mydim, int cdim>
 	class Geometry
 	{
         };
@@ -64,8 +64,8 @@ namespace Dune
 
 
         /// Specialization for 3-dimensional geometries, i.e. cells.
-	template <int cdim, class GridImp> // GridImp arg never used
-	class Geometry<3, cdim, GridImp>
+	template <int cdim>
+	class Geometry<3, cdim>
 	{
 	    static_assert(cdim == 3, "");
 	public:
@@ -304,8 +304,8 @@ namespace Dune
 
         /// Specialization for 2 dimensional geometries, that is
         /// intersections (since codim 1 entities are not in CpGrid).
-	template <int cdim, class GridImp> // GridImp arg never used
-	class Geometry<2, cdim, GridImp>
+	template <int cdim> // GridImp arg never used
+	class Geometry<2, cdim>
 	{
 	    static_assert(cdim == 3, "");
 	public:
@@ -428,8 +428,8 @@ namespace Dune
 
 
         /// Specialization for 0 dimensional geometries, i.e. vertices.
-	template <int cdim, class GridImp> // GridImp arg never used
-	class Geometry<0, cdim, GridImp>
+	template <int cdim> // GridImp arg never used
+	class Geometry<0, cdim>
 	{
 	    static_assert(cdim == 3, "");
 	public:

--- a/dune/grid/cpgrid/Intersection.hpp
+++ b/dune/grid/cpgrid/Intersection.hpp
@@ -73,8 +73,8 @@ namespace Dune
 	    /// @todo Doc me!
 	    typedef cpgrid::Entity<0, GridType> Entity;
 	    typedef cpgrid::EntityPointer<0, GridType> EntityPointer;
-// 	    typedef cpgrid::Geometry<2,3, GridType> Geometry;
-// 	    typedef cpgrid::Geometry<2,3, GridType> LocalGeometry;
+// 	    typedef cpgrid::Geometry<2,3> Geometry;
+// 	    typedef cpgrid::Geometry<2,3> LocalGeometry;
 	    typedef typename GridType::template Codim<1>::Geometry Geometry;
 	    typedef Geometry LocalGeometry;
 	    typedef double ctype;

--- a/dune/grid/cpgrid/readEclipseFormat.cpp
+++ b/dune/grid/cpgrid/readEclipseFormat.cpp
@@ -664,9 +664,9 @@ namespace Dune
 	template <int dim>
 	struct MakeGeometry
 	{
-	    cpgrid::Geometry<dim, 3, CpGrid> operator()(const FieldVector<double, 3>& pos)
+	    cpgrid::Geometry<dim, 3> operator()(const FieldVector<double, 3>& pos)
 	    {
-		return cpgrid::Geometry<dim, 3, CpGrid>(pos);
+		return cpgrid::Geometry<dim, 3>(pos);
 	    }
 	};
 
@@ -679,11 +679,11 @@ namespace Dune
 		: allcorners_(allcorners)
 	    {
 	    }
-	    cpgrid::Geometry<3, 3, CpGrid> operator()(const FieldVector<double, 3>& pos,
+	    cpgrid::Geometry<3, 3> operator()(const FieldVector<double, 3>& pos,
                                                       double vol,
                                                       const array<int,8>& corner_indices)
 	    {
-		return cpgrid::Geometry<3, 3, CpGrid>(pos, vol, allcorners_, &corner_indices[0]);
+		return cpgrid::Geometry<3, 3>(pos, vol, allcorners_, &corner_indices[0]);
 	    }
 	};
 
@@ -691,9 +691,9 @@ namespace Dune
 	template <>
 	struct MakeGeometry<2>
 	{
-	    cpgrid::Geometry<2, 3, CpGrid> operator()(const FieldVector<double, 3>& pos, double vol)
+	    cpgrid::Geometry<2, 3> operator()(const FieldVector<double, 3>& pos, double vol)
 	    {
-		return cpgrid::Geometry<2, 3, CpGrid>(pos, vol);
+		return cpgrid::Geometry<2, 3>(pos, vol);
 	    }
 	};
 
@@ -807,8 +807,8 @@ namespace Dune
 	    // C) slow
 	    // D) copied from readSintefLegacyFormat.cpp
 	    // Cells
-	    cpgrid::EntityVariable<cpgrid::Geometry<3, 3, CpGrid>, 0> cellgeom;
-	    std::vector<cpgrid::Geometry<3, 3, CpGrid> > cg;
+	    cpgrid::EntityVariable<cpgrid::Geometry<3, 3>, 0> cellgeom;
+	    std::vector<cpgrid::Geometry<3, 3> > cg;
 	    cg.reserve(nc);
 	    MakeGeometry<3> mcellg(&allcorners[0]);
 // 	    std::transform(cell_centroids.begin(), cell_centroids.end(),
@@ -819,16 +819,16 @@ namespace Dune
 	    }
 	    cellgeom.assign(cg.begin(), cg.end());
 	    // Faces
-	    cpgrid::EntityVariable<cpgrid::Geometry<2, 3, CpGrid>, 1> facegeom;
-	    std::vector<cpgrid::Geometry<2, 3, CpGrid> > fg;
+	    cpgrid::EntityVariable<cpgrid::Geometry<2, 3>, 1> facegeom;
+	    std::vector<cpgrid::Geometry<2, 3> > fg;
 	    MakeGeometry<2> mfaceg;
 	    std::transform(face_centroids.begin(), face_centroids.end(),
 			   face_areas.begin(),
 			   std::back_inserter(fg), mfaceg);
 	    facegeom.assign(fg.begin(), fg.end());
 	    // Points
-	    cpgrid::EntityVariable<cpgrid::Geometry<0, 3, CpGrid>, 3> pointgeom;
-	    std::vector<cpgrid::Geometry<0, 3, CpGrid> > pg;
+	    cpgrid::EntityVariable<cpgrid::Geometry<0, 3>, 3> pointgeom;
+	    std::vector<cpgrid::Geometry<0, 3> > pg;
 	    MakeGeometry<0> mpointg;
 	    std::transform(points.begin(), points.end(),
 			   std::back_inserter(pg), mpointg);

--- a/dune/grid/cpgrid/readSintefLegacyFormat.cpp
+++ b/dune/grid/cpgrid/readSintefLegacyFormat.cpp
@@ -200,18 +200,18 @@ namespace Dune
 	template <int dim>
 	struct MakeGeometry
 	{
-	    cpgrid::Geometry<dim, 3, CpGrid> operator()(const FieldVector<double, 3> pos, double vol = 1.0)
+	    cpgrid::Geometry<dim, 3> operator()(const FieldVector<double, 3> pos, double vol = 1.0)
 	    {
-		return cpgrid::Geometry<dim, 3, CpGrid>(pos, vol);
+		return cpgrid::Geometry<dim, 3>(pos, vol);
 	    }
 	};
 
 	template <>
 	struct MakeGeometry<0>
 	{
-	    cpgrid::Geometry<0, 3, CpGrid> operator()(const FieldVector<double, 3> pos)
+	    cpgrid::Geometry<0, 3> operator()(const FieldVector<double, 3> pos)
 	    {
-		return cpgrid::Geometry<0, 3, CpGrid>(pos);
+		return cpgrid::Geometry<0, 3>(pos);
 	    }
 	};
 
@@ -298,24 +298,24 @@ namespace Dune
 
 	    // Code below has been copied to readEclipseFormat: \TODO Refactor!
 	    // Cells
-	    cpgrid::EntityVariable<cpgrid::Geometry<3, 3, CpGrid>, 0> cellgeom;
-	    std::vector<cpgrid::Geometry<3, 3, CpGrid> > cg;
+	    cpgrid::EntityVariable<cpgrid::Geometry<3, 3>, 0> cellgeom;
+	    std::vector<cpgrid::Geometry<3, 3> > cg;
 	    MakeGeometry<3> mcellg;
 	    std::transform(cell_centroids.begin(), cell_centroids.end(),
 			   cell_volumes.begin(),
 			   std::back_inserter(cg), mcellg);
 	    cellgeom.assign(cg.begin(), cg.end());
 	    // Faces
-	    cpgrid::EntityVariable<cpgrid::Geometry<2, 3, CpGrid>, 1> facegeom;
-	    std::vector<cpgrid::Geometry<2, 3, CpGrid> > fg;
+	    cpgrid::EntityVariable<cpgrid::Geometry<2, 3>, 1> facegeom;
+	    std::vector<cpgrid::Geometry<2, 3> > fg;
 	    MakeGeometry<2> mfaceg;
 	    std::transform(face_centroids.begin(), face_centroids.end(),
 			   face_areas.begin(),
 			   std::back_inserter(fg), mfaceg);
 	    facegeom.assign(fg.begin(), fg.end());
 	    // Points
-	    cpgrid::EntityVariable<cpgrid::Geometry<0, 3, CpGrid>, 3> pointgeom;
-	    std::vector<cpgrid::Geometry<0, 3, CpGrid> > pg;
+	    cpgrid::EntityVariable<cpgrid::Geometry<0, 3>, 3> pointgeom;
+	    std::vector<cpgrid::Geometry<0, 3> > pg;
 	    MakeGeometry<0> mpointg;
 	    std::transform(points.begin(), points.end(),
 			   std::back_inserter(pg), mpointg);

--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -36,7 +36,7 @@ class Null;
 
 BOOST_AUTO_TEST_CASE(vertexgeom)
 {
-    typedef cpgrid::Geometry<0, 3, Null> Geometry;
+    typedef cpgrid::Geometry<0, 3> Geometry;
     // Default construction.
     Geometry g_default;
 
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(vertexgeom)
 
 BOOST_AUTO_TEST_CASE(intersectiongeom)
 {
-    typedef cpgrid::Geometry<2, 3, Null> Geometry;
+    typedef cpgrid::Geometry<2, 3> Geometry;
     // Default construction.
     Geometry g_default;
 
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(intersectiongeom)
 
 BOOST_AUTO_TEST_CASE(cellgeom)
 {
-    typedef cpgrid::Geometry<3, 3, Null> Geometry;
+    typedef cpgrid::Geometry<3, 3> Geometry;
     // Default construction.
     Geometry g_default;
 


### PR DESCRIPTION
While inspecting dune-cornerpoint I came across this third template
parameter which is used nowhere. It is not needed as explained in
a comment. This patch removes it from Geometry and updates the
rest of the module accordingly.
