### PR TITLE
Fix compile failure for mpi without zoltan

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -116,6 +116,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	dune/grid/cpgrid/PartitionTypeIndicator.hpp
 	dune/grid/cpgrid/PersistentContainer.hpp
 	dune/grid/common/CartesianIndexMapper.hpp
+	dune/grid/common/WellConnections.hpp
 	dune/grid/common/ZoltanGraphFunctions.hpp
 	dune/grid/common/ZoltanPartition.hpp
 	dune/grid/polyhedralgrid/capabilities.hh

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -39,6 +39,7 @@ list (APPEND MAIN_SOURCE_FILES
 	dune/grid/cpgrid/writeSintefLegacyFormat.cpp
 	dune/grid/common/GeometryHelpers.cpp
 	dune/grid/common/GridPartitioning.cpp
+	dune/grid/common/WellConnections.cpp
 	dune/grid/common/ZoltanGraphFunctions.cpp
 	dune/grid/common/ZoltanPartition.cpp
 	)

--- a/dune/grid/common/WellConnections.cpp
+++ b/dune/grid/common/WellConnections.cpp
@@ -36,6 +36,13 @@ WellConnections::WellConnections(const Opm::EclipseStateConstPtr eclipseState,
                                  const std::array<int, 3>& cartesianSize,
                                  const std::vector<int>& cartesian_to_compressed)
 {
+    init(eclipseState, cartesianSize, cartesian_to_compressed);
+}
+
+void WellConnections::init(const Opm::EclipseStateConstPtr eclipseState,
+                           const std::array<int, 3>& cartesianSize,
+                           const std::vector<int>& cartesian_to_compressed)
+{
     std::vector<const Opm::Well*>  wells  = eclipseState->getSchedule()->getWells();
     int last_time_step = eclipseState->getSchedule()->getTimeMap()->size()-1;
     well_indices_.resize(wells.size());

--- a/dune/grid/common/WellConnections.cpp
+++ b/dune/grid/common/WellConnections.cpp
@@ -1,0 +1,190 @@
+/*
+  Copyright 2016 Dr. Blatt - HPC-Simulation-Software & Services.
+  Copyright 2016 Statoil AS
+
+  This file is part of The Open Porous Media project  (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <map>
+
+#include <dune/grid/common/WellConnections.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+
+namespace Dune
+{
+namespace cpgrid
+{
+WellConnections::WellConnections(const Opm::EclipseStateConstPtr eclipseState,
+                                 const std::array<int, 3>& cartesianSize,
+                                 const std::vector<int>& cartesian_to_compressed)
+{
+    std::vector<const Opm::Well*>  wells  = eclipseState->getSchedule()->getWells();
+    int last_time_step = eclipseState->getSchedule()->getTimeMap()->size()-1;
+    well_indices_.resize(wells.size());
+
+    // We assume that we know all the wells.
+    int index=0;
+    for (const auto well : wells) {
+        std::set<int>& well_indices = well_indices_[index];
+        Opm::CompletionSetConstPtr completionSet = well->getCompletions(last_time_step);
+        for (size_t c=0; c<completionSet->size(); c++) {
+            Opm::CompletionConstPtr completion = completionSet->get(c);
+            int i = completion->getI();
+            int j = completion->getJ();
+            int k = completion->getK();
+            int cart_grid_idx = i + cartesianSize[0]*(j + cartesianSize[1]*k);
+            int compressed_idx = cartesian_to_compressed[cart_grid_idx];
+            if ( compressed_idx >= 0 ) // Ignore completions in inactive cells.
+            {
+                well_indices.insert(compressed_idx);
+            }
+        }
+        ++index;
+    }
+}
+
+std::vector<std::vector<int> >
+postProcessPartitioningForWells(std::vector<int>& parts,
+                                const Opm::EclipseStateConstPtr eclipseState,
+                                const WellConnections& well_connections,
+                                std::size_t no_procs)
+{
+    std::vector<const Opm::Well*>  wells  = eclipseState->getSchedule()->getWells();
+    // Contains for each process the indices of the wells assigned to it.
+    std::vector<std::vector<int> > well_indices_on_proc(no_procs);
+
+    if( ! well_connections.size() )
+    {
+        // No wells to be processed
+        return well_indices_on_proc;
+    }
+
+    // prevent memory allocation
+    for(auto& well_indices : well_indices_on_proc)
+    {
+        well_indices.reserve(wells.size());
+    }
+
+    // Check that all completions of a well have ended up on one process.
+    // If that is not the case for well then move them manually to the
+    // process that already has the most completions on it.
+    int well_index = 0;
+
+    for (const auto* well: wells) {
+        const auto& well_completions = well_connections[well_index];
+        std::map<int,std::size_t> no_completions_on_proc;
+        for ( auto completion_index: well_completions )
+        {
+            ++no_completions_on_proc[parts[completion_index]];
+        }
+
+        int owner = no_completions_on_proc.begin()->first;
+
+        if ( no_completions_on_proc.size() > 1 )
+        {
+            // partition with the most completions on it becomes new owner
+            int new_owner = std::max_element(no_completions_on_proc.begin(),
+                                             no_completions_on_proc.end(),
+                                             [](const std::pair<int,std::size_t>& p1,
+                                                const std::pair<int,std::size_t>& p2){
+                                                 return ( p1.second > p2.second );
+                                             })->first;
+            std::cout << "Manually moving well " << well->name() << " to partition "
+                      << new_owner << std::endl;
+
+            for ( size_t c = 0; c < well_completions.size(); c++ )
+            {
+                parts[c] = new_owner;
+            }
+
+            owner = new_owner;
+        }
+
+        well_indices_on_proc[owner].push_back(well_index);
+        ++well_index;
+    }
+    return well_indices_on_proc;
+
+}
+
+#ifdef HAVE_MPI
+std::unordered_set<std::string>
+computeDefunctWellNames(const std::vector<std::vector<int> >& wells_on_proc,
+                        const Opm::EclipseStateConstPtr eclipseState,
+                        const CollectiveCommunication<MPI_Comm>& cc,
+                        int root)
+{
+    std::vector<const Opm::Well*>  wells  = eclipseState->getSchedule()->getWells();
+    std::vector<int> my_well_indices;
+    const int well_information_tag = 267553;
+
+    if( root == cc.rank() )
+    {
+        std::vector<MPI_Request> reqs(cc.size(), MPI_REQUEST_NULL);
+        my_well_indices = wells_on_proc[root];
+        for ( int i=0; i < cc.size(); ++i )
+        {
+            if(i==root)
+            {
+                continue;
+            }
+            MPI_Isend(const_cast<int*>(wells_on_proc[i].data()),
+                      wells_on_proc[i].size(),
+                      MPI_INT, i, well_information_tag, cc, &reqs[i]);
+        }
+        std::vector<MPI_Status> stats(reqs.size());
+        MPI_Waitall(reqs.size(), reqs.data(), stats.data());
+    }
+    else
+    {
+        MPI_Status stat;
+        MPI_Probe(root, well_information_tag, cc, &stat);
+        int msg_size;
+        MPI_Get_count(&stat, MPI_INT, &msg_size);
+        my_well_indices.resize(msg_size);
+        MPI_Recv(my_well_indices.data(), msg_size, MPI_INT, root,
+                 well_information_tag, cc, &stat);
+    }
+
+    // Compute defunct wells in parallel run.
+    std::vector<int> defunct_wells(wells.size(), true);
+
+    for(auto well_index : my_well_indices)
+    {
+        defunct_wells[well_index] = false;
+    }
+
+    // We need to use well names as only they are consistent.
+    std::unordered_set<std::string> defunct_well_names;
+
+    for(auto defunct = defunct_wells.begin(); defunct != defunct_wells.end(); ++defunct)
+    {
+        if ( *defunct )
+        {
+            defunct_well_names.insert(wells[defunct-defunct_wells.begin()]->name());
+        }
+    }
+
+    return defunct_well_names;
+}
+#endif
+} // end namespace cpgrid
+} // end namespace Dune

--- a/dune/grid/common/WellConnections.cpp
+++ b/dune/grid/common/WellConnections.cpp
@@ -117,9 +117,9 @@ postProcessPartitioningForWells(std::vector<int>& parts,
             std::cout << "Manually moving well " << well->name() << " to partition "
                       << new_owner << std::endl;
 
-            for ( size_t c = 0; c < well_completions.size(); c++ )
+            for ( auto well_index: well_completions )
             {
-                parts[c] = new_owner;
+                parts[well_index] = new_owner;
             }
 
             owner = new_owner;

--- a/dune/grid/common/WellConnections.hpp
+++ b/dune/grid/common/WellConnections.hpp
@@ -38,7 +38,8 @@ namespace cpgrid
 
 /// \brief A class calculating and representing all connections of wells.
 ///
-/// Wells are identified by their position as ecported by the eclipse file.
+/// Wells are identified by their position as exported by the wells method
+/// of the eclipse parser.
 /// For each well the container stores at the well index all indices of cells
 /// that the well perforates.
 class WellConnections

--- a/dune/grid/common/WellConnections.hpp
+++ b/dune/grid/common/WellConnections.hpp
@@ -1,0 +1,87 @@
+/*
+  Copyright 2016 Dr. Blatt - HPC-Simulation-Software & Services.
+  Copyright 2016 Statoil AS
+
+  This file is part of The Open Porous Media project  (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef DUNE_CPGRID_WELL_CONNECTIONS_HEADER_INCLUDED
+#define DUNE_CPGRID_WELL_CONNECTIONS_HEADER_INCLUDED
+
+#include <set>
+#include <unordered_set>
+#include <vector>
+
+#ifdef HAVE_MPI
+#include "mpi.h"
+#endif
+
+#include <dune/common/parallel/mpicollectivecommunication.hh>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
+namespace Dune
+{
+namespace cpgrid
+{
+
+class WellConnections
+{
+public:
+    typedef std::vector<std::set<int> >::const_iterator const_iterator;
+    typedef const_iterator iterator;
+
+    WellConnections(const Opm::EclipseStateConstPtr eclipseState,
+                    const std::array<int, 3>& cartesianSize,
+                    const std::vector<int>& cartesian_to_compressed);
+
+    const std::set<int>& operator[](std::size_t i) const
+    {
+        return well_indices_[i];
+    }
+
+    const_iterator begin() const
+    {
+        return well_indices_.begin();
+    }
+
+    const_iterator end() const
+    {
+        return well_indices_.end();
+    }
+
+    std::size_t size() const
+    {
+        return well_indices_.size();
+    }
+private:
+    std::vector<std::set<int> > well_indices_;
+};
+
+std::vector<std::vector<int> >
+postProcessPartitioningForWells(std::vector<int>& parts,
+                                const Opm::EclipseStateConstPtr eclipseState,
+                                const WellConnections& well_connections,
+                                std::size_t no_procs);
+
+#ifdef HAVE_MPI
+std::unordered_set<std::string>
+computeDefunctWellNames(const std::vector<std::vector<int> >& wells_on_proc,
+                        const Opm::EclipseStateConstPtr eclipseState,
+                        const CollectiveCommunication<MPI_Comm>& cc,
+                        int root);
+#endif
+} // end namespace cpgrid
+} // end namespace Dune
+#endif

--- a/dune/grid/common/WellConnections.hpp
+++ b/dune/grid/common/WellConnections.hpp
@@ -50,6 +50,8 @@ public:
     /// \brief The iterator type (always const).
     typedef const_iterator iterator;
 
+    WellConnections() = default;
+
     /// \brief Constructor
     /// \param eclipseState The eclipse information
     /// \param cartesianSize The logical cartesian size of the grid.

--- a/dune/grid/common/WellConnections.hpp
+++ b/dune/grid/common/WellConnections.hpp
@@ -36,39 +36,80 @@ namespace Dune
 namespace cpgrid
 {
 
+/// \brief A class calculating and representing all connections of wells.
+///
+/// Wells are identified by their position as ecported by the eclipse file.
+/// For each well the container stores at the well index all indices of cells
+/// that the well perforates.
 class WellConnections
 {
 public:
+    /// \brief The const iterator type.
     typedef std::vector<std::set<int> >::const_iterator const_iterator;
+
+    /// \brief The iterator type (always const).
     typedef const_iterator iterator;
 
+    /// \brief Constructor
+    /// \param eclipseState The eclipse information
+    /// \param cartesianSize The logical cartesian size of the grid.
+    /// \param cartesian_to_compressed Mapping of cartesian index
+    ///        compressed cell index. The compressed index is used
+    ///        to represent the well conditions.
     WellConnections(const Opm::EclipseStateConstPtr eclipseState,
                     const std::array<int, 3>& cartesianSize,
                     const std::vector<int>& cartesian_to_compressed);
 
+    /// \brief Initialze the data of the container
+    /// \param eclipseState The eclipse information
+    /// \param cartesianSize The logical cartesian size of the grid.
+    /// \param cartesian_to_compressed Mapping of cartesian index
+    ///        compressed cell index. The compressed index is used
+    ///        to represent the well conditions.
+    void init(const Opm::EclipseStateConstPtr eclipseState,
+              const std::array<int, 3>& cartesianSize,
+              const std::vector<int>& cartesian_to_compressed);
+
+    /// \brief Access all connections of a well
+    /// \param i The index of the well (position of the well in the
+    ///          eclipse schedule.
+    /// \return The set of compressed indices of cells perforated by the well.
     const std::set<int>& operator[](std::size_t i) const
     {
         return well_indices_[i];
     }
 
+    /// \brief Get a begin iterator
     const_iterator begin() const
     {
         return well_indices_.begin();
     }
 
+    /// \brief Get the end iterator
     const_iterator end() const
     {
         return well_indices_.end();
     }
 
+    /// \breif Get the number of wells
     std::size_t size() const
     {
         return well_indices_.size();
     }
 private:
+    /// Stores at index i all cells that are perforated by
+    /// the well at position i of the eclipse schedule.
     std::vector<std::set<int> > well_indices_;
 };
 
+/// \brief Computes wells assigned to processes.
+///
+/// Computes for all processes all indices of wells that
+/// will be assigned to this process.
+/// \param parts The partition number for each cell
+/// \param eclipseState The eclipse information
+/// \param well_connecton The informatio about the perforations of each well.
+/// \param no_procs The number of processes.
 std::vector<std::vector<int> >
 postProcessPartitioningForWells(std::vector<int>& parts,
                                 const Opm::EclipseStateConstPtr eclipseState,
@@ -76,6 +117,12 @@ postProcessPartitioningForWells(std::vector<int>& parts,
                                 std::size_t no_procs);
 
 #ifdef HAVE_MPI
+/// \brief Computes that names that of all wells not handled by this process
+/// \param wells_on_proc well indices assigned to each process
+/// \param eclipseState The eclipse information
+/// \param cc The communicator
+/// \param root The rank of the process that has the complete partitioning
+///             information.
 std::unordered_set<std::string>
 computeDefunctWellNames(const std::vector<std::vector<int> >& wells_on_proc,
                         const Opm::EclipseStateConstPtr eclipseState,

--- a/dune/grid/common/ZoltanGraphFunctions.cpp
+++ b/dune/grid/common/ZoltanGraphFunctions.cpp
@@ -345,90 +345,15 @@ CombinedGridWellGraph::CombinedGridWellGraph(const CpGrid& grid,
     wellsGraph_.resize(grid.numCells());
     const auto& cpgdim = grid.logicalCartesianSize();
     // create compressed lookup from cartesian.
-    std::vector<const Opm::Well*> wells  = eclipseState->getSchedule()->getWells();
     std::vector<int> cartesian_to_compressed(cpgdim[0]*cpgdim[1]*cpgdim[2], -1);
     int last_time_step = eclipseState->getSchedule()->getTimeMap()->size()-1;
     for( int i=0; i < grid.numCells(); ++i )
     {
         cartesian_to_compressed[grid.globalCell()[i]] = i;
     }
-    well_indices_.resize(wells.size());
-
-    // We assume that we know all the wells.
-    for (auto wellIter= wells.begin(); wellIter != wells.end(); ++wellIter) {
-        const Opm::Well* well = (*wellIter);
-        std::set<int>& well_indices = well_indices_[wellIter - wells.begin()];
-        Opm::CompletionSetConstPtr completionSet = well->getCompletions(last_time_step);
-        for (size_t c=0; c<completionSet->size(); c++) {
-            Opm::CompletionConstPtr completion = completionSet->get(c);
-            int i = completion->getI();
-            int j = completion->getJ();
-            int k = completion->getK();
-            int cart_grid_idx = i + cpgdim[0]*(j + cpgdim[1]*k);
-            int compressed_idx = cartesian_to_compressed[cart_grid_idx];
-            if ( compressed_idx >= 0 ) // Ignore completions in inactive cells.
-            {
-                well_indices.insert(compressed_idx);
-            }
-        }
-        addCompletionSetToGraph(well_indices);
-    }
-}
-
-std::vector<std::vector<int> >
-CombinedGridWellGraph::postProcessPartitioningForWells(std::vector<int>& parts,
-                                                       std::size_t no_procs)
-{
-    // Contains for each process the indices of the wells assigned to it.
-    std::vector<std::vector<int> > well_indices_on_proc(no_procs);
-
-    if( ! wellsGraph_.size() )
-    {
-        // No wells to be processed
-        return well_indices_on_proc;
-    }
-    std::vector<const Opm::Well*> wells  = eclipseState_->getSchedule()->getWells();
-
-    // prevent memory allocation
-    for(auto& well_indices : well_indices_on_proc)
-    {
-        well_indices.reserve(wells.size());
-    }
-
-    // Check that all completions of a well have ended up on one process.
-    // If that is not the case for well then move them manually to the
-    // process that already has the most completions on it.
-    for (auto wellIter= wells.begin(); wellIter != wells.end(); ++wellIter) {
-        const Opm::Well* well = (*wellIter);
-        const std::set<int>& well_indices = well_indices_[wellIter - wells.begin()];
-        std::map<int,std::size_t> no_completions_on_proc;
-        for ( auto well_index: well_indices )
-        {
-            ++no_completions_on_proc[parts[well_index]];
-        }
-
-        int owner = no_completions_on_proc.begin()->first;
-
-        if ( no_completions_on_proc.size() > 1 )
-        {
-            // partition with the most completions on it becomes new owner
-            int new_owner = std::max_element(no_completions_on_proc.begin(),
-                                             no_completions_on_proc.end(),
-                                             [](const std::pair<int,std::size_t>& p1,
-                                                const std::pair<int,std::size_t>& p2){
-                                                 return ( p1.second > p2.second );
-                                             })->first;
-            std::cout << "Manually moving well " << well->name() << " to partition "
-                      << new_owner << std::endl;
-             for ( size_t c = 0; c < well_indices.size(); c++ )
-             {
-                 parts[c] = new_owner;
-             }
-             owner = new_owner;
-        }
-        well_indices_on_proc[owner].push_back(wellIter - wells.begin());
-    }
-    return well_indices_on_proc;
+    well_indices_.init(eclipseState, cpgdim, cartesian_to_compressed);
+    std::vector<int>().swap(cartesian_to_compressed); // free memory.
+    addCompletionSetToGraph();
 }
 
 void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz, const Dune::CpGrid& grid,

--- a/dune/grid/common/ZoltanGraphFunctions.cpp
+++ b/dune/grid/common/ZoltanGraphFunctions.cpp
@@ -346,7 +346,7 @@ CombinedGridWellGraph::CombinedGridWellGraph(const CpGrid& grid,
     const auto& cpgdim = grid.logicalCartesianSize();
     // create compressed lookup from cartesian.
     std::vector<int> cartesian_to_compressed(cpgdim[0]*cpgdim[1]*cpgdim[2], -1);
-    int last_time_step = eclipseState->getSchedule()->getTimeMap()->size()-1;
+
     for( int i=0; i < grid.numCells(); ++i )
     {
         cartesian_to_compressed[grid.globalCell()[i]] = i;


### PR DESCRIPTION
Up to now everything worked whenever ZOLTAN was installed and eclipse state was passed to the load balancing method. Unfortunately, I missed checking the parallel code without MPI. With this PR that code works now too and for the first time calculates the well partitioning, too. It should be fully functional but load balancing might be pure as it works on the cartesian grid.

As a side effect we also fix an issue when loadbalancing is used without an eclipse state. That problem was discussed by @akva2 in #234 