### PR TITLE
Make sure that non-connected cells are not dropped without Zoltan.

### DIFF
--- a/dune/grid/common/GridPartitioning.cpp
+++ b/dune/grid/common/GridPartitioning.cpp
@@ -189,7 +189,8 @@ namespace Dune
                    const coord_t& initial_split,
                    int& num_part,
                    std::vector<int>& cell_part,
-                   bool recursive)
+                   bool recursive,
+                   bool ensureConnectivity)
     {
         // Checking that the initial split makes sense (that there may be at least one cell
         // in each expected partition).
@@ -231,7 +232,10 @@ namespace Dune
         cell_part.swap(my_part);
 
         // Check the connectivity, split.
-        ensureConnectedPartitions(grid, num_part, cell_part, recursive);
+        if ( ensureConnectivity )
+        {
+            ensureConnectedPartitions(grid, num_part, cell_part, recursive);
+        }
     }
 
 /// \brief Adds cells to the overlap that just share a point with an owner cell.

--- a/dune/grid/common/GridPartitioning.hpp
+++ b/dune/grid/common/GridPartitioning.hpp
@@ -66,7 +66,8 @@ namespace Dune
                    const std::array<int, 3>& initial_split,
                    int& num_part,
                    std::vector<int>& cell_part,
-                   bool recursive = false);
+                   bool recursive = false,
+                   bool ensureConnectivity = true);
 
 /// \brief Adds a layer of overlap cells to a partitioning.
 /// \param[in] grid The grid that is partitioned.

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -97,7 +97,7 @@ CpGrid::scatterGrid(Opm::EclipseStateConstPtr ecl,
     std::array<int, 3> initial_split;
     initial_split[1]=initial_split[2]=std::pow(cc.size(), 1.0/3.0);
     initial_split[0]=cc.size()/(initial_split[1]*initial_split[2]);
-    partition(*this, initial_split, num_parts, cell_part);
+    partition(*this, initial_split, num_parts, cell_part, false, false);
     const auto& cpgdim =  logicalCartesianSize();
     std::vector<int> cartesian_to_compressed(cpgdim[0]*cpgdim[1]*cpgdim[2], -1);
     for( int i=0; i < numCells(); ++i )


### PR DESCRIPTION
When configured without Zoltan we use the vanilla load balancing
methods from GridPartitioning. Unfortunately, partition did drop
all cells that had no connections to the rest of the active grid
cells. This commit switches off this dropping of cells.

Closes #197