### PR TITLE
fix usage of the ACTNUM keyword exported by EclipseGrid

### DIFF
--- a/dune/grid/cpgrid/readEclipseFormat.cpp
+++ b/dune/grid/cpgrid/readEclipseFormat.cpp
@@ -404,7 +404,7 @@ namespace cpgrid
 			cellz_t cellvals = getCellZvals(indexToIjk(n, old_cell_index), n, old_zcorn);
 			// cout << new_cell_index << ' ' << old_cell_index << ' ' << cellvals << endl;
 			setCellZvals(indexToIjk(new_n, new_cell_index), new_n, &zcorn[0], cellvals);
-			actnum[new_cell_index] = old_actnum[old_cell_index];
+			actnum[new_cell_index] = old_actnum?old_actnum[old_cell_index]:1;
 			if (ix == 0 || ix == new_n[0] - 1
 			    || jy == 0 || jy == new_n[1] - 1) {
 			    actnum[new_cell_index] = 1;  // This line is changed from the original.


### PR DESCRIPTION
it turns out that EclipseGrid::exportACTNUM() produces a vector of
zero length instead of an all-1 one of the size of the logically
Cartesian grid if ACTNUM is not set.

Strangely enough, this worked if libstdc++'s debug mode was not
enabled. (maybe because dune-cornerpoint does not consider ACTNUM?)

@akva2: does this fix the recent opm-upscaling issues?
