### PR TITLE
cosmetics in jenkins build scripts after module renaming

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -1,18 +1,18 @@
-# dune-cornerpoint jenkins build scripts:
+# opm-grid jenkins build scripts:
 
-**build-dune-cornerpoint.sh**:
+**build-opm-grid.sh**:
 This is a helper script which contains a function for building,
-testing and cloning dune-cornerpoint and its dependencies.
+testing and cloning opm-grid and its dependencies.
 
 **build.sh**:
-This script will build dependencies, then build dune-cornerpoint and execute its tests.
+This script will build dependencies, then build opm-grid and execute its tests.
 It is intended for post-merge builds of the master branch.
 
 **build-pr.sh**:
-This script will build dependencies, then build dune-cornerpoint and execute its tests.
+This script will build dependencies, then build opm-grid and execute its tests.
 It inspects the $ghbPrBuildComment environmental variable to obtain a pull request
 to use for ert, opm-common, opm-parser, opm-material and
-opm-core (defaults to master) and then builds $sha1 of dune-cornerpoint.
+opm-core (defaults to master) and then builds $sha1 of opm-grid.
 
 It is intended for pre-merge builds of pull requests.
 

--- a/jenkins/build-opm-grid.sh
+++ b/jenkins/build-opm-grid.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-function build_dune_cornerpoint {
+function build_opm_grid {
   # Build ERT
   pushd .
   mkdir -p $WORKSPACE/deps/ert
@@ -52,10 +52,10 @@ function build_dune_cornerpoint {
   clone_and_build_module opm-core "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install -DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install" $OPM_CORE_REVISION $WORKSPACE/serial
   test $? -eq 0 || exit 1
 
-  # Build dune-cornerpoint
+  # Build opm-grid
   pushd .
-  mkdir serial/build-dune-cornerpoint
-  cd serial/build-dune-cornerpoint
+  mkdir serial/build-opm-grid
+  cd serial/build-opm-grid
   build_module "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install" 1 $WORKSPACE
   test $? -eq 0 || exit 1
   popd

--- a/jenkins/build-pr.sh
+++ b/jenkins/build-pr.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-source `dirname $0`/build-dune-cornerpoint.sh
+source `dirname $0`/build-opm-grid.sh
 
 ERT_REVISION=master
 OPM_COMMON_REVISION=master
 OPM_PARSER_REVISION=master
 OPM_MATERIAL_REVISION=master
 OPM_CORE_REVISION=master
-DUNE_CORNERPOINT_REVISION=$sha1
+OPM_GRID_REVISION=$sha1
 
 if grep -q "ert=" <<< $ghprbCommentBody
 then
@@ -34,9 +34,9 @@ then
   OPM_CORE_REVISION=pull/`echo $ghprbCommentBody | sed -r 's/.*opm-core=([0-9]+).*/\1/g'`/merge
 fi
 
-echo "Building with ert=$ERT_REVISION opm-common=$OPM_COMMON_REVISION opm-parser=$OPM_PARSER_REVISION opm-material=$OPM_MATERIAL_REVISION opm-core=$OPM_CORE_REVISION dune-cornerpoint=$DUNE_CORNERPOINT_REVISION"
+echo "Building with ert=$ERT_REVISION opm-common=$OPM_COMMON_REVISION opm-parser=$OPM_PARSER_REVISION opm-material=$OPM_MATERIAL_REVISION opm-core=$OPM_CORE_REVISION opm-grid=$OPM_GRID_REVISION"
 
-build_dune_cornerpoint
+build_opm_grid
 test $? -eq 0 || exit 1
 
-cp serial/build-dune-cornerpoint/testoutput.xml .
+cp serial/build-opm-grid/testoutput.xml .

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source `dirname $0`/build-dune-cornerpoint.sh
+source `dirname $0`/build-opm-grid.sh
 
 ERT_REVISION=master
 OPM_COMMON_REVISION=master
@@ -8,7 +8,7 @@ OPM_PARSER_REVISION=master
 OPM_MATERIAL_REVISION=master
 OPM_CORE_REVISION=master
 
-build_dune_cornerpoint
+build_opm_grid
 test $? -eq 0 || exit 1
 
-cp serial/build-dune-cornerpoint/testoutput.xml .
+cp serial/build-opm-grid/testoutput.xml .


### PR DESCRIPTION
no functional differences, just replaces old references to
dune-cornerpoint with references to opm-grid.

@atgeirr please include in your merge run.