### PR TITLE
Use manual main method to prevent segmentation faults for parallel boost::unit_test.

### DIFF
--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -6,6 +6,7 @@
 #define BOOST_TEST_DYN_LINK
 #endif
 #define BOOST_TEST_MODULE DistributedCpGridTests
+#define BOOST_TEST_NO_MAIN
 #include <boost/test/unit_test.hpp>
 
 #include <dune/grid/CpGrid.hpp>
@@ -329,4 +330,18 @@ BOOST_AUTO_TEST_CASE(distribute)
         grid.gatherData(gather_gid_set_data);
 
     }
+}
+
+
+bool
+init_unit_test_func()
+{
+    return true;
+}
+
+int main(int argc, char** argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+    boost::unit_test::unit_test_main(&init_unit_test_func,
+                                     argc, argv);
 }

--- a/tests/cpgrid/entity_test.cpp
+++ b/tests/cpgrid/entity_test.cpp
@@ -41,6 +41,7 @@
 
 
 #define BOOST_TEST_MODULE EntityTests
+#define BOOST_TEST_NO_MAIN
 #include <boost/test/unit_test.hpp>
 #include <sstream>
 
@@ -99,3 +100,16 @@ BOOST_AUTO_TEST_CASE(entity_ptr)
 //     BOOST_CHECK(e2 == ee2);
 }
 
+
+bool
+init_unit_test_func()
+{
+    return true;
+}
+
+int main(int argc, char** argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+    boost::unit_test::unit_test_main(&init_unit_test_func,
+                                     argc, argv);
+}

--- a/tests/cpgrid/facetag_test.cpp
+++ b/tests/cpgrid/facetag_test.cpp
@@ -26,6 +26,7 @@
 
 
 #define BOOST_TEST_MODULE FaceTagTests
+#define BOOST_TEST_NO_MAIN
 #include <boost/test/unit_test.hpp>
 #include <dune/grid/CpGrid.hpp>
 #include <dune/grid/cpgrid/GridHelpers.hpp>
@@ -93,4 +94,17 @@ BOOST_AUTO_TEST_CASE(facetag)
             }
         }
     }
+}
+
+bool
+init_unit_test_func()
+{
+    return true;
+}
+
+int main(int argc, char** argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+    boost::unit_test::unit_test_main(&init_unit_test_func,
+                                     argc, argv);
 }

--- a/tests/cpgrid/partition_iterator_test.cpp
+++ b/tests/cpgrid/partition_iterator_test.cpp
@@ -4,6 +4,7 @@
 #define BOOST_TEST_DYN_LINK
 #endif
 #define BOOST_TEST_MODULE PartitionIteratorCpGridTests
+#define BOOST_TEST_NO_MAIN
 #include <boost/test/unit_test.hpp>
 
 #include <dune/common/version.hh>
@@ -106,4 +107,17 @@ BOOST_AUTO_TEST_CASE(partitionIteratorTest)
 #if HAVE_DUNE_GRID_CHECKS
     checkPartitionType( grid.leafGridView() );
 #endif // HAVE_DUNE_GRID_CHECKS
+
+}
+
+bool
+init_unit_test_func()
+{
+    return true;
+}
+
+int main(int argc, char** argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+    boost::unit_test::unit_test_main(&init_unit_test_func, argc, argv);
 }

--- a/tests/cpgrid/zoltan_test.cpp
+++ b/tests/cpgrid/zoltan_test.cpp
@@ -24,6 +24,7 @@
 #define BOOST_TEST_DYN_LINK
 #endif
 #define BOOST_TEST_MODULE ZoltanTests
+#define BOOST_TEST_NO_MAIN
 #include <boost/test/unit_test.hpp>
 
 #include <dune/grid/CpGrid.hpp>
@@ -161,4 +162,17 @@ BOOST_AUTO_TEST_CASE(zoltan)
         }
 #endif
     }
+}
+
+bool
+init_unit_test_func()
+{
+    return true;
+}
+
+int main(int argc, char** argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+    boost::unit_test::unit_test_main(&init_unit_test_func,
+                                     argc, argv);
 }


### PR DESCRIPTION
For the parallel test using MPI experienced weired segmentation occurred
during program exit in some scenarios. Running make test worked. Running
a single test with mpirun worked. Running a single test without mpirun
caused a segmentation fault after all tests ran and the program exited.
Something like "memory access violation at address: 0x00000008: no mapping at fault address".

I guess the problem was that MPI_Finalize was not the last thing that ran
in the program.

This commit changes all the tests such that they have their own main method
with MPI_Init first and MPI_Finalize last. The unit tests are started
manually in between. This resolved the problems on my machine.