### PR TITLE
Provide and interface for real scattering/gathering cell data.

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -1194,9 +1194,32 @@ namespace Dune
 
         /// \brief Get an interface for gathering/scattering data with communication.
         ///
+        /// Scattering means sending data from the indices of the global grid on
+        /// process 0 to the distributed grid on all ranks independent of the grid.
+        /// Gathering is the other way around.
         /// The interface can be used with VariableSizeCommunicator and a custom
         /// index based data handle to scatter (forward direction of the communicator)
-        // and gather data (backward direction of the communicator).
+        /// and gather data (backward direction of the communicator).
+        /// Here is a small example that prints the received values when scattering:
+        /// \code
+        /// struct Handle{
+        ///   typedef int DataType;
+        ///   const std::vector<int>& vals;
+        ///   bool fixedsize() { return true; }
+        ///   size_t size() { return 1; }
+        ///   void gather(auto& B buf, size_t i)[ buf.write(vals[i]); }
+        ///   void scatter(auto& B buf, size_t i) {
+        ///     int val;
+        ///     buf.read(val);
+        ///     cout<<i<<": "<<val<<" "; }
+        /// };
+        ///
+        /// Handle handle;
+        /// handle.vals.resize(grid.size(0), -1);
+        /// Dune::VariableSizeCommunicator<> comm(grid.comm(),
+        ///                                       grid.cellScatterGatherInterface());
+        /// comm.forward(handle);
+        /// \endcode
         const InterfaceMap& cellScatterGatherInterface()
         {
             return *cell_scatter_gather_interfaces_;

--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -47,6 +47,12 @@
 // Warning suppression for Dune includes.
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
 
+#include <dune/common/version.hh>
+
+#if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#include <dune/common/parallel/variablesizecommunicator.hh>
+#endif
+
 #include <dune/grid/common/capabilities.hh>
 #include <dune/grid/common/grid.hh>
 #include <dune/grid/common/gridenums.hh>
@@ -1175,9 +1181,16 @@ namespace Dune
             (void) handle;
 #endif
         }
-
+#if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
         /// \brief The type of the map describing communication interfaces.
         typedef VariableSizeCommunicator<>::InterfaceMap InterfaceMap;
+#else
+        // bogus definition for the non parallel type. VariableSizeCommunicator not
+        // availabe
+
+        /// \brief The type of the map describing communication interfaces.
+        typedef std::map<int, std::list<int> > InterfaceMap;
+#endif
 
         /// \brief Get an interface for gathering/scattering data with communication.
         ///

--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -1220,7 +1220,7 @@ namespace Dune
         ///                                       grid.cellScatterGatherInterface());
         /// comm.forward(handle);
         /// \endcode
-        const InterfaceMap& cellScatterGatherInterface()
+        const InterfaceMap& cellScatterGatherInterface() const
         {
             return *cell_scatter_gather_interfaces_;
         }

--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -1137,6 +1137,9 @@ namespace Dune
         //@{
         ///
         /// \brief Moves data from the global (all data on process) view to the distributed view.
+        ///
+        /// This method does not do communication but assumes that the global grid
+        /// is present on every process and simply copies data to the distributed view.
         /// \tparam DataHandle The type of the data handle describing the data and responsible for
         ///         gathering and scattering the data.
         /// \param handle The data handle describing the data and responsible for
@@ -1171,6 +1174,19 @@ namespace Dune
             // Suppress warnings for unused argument.
             (void) handle;
 #endif
+        }
+
+        /// \brief The type of the map describing communication interfaces.
+        typedef VariableSizeCommunicator<>::InterfaceMap InterfaceMap;
+
+        /// \brief Get an interface for gathering/scattering data with communication.
+        ///
+        /// The interface can be used with VariableSizeCommunicator and a custom
+        /// index based data handle to scatter (forward direction of the communicator)
+        // and gather data (backward direction of the communicator).
+        const InterfaceMap& cellScatterGatherInterface()
+        {
+            return *cell_scatter_gather_interfaces_;
         }
 
         /// \brief Switch to the global view.
@@ -1263,6 +1279,12 @@ namespace Dune
         cpgrid::CpGridData* current_view_data_;
         /** @brief The data stored for the distributed grid. */
         std::shared_ptr<cpgrid::CpGridData> distributed_data_;
+        /**
+         * @brief Interface for scattering and gathering cell data.
+         *
+         * @warning Will only update owner cells
+         */
+        std::shared_ptr<InterfaceMap> cell_scatter_gather_interfaces_;
     }; // end Class CpGrid
 
 

--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -1206,9 +1206,9 @@ namespace Dune
         ///   typedef int DataType;
         ///   const std::vector<int>& vals;
         ///   bool fixedsize() { return true; }
-        ///   size_t size() { return 1; }
+        ///   size_t size(std::size_t) { return 1; }
         ///   void gather(auto& B buf, size_t i)[ buf.write(vals[i]); }
-        ///   void scatter(auto& B buf, size_t i) {
+        ///   void scatter(auto& B buf, size_t i, std::size_t) {
         ///     int val;
         ///     buf.read(val);
         ///     cout<<i<<": "<<val<<" "; }

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -58,7 +58,8 @@ namespace Dune
     CpGrid::CpGrid()
         : data_( new cpgrid::CpGridData(*this)),
           current_view_data_(data_.get()),
-          distributed_data_()
+          distributed_data_(),
+          cell_scatter_gather_interfaces_(new InterfaceMap)
     {}
 
 

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -133,7 +133,7 @@ public:
         buffer.write(sendindex_[i]);
     }
     template<class B>
