### PR TITLE
fix build on GCC 4.4

### DIFF
--- a/dune/grid/cpgrid/readEclipseFormat.cpp
+++ b/dune/grid/cpgrid/readEclipseFormat.cpp
@@ -102,7 +102,7 @@ namespace cpgrid
         Opm::DeckConstPtr deck(parser->parseFile(filename));
         std::shared_ptr<const Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck));
         std::shared_ptr<const Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck));
-        Opm::EclipseGridPtr ecl_grid(new Opm::EclipseGrid(runspecSection, gridSection));
+        Opm::EclipseGridConstPtr ecl_grid(new Opm::EclipseGrid(runspecSection, gridSection));
         processEclipseFormat(ecl_grid, z_tolerance, periodic_extension, turn_normals);
     }
 
@@ -110,7 +110,7 @@ namespace cpgrid
     {
         std::shared_ptr<const Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck));
         std::shared_ptr<const Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck));
-        Opm::EclipseGridPtr ecl_grid(new Opm::EclipseGrid(runspecSection, gridSection));
+        Opm::EclipseGridConstPtr ecl_grid(new Opm::EclipseGrid(runspecSection, gridSection));
         processEclipseFormat(ecl_grid, z_tolerance, periodic_extension, turn_normals, clip_z);
     }
 


### PR DESCRIPTION
the usual problem: GCC 4.4 sometimes has problems to implicitly cast
std::shared_ptr<Foo> to std::shared_ptr<const Foo>. sorry for the
hiccup...
