### PR TITLE
Add MINPV processing to grid construction.

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -231,7 +231,9 @@ namespace Dune
         ///        side. That is, i- faces will match i+ faces etc.
         /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
         /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
-        void processEclipseFormat(Opm::DeckConstPtr deck, bool periodic_extension, bool turn_normals = false, bool clip_z = false);
+        /// \param poreVolume pore volumes for use in MINPV processing, if asked for in deck
+        void processEclipseFormat(Opm::DeckConstPtr deck, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
+                                  const std::vector<double>& poreVolume = std::vector<double>());
 
         /// Read the Eclipse grid format ('grdecl').
         /// \param ecl_grid the high-level object from opm-parser which represents the simulation's grid
@@ -240,7 +242,9 @@ namespace Dune
         ///        side. That is, i- faces will match i+ faces etc.
         /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
         /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
-        void processEclipseFormat(Opm::EclipseGridConstPtr ecl_grid, bool periodic_extension, bool turn_normals = false, bool clip_z = false);
+        /// \param poreVolume pore volumes for use in MINPV processing, if asked for in deck
+        void processEclipseFormat(Opm::EclipseGridConstPtr ecl_grid, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
+                                  const std::vector<double>& poreVolume = std::vector<double>());
 
         /// Read the Eclipse grid format ('grdecl').
         /// \param input_data the data in grdecl format, declared in preprocess.h.

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -203,19 +203,23 @@ bool CpGrid::scatterGrid()
     }
 
     void CpGrid::processEclipseFormat(Opm::DeckConstPtr deck,
-                                  bool periodic_extension,
-                                  bool turn_normals, bool clip_z)
+                                      bool periodic_extension,
+                                      bool turn_normals, bool clip_z,
+                                      const std::vector<double>& poreVolume)
     {
         current_view_data_->processEclipseFormat(deck, periodic_extension,
-                                                 turn_normals, clip_z);
+                                                 turn_normals, clip_z,
+                                                 poreVolume);
     }
 
     void CpGrid::processEclipseFormat(Opm::EclipseGridConstPtr ecl_grid,
                                       bool periodic_extension,
-                                      bool turn_normals, bool clip_z)
+                                      bool turn_normals, bool clip_z,
+                                      const std::vector<double>& poreVolume)
     {
         current_view_data_->processEclipseFormat(ecl_grid, periodic_extension,
-                                                 turn_normals, clip_z);
+                                                 turn_normals, clip_z,
+                                                 poreVolume);
     }
 
     void CpGrid::processEclipseFormat(const grdecl& input_data, double z_tolerance, 

--- a/dune/grid/cpgrid/CpGridData.hpp
+++ b/dune/grid/cpgrid/CpGridData.hpp
@@ -158,7 +158,9 @@ public:
     ///        side. That is, i- faces will match i+ faces etc.
     /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
     /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
-    void processEclipseFormat(Opm::DeckConstPtr deck, bool periodic_extension, bool turn_normals = false, bool clip_z = false);
+    /// \param poreVolume pore volumes for use in MINPV processing, if asked for in deck
+    void processEclipseFormat(Opm::DeckConstPtr deck, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
+                              const std::vector<double>& poreVolume = std::vector<double>());
 
     /// Read the Eclipse grid format ('grdecl').
     /// \param ecl_grid the high-level object from opm-parser which represents the simulation's grid
@@ -167,7 +169,9 @@ public:
     ///        side. That is, i- faces will match i+ faces etc.
     /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
     /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
-    void processEclipseFormat(Opm::EclipseGridConstPtr ecl_grid, bool periodic_extension, bool turn_normals = false, bool clip_z = false);
+    /// \param poreVolume pore volumes for use in MINPV processing, if asked for in deck
+    void processEclipseFormat(Opm::EclipseGridConstPtr ecl_grid, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
+                              const std::vector<double>& poreVolume = std::vector<double>());
 
     /// Read the Eclipse grid format ('grdecl').
     /// \param input_data the data in grdecl format, declared in preprocess.h.


### PR DESCRIPTION
This adds MINPV processing using the same class as for the opm-core code.

Requires OPM/opm-core#637.
