### PR TITLE
added: downstream build support in the jenkins trigger

### DIFF
--- a/jenkins/build-opm-grid.sh
+++ b/jenkins/build-opm-grid.sh
@@ -40,23 +40,13 @@ function build_opm_grid {
   test $? -eq 0 || exit 1
   popd
 
-  # Build opm-parser
-  clone_and_build_module opm-parser "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install -DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install" $OPM_PARSER_REVISION $WORKSPACE/serial
-  test $? -eq 0 || exit 1
-
-  # Build opm-material
-  clone_and_build_module opm-material "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install -DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install" $OPM_MATERIAL_REVISION $WORKSPACE/serial
-  test $? -eq 0 || exit 1
-
-  # Build opm-core
-  clone_and_build_module opm-core "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install -DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install" $OPM_CORE_REVISION $WORKSPACE/serial
-  test $? -eq 0 || exit 1
+  build_upstreams
 
   # Build opm-grid
   pushd .
   mkdir serial/build-opm-grid
   cd serial/build-opm-grid
-  build_module "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install" 1 $WORKSPACE
+  build_module "-DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install -DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install" 1 $WORKSPACE
   test $? -eq 0 || exit 1
   popd
 }

--- a/jenkins/build-pr.sh
+++ b/jenkins/build-pr.sh
@@ -2,12 +2,18 @@
 
 source `dirname $0`/build-opm-grid.sh
 
+declare -a upstreams
+upstreams=(opm-parser
+           opm-material
+           opm-core)
+
+declare -A upstreamRev
+upstreamRev[opm-parser]=master
+upstreamRev[opm-material]=master
+upstreamRev[opm-core]=master
+
 ERT_REVISION=master
 OPM_COMMON_REVISION=master
-OPM_PARSER_REVISION=master
-OPM_MATERIAL_REVISION=master
-OPM_CORE_REVISION=master
-OPM_GRID_REVISION=$sha1
 
 if grep -q "ert=" <<< $ghprbCommentBody
 then
@@ -19,24 +25,42 @@ then
   OPM_COMMON_REVISION=pull/`echo $ghprbCommentBody | sed -r 's/.*opm-common=([0-9]+).*/\1/g'`/merge
 fi
 
-if grep -q "opm-parser=" <<< $ghprbCommentBody
-then
-  OPM_PARSER_REVISION=pull/`echo $ghprbCommentBody | sed -r 's/.*opm-parser=([0-9]+).*/\1/g'`/merge
-fi
+for upstream in $upstreams
+do
+  if grep -q "$upstream=" <<< $ghprbCommentBody
+  then
+    upstreamRev[$upstream]=pull/`echo $ghprbCommentBody | sed -r "s/.*$upstream=([0-9]+).*/\1/g"`/merge
+  fi
+done
 
-if grep -q "opm-material=" <<< $ghprbCommentBody
-then
-  OPM_MATERIAL_REVISION=pull/`echo $ghprbCommentBody | sed -r 's/.*opm-material=([0-9]+).*/\1/g'`/merge
-fi
-
-if grep -q "opm-core=" <<< $ghprbCommentBody
-then
-  OPM_CORE_REVISION=pull/`echo $ghprbCommentBody | sed -r 's/.*opm-core=([0-9]+).*/\1/g'`/merge
-fi
-
-echo "Building with ert=$ERT_REVISION opm-common=$OPM_COMMON_REVISION opm-parser=$OPM_PARSER_REVISION opm-material=$OPM_MATERIAL_REVISION opm-core=$OPM_CORE_REVISION opm-grid=$OPM_GRID_REVISION"
+echo "Building with ert=$ERT_REVISION opm-common=$OPM_COMMON_REVISION opm-parser=${upstreamRev[opm-parser]} opm-material=${upstreamRev[opm-material]} opm-core=${upstreamRev[opm-core]} opm-grid=$sha1"
 
 build_opm_grid
 test $? -eq 0 || exit 1
 
-cp serial/build-opm-grid/testoutput.xml .
+# If no downstream builds we are done
+if ! grep -q "with downstreams" <<< $ghprbCommentBody
+then
+  cp serial/build-opm-grid/testoutput.xml .
+  exit 0
+fi
+
+# Downstreams and default revisions
+declare -a downstreams
+downstreams=(opm-output
+             opm-simulators
+             opm-upscaling
+             ewoms)
+
+declare -A downstreamRev
+downstreamRev[opm-output]=master
+downstreamRev[opm-simulators]=master
+downstreamRev[opm-upscaling]=master
+downstreamRev[ewoms]=master
+
+source $WORKSPACE/deps/opm-common/jenkins/setup-opm-data.sh
+source $WORKSPACE/deps/opm-common/jenkins/build-opm-module.sh
+
+build_downstreams opm-grid
+
+test $? -eq 0 || exit 1

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -2,11 +2,18 @@
 
 source `dirname $0`/build-opm-grid.sh
 
+declare -a upstreams
+upstreams=(opm-parser
+           opm-material
+           opm-core)
+
+declare -A upstreamRev
+upstreamRev[opm-parser]=master
+upstreamRev[opm-material]=master
+upstreamRev[opm-core]=master
+
 ERT_REVISION=master
 OPM_COMMON_REVISION=master
-OPM_PARSER_REVISION=master
-OPM_MATERIAL_REVISION=master
-OPM_CORE_REVISION=master
 
 build_opm_grid
 test $? -eq 0 || exit 1


### PR DESCRIPTION
use 'jenkins build this with downstreams please'.

this will build all downstreams against the PR, and
execute their tests. PR's for upstream and downstream modules
can be specified.

the aggregated test results are attached to the job result on jenkins.

depends on https://github.com/OPM/opm-common/pull/111