### PR TITLE
fixed: building with dune > 2.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ include (CMakeLists_files.cmake)
 
 macro (config_hook)
 	opm_need_version_of ("dune-common")
+	opm_need_version_of ("dune-grid")
 	find_file(_HAVE_DUNE_GRID_CHECKS checkpartition.cc HINTS ${dune-grid_INCLUDE_DIR}
 		PATH_SUFFIXES dune/grid/test)
 	if(_HAVE_DUNE_GRID_CHECKS)

--- a/dune/grid/cpgrid/CpGridData.hpp
+++ b/dune/grid/cpgrid/CpGridData.hpp
@@ -61,7 +61,11 @@
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 3, 0)
+#include <dune/common/parallel/collectivecommunication.hh>
+#else
 #include <dune/common/collectivecommunication.hh>
+#endif
 #include <dune/common/parallel/indexset.hh>
 #include <dune/common/parallel/interface.hh>
 #include <dune/common/parallel/plocalindex.hh>

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -208,8 +208,13 @@ BOOST_AUTO_TEST_CASE(distribute)
         for (Dune::CpGrid::Codim<0>::LeafIterator it = grid.leafbegin<0>();
              it != grid.leafend<0>(); ++it) {
             Dune::GeometryType gt = it->type () ;
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+            const Dune::ReferenceElement<Dune::CpGrid::ctype, 3>& ref=
+                Dune::ReferenceElements<Dune::CpGrid::ctype, 3>::general(gt);
+#else
             const Dune::GenericReferenceElement<Dune::CpGrid::ctype, 3>& ref=
                 Dune::GenericReferenceElements<Dune::CpGrid::ctype, 3>::general(gt);
+#endif
             
             cell_indices.push_back(ix.index(*it));
             cell_centers.push_back(it->geometry().center());
@@ -258,8 +263,13 @@ BOOST_AUTO_TEST_CASE(distribute)
         for (Dune::CpGrid::Codim<0>::LeafIterator it = grid.leafbegin<0>();
              it != grid.leafend<0>(); ++it) {
             Dune::GeometryType gt = it->type () ;
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+            const Dune::ReferenceElement<Dune::CpGrid::ctype, 3>& ref=
+                Dune::ReferenceElements<Dune::CpGrid::ctype, 3>::general(gt);
+#else
             const Dune::GenericReferenceElement<Dune::CpGrid::ctype, 3>& ref=
                 Dune::GenericReferenceElements<Dune::CpGrid::ctype, 3>::general(gt);
+#endif
 
             BOOST_REQUIRE(cell_indices[cell_index]==ix1.index(*it));
             BOOST_REQUIRE(cell_centers[cell_index++]==it->geometry().center());


### PR DESCRIPTION
- symbols were deprecated in 2.3 and removed in master
- a header changed location in what will become 3.0

@blattms your code i believe (nothing controversial but just in case..)
