### PR TITLE
Update Intersection.cpp

### DIFF
--- a/dune/grid/cpgrid/Intersection.cpp
+++ b/dune/grid/cpgrid/Intersection.cpp
@@ -89,7 +89,7 @@ void Intersection::update()
                     cells_of_face[0].index()==std::numeric_limits<int>::max() ||
                     cells_of_face[1].index()==std::numeric_limits<int>::max();
                 if (has_no_nbcell) {
-                    nbcell_ = index_; // self is invalid value
+                    nbcell_ = std::numeric_limits<int>::max(); // neighbor is not within this process
                 } else {
                     assert(cells_of_face.size() == 2);
                     if (cells_of_face[0].index() == index_) {


### PR DESCRIPTION
When running in parallel, the method Intersection::neighbor() has to return "false" for intersections which do not have a neighbor in the current process. However, currently it seems to return "true" for intersections on the outside boundary of overlapping cells. We stumbled on this problem when we tried to run a Dumux simulation using cpgrid in parallel. The suggested change solved our problem.
Could please somebody have a look if the changes should be merged?

Regards Birger