### PR TITLE
[bugfix][CpGridData] make code compile when dune-istl is not found.

### DIFF
--- a/dune/grid/cpgrid/CpGridData.hpp
+++ b/dune/grid/cpgrid/CpGridData.hpp
@@ -406,7 +406,7 @@ private:
     typedef Dune::OwnerOverlapCopyAttributeSet::AttributeSet AttributeSet;
 #else
     /// \brief The type of the set of the attributes
-    enum AttributeSet{owner, overlap};
+    enum AttributeSet{owner, overlap, copy};
 #endif
 
 #if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)


### PR DESCRIPTION
When dune-istl is not found successfully, opm-grid does not compile. his fixes this issue.