### PR TITLE
Add methods that calculates face geometry based on cell corners

### DIFF
--- a/dune/grid/cpgrid/GridHelpers.cpp
+++ b/dune/grid/cpgrid/GridHelpers.cpp
@@ -104,6 +104,26 @@ double cellCenterDepth(const Dune::CpGrid& grid, int cell_index)
     return grid.cellCenterDepth(cell_index);
 }
 
+Vector faceCenterEcl(const Dune::CpGrid& grid, int cell_index, int face_tag)
+{
+    // This method is an alternative to the method faceCentroid(...) below.
+    // The face center is computed as a raw average of cell corners.
+    // For faulted grids, this is likely to give slightly different depths that seem
+    // to agree with eclipse.
+    return grid.faceCenterEcl(cell_index, face_tag);
+}
+
+
+Vector faceAreaNormalEcl(const Dune::CpGrid& grid, int face_index)
+{
+    // This method is an alternative to the method faceNormal(...) below.
+    // The face Normal area is computed based on the face corners without introducing
+    // a center point.
+    // For cornerpoint grids, this is likely to give slightly different depths that seem
+    // to agree with eclipse.
+    return grid.faceAreaNormalEcl(face_index);
+}
+
 FaceCentroidTraits<Dune::CpGrid>::IteratorType
 beginFaceCentroids(const Dune::CpGrid& grid)
 {

--- a/dune/grid/cpgrid/GridHelpers.hpp
+++ b/dune/grid/cpgrid/GridHelpers.hpp
@@ -381,6 +381,8 @@ struct CellCentroidTraits<Dune::CpGrid>
     typedef const double* ValueType;
 };
 
+typedef Dune::FieldVector<double, 3> Vector;
+
 /// \brief Get the number of cells of a grid.
 int numCells(const Dune::CpGrid& grid);
 
@@ -425,6 +427,22 @@ const double* cellCentroid(const Dune::CpGrid& grid, int cell_index);
 /// \brief grid The grid.
 /// \brief cell_index The index of the specific cell.
 double cellCenterDepth(const Dune::CpGrid& grid, int cell_index);
+
+
+/// \brief Get a coordinate of a specific face center.
+/// \brief calculated as the raw average of the cell corners
+/// \param grid The grid.
+/// \param cell_index The index of the specific cell.
+/// \param face_tag The logical cartesian index of the face
+Vector faceCenterEcl(const Dune::CpGrid& grid, int cell_index, int face_tag);
+
+/// \brief Get a area weighted normal vector of a specific face.
+/// \brief calculated without introducing a center point
+/// \brief For cornerpoint grids this is supposed to give
+/// \brief values closer to Ecl.
+/// \param grid The grid.
+/// \param face_index The index of the specific face.
+Vector faceAreaNormalEcl(const Dune::CpGrid& grid, int face_index);
 
 /// \brief Get the volume of a cell.
 /// \param grid The grid the cell belongs to.

--- a/opm/core/grid/GridHelpers.cpp
+++ b/opm/core/grid/GridHelpers.cpp
@@ -198,13 +198,11 @@ Dune::FieldVector<double,3> faceAreaNormalEcl(const UnstructuredGrid& grid, int 
         break;
     case 3:
         {
-
-        Vector a = { (grid.node_coordinates+nd*(grid.face_nodes[start] ))[0] - (grid.node_coordinates+nd*(grid.face_nodes[start+2]))[0] ,
-                     (grid.node_coordinates+nd*(grid.face_nodes[start] ))[1] - (grid.node_coordinates+nd*(grid.face_nodes[start+2]))[1] ,
-                     (grid.node_coordinates+nd*(grid.face_nodes[start] ))[2] - (grid.node_coordinates+nd*(grid.face_nodes[start+2]))[2] };
-        Vector b = { (grid.node_coordinates+nd*(grid.face_nodes[start+1]))[0] - (grid.node_coordinates+nd*(grid.face_nodes[start+2]))[0] ,
-                     (grid.node_coordinates+nd*(grid.face_nodes[start+1]))[1] - (grid.node_coordinates+nd*(grid.face_nodes[start+2]))[1] ,
-                     (grid.node_coordinates+nd*(grid.face_nodes[start+1]))[2] - (grid.node_coordinates+nd*(grid.face_nodes[start+2]))[2] };
+        Vector a, b;
+        for (int i = 0; i < 3; ++i) {
+            a[i] = (grid.node_coordinates+nd*(grid.face_nodes[start] ))[i] - (grid.node_coordinates+nd*(grid.face_nodes[start+2]))[i];
+            b[i] = (grid.node_coordinates+nd*(grid.face_nodes[start+1]))[i] - (grid.node_coordinates+nd*(grid.face_nodes[start+2]))[i];
+        }
         Vector areaNormal  = cross( a, b);
         areaNormal *= 0.5;
         return areaNormal;
@@ -212,14 +210,12 @@ Dune::FieldVector<double,3> faceAreaNormalEcl(const UnstructuredGrid& grid, int 
         break;
     case 4:
         {
-        Vector a = { (grid.node_coordinates+nd*(grid.face_nodes[start] ))[0] - (grid.node_coordinates+nd*(grid.face_nodes[start+2]))[0] ,
-                     (grid.node_coordinates+nd*(grid.face_nodes[start] ))[1] - (grid.node_coordinates+nd*(grid.face_nodes[start+2]))[1] ,
-                     (grid.node_coordinates+nd*(grid.face_nodes[start] ))[2] - (grid.node_coordinates+nd*(grid.face_nodes[start+2]))[2] };
-        Vector b = { (grid.node_coordinates+nd*(grid.face_nodes[start+1]))[0] - (grid.node_coordinates+nd*(grid.face_nodes[start+3]))[0] ,
-                     (grid.node_coordinates+nd*(grid.face_nodes[start+1]))[1] - (grid.node_coordinates+nd*(grid.face_nodes[start+ 3]))[1] ,
-                     (grid.node_coordinates+nd*(grid.face_nodes[start+1]))[2] - (grid.node_coordinates+nd*(grid.face_nodes[start+ 3]))[2] };
-
-        Vector areaNormal  = cross( a, b);
+        Vector a, b;
+        for (int i = 0; i < 3; ++i) {
+            a[i] = (grid.node_coordinates+nd*(grid.face_nodes[start] ))[i] - (grid.node_coordinates+nd*(grid.face_nodes[start+2]))[i];
+            b[i] = (grid.node_coordinates+nd*(grid.face_nodes[start+1]))[i] - (grid.node_coordinates+nd*(grid.face_nodes[start+3]))[i];
+        }
+        Vector areaNormal  = Dune::cross( a, b);
         areaNormal *= 0.5;
         return areaNormal;
         }
@@ -230,30 +226,23 @@ Dune::FieldVector<double,3> faceAreaNormalEcl(const UnstructuredGrid& grid, int 
             int k = (nv % 2) ? 0 : nv - 1;
 
             Vector areaNormal ( 0 );
+            Vector a, b;
             // First quads
             for (int i = 1; i < h; ++i)
             {
-                Vector a = { (grid.node_coordinates+nd*(grid.face_nodes[start+2*i ] ))[0] - (grid.node_coordinates+nd*(grid.face_nodes[start]))[0] ,
-                             (grid.node_coordinates+nd*(grid.face_nodes[start+2*i ] ))[1] - (grid.node_coordinates+nd*(grid.face_nodes[start]))[1] ,
-                             (grid.node_coordinates+nd*(grid.face_nodes[start+2*i ] ))[2] - (grid.node_coordinates+nd*(grid.face_nodes[start]))[2] };
-                Vector b = { (grid.node_coordinates+nd*(grid.face_nodes[start+2*i + 1]))[0] - (grid.node_coordinates+nd*(grid.face_nodes[start+ 2*i-1]))[0] ,
-                             (grid.node_coordinates+nd*(grid.face_nodes[start+2*i + 1]))[1] - (grid.node_coordinates+nd*(grid.face_nodes[start+ 2*i-1]))[1] ,
-                             (grid.node_coordinates+nd*(grid.face_nodes[start+2*i + 1]))[2] - (grid.node_coordinates+nd*(grid.face_nodes[start+ 2*i-1]))[2] };
-
-                Vector areaN = cross( a , b );
-                areaNormal += areaN ;
+                for (int i = 0; i < 3; ++i) {
+                    a[i] = (grid.node_coordinates+nd*(grid.face_nodes[start+2*i] ))[i] - (grid.node_coordinates+nd*(grid.face_nodes[start]))[i];
+                    b[i] = (grid.node_coordinates+nd*(grid.face_nodes[start+2*i + 1]))[i] - (grid.node_coordinates+nd*(grid.face_nodes[start+ 2*i-1]))[i];
+                }
+                areaNormal += cross( a , b ) ;
             }
 
             // Last triangle or quad
-            Vector a = { (grid.node_coordinates+nd*(grid.face_nodes[start+2*h ] ))[0] - (grid.node_coordinates+nd*(grid.face_nodes[start]))[0] ,
-                         (grid.node_coordinates+nd*(grid.face_nodes[start+2*h ] ))[1] - (grid.node_coordinates+nd*(grid.face_nodes[start]))[1] ,
-                         (grid.node_coordinates+nd*(grid.face_nodes[start+2*h ] ))[2] - (grid.node_coordinates+nd*(grid.face_nodes[start]))[2] };
-            Vector b = { (grid.node_coordinates+nd*(grid.face_nodes[start+k]))[0] - (grid.node_coordinates+nd*(grid.face_nodes[start+ 2*h-1]))[0] ,
-                         (grid.node_coordinates+nd*(grid.face_nodes[start+k]))[1] - (grid.node_coordinates+nd*(grid.face_nodes[start+ 2*h-1]))[1] ,
-                         (grid.node_coordinates+nd*(grid.face_nodes[start+k]))[2] - (grid.node_coordinates+nd*(grid.face_nodes[start+ 2*h-1]))[2] };
-
-            Vector areaN = cross( a , b );
-            areaNormal += areaN ;
+            for (int i = 0; i < 3; ++i) {
+                a[i] = (grid.node_coordinates+nd*(grid.face_nodes[start+2*h] ))[i] - (grid.node_coordinates+nd*(grid.face_nodes[start]))[i];
+                b[i] = (grid.node_coordinates+nd*(grid.face_nodes[start+k]))[i] - (grid.node_coordinates+nd*(grid.face_nodes[start+ 2*h-1]))[i];
+            }
+            areaNormal += cross( a , b ) ;
             areaNormal *= 0.5;
             return areaNormal;
         }

--- a/opm/core/grid/GridHelpers.hpp
+++ b/opm/core/grid/GridHelpers.hpp
@@ -149,6 +149,21 @@ beginCellCentroids(const UnstructuredGrid& grid);
 /// \brief cell_index The index of the specific cell.
 double cellCenterDepth(const UnstructuredGrid& grid, int cell_index);
 
+/// \brief Get a coordinate of a specific face center.
+/// \brief calculated as the raw average of the cell corners
+/// \param grid The grid.
+/// \param cell_index The index of the specific cell.
+/// \param face_tag The logical cartesian index of the face
+std::vector<double> faceCenterEcl(const UnstructuredGrid& grid, int cell_index, int face_tag);
+
+/// \brief Get a area weighted normal vector of a specific face.
+/// \brief calculated without introducing a center point
+/// \brief For cornerpoint grids this is supposed to give
+/// \brief values closer to Ecl.
+/// \param grid The grid.
+/// \param face_index The index of the specific face.
+std::vector<double> faceAreaNormalEcl(const UnstructuredGrid& grid, int face_index);
+
 
 /// \brief Get a coordinate of a specific cell centroid.
 /// \brief grid The grid.


### PR DESCRIPTION
-The face center is calculated as raw average of the cell corners
-The face area normals is calculated as the projection of the face
corners.

The methods assumes that the cell corners and face nodes are ordered in
a particular way. i.e. as created from eclGrid.

This implementation gives transmissibilities closer to eclipse.