### PR TITLE
Cleanup DUNE_VERSION_NEWER( 2 , 3 )

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -49,7 +49,7 @@
 
 #include <dune/common/version.hh>
 
-#if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#if HAVE_MPI
 #include <dune/common/parallel/variablesizecommunicator.hh>
 #endif
 
@@ -1152,7 +1152,7 @@ namespace Dune
         template<class DataHandle>
         void scatterData(DataHandle& handle)
         {
-#if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#if HAVE_MPI
             if(!distributed_data_)
                 OPM_THROW(std::runtime_error, "Moving Data only allowed with a load balanced grid!");
             distributed_data_->scatterData(handle, data_.get(), distributed_data_.get());
@@ -1171,7 +1171,7 @@ namespace Dune
         template<class DataHandle>
         void gatherData(DataHandle& handle)
         {
-#if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#if HAVE_MPI
             if(!distributed_data_)
                 OPM_THROW(std::runtime_error, "Moving Data only allowed with a load balance grid!");
             distributed_data_->gatherData(handle, data_.get(), distributed_data_.get());
@@ -1180,7 +1180,7 @@ namespace Dune
             (void) handle;
 #endif
         }
-#if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#if HAVE_MPI
         /// \brief The type of the map describing communication interfaces.
         typedef VariableSizeCommunicator<>::InterfaceMap InterfaceMap;
 #else
@@ -1236,35 +1236,8 @@ namespace Dune
             current_view_data_=distributed_data_.get();
         }
         //@}
-#if ! DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
 
