### PR TITLE
build system: do not special-case MPI and openMP anymore, make it possible to disable any package

### DIFF
--- a/cmake/Modules/OpmFind.cmake
+++ b/cmake/Modules/OpmFind.cmake
@@ -131,7 +131,7 @@ macro (find_and_append_package_to prefix name)
   endif ((NOT (_${name}_exempted EQUAL -1)) AND (DEFINED ${name}_DIR))
 
   # if we're told not to look for the package, pretend it was never found
-  if (CMAKE_DISABLE_FIND_PACKAGE_${name})
+  if (DEFINED "USE_${name}" AND NOT "USE_${name}")
 	set (${name}_FOUND FALSE)
 	set (${NAME}_FOUND FALSE)
   else ()

--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -71,16 +71,6 @@ include (UseOptimization)
 # dependencies, in case they alter the list of warnings
 include (UseWarnings)
 
-# parallel computing must be explicitly enabled
-option (USE_MPI "Use Message Passing Interface for parallel computing" OFF)
-if (NOT USE_MPI)
-	set (CMAKE_DISABLE_FIND_PACKAGE_MPI TRUE)
-endif (NOT USE_MPI)
-
-# parallel programming
-include (UseOpenMP)
-find_openmp (${project})
-
 # callback hook to setup additional dependencies
 if (COMMAND prereqs_hook)
 	prereqs_hook ()


### PR DESCRIPTION
see OPM/opm-core#636
