### PR TITLE
add compatibility to opm-parser

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -5,7 +5,7 @@
 // Created: Fri May 29 20:26:36 2009
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
-//            Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            Bï¿½rd Skaflestad     <bard.skaflestad@sintef.no>
 //
 // $Date$
 //
@@ -52,6 +52,7 @@
 #include "cpgrid/Indexsets.hpp"
 #include "cpgrid/DefaultGeometryPolicy.hpp"
 #include <opm/core/grid/cpgpreprocess/preprocess.h>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 
 #include <iostream>
 
@@ -234,6 +235,17 @@ namespace Dune
         /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
         /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
         void processEclipseFormat(const Opm::EclipseGridParser& input_parser, double z_tolerance, bool periodic_extension, bool turn_normals = false, bool clip_z = false);
+
+        /// Read the Eclipse grid format ('grdecl').
+        /// \param input_data the data contained in a parser object.
+        /// \param z_tolerance points along a pillar that are closer together in z
+        ///        coordinate than this parameter, will be replaced by a single point.
+        /// \param periodic_extension if true, the grid will be (possibly) refined, so that
+        ///        intersections/faces along i and j boundaries will match those on the other
+        ///        side. That is, i- faces will match i+ faces etc.
+        /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
+        /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
+        void processEclipseFormat(Opm::DeckConstPtr deck, double z_tolerance, bool periodic_extension, bool turn_normals = false, bool clip_z = false);
 
         /// Read the Eclipse grid format ('grdecl').
         /// \param input_data the data in grdecl format, declared in preprocess.h.

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -5,7 +5,7 @@
 // Created: Thu Jun  4 12:55:28 2009
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
-//            Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            Bï¿½rd Skaflestad     <bard.skaflestad@sintef.no>
 //
 // $Date$
 //
@@ -205,6 +205,14 @@ bool CpGrid::scatterGrid()
                                   bool turn_normals, bool clip_z)
     {
         current_view_data_->processEclipseFormat(input_parser, z_tolerance, periodic_extension,
+                                                 turn_normals, clip_z);
+    }
+
+    void CpGrid::processEclipseFormat(Opm::DeckConstPtr deck,
+                                  double z_tolerance, bool periodic_extension,
+                                  bool turn_normals, bool clip_z)
+    {
+        current_view_data_->processEclipseFormat(deck, z_tolerance, periodic_extension,
                                                  turn_normals, clip_z);
     }
 

--- a/dune/grid/cpgrid/CpGridData.hpp
+++ b/dune/grid/cpgrid/CpGridData.hpp
@@ -59,6 +59,7 @@
 #include "DefaultGeometryPolicy.hpp"
 #include <opm/core/grid/cpgpreprocess/preprocess.h>
 #include <opm/core/io/eclipse/EclipseGridParser.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <dune/common/collectivecommunication.hh>
 #include <dune/common/parallel/indexset.hh>
 #include <dune/common/parallel/interface.hh>
@@ -156,6 +157,17 @@ public:
     /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
     /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
     void processEclipseFormat(const Opm::EclipseGridParser& input_parser, double z_tolerance, bool periodic_extension, bool turn_normals = false, bool clip_z = false);
+
+    /// Read the Eclipse grid format ('grdecl').
+    /// \param input_data the data contained in a parser object.
+    /// \param z_tolerance points along a pillar that are closer together in z
+    ///        coordinate than this parameter, will be replaced by a single point.
+    /// \param periodic_extension if true, the grid will be (possibly) refined, so that
+    ///        intersections/faces along i and j boundaries will match those on the other
+    ///        side. That is, i- faces will match i+ faces etc.
+    /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
+    /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
+    void processEclipseFormat(Opm::DeckConstPtr deck, double z_tolerance, bool periodic_extension, bool turn_normals = false, bool clip_z = false);
 
     /// Read the Eclipse grid format ('grdecl').
     /// \param input_data the data in grdecl format, declared in preprocess.h.
@@ -720,7 +732,6 @@ void CpGridData::gatherCodimData(DataHandle& data, CpGridData* global_data,
     const std::vector<int>& mapping =
         static_cast<GlobalIdMapping*>(distributed_data
                                       ->global_id_set_)->getMapping<codim>();
-    typedef std::vector<int>::const_iterator Iter;
 
     // Get the global indices and data size for the entities whose data is
     // to be sent, i.e. the ones that we own.


### PR DESCRIPTION
this is a prequisite to convert opm-{porsol,upscaling,verteq,benchmarks} but those modules have to wait until the PRs for their build breakers have been merged.

Note that this PR does _not_ depend on OPM/opm-core#579...