-        /// \name backward compatibility with dune-grid-2.2
-        //@{
-        //! View for a grid level
-        template<PartitionIteratorType pitype>
-        typename Partition<pitype>::LevelGridView levelGridView(int level) const {
-          return this->template levelView<pitype>(level);
-        }
-
-        //! View for the leaf grid
-        template<PartitionIteratorType pitype>
-        typename Partition<pitype>::LeafGridView leafGridView() const {
-          return this->template leafView<pitype>();
-        }
-
-        //! View for a grid level for All_Partition
-        LevelGridView levelGridView(int level) const {
-          return this->levelView(level);
-        }
-
-        //! View for the leaf grid for All_Partition
-        LeafGridView leafGridView() const {
-          return this->leafView();
-        }
-        //@}
-#endif
-
-#if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#if HAVE_MPI
         /// \brief The type of the parallel index set
         typedef cpgrid::CpGridData::ParallelIndexSet ParallelIndexSet;
         /// \brief The type of the remote indices information

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -74,7 +74,7 @@ CpGrid::scatterGrid(const Opm::EclipseState* ecl,
     static_cast<void>(ecl);
     static_cast<void>(transmissibilities);
     static_cast<void>(overlapLayers);
-#if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#if HAVE_MPI
     if(distributed_data_)
     {
         std::cerr<<"There is already a distributed version of the grid."
@@ -86,12 +86,12 @@ CpGrid::scatterGrid(const Opm::EclipseState* ecl,
 
     int my_num=cc.rank();
 #ifdef HAVE_ZOLTAN
-    auto part_and_wells = cpgrid::zoltanGraphPartitionGridOnRoot(*this, ecl, transmissibilities,
-                                                       cc, 0);
+    auto part_and_wells =
+        cpgrid::zoltanGraphPartitionGridOnRoot(*this, ecl, transmissibilities, cc, 0);
     int num_parts = cc.size();
     using std::get;
-    auto cell_part = get<0>(part_and_wells);
-    auto defunct_wells = get<1>(part_and_wells);
+    auto cell_part = std::get<0>(part_and_wells);
+    auto defunct_wells = std::get<1>(part_and_wells);
 #else
     std::vector<int> cell_part(current_view_data_->global_cell_.size());
     int  num_parts=-1;
@@ -200,7 +200,7 @@ CpGrid::scatterGrid(const Opm::EclipseState* ecl,
     current_view_data_ = distributed_data_.get();
     return std::make_pair(true, defunct_wells);
 
-#else // #if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#else // #if HAVE_MPI
     std::cerr << "CpGrid::scatterGrid() is non-trivial only with "
               << "MPI support and if the target Dune platform is "
               << "sufficiently recent.\n";

--- a/dune/grid/cpgrid/CpGridData.cpp
+++ b/dune/grid/cpgrid/CpGridData.cpp
@@ -31,9 +31,7 @@ CpGridData::CpGridData(const CpGridData& g)
 {
 #if HAVE_MPI
     ccobj_=CollectiveCommunication(MPI_COMM_SELF);
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
-    cell_interfaces_=make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
-#endif
+    cell_interfaces_=std::make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
 #endif
 }
 
@@ -44,19 +42,17 @@ CpGridData::CpGridData()
 {
 #if HAVE_MPI
     ccobj_=CollectiveCommunication(MPI_COMM_SELF);
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
-    cell_interfaces_=make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
-#endif
+    cell_interfaces_=std::make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
 #endif
 }
 
-#if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#if HAVE_MPI
 CpGridData::CpGridData(MPI_Comm comm)
     : index_set_(new IndexSet(*this)), local_id_set_(new IdSet(*this)),
       global_id_set_(new GlobalIdSet(local_id_set_)), partition_type_indicator_(new PartitionTypeIndicator(*this)),
       ccobj_(comm), use_unique_boundary_ids_(false)
 {
-    cell_interfaces_=make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
+    cell_interfaces_=std::make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
 }
 #endif
 
@@ -67,9 +63,7 @@ CpGridData::CpGridData(CpGrid&)
 {
 #if HAVE_MPI
     ccobj_=CollectiveCommunication(MPI_COMM_SELF);
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
-    cell_interfaces_=make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
-#endif
+    cell_interfaces_=std::make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
 #endif
 }
 
@@ -86,20 +80,20 @@ void freeInterfaces(InterfaceMap& map)
 }
 
 template<class InterfaceMap>
-void freeInterfaces(tuple<InterfaceMap,InterfaceMap,InterfaceMap,InterfaceMap,InterfaceMap>&
+void freeInterfaces(std::tuple<InterfaceMap,InterfaceMap,InterfaceMap,InterfaceMap,InterfaceMap>&
                     interfaces)
 {
-    freeInterfaces(get<0>(interfaces));
-    freeInterfaces(get<1>(interfaces));
-    freeInterfaces(get<2>(interfaces));
-    freeInterfaces(get<3>(interfaces));
-    freeInterfaces(get<4>(interfaces));
+    freeInterfaces(std::get<0>(interfaces));
+    freeInterfaces(std::get<1>(interfaces));
+    freeInterfaces(std::get<2>(interfaces));
+    freeInterfaces(std::get<3>(interfaces));
+    freeInterfaces(std::get<4>(interfaces));
 }
 #endif
 
 CpGridData::~CpGridData()
 {
-#if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#if HAVE_MPI
     // code deactivated, because users cannot access face indices and therefore
     // communication on faces makes no sense!
     //freeInterfaces(face_interfaces_);
@@ -146,7 +140,7 @@ int CpGridData::size(int codim) const
     }
 }
 
-#if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#if HAVE_MPI
 
  // A functor that counts existent entries and renumbers them.
 struct CountExistent
@@ -329,11 +323,11 @@ struct InterfaceTupleFunctor
 
     void operator()(int rank, std::size_t index, PartitionType mine, PartitionType other)
     {
-        get<0>(t_)(rank, index, mine, other);
-        get<1>(t_)(rank, index, mine, other);
-        get<2>(t_)(rank, index, mine, other);
-        get<3>(t_)(rank, index, mine, other);
-        get<4>(t_)(rank, index, mine, other);
+        std::get<0>(t_)(rank, index, mine, other);
+        std::get<1>(t_)(rank, index, mine, other);
+        std::get<2>(t_)(rank, index, mine, other);
+        std::get<3>(t_)(rank, index, mine, other);
+        std::get<4>(t_)(rank, index, mine, other);
     }
     Tuple& t_;
 };
@@ -347,10 +341,10 @@ struct Converter
     typedef Combine<Interior,Border> InteriorBorder;
     typedef Combine<Overlap,Front> OverlapFront;
 
-    typedef tuple<InteriorBorder, InteriorBorder,        Overlap     , Overlap,
-                  AllSet<PartitionType> > SourceTuple;
-    typedef tuple<InteriorBorder, AllSet<PartitionType>, OverlapFront, AllSet<PartitionType>,
-                  AllSet<PartitionType> > DestinationTuple;
+    typedef std::tuple<InteriorBorder, InteriorBorder,        Overlap     , Overlap,
+                       AllSet<PartitionType> > SourceTuple;
+    typedef std::tuple<InteriorBorder, AllSet<PartitionType>, OverlapFront, AllSet<PartitionType>,
+                       AllSet<PartitionType> > DestinationTuple;
 };
 
 /**
@@ -361,12 +355,12 @@ struct Converter
  */
 template<std::size_t i, class InterfaceMap>
 void reserve(const std::vector<std::map<int,std::pair<std::size_t,std::size_t> > >& sizes,
-             tuple<InterfaceMap,InterfaceMap,InterfaceMap,InterfaceMap,InterfaceMap>&
+             std::tuple<InterfaceMap,InterfaceMap,InterfaceMap,InterfaceMap,InterfaceMap>&
              interfaces)
 {
     typedef typename std::map<int,std::pair<std::size_t,std::size_t> >::const_iterator Iter;
     const std::map<int,std::pair<std::size_t,std::size_t> >& sizeMap=sizes[i];
-    InterfaceMap& interfaceMap=get<i>(interfaces);
+    InterfaceMap& interfaceMap=std::get<i>(interfaces);
 
     for(Iter iter=sizeMap.begin(), end =sizeMap.end(); iter!=end; ++iter)
     {
@@ -383,7 +377,7 @@ void reserve(const std::vector<std::map<int,std::pair<std::size_t,std::size_t> >
  */
 template<class InterfaceMap>
 void reserve(const std::vector<std::map<int,std::pair<std::size_t,std::size_t> > >& sizes,
-             tuple<InterfaceMap,InterfaceMap,InterfaceMap,InterfaceMap,InterfaceMap>&
+             std::tuple<InterfaceMap,InterfaceMap,InterfaceMap,InterfaceMap,InterfaceMap>&
              interfaces)
 {
     reserve<0>(sizes, interfaces);
@@ -400,12 +394,12 @@ void reserve(const std::vector<std::map<int,std::pair<std::size_t,std::size_t> >
 template<std::size_t i>
 struct SizeFunctor :
     public InterfaceFunctor<std::size_t, InterfaceIncrementor,
-                            typename tuple_element<i,typename Converter::SourceTuple>::type,
-                            typename tuple_element<i,typename Converter::DestinationTuple>::type>
+                            typename std::tuple_element<i,typename Converter::SourceTuple>::type,
+                            typename std::tuple_element<i,typename Converter::DestinationTuple>::type>
 {
     typedef InterfaceFunctor<std::size_t, InterfaceIncrementor,
-                             typename tuple_element<i,typename Converter::SourceTuple>::type,
-                             typename tuple_element<i,typename Converter::DestinationTuple>::type>
+                             typename std::tuple_element<i,typename Converter::SourceTuple>::type,
+                             typename std::tuple_element<i,typename Converter::DestinationTuple>::type>
     Base;
     SizeFunctor(std::map<int,std::pair<std::size_t,std::size_t> >& m)
         :Base(m)
@@ -419,12 +413,12 @@ struct SizeFunctor :
 template<std::size_t i>
 struct AddFunctor :
     public InterfaceFunctor<InterfaceInformation, InterfaceAdder,
-                             typename tuple_element<i,typename Converter::SourceTuple>::type,
-                             typename tuple_element<i,typename Converter::DestinationTuple>::type>
+                             typename std::tuple_element<i,typename Converter::SourceTuple>::type,
+                             typename std::tuple_element<i,typename Converter::DestinationTuple>::type>
 {
     typedef InterfaceFunctor<InterfaceInformation, InterfaceAdder,
-                             typename tuple_element<i,typename Converter::SourceTuple>::type,
-                             typename tuple_element<i,typename Converter::DestinationTuple>::type>
+                             typename std::tuple_element<i,typename Converter::SourceTuple>::type,
+                             typename std::tuple_element<i,typename Converter::DestinationTuple>::type>
     Base;
     AddFunctor(std::map<int,std::pair<InterfaceInformation,InterfaceInformation> >& m)
         : Base(m)
@@ -486,38 +480,39 @@ void iterate_over_attributes(std::vector<std::map<int,char> >& attributes,
 template<class InterfaceMap,class T>
 void createInterfaces(std::vector<std::map<int,char> >& attributes,
                       T partition_type_iterator,
-                      tuple<InterfaceMap,InterfaceMap,InterfaceMap,InterfaceMap,InterfaceMap>&
+                      std::tuple<InterfaceMap,InterfaceMap,InterfaceMap,InterfaceMap,InterfaceMap>&
                       interfaces)
 {
     // calculate sizes
     std::vector<std::map<int,std::pair<std::size_t,std::size_t> > > sizes(5);
-    typedef tuple<SizeFunctor<0>,SizeFunctor<1>,SizeFunctor<2>,SizeFunctor<3>,
-                  SizeFunctor<4> > SizeTuple;
+    typedef std::tuple<SizeFunctor<0>,SizeFunctor<1>,SizeFunctor<2>,SizeFunctor<3>,
+                       SizeFunctor<4> > SizeTuple;
+
     SizeTuple
-        size_functor_tuple = make_tuple(SizeFunctor<0>(sizes[0]),
-                                        SizeFunctor<1>(sizes[1]),
-                                        SizeFunctor<2>(sizes[2]),
-                                        SizeFunctor<3>(sizes[3]),
-                                        SizeFunctor<4>(sizes[4]));
+    size_functor_tuple = std::make_tuple(SizeFunctor<0>(sizes[0]),
+                                         SizeFunctor<1>(sizes[1]),
+                                         SizeFunctor<2>(sizes[2]),
+                                         SizeFunctor<3>(sizes[3]),
+                                         SizeFunctor<4>(sizes[4]));
     InterfaceTupleFunctor<SizeTuple> size_functor(size_functor_tuple);
     iterate_over_attributes(attributes, partition_type_iterator, size_functor);
     // reserve space
     reserve(sizes, interfaces);
     // add indices to the interface
-    typedef tuple<AddFunctor<0>,AddFunctor<1>,AddFunctor<2>,AddFunctor<3>,
-                  AddFunctor<4> > AddTuple;
+    typedef std::tuple<AddFunctor<0>,AddFunctor<1>,AddFunctor<2>,AddFunctor<3>,
+                       AddFunctor<4> > AddTuple;
     AddTuple
-        add_functor_tuple(AddFunctor<0>(get<0>(interfaces)),
-                          AddFunctor<1>(get<1>(interfaces)),
-                          AddFunctor<2>(get<2>(interfaces)),
-                          AddFunctor<3>(get<3>(interfaces)),
-                          AddFunctor<4>(get<4>(interfaces)));
+        add_functor_tuple(AddFunctor<0>(std::get<0>(interfaces)),
+                          AddFunctor<1>(std::get<1>(interfaces)),
+                          AddFunctor<2>(std::get<2>(interfaces)),
+                          AddFunctor<3>(std::get<3>(interfaces)),
+                          AddFunctor<4>(std::get<4>(interfaces)));
     InterfaceTupleFunctor<AddTuple> add_functor(add_functor_tuple);
     iterate_over_attributes(attributes, partition_type_iterator, add_functor);
 
 }
 
-#endif // #if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#endif // #if HAVE_MPI
 
 
 void CpGridData::distributeGlobalGrid(const CpGrid& grid,
@@ -525,7 +520,7 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
                                       const std::vector<int>& cell_part,
                                       int overlap_layers)
 {
-#if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#if HAVE_MPI
     Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator>& ccobj=ccobj_;
     int my_rank=ccobj.rank();
 #if 0
@@ -936,21 +931,21 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
     }
 
     // Compute the interface information for cells
-    get<InteriorBorder_All_Interface>(cell_interfaces_)
+    std::get<InteriorBorder_All_Interface>(cell_interfaces_)
         .build(cell_remote_indices_, EnumItem<AttributeSet, AttributeSet::owner>(),
                AllSet<AttributeSet>());
-    get<Overlap_OverlapFront_Interface>(cell_interfaces_)
+    std::get<Overlap_OverlapFront_Interface>(cell_interfaces_)
         .build(cell_remote_indices_, EnumItem<AttributeSet, AttributeSet::copy>(),
                EnumItem<AttributeSet, AttributeSet::copy>());
-    get<Overlap_All_Interface>(cell_interfaces_)
+    std::get<Overlap_All_Interface>(cell_interfaces_)
         .build(cell_remote_indices_, EnumItem<AttributeSet, AttributeSet::copy>(),
                                  AllSet<AttributeSet>());
-    get<All_All_Interface>(cell_interfaces_)
+    std::get<All_All_Interface>(cell_interfaces_)
         .build(cell_remote_indices_, AllSet<AttributeSet>(), AllSet<AttributeSet>());
 
     // Now we use the all_all communication of the cells to compute which faces and points
     // are also present on other processes and with what attribute.
-    Dune::VariableSizeCommunicator<> comm(get<All_All_Interface>(cell_interfaces_));
+    Dune::VariableSizeCommunicator<> comm(std::get<All_All_Interface>(cell_interfaces_));
     /*
       // code deactivated, because users cannot access face indices and therefore
       // communication on faces makes no sense!
@@ -959,7 +954,7 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
         face_handle(ccobj_.rank(), *partition_type_indicator_,
                     face_attributes, static_cast<Opm::SparseTable<EntityRep<1> >&>(cell_to_face_),
                     *this);
-    if( get<All_All_Interface>(cell_interfaces_).interfaces().size() )
+    if( std::get<All_All_Interface>(cell_interfaces_).interfaces().size() )
     {
         comm.forward(face_handle);
     }
@@ -971,14 +966,14 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
     AttributeDataHandle<std::vector<std::array<int,8> > >
         point_handle(ccobj_.rank(), *partition_type_indicator_,
                      point_attributes, cell_to_point_, *this);
-    if( static_cast<const Dune::Interface&>(get<All_All_Interface>(cell_interfaces_))
+    if( static_cast<const Dune::Interface&>(std::get<All_All_Interface>(cell_interfaces_))
         .interfaces().size() )
     {
         comm.forward(point_handle);
     }
     createInterfaces(point_attributes, partition_type_indicator_->point_indicator_.begin(),
                      point_interfaces_);
-#else // #if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#else // #if HAVE_MPI
     static_cast<void>(grid);
     static_cast<void>(view_data);
     static_cast<void>(cell_part);

--- a/dune/grid/cpgrid/Geometry.hpp
+++ b/dune/grid/cpgrid/Geometry.hpp
@@ -179,13 +179,8 @@ namespace Dune
                 // This code is modified from dune/grid/genericgeometry/mapping.hh
                 // \todo: Implement direct computation.
                 const ctype epsilon = 1e-12;
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
                 const ReferenceElement< ctype , 3 > & refElement =
                     ReferenceElements< ctype, 3 >::general(type());
-#else
-                const GenericReferenceElement< ctype , 3 > & refElement =
-                    GenericReferenceElements< ctype, 3 >::general(type());
-#endif
                 LocalCoordinate x = refElement.position(0,0);
                 LocalCoordinate dx;
                 do {

--- a/dune/grid/cpgrid/PersistentContainer.hpp
+++ b/dune/grid/cpgrid/PersistentContainer.hpp
@@ -6,51 +6,30 @@
 #include <dune/grid/utility/persistentcontainer.hh>
 #include <dune/grid/CpGrid.hpp>
 
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
 #include <dune/grid/utility/persistentcontainervector.hh>
-#endif
 
 namespace Dune
 {
   // PersistentContainer for CpGrid
   // -------------------------------
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
   template< class Data >
   class PersistentContainer< CpGrid, Data >
   : public PersistentContainerVector< CpGrid,
                                       typename CpGrid::Traits::LeafIndexSet,
                                       std::vector<Data> >
-#else
-  template< class Data, class Allocator >
-  class PersistentContainer< CpGrid, Data, Allocator >
-  : public PersistentContainerVector< CpGrid,
-                                      typename CpGrid::Traits::LeafIndexSet,
-                                      std::vector<Data,Allocator> >
-#endif
   {
   public:
     typedef CpGrid  GridType;
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
     typedef typename std::vector<Data>::allocator_type Allocator;
-#endif
 
   private:
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
     typedef PersistentContainerVector< GridType, typename GridType::Traits::LeafIndexSet, std::vector<Data> > BaseType;
-#else
-    typedef PersistentContainerVector< GridType, typename GridType::Traits::LeafIndexSet, std::vector<Data,Allocator> > BaseType;
-#endif
 
   public:
     //! Constructor filling the container with values using the default constructor
     //! Depending on the implementation this could be achieved without allocating memory
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
     PersistentContainer ( const GridType &grid, const int codim, const Data& data = Data(), const Allocator &allocator = Allocator() )
     : BaseType( grid.leafIndexSet(), codim, data, allocator )
-#else
-    PersistentContainer ( const GridType &grid, const int codim, const Allocator &allocator = Allocator() )
-    : BaseType( grid, codim, grid.leafIndexSet(), 1.1, allocator )
-#endif
     {}
   };
 

--- a/dune/grid/polyhedralgrid/persistentcontainer.hh
+++ b/dune/grid/polyhedralgrid/persistentcontainer.hh
@@ -8,51 +8,30 @@
 #include <dune/grid/utility/persistentcontainer.hh>
 #include <dune/grid/polyhedralgrid/grid.hh>
 
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
 #include <dune/grid/utility/persistentcontainervector.hh>
-#endif
 
 namespace Dune
 {
   // PersistentContainer for CpGrid
   // -------------------------------
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
   template< int dim, int dimworld, class Data >
   class PersistentContainer< PolyhedralGrid< dim, dimworld >, Data >
   : public PersistentContainerVector< PolyhedralGrid< dim, dimworld >,
                                       typename PolyhedralGrid< dim, dimworld >::Traits::LeafIndexSet,
                                       std::vector<Data> >
-#else
-  template< int dim, int dimworld, class Data, class Allocator >
-  class PersistentContainer< PolyhedralGrid< dim, dimworld >, Data, Allocator >
-  : public PersistentContainerVector< PolyhedralGrid< dim, dimworld >,
-                                      typename PolyhedralGrid< dim, dimworld >::Traits::LeafIndexSet,
-                                      std::vector<Data,Allocator> >
-#endif
   {
   public:
     typedef PolyhedralGrid< dim, dimworld >  GridType;
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
     typedef typename std::vector<Data>::allocator_type Allocator;
-#endif
 
   private:
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
     typedef PersistentContainerVector< GridType, typename GridType::Traits::LeafIndexSet, std::vector<Data> > BaseType;
-#else
-    typedef PersistentContainerVector< GridType, typename GridType::Traits::LeafIndexSet, std::vector<Data,Allocator> > BaseType;
-#endif
 
   public:
     //! Constructor filling the container with values using the default constructor
     //! Depending on the implementation this could be achieved without allocating memory
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
     PersistentContainer ( const GridType &grid, const int codim, const Data& data = Data(), const Allocator &allocator = Allocator() )
     : BaseType( grid.leafIndexSet(), codim, data, allocator )
-#else
-    PersistentContainer ( const GridType &grid, const int codim, const Allocator &allocator = Allocator() )
-    : BaseType( grid, codim, grid.leafIndexSet(), 1.1, allocator )
-#endif
     {}
   };
 

--- a/examples/finitevolume/evolve.hh
+++ b/examples/finitevolume/evolve.hh
@@ -39,24 +39,15 @@ void evolve(const G& grid, const M& mapper, V& c, double t, double& dt)
 
         // cell center in reference element
         const Dune::FieldVector<ct,dim>&
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
         local = Dune::ReferenceElements<ct,dim>::general(gt).position(0,0);
-#else
-        local = Dune::GenericReferenceElements<ct,dim>::general(gt).position(0,0);
-#endif
 
         // cell center in global coordinates
         /*        Dune::FieldVector<ct,dimworld>
                   global = it->geometry().center(); */
 
         // cell volume, assume linear map here
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
         double volume = it->geometry().integrationElement(local)
             *Dune::ReferenceElements<ct,dim>::general(gt).volume();
-#else
-        double volume = it->geometry().integrationElement(local)
-            *Dune::GenericReferenceElements<ct,dim>::general(gt).volume();
-#endif
         // double volume = it->geometry().volume();
 
 #if DUNE_VERSION_NEWER(DUNE_GRID, 2, 4)
@@ -79,21 +70,13 @@ void evolve(const G& grid, const M& mapper, V& c, double t, double& dt)
 
             // center in face's reference element
             const Dune::FieldVector<ct,dim-1>&
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
             facelocal = Dune::ReferenceElements<ct,dim-1>::general(gtf).position(0,0);
-#else
-            facelocal = Dune::GenericReferenceElements<ct,dim-1>::general(gtf).position(0,0);
-#endif
 
             // get normal vector scaled with volume
             Dune::FieldVector<ct,dimworld> integrationOuterNormal
             = is->integrationOuterNormal(facelocal);
             integrationOuterNormal
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
             *= Dune::ReferenceElements<ct,dim-1>::general(gtf).volume();
-#else
-            *= Dune::GenericReferenceElements<ct,dim-1>::general(gtf).volume();
-#endif
 
             // center of face in global coordinates
             Dune::FieldVector<ct,dimworld>
@@ -128,15 +111,10 @@ void evolve(const G& grid, const M& mapper, V& c, double t, double& dt)
                     // compute factor in neighbor
                     Dune::GeometryType nbgt = outside->type();
                     const Dune::FieldVector<ct,dim>&
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
                     nblocal = Dune::ReferenceElements<ct,dim>::general(nbgt).position(0,0);
                     double nbvolume = outside->geometry().integrationElement(nblocal)
                                       *Dune::ReferenceElements<ct,dim>::general(nbgt).volume();
-#else
-                    nblocal = Dune::GenericReferenceElements<ct,dim>::general(nbgt).position(0,0);
-                    double nbvolume = outside->geometry().integrationElement(nblocal)
-                                      *Dune::GenericReferenceElements<ct,dim>::general(nbgt).volume();
-#endif
+
                     double nbfactor = velocity*integrationOuterNormal/nbvolume;
 
                     if (factor<0) // inflow

--- a/examples/finitevolume/finitevolume.cc
+++ b/examples/finitevolume/finitevolume.cc
@@ -12,11 +12,7 @@
 #include <dune/grid/common/mcmgmapper.hh> // mapper class
 
 #include <dune/common/version.hh>
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
 #include <dune/common/parallel/mpihelper.hh> // include mpi helper class
-#else
-#include <dune/common/mpihelper.hh> // include mpi helper class
-#endif
 
 // checks for defined gridtype and inlcudes appropriate dgfparser implementation
 //#include <dune/grid/io/file/dgfparser/dgfgridtype.hh>

--- a/examples/finitevolume/initialize.hh
+++ b/examples/finitevolume/initialize.hh
@@ -30,11 +30,7 @@ void initialize(const G& grid, const M& mapper, V& c)
 
         // get cell center in reference element
         const Dune::FieldVector<ct,dim>&
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
         local = Dune :: ReferenceElements<ct,dim >::general(gt).position(0,0);
-#else
-        local = Dune :: GenericReferenceElements<ct,dim >::general(gt).position(0,0);
-#endif
 
         // get global coordinate of cell center
         Dune::FieldVector<ct,dimworld> global =

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -271,13 +271,8 @@ BOOST_AUTO_TEST_CASE(distribute)
         for (LeafIterator it = gridView.begin<0>();
              it != gridView.end<0>(); ++it) {
             Dune::GeometryType gt = it->type () ;
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
             const Dune::ReferenceElement<Dune::CpGrid::ctype, 3>& ref=
                 Dune::ReferenceElements<Dune::CpGrid::ctype, 3>::general(gt);
-#else
-            const Dune::GenericReferenceElement<Dune::CpGrid::ctype, 3>& ref=
-                Dune::GenericReferenceElements<Dune::CpGrid::ctype, 3>::general(gt);
-#endif
 
             cell_indices.push_back(ix.index(*it));
             cell_centers.push_back(it->geometry().center());
@@ -307,11 +302,11 @@ BOOST_AUTO_TEST_CASE(distribute)
         grid.getIJK(0, ijk);
     }
 
-#if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#if HAVE_MPI
     // Dune::CpGrid::loadBalance() is non-trivial only if we have MPI
     // *and* if the target Dune platform is sufficiently recent.
     BOOST_REQUIRE(grid.comm()!=MPI_COMM_SELF||MPI_COMM_WORLD==MPI_COMM_SELF);
-#endif // HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#endif // HAVE_MPI
 
     if(procs==1)
     {
@@ -323,20 +318,15 @@ BOOST_AUTO_TEST_CASE(distribute)
         int cell_index=0, face_index=0, point_index=0;
 
         const Dune::CpGrid::LeafIndexSet& ix1 = grid.leafIndexSet();
-#if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#if HAVE_MPI
         BOOST_REQUIRE(&ix!=&ix1);
 #endif
 
         for (Dune::CpGrid::Codim<0>::LeafIterator it = grid.leafbegin<0>();
              it != grid.leafend<0>(); ++it) {
             Dune::GeometryType gt = it->type () ;
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
             const Dune::ReferenceElement<Dune::CpGrid::ctype, 3>& ref=
                 Dune::ReferenceElements<Dune::CpGrid::ctype, 3>::general(gt);
-#else
-            const Dune::GenericReferenceElement<Dune::CpGrid::ctype, 3>& ref=
-                Dune::GenericReferenceElements<Dune::CpGrid::ctype, 3>::general(gt);
-#endif
 
             BOOST_REQUIRE(cell_indices[cell_index]==ix1.index(*it));
             BOOST_REQUIRE(cell_centers[cell_index++]==it->geometry().center());
@@ -393,7 +383,7 @@ BOOST_AUTO_TEST_CASE(cellGatherScatterWithMPI)
                                                 grid.globalCell());
     auto gather_handle = CheckGlobalCellHandle(grid.globalCell(),
                                                global_grid.globalCell());
-#if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#if HAVE_MPI
     Dune::VariableSizeCommunicator<> scatter_gather_comm(grid.comm(), grid.cellScatterGatherInterface());
     scatter_gather_comm.forward(scatter_handle);
     scatter_gather_comm.backward(gather_handle);


### PR DESCRIPTION
DUNE 2.3 is a hard dependency so all checks of the form DUNE_VERSION_NEWER( ..., 2 ,3 ) can be safely removed. To also remove some warning the use of Dune::tuple, which is a forward to std::tuple was removed and std::tuple is used consequently. 

This should not be backported to the current release.