### PR TITLE
Add pointer deref forgotten in shared_ptr purge.

### DIFF
--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -109,17 +109,17 @@ CpGrid::scatterGrid(const Opm::EclipseState* ecl,
 
     if ( ecl )
     {
-        cpgrid::WellConnections well_connections(ecl,
+        cpgrid::WellConnections well_connections(*ecl,
                                                  cpgdim,
                                                  cartesian_to_compressed);
 
         auto wells_on_proc =
             cpgrid::postProcessPartitioningForWells(cell_part,
-                                                    ecl,
+                                                    *ecl,
                                                     well_connections,
                                                     cc.size());
         defunct_wells = cpgrid::computeDefunctWellNames(wells_on_proc,
-                                                        ecl,
+                                                        *ecl,
                                                         cc,
                                                         0);
     }


### PR DESCRIPTION
Code in question is the MPI-but-not-Zoltan part. All derefs occur inside if-blocks guaranteeing that the pointer is non-null.

Will self-merge since it is rather trivial, and a compile error showstopper.