### PR TITLE
Silence missing-braces warning.

### DIFF
--- a/tests/cpgrid/facetag_test.cpp
+++ b/tests/cpgrid/facetag_test.cpp
@@ -38,8 +38,8 @@ BOOST_AUTO_TEST_CASE(facetag)
     char** m_argv = boost::unit_test::framework::master_test_suite().argv;
     Dune::MPIHelper::instance(m_argc, m_argv);
     Dune::CpGrid grid;
-    std::array<int, 3>    dims     = { 3, 3, 3 };
-    std::array<double, 3> cellsize = { 1., 1., 1. };
+    std::array<int, 3>    dims     = {{ 3, 3, 3 }};
+    std::array<double, 3> cellsize = {{ 1., 1., 1. }};
     grid.createCartesian(dims, cellsize);
     Dune::cpgrid::Cell2FacesContainer c2f(&grid);
     


### PR DESCRIPTION
At some point this will no longer be needed, but for now it avoids a warning from clang.