### PR TITLE
BUGFIX fix areaNormal computations for faces with nodes > 4

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -899,24 +899,22 @@ namespace Dune
                     int h = (nv - 1)/2;
                     int k = (nv % 2) ? 0 : nv - 1;
 
+                    Vector areaNormal(0.0);
                     // First quads
                     for (int i = 1; i < h; ++i)
                     {
                         Vector a = vertexPosition(current_view_data_->face_to_point_[face][2*i]) - vertexPosition(current_view_data_->face_to_point_[face][0]);
                         Vector b = vertexPosition(current_view_data_->face_to_point_[face][2*i+1]) - vertexPosition(current_view_data_->face_to_point_[face][2*i-1]);
-                        Vector areaNormal = cross(a,b);
-                        for (int i=0; i<nd; ++i) {
-                            areaNormal[i] /= 2;
-                        }
+                        areaNormal += cross(a,b);
                     }
 
                     // Last triangle or quad
                     Vector a = vertexPosition(current_view_data_->face_to_point_[face][2*h]) - vertexPosition(current_view_data_->face_to_point_[face][0]);
                     Vector b = vertexPosition(current_view_data_->face_to_point_[face][k]) - vertexPosition(current_view_data_->face_to_point_[face][2*h-1]);
-                    Vector areaNormal = cross(a,b);
-                    for (int i=0; i<nd; ++i) {
-                        areaNormal[i] /= 2;
-                    }
+                    areaNormal += cross(a,b);
+
+                    areaNormal *= 0.5;
+
                     return areaNormal;
                 }
 

--- a/opm/core/grid/GridHelpers.cpp
+++ b/opm/core/grid/GridHelpers.cpp
@@ -228,11 +228,11 @@ Dune::FieldVector<double,3> faceAreaNormalEcl(const UnstructuredGrid& grid, int 
             Vector areaNormal ( 0 );
             Vector a, b;
             // First quads
-            for (int i = 1; i < h; ++i)
+            for (int j = 1; j < h; ++j)
             {
                 for (int i = 0; i < 3; ++i) {
-                    a[i] = (grid.node_coordinates+nd*(grid.face_nodes[start+2*i] ))[i] - (grid.node_coordinates+nd*(grid.face_nodes[start]))[i];
-                    b[i] = (grid.node_coordinates+nd*(grid.face_nodes[start+2*i + 1]))[i] - (grid.node_coordinates+nd*(grid.face_nodes[start+ 2*i-1]))[i];
+                    a[i] = (grid.node_coordinates+nd*(grid.face_nodes[start+2*j] ))[i] - (grid.node_coordinates+nd*(grid.face_nodes[start]))[i];
+                    b[i] = (grid.node_coordinates+nd*(grid.face_nodes[start+2*j + 1]))[i] - (grid.node_coordinates+nd*(grid.face_nodes[start+ 2*j-1]))[i];
                 }
                 areaNormal += cross( a , b ) ;
             }


### PR DESCRIPTION
With these bugfixes TRANX(YZ) matches ecl excellently for all cells not effected by MINPV and PINCH for Norne and Model 2. 