### PR TITLE
Refactor stopwatch to use std::chrono

### DIFF
--- a/opm/core/utility/StopWatch.cpp
+++ b/opm/core/utility/StopWatch.cpp
@@ -44,7 +44,7 @@ namespace Opm
 
     namespace time
     {
-        using Duration = boost::posix_time::time_duration;
+        using Duration = std::chrono::duration<double>;
 
 	StopWatch::StopWatch()
 	    : state_(State::UnStarted)
@@ -81,7 +81,7 @@ namespace Opm
 	    }
 	    Duration dur = run_time - last_time_;
 	    last_time_ = run_time;
-	    return double(dur.total_microseconds())/1000000.0;
+	    return dur.count();
 	}
 
 	double StopWatch::secsSinceStart()
@@ -96,12 +96,12 @@ namespace Opm
 		OPM_THROW(std::runtime_error, "Called secsSinceStart() on a StopWatch that had not been started.");
 	    }
 	    Duration dur = run_time - start_time_;
-	    return double(dur.total_microseconds())/1000000.0;
+	    return dur.count();
 	}
 
         StopWatch::TimePoint StopWatch::currentTime() const
         {
-            return boost::posix_time::microsec_clock::local_time();
+            return std::chrono::high_resolution_clock::now();
         }
 
     } // namespace time

--- a/opm/core/utility/StopWatch.cpp
+++ b/opm/core/utility/StopWatch.cpp
@@ -44,59 +44,65 @@ namespace Opm
 
     namespace time
     {
+        using Duration = boost::posix_time::time_duration;
 
 	StopWatch::StopWatch()
-	    : state_(UnStarted)
+	    : state_(State::UnStarted)
 	{
 	}
 
 
 	void StopWatch::start()
 	{
-	    start_time_ = boost::posix_time::microsec_clock::local_time();
+	    start_time_ = currentTime();
 	    last_time_ = start_time_;
-	    state_ = Running;
+	    state_ = State::Running;
 	}
 
 	void StopWatch::stop()
 	{
-	    if (state_ != Running) {
+	    if (state_ != State::Running) {
 		OPM_THROW(std::runtime_error, "Called stop() on a StopWatch that was not running.");
 	    }
-	    stop_time_ = boost::posix_time::microsec_clock::local_time();
-	    state_ = Stopped;
+	    stop_time_ = currentTime();
+	    state_ = State::Stopped;
 	}
 
 	double StopWatch::secsSinceLast()
 	{
-	    boost::posix_time::ptime run_time;
-	    if (state_ == Running) {
-		run_time = boost::posix_time::microsec_clock::local_time();
-	    } else if (state_ == Stopped) {
+	    TimePoint run_time;
+	    if (state_ == State::Running) {
+		run_time = currentTime();
+	    } else if (state_ == State::Stopped) {
 		run_time = stop_time_;
 	    } else {
-		assert(state_ == UnStarted);
+		assert(state_ == State::UnStarted);
 		OPM_THROW(std::runtime_error, "Called secsSinceLast() on a StopWatch that had not been started.");
 	    }
-	    boost::posix_time::time_duration dur = run_time - last_time_;
+	    Duration dur = run_time - last_time_;
 	    last_time_ = run_time;
 	    return double(dur.total_microseconds())/1000000.0;
 	}
 
 	double StopWatch::secsSinceStart()
 	{
-	    boost::posix_time::ptime run_time;
-	    if (state_ == Running) {
-		run_time = boost::posix_time::microsec_clock::local_time();
-	    } else if (state_ == Stopped) {
+	    TimePoint run_time;
+	    if (state_ == State::Running) {
+		run_time = currentTime();
+	    } else if (state_ == State::Stopped) {
 		run_time = stop_time_;
 	    } else {
-		assert(state_ == UnStarted);
+		assert(state_ == State::UnStarted);
 		OPM_THROW(std::runtime_error, "Called secsSinceStart() on a StopWatch that had not been started.");
 	    }
-	    boost::posix_time::time_duration dur = run_time - start_time_;
+	    Duration dur = run_time - start_time_;
 	    return double(dur.total_microseconds())/1000000.0;
 	}
+
+        StopWatch::TimePoint StopWatch::currentTime() const
+        {
+            return boost::posix_time::microsec_clock::local_time();
+        }
 
     } // namespace time
 

--- a/opm/core/utility/StopWatch.hpp
+++ b/opm/core/utility/StopWatch.hpp
@@ -66,12 +66,15 @@ namespace Opm
 	    double secsSinceStart();
 
 	private:
-	    enum StopWatchState { UnStarted, Running, Stopped };
+	    enum class State { UnStarted, Running, Stopped };
+            using TimePoint = boost::posix_time::ptime;
 
-	    StopWatchState state_;
-	    boost::posix_time::ptime start_time_;
-	    boost::posix_time::ptime last_time_;
-	    boost::posix_time::ptime stop_time_;
+            TimePoint currentTime() const;
+
+	    State state_;
+	    TimePoint start_time_;
+	    TimePoint last_time_;
+	    TimePoint stop_time_;
 	};
 
     } // namespace time

--- a/opm/core/utility/StopWatch.hpp
+++ b/opm/core/utility/StopWatch.hpp
@@ -35,7 +35,7 @@
 #ifndef OPM_STOPWATCH_HEADER
 #define OPM_STOPWATCH_HEADER
 
-#include <boost/date_time/posix_time/posix_time.hpp>
+#include <chrono>
 
 namespace Opm
 {
@@ -67,7 +67,7 @@ namespace Opm
 
 	private:
 	    enum class State { UnStarted, Running, Stopped };
-            using TimePoint = boost::posix_time::ptime;
+            using TimePoint = std::chrono::high_resolution_clock::time_point;
 
             TimePoint currentTime() const;
 


### PR DESCRIPTION
This removes the boost dependency from this class. Split in two commits, the first refactors and the second replaces boost with std::chrono usage.