### PR TITLE
Require non-trivial distribution only for recent Dune

### DIFF
--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -135,7 +135,9 @@ bool CpGrid::scatterGrid()
     current_view_data_ = distributed_data_;
     return true;
 #else
-    std::cerr<<"CpGrid::scatterGrid() only performs computations with MPI support."<<std::endl;
+    std::cerr << "CpGrid::scatterGrid() is non-trivial only with "
+              << "MPI support and if the target Dune platform is "
+              << "sufficiently recent.\n";
     return false;
 #endif
 }

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -233,9 +233,12 @@ BOOST_AUTO_TEST_CASE(distribute)
 
     grid.loadBalance(data);
 
-#if HAVE_MPI
+#if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+    // Dune::CpGrid::loadBalance() is non-trivial only if we have MPI
+    // *and* if the target Dune platform is sufficiently recent.
     BOOST_REQUIRE(grid.comm()!=MPI_COMM_SELF||MPI_COMM_WORLD==MPI_COMM_SELF);
-#endif
+#endif // HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+
     if(procs==1)
     {
         // Check whether the scattered grid is identical to the orinal one.


### PR DESCRIPTION
The `CpGrid::scatterGrid()` method produces non-trivial results only if we have MPI support **and** if the target Dune platform is sufficiently recent (i.e., dune-grid >= 2.3).  Therefore, we cannot "REQUIRE" non-trivial results unless both conditions are satisfied.

In the process, also extend the diagnostic in `CpGrid::scatterGrid()` to include information about the dune-grid requirement.

This fixes "make test" in configurations with MPI and Dune 2.2.1.
