### PR TITLE
Use the Opm::EclipseGrid class instead of the deck directly

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -53,6 +53,7 @@
 #include "cpgrid/DefaultGeometryPolicy.hpp"
 #include <opm/core/grid/cpgpreprocess/preprocess.h>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
 #include <iostream>
 
@@ -224,8 +225,9 @@ namespace Dune
 	///        side. That is, i- faces will match i+ faces etc.
 	void readEclipseFormat(const std::string& filename, double z_tolerance, bool periodic_extension, bool turn_normals = false);
 
+
         /// Read the Eclipse grid format ('grdecl').
-        /// \param input_data the data contained in a parser object.
+        /// \param deck the parsed deck from opm-parser (which is a low-level object)
         /// \param z_tolerance points along a pillar that are closer together in z
         ///        coordinate than this parameter, will be replaced by a single point.
         /// \param periodic_extension if true, the grid will be (possibly) refined, so that
@@ -234,6 +236,17 @@ namespace Dune
         /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
         /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
         void processEclipseFormat(Opm::DeckConstPtr deck, double z_tolerance, bool periodic_extension, bool turn_normals = false, bool clip_z = false);
+
+        /// Read the Eclipse grid format ('grdecl').
+        /// \param ecl_grid the high-level object from opm-parser which represents the simulation's grid
+        /// \param z_tolerance points along a pillar that are closer together in z
+        ///        coordinate than this parameter, will be replaced by a single point.
+        /// \param periodic_extension if true, the grid will be (possibly) refined, so that
+        ///        intersections/faces along i and j boundaries will match those on the other
+        ///        side. That is, i- faces will match i+ faces etc.
+        /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
+        /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
+        void processEclipseFormat(Opm::EclipseGridConstPtr ecl_grid, double z_tolerance, bool periodic_extension, bool turn_normals = false, bool clip_z = false);
 
         /// Read the Eclipse grid format ('grdecl').
         /// \param input_data the data in grdecl format, declared in preprocess.h.

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -208,6 +208,14 @@ bool CpGrid::scatterGrid()
                                                  turn_normals, clip_z);
     }
 
+    void CpGrid::processEclipseFormat(Opm::EclipseGridConstPtr ecl_grid,
+                                      double z_tolerance, bool periodic_extension,
+                                      bool turn_normals, bool clip_z)
+    {
+        current_view_data_->processEclipseFormat(ecl_grid, z_tolerance, periodic_extension,
+                                                 turn_normals, clip_z);
+    }
+
     void CpGrid::processEclipseFormat(const grdecl& input_data, double z_tolerance, 
                                       bool remove_ij_boundary, bool turn_normals)
     {

--- a/dune/grid/cpgrid/CpGridData.hpp
+++ b/dune/grid/cpgrid/CpGridData.hpp
@@ -60,6 +60,7 @@
 #include <opm/core/grid/cpgpreprocess/preprocess.h>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 3, 0)
 #include <dune/common/parallel/collectivecommunication.hh>
@@ -153,7 +154,7 @@ public:
     void readEclipseFormat(const std::string& filename, double z_tolerance, bool periodic_extension, bool turn_normals = false);
 
     /// Read the Eclipse grid format ('grdecl').
-    /// \param input_data the data contained in a parser object.
+    /// \param deck the parsed deck from opm-parser (which is a low-level object)
     /// \param z_tolerance points along a pillar that are closer together in z
     ///        coordinate than this parameter, will be replaced by a single point.
     /// \param periodic_extension if true, the grid will be (possibly) refined, so that
@@ -162,6 +163,17 @@ public:
     /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
     /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
     void processEclipseFormat(Opm::DeckConstPtr deck, double z_tolerance, bool periodic_extension, bool turn_normals = false, bool clip_z = false);
+
+    /// Read the Eclipse grid format ('grdecl').
+    /// \param ecl_grid the high-level object from opm-parser which represents the simulation's grid
+    /// \param z_tolerance points along a pillar that are closer together in z
+    ///        coordinate than this parameter, will be replaced by a single point.
+    /// \param periodic_extension if true, the grid will be (possibly) refined, so that
+    ///        intersections/faces along i and j boundaries will match those on the other
+    ///        side. That is, i- faces will match i+ faces etc.
+    /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
+    /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
+    void processEclipseFormat(Opm::EclipseGridConstPtr ecl_grid, double z_tolerance, bool periodic_extension, bool turn_normals = false, bool clip_z = false);
 
     /// Read the Eclipse grid format ('grdecl').
     /// \param input_data the data in grdecl format, declared in preprocess.h.


### PR DESCRIPTION
this has the advantage that the gazillion ways of specifying an ECL
grid are abstracted away, and thus e.g. using D{X,Y,Z}V is
automatically supported. Also, if additional grid construction methods
are implemented in Opm::EclipseGrid, these will automatically be
supported by dune-cornerpoint as well. (If the API for
Opm::EclipseGrid does not change, that is.)
