### PR TITLE
[bugfix] Fixes the return type of CentroidIterator::elemenetAt.

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -723,7 +723,7 @@ namespace Dune
             {
                 ++iter_;
             }
-            const int* elementAt(int n)
+            const FieldVector<double, 3>& elementAt(int n)
             {
                 return iter_[n]->center();
             }


### PR DESCRIPTION
The method has to return the reference type of the iterator (which is a const reference to a FieldVector and not const int*) This is now done with this patch. Kudos to Bard for finding this.
