### PR TITLE
Fix grid creation from incomplete decks.

### DIFF
--- a/dune/grid/cpgrid/readEclipseFormat.cpp
+++ b/dune/grid/cpgrid/readEclipseFormat.cpp
@@ -47,7 +47,6 @@
 #include <opm/core/utility/StopWatch.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
@@ -111,8 +110,10 @@ namespace cpgrid
     void CpGridData::processEclipseFormat(Opm::DeckConstPtr deck, bool periodic_extension, bool turn_normals, bool clip_z,
                                           const std::vector<double>& poreVolume)
     {
-        Opm::EclipseState es(deck, Opm::ParseContext());
-        Opm::EclipseGridConstPtr ecl_grid = es.getInputGrid();
+        const int* actnum = deck->hasKeyword("ACTNUM")
+          ? deck->getKeyword("ACTNUM").getIntData().data()
+          : nullptr;
+        const auto ecl_grid = std::make_shared<Opm::EclipseGrid>(deck, actnum);
         processEclipseFormat(ecl_grid, periodic_extension, turn_normals, clip_z, poreVolume);
     }
 

--- a/dune/grid/polyhedralgrid/grid.hh
+++ b/dune/grid/polyhedralgrid/grid.hh
@@ -40,9 +40,6 @@
 #include <opm/core/grid/cornerpoint_grid.h>
 #include <opm/core/grid/MinpvProcessor.hpp>
 
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
-
 namespace Dune
 {
 
@@ -784,8 +781,11 @@ namespace Dune
   protected:
     UnstructuredGridType* createGrid( Opm::DeckConstPtr deck, const std::vector< double >& poreVolumes ) const
     {
-        Opm::EclipseState es(deck, Opm::ParseContext());
-        auto eclipseGrid = es.getInputGrid();
+        const int* rawactnum = deck->hasKeyword("ACTNUM")
+          ? deck->getKeyword("ACTNUM").getIntData().data()
+          : nullptr;
+        const auto eclipseGrid = std::make_shared<Opm::EclipseGrid>(deck, rawactnum);
+
         struct grdecl g;
         std::vector<int> actnum;
         std::vector<double> coord;


### PR DESCRIPTION
This is necessary for working with .grdecl files directly. That ability was temporarily lost by the merging of #213.

@joakim-hove I would appreciate if you could review and merge this (if ok).