### PR TITLE
[bugfix] dune version 3.0 has been renamed to 2.4. 

### DIFF
--- a/dune/grid/cpgrid/CpGridData.hpp
+++ b/dune/grid/cpgrid/CpGridData.hpp
@@ -62,7 +62,7 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 3, 0)
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/collectivecommunication.hh>
 #else
 #include <dune/common/collectivecommunication.hh>


### PR DESCRIPTION
Also, since collectivecommunication.hh was already alvailable in parallel sub folder in 2.3 lets use it from there. 