-    void scatter(B& buffer, const std::size_t& i, std::size_t size)
+    void scatter(B& buffer, const std::size_t& i, std::size_t)
     {
         int gid;
         buffer.read(gid);
@@ -385,10 +385,6 @@ BOOST_AUTO_TEST_CASE(cellGatherScatterWithMPI)
     typedef Dune::CpGrid::LeafGridView GridView;
     GridView gridView(grid.leafGridView());
     enum{dimWorld = GridView::dimensionworld};
-    typedef typename GridView::ctype CoordScalar;
-    typedef Dune::FieldVector<CoordScalar,dimWorld> GlobalPosition;
-    typedef GridView::Codim<0>::Iterator ElementIterator;
-    typedef typename GridView::IntersectionIterator IntersectionIterator;
 
     grid.loadBalance();
     auto global_grid = grid;
@@ -402,6 +398,9 @@ BOOST_AUTO_TEST_CASE(cellGatherScatterWithMPI)
     Dune::VariableSizeCommunicator<> scatter_gather_comm(grid.comm(), grid.cellScatterGatherInterface());
     scatter_gather_comm.forward(scatter_handle);
     scatter_gather_comm.backward(gather_handle);
+#else
+    (void) scatter_handle;
+    (void) gather_handle;
 #endif
 }
 

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -398,9 +398,11 @@ BOOST_AUTO_TEST_CASE(cellGatherScatterWithMPI)
                                                 grid.globalCell());
     auto gather_handle = CheckGlobalCellHandle(grid.globalCell(),
                                                global_grid.globalCell());
+#if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
     Dune::VariableSizeCommunicator<> scatter_gather_comm(grid.comm(), grid.cellScatterGatherInterface());
     scatter_gather_comm.forward(scatter_handle);
     scatter_gather_comm.backward(gather_handle);
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(intersectionOverlap)

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -17,6 +17,7 @@
 
 #include <dune/geometry/referenceelements.hh>
 #include <dune/common/fvector.hh>
+#include <dune/common/parallel/variablesizecommunicator.hh>
 #if HAVE_DUNE_GRID_CHECKS
 // The header below are not installed for dune-grid
 // Therefore we need to deactivate testing, if they
@@ -102,6 +103,45 @@ private:
     const Dune::CpGrid& grid_;
     std::vector<int>& dist_point_ids_;
     std::vector<int>& dist_cell_ids_;
+};
+
+/// \brief A data handle to use with CpGrid::.cellScatterGatherInterface()
+/// that checks the correctness of the global cell index at the receiving
+/// end.
+class CheckGlobalCellHandle
+{
+public:
+    CheckGlobalCellHandle(const std::vector<int>& sendindex,
+                          const std::vector<int>& recvindex)
+        : sendindex_(sendindex), recvindex_(recvindex)
+    {}
+
+    typedef int DataType;
+    bool fixedsize()
+    {
+        return true;
+    }
+
+    template<class T>
+    std::size_t size(const T&)
+    {
+        return 1;
+    }
+    template<class B>
+    void gather(B& buffer, std::size_t i)
+    {
+        buffer.write(sendindex_[i]);
+    }
+    template<class B>
+    void scatter(B& buffer, const std::size_t& i, std::size_t size)
+    {
+        int gid;
+        buffer.read(gid);
+        BOOST_REQUIRE(gid==recvindex_[i]);
+    }
+private:
+    const std::vector<int>& sendindex_;
+    const std::vector<int>& recvindex_;
 };
 
 class GatherGlobalIdDataHandle
@@ -330,6 +370,37 @@ BOOST_AUTO_TEST_CASE(distribute)
         grid.gatherData(gather_gid_set_data);
 
     }
+}
+
+// A small test that gathers/scatter the global cell indices.
+// On the sending side these are sent and on the receiving side
+// these are check with the globalCell values.
+BOOST_AUTO_TEST_CASE(cellGatherScatterWithMPI)
+{
+
+    Dune::CpGrid grid;
+    std::array<int, 3> dims={{8, 4, 2}};
+    std::array<double, 3> size={{ 8.0, 4.0, 2.0}};
+    grid.createCartesian(dims, size);
+    typedef Dune::CpGrid::LeafGridView GridView;
+    GridView gridView(grid.leafGridView());
+    enum{dimWorld = GridView::dimensionworld};
+    typedef typename GridView::ctype CoordScalar;
+    typedef Dune::FieldVector<CoordScalar,dimWorld> GlobalPosition;
+    typedef GridView::Codim<0>::Iterator ElementIterator;
+    typedef typename GridView::IntersectionIterator IntersectionIterator;
+
+    grid.loadBalance();
+    auto global_grid = grid;
+    global_grid.switchToGlobalView();
+
+    auto scatter_handle = CheckGlobalCellHandle(global_grid.globalCell(),
+                                                grid.globalCell());
+    auto gather_handle = CheckGlobalCellHandle(grid.globalCell(),
+                                               global_grid.globalCell());
+    Dune::VariableSizeCommunicator<> scatter_gather_comm(grid.comm(), grid.cellScatterGatherInterface());
+    scatter_gather_comm.forward(scatter_handle);
+    scatter_gather_comm.backward(gather_handle);
 }
 
 BOOST_AUTO_TEST_CASE(intersectionOverlap)


### PR DESCRIPTION
The current `scatterData` method relies on the global grid being stored on all processes. The `gatherData` code is a bit complicated. In addition we might need to able to gather data arrays (and not complete `ReservoirState` together with the well information) in `flow_ebos`. Hopefully, we can shrink the code of `ParallelOutputState` with this quite a lot. The current implementation works just for data attached to cells.