### PR TITLE
Forward declare CpGridData class.

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -44,7 +44,6 @@
 #include <dune/grid/common/grid.hh>
 #include <dune/grid/common/gridenums.hh>
 
-#include "cpgrid/CpGridData.hpp"
 #include "cpgrid/Intersection.hpp"
 #include "cpgrid/Entity.hpp"
 #include "cpgrid/Geometry.hpp"
@@ -68,6 +67,11 @@ namespace Dune
 {
 
     class CpGrid;
+
+    namespace cpgrid
+    {
+        class CpGridData;
+    }
 
     ////////////////////////////////////////////////////////////////////////
     //


### PR DESCRIPTION
The CpGridData.hpp header uses version macros, and should therefore be considered a private header. With this we avoid including that file from CpGrid.hpp.

This fixes and closes #107.
