### PR TITLE
fix some annoying clang specific warnings

### DIFF
--- a/opm/core/grid/MinpvProcessor.hpp
+++ b/opm/core/grid/MinpvProcessor.hpp
@@ -62,8 +62,8 @@ namespace Opm
     };
 
     inline MinpvProcessor::MinpvProcessor(const int nx, const int ny, const int nz) :
-        dims_( {nx,ny,nz} ),
-        delta_( {1 , 2*nx , 4*nx*ny} )
+        dims_( {{nx,ny,nz}} ),
+        delta_( {{1 , 2*nx , 4*nx*ny}} )
     { }
 
 


### PR DESCRIPTION
GCC does not complain about those missing brackets, but it accepts
their presence without lamenting about them...