### PR TITLE
Changed EclipseGrid() construction

### DIFF
--- a/dune/grid/cpgrid/readEclipseFormat.cpp
+++ b/dune/grid/cpgrid/readEclipseFormat.cpp
@@ -48,7 +48,7 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
 #include <fstream>
-#include <iostream>
+#include <iostream> 
 
 namespace Dune
 {
@@ -100,17 +100,43 @@ namespace cpgrid
 #endif
         Opm::ParserPtr parser(new Opm::Parser());
         Opm::DeckConstPtr deck(parser->parseFile(filename));
-        std::shared_ptr<const Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck));
         std::shared_ptr<const Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck));
-        Opm::EclipseGridConstPtr ecl_grid(new Opm::EclipseGrid(runspecSection, gridSection));
+        Opm::EclipseGridConstPtr ecl_grid;
+        
+        if (Opm::Section::hasRUNSPEC(deck)) {
+            std::shared_ptr<const Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck));
+            ecl_grid.reset( new Opm::EclipseGrid(runspecSection, gridSection) );
+        } else {
+            Opm::DeckKeywordConstPtr specGridKeyword = deck->getKeyword("SPECGRID");
+            Opm::DeckRecordConstPtr record = specGridKeyword->getRecord(0);
+            int nx = record->getItem("NX")->getInt(0);
+            int ny = record->getItem("NY")->getInt(0);
+            int nz = record->getItem("NZ")->getInt(0);
+            
+            ecl_grid.reset( new Opm::EclipseGrid(nx , ny , nz , gridSection) );
+        }
+            
         processEclipseFormat(ecl_grid, z_tolerance, periodic_extension, turn_normals);
     }
 
     void CpGridData::processEclipseFormat(Opm::DeckConstPtr deck, double z_tolerance, bool periodic_extension, bool turn_normals, bool clip_z)
     {
-        std::shared_ptr<const Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck));
         std::shared_ptr<const Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck));
-        Opm::EclipseGridConstPtr ecl_grid(new Opm::EclipseGrid(runspecSection, gridSection));
+        Opm::EclipseGridConstPtr ecl_grid;
+        
+        if (Opm::Section::hasRUNSPEC(deck)) {
+            std::shared_ptr<const Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck));
+            ecl_grid.reset( new Opm::EclipseGrid(runspecSection, gridSection) );
+        } else {
+            Opm::DeckKeywordConstPtr specGridKeyword = deck->getKeyword("SPECGRID");
+            Opm::DeckRecordConstPtr record = specGridKeyword->getRecord(0);
+            int nx = record->getItem("NX")->getInt(0);
+            int ny = record->getItem("NY")->getInt(0);
+            int nz = record->getItem("NZ")->getInt(0);
+            
+            ecl_grid.reset( new Opm::EclipseGrid(nx , ny , nz , gridSection) );
+        }
+
         processEclipseFormat(ecl_grid, z_tolerance, periodic_extension, turn_normals, clip_z);
     }
 


### PR DESCRIPTION
If the deck does not have the RUNSPEC section (nx,ny,nz) are read from
the SPECGRID keyword in the GRID section.
