### PR TITLE
Loadbalance returns set of defunct wells on process

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -41,6 +41,7 @@
 #include <string>
 #include <map>
 #include <array>
+#include <unordered_set>
 #include <opm/common/ErrorMacros.hpp>
 
 // Warning suppression for Dune includes.
@@ -594,7 +595,7 @@ namespace Dune
         ///            possible pairs of cells in the completion set of a well.
         /// \param The number of layers of cells of the overlap region (default: 1).
         /// \warning May only be called once.
-        std::pair<bool, std::vector<int> >
+        std::pair<bool, std::unordered_set<std::string> >
         loadBalance(Opm::EclipseStateConstPtr ecl,
                     const double* transmissibilities = nullptr,
                     int overlapLayers=1)
@@ -628,7 +629,7 @@ namespace Dune
         /// \tparam DataHandle The type implementing DUNE's DataHandle interface.
         /// \warning May only be called once.
         template<class DataHandle>
-        std::pair<bool, std::vector<int> >
+        std::pair<bool, std::unordered_set<std::string> >
         loadBalance(DataHandle& data,
                     Opm::EclipseStateConstPtr ecl,
                     const double* transmissibilities = nullptr,
@@ -1151,7 +1152,7 @@ namespace Dune
         ///            of each well are stored on one process. This done by
         ///            adding an edge with a very high edge weight for all
         ///            possible pairs of cells in the completion set of a well.
-        std::pair<bool, std::vector<int> >
+        std::pair<bool, std::unordered_set<std::string> >
         scatterGrid(Opm::EclipseStateConstPtr ecl, const double* transmissibilities,
                     int overlapLayers);
 

--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -594,11 +594,24 @@ namespace Dune
         ///            possible pairs of cells in the completion set of a well.
         /// \param The number of layers of cells of the overlap region (default: 1).
         /// \warning May only be called once.
-        bool loadBalance(Opm::EclipseStateConstPtr ecl=Opm::EclipseStateConstPtr(),
-                         const double* transmissibilities = nullptr,
-                         int overlapLayers=1)
+        std::pair<bool, std::vector<int> >
+        loadBalance(Opm::EclipseStateConstPtr ecl,
+                    const double* transmissibilities = nullptr,
+                    int overlapLayers=1)
         {
             return scatterGrid(ecl, transmissibilities, overlapLayers);
+        }
+
+        // loadbalance is not part of the grid interface therefore we skip it.
+
+        /// \brief Distributes this grid over the available nodes in a distributed machine
+        /// \param The number of layers of cells of the overlap region (default: 1).
+        /// \warning May only be called once.
+        bool loadBalance(int overlapLayers=1)
+        {
+            using std::get;
+            return get<0>(scatterGrid(Opm::EclipseStateConstPtr(), nullptr,
+                                      overlapLayers ));
         }
 
         /// \brief Distributes this grid and data over the available nodes in a distributed machine.
@@ -615,12 +628,28 @@ namespace Dune
         /// \tparam DataHandle The type implementing DUNE's DataHandle interface.
         /// \warning May only be called once.
         template<class DataHandle>
+        std::pair<bool, std::vector<int> >
+        loadBalance(DataHandle& data,
+                    Opm::EclipseStateConstPtr ecl,
+                    const double* transmissibilities = nullptr,
+                    int overlapLayers=1)
+        {
+            auto ret = loadBalance(ecl, transmissibilities, overlapLayers);
+            scatterData(data);
+            return ret;
+        }
+
+        /// \brief Distributes this grid and data over the available nodes in a distributed machine.
+        /// \param data A data handle describing how to distribute attached data.
+        /// \param overlapLayers The number of layers of overlap cells to be added
+        ///        (default: 1)
+        /// \tparam DataHandle The type implementing DUNE's DataHandle interface.
+        /// \warning May only be called once.
+        template<class DataHandle>
         bool loadBalance(DataHandle& data,
-                         Opm::EclipseStateConstPtr ecl=Opm::EclipseStateConstPtr(),
-                         const double* transmissibilities = nullptr,
                          int overlapLayers=1)
         {
-            bool ret = scatterGrid(ecl, transmissibilities, overlapLayers);
+            bool ret = loadBalance(overlapLayers);
             scatterData(data);
             return ret;
         }
@@ -1122,8 +1151,9 @@ namespace Dune
         ///            of each well are stored on one process. This done by
         ///            adding an edge with a very high edge weight for all
         ///            possible pairs of cells in the completion set of a well.
-        bool scatterGrid(Opm::EclipseStateConstPtr ecl, const double* transmissibilities,
-                         int overlapLayers);
+        std::pair<bool, std::vector<int> >
+        scatterGrid(Opm::EclipseStateConstPtr ecl, const double* transmissibilities,
+                    int overlapLayers);
 
         /** @brief The data stored in the grid.
          *

--- a/dune/grid/common/ZoltanGraphFunctions.cpp
+++ b/dune/grid/common/ZoltanGraphFunctions.cpp
@@ -388,7 +388,6 @@ CombinedGridWellGraph::postProcessPartitioningForWells(std::vector<int>& parts,
         return well_indices_on_proc;
     }
     std::vector<const Opm::Well*> wells  = eclipseState_->getSchedule()->getWells();
-    int last_time_step = eclipseState_->getSchedule()->getTimeMap()->size()-1;
 
     // prevent memory allocation
     for(auto& well_indices : well_indices_on_proc)

--- a/dune/grid/common/ZoltanGraphFunctions.cpp
+++ b/dune/grid/common/ZoltanGraphFunctions.cpp
@@ -376,10 +376,11 @@ CombinedGridWellGraph::CombinedGridWellGraph(const CpGrid& grid,
 }
 
 std::vector<std::vector<int> >
-CombinedGridWellGraph::postProcessPartitioningForWells(std::vector<int>& parts)
+CombinedGridWellGraph::postProcessPartitioningForWells(std::vector<int>& parts,
+                                                       std::size_t no_procs)
 {
     // Contains for each process the indices of the wells assigned to it.
-    std::vector<std::vector<int> > well_indices_on_proc(grid_.comm().size());
+    std::vector<std::vector<int> > well_indices_on_proc(no_procs);
 
     if( ! wellsGraph_.size() )
     {
@@ -402,9 +403,9 @@ CombinedGridWellGraph::postProcessPartitioningForWells(std::vector<int>& parts)
         const Opm::Well* well = (*wellIter);
         const std::set<int>& well_indices = well_indices_[wellIter - wells.begin()];
         std::map<int,std::size_t> no_completions_on_proc;
-        for ( size_t c = 0; c < well_indices.size(); c++  )
+        for ( auto well_index: well_indices )
         {
-            ++no_completions_on_proc[parts[c]];
+            ++no_completions_on_proc[parts[well_index]];
         }
 
         int owner = no_completions_on_proc.begin()->first;

--- a/dune/grid/common/ZoltanGraphFunctions.hpp
+++ b/dune/grid/common/ZoltanGraphFunctions.hpp
@@ -172,6 +172,7 @@ private:
     Opm::EclipseStateConstPtr eclipseState_;
     GraphType wellsGraph_;
     const double* transmissibilities_;
+    std::vector<std::set<int> > well_indices_;
 };
 
 

--- a/dune/grid/common/ZoltanGraphFunctions.hpp
+++ b/dune/grid/common/ZoltanGraphFunctions.hpp
@@ -144,7 +144,10 @@ public:
     }
     /// \brief Post process partitioning to ensure a well is completely on one process.
     /// \param[inout] parts The assigned partition numbers for each vertex.
-    void postProcessPartitioningForWells(std::vector<int>& parts);
+    /// \return A vector containing for each process the set of indices of the wells
+    ///         that are assigned to it.
+    std::vector<std::vector<int> >
+    postProcessPartitioningForWells(std::vector<int>& parts);
 
     double transmissibility(int face_index) const
     {

--- a/dune/grid/common/ZoltanGraphFunctions.hpp
+++ b/dune/grid/common/ZoltanGraphFunctions.hpp
@@ -144,10 +144,11 @@ public:
     }
     /// \brief Post process partitioning to ensure a well is completely on one process.
     /// \param[inout] parts The assigned partition numbers for each vertex.
+    /// \param[in]    no_parts The number of partitions.
     /// \return A vector containing for each process the set of indices of the wells
     ///         that are assigned to it.
     std::vector<std::vector<int> >
-    postProcessPartitioningForWells(std::vector<int>& parts);
+    postProcessPartitioningForWells(std::vector<int>& parts, std::size_t no_parts);
 
     double transmissibility(int face_index) const
     {

--- a/dune/grid/common/ZoltanPartition.cpp
+++ b/dune/grid/common/ZoltanPartition.cpp
@@ -140,6 +140,7 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
 
     cc.broadcast(&parts[0], parts.size(), root);
     std::vector<int> my_well_indices;
+    const int well_information_tag = 267553;
 
     if( partitionIsWholeGrid )
     {
@@ -152,7 +153,7 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
                 continue;
             }
             MPI_Isend(wells_on_proc[i].data(), wells_on_proc[i].size(),
-                      MPI_INT, i, 267553, cc, &reqs[i]);
+                      MPI_INT, i, well_information_tag, cc, &reqs[i]);
         }
         std::vector<MPI_Status> stats(reqs.size());
         MPI_Waitall(reqs.size(), reqs.data(), stats.data());
@@ -160,12 +161,12 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
     else
     {
         MPI_Status stat;
-        MPI_Probe(root, 267553, cc, &stat);
+        MPI_Probe(root, well_information_tag, cc, &stat);
         int msg_size;
         MPI_Get_count(&stat, MPI_INT, &msg_size);
         my_well_indices.resize(msg_size);
-        MPI_Recv(my_well_indices.data(), msg_size, MPI_INT, root, 267553,
-                 cc, &stat);
+        MPI_Recv(my_well_indices.data(), msg_size, MPI_INT, root,
+                 well_information_tag, cc, &stat);
     }
 
     // Compute defunct wells in parallel run.

--- a/dune/grid/common/ZoltanPartition.hpp
+++ b/dune/grid/common/ZoltanPartition.hpp
@@ -20,6 +20,8 @@
 #ifndef DUNE_CPGRID_ZOLTANPARTITION_HEADER
 #define DUNE_CPGRID_ZOLTANPARTITION_HEADER
 
+#include <unordered_set>
+
 #include <dune/grid/CpGrid.hpp>
 #include <dune/grid/common/ZoltanGraphFunctions.hpp>
 
@@ -41,9 +43,11 @@ namespace cpgrid
 /// @paramm cc  The MPI communicator to use for the partitioning.
 ///             The will be partitioned among the partiticipating processes.
 /// @param root The process number that holds the global grid.
-/// @return A vector that contains for each local cell of the grid the
-///         the number of the process that owns it after repartitioning.
-std::pair<std::vector<int>,std::vector<int> >
+/// @return A pair consisting of a vector that contains for each local cell of the grid the
+///         the number of the process that owns it after repartitioning,
+///         and a set of names of wells that should be defunct in a parallel
+///         simulation.
+std::pair<std::vector<int>,std::unordered_set<std::string> >
 zoltanGraphPartitionGridOnRoot(const CpGrid& grid,
                                     const Opm::EclipseStateConstPtr eclipseState,
                                     const double* transmissibilities,

--- a/dune/grid/common/ZoltanPartition.hpp
+++ b/dune/grid/common/ZoltanPartition.hpp
@@ -43,11 +43,12 @@ namespace cpgrid
 /// @param root The process number that holds the global grid.
 /// @return A vector that contains for each local cell of the grid the
 ///         the number of the process that owns it after repartitioning.
-std::vector<int> zoltanGraphPartitionGridOnRoot(const CpGrid& grid,
-                                                const Opm::EclipseStateConstPtr eclipseState,
-                                                const double* transmissibilities,
-                                                const CollectiveCommunication<MPI_Comm>& cc,
-                                                int root);
+std::pair<std::vector<int>,std::vector<int> >
+zoltanGraphPartitionGridOnRoot(const CpGrid& grid,
+                                    const Opm::EclipseStateConstPtr eclipseState,
+                                    const double* transmissibilities,
+                                    const CollectiveCommunication<MPI_Comm>& cc,
+                                    int root);
 }
 }
 #endif // HAVE_ZOLTAN

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -64,7 +64,7 @@ namespace Dune
 
 
 
-std::pair<bool, std::vector<int> >
+std::pair<bool, std::unordered_set<std::string> >
 CpGrid::scatterGrid(Opm::EclipseStateConstPtr ecl,
                     const double* transmissibilities, int overlapLayers)
 {
@@ -77,7 +77,7 @@ CpGrid::scatterGrid(Opm::EclipseStateConstPtr ecl,
     {
         std::cerr<<"There is already a distributed version of the grid."
                  << " Maybe scatterGrid was called before?"<<std::endl;
-        return std::make_pair(false, std::vector<int>());
+        return std::make_pair(false, std::unordered_set<std::string>());
     }
 
     CollectiveCommunication cc(MPI_COMM_WORLD);
@@ -131,7 +131,7 @@ CpGrid::scatterGrid(Opm::EclipseStateConstPtr ecl,
     std::cerr << "CpGrid::scatterGrid() is non-trivial only with "
               << "MPI support and if the target Dune platform is "
               << "sufficiently recent.\n";
-    return std::make_pair(false, std::vector<int>());
+    return std::make_pair(false, std::unordered_set<std::string>());
 #endif
 }
 


### PR DESCRIPTION
Previously, we tried to compute this information in the WellsManager of opm-core. In part this was not done correctly and in the situation were the eclipse file contains completion cells of a well that are not
contained in the global grid this is not even possible.

With this commit we change the loadbalancing routines such that they return the set of names of wells that are not associated with the process. This will then be passed by the simulator to the WellsManager. uing OPM/opm-core#1062.

I habe not really tested it, but it should be save to merge this PR even without the accompanying ones in opm-core, and opm-simulator

