### PR TITLE
Fix "make install"

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -91,9 +91,11 @@ list (APPEND PUBLIC_HEADER_FILES
 	dune/grid/cpgrid/CpGridData.hpp
 	dune/grid/cpgrid/DefaultGeometryPolicy.hpp
 	dune/grid/cpgrid/dgfparser.hh
+	dune/grid/cpgrid/Entity2IndexDataHandle.hpp
 	dune/grid/cpgrid/Entity.hpp
 	dune/grid/cpgrid/EntityRep.hpp
 	dune/grid/cpgrid/Geometry.hpp
+	dune/grid/cpgrid/GlobalIdMapping.hpp
 	dune/grid/CpGrid.hpp
 	dune/grid/cpgrid/Indexsets.hpp
 	dune/grid/cpgrid/Intersection.hpp


### PR DESCRIPTION
The headers "Entity2IndexDataHandle.hpp" and "GlobalIdMapping.hpp" were new on master in commit 1596c07.  These must be listed among the public headers lest downstream software using installed  versions of dune-cornerpoint fail to build.

This fixes the Jenkins build of opm-porsol.

Insufficient testing by: @bska
