### PR TITLE
quell deprecation warning with dune 2.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include (${project}-prereqs)
 include (CMakeLists_files.cmake)
 
 macro (config_hook)
-#	opm_need_version_of ("dune-common")
+	opm_need_version_of ("dune-common")
 endmacro (config_hook)
 
 macro (prereqs_hook)

--- a/dune/grid/common/Volumes.hpp
+++ b/dune/grid/common/Volumes.hpp
@@ -37,7 +37,12 @@
 
 #include <numeric>
 
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
+#include <dune/common/math.hh>
+#else
 #include <dune/common/misc.hh>
+#endif
 #include <dune/common/fvector.hh>
 
 namespace Dune


### PR DESCRIPTION
while it is very unlikely to harm anything, there is little reason to include it in 2013.10.
