### PR TITLE
disable native tuning in packaging

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -21,7 +21,7 @@ override_dh_auto_build:
 
 # consider using -DUSE_VERSIONED_DIR=ON if backporting
 override_dh_auto_configure:
-	dh_auto_configure -v --buildsystem=cmake -- -DCMAKE_BUILD_TYPE=Release -DUSE_MPI=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_DOCDIR=share/doc/libopm-grid1 -DWHOLE_PROG_OPTIM=ON -DUSE_RUNPATH=OFF
+	dh_auto_configure -v --buildsystem=cmake -- -DCMAKE_BUILD_TYPE=Release -DUSE_MPI=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_DOCDIR=share/doc/libopm-grid1 -DWHOLE_PROG_OPTIM=ON -DUSE_RUNPATH=OFF -DWITH_NATIVE=OFF
 
 override_dh_auto_install:
 	dh_auto_install -- install-html

--- a/redhat/opm-grid.spec
+++ b/redhat/opm-grid.spec
@@ -14,7 +14,7 @@ Url:            http://www.opm-project.org/
 Source0:        https://github.com/OPM/%{name}/archive/release/%{version}/%{tag}.tar.gz#/%{name}-%{version}.tar.gz
 BuildRequires:  blas-devel lapack-devel dune-common-devel
 BuildRequires:  git suitesparse-devel doxygen bc ert.ecl-devel opm-common-devel
-BuildRequires:  tinyxml-devel dune-istl-devel opm-core-devel dune-grid-devel
+BuildRequires:  tinyxml-devel dune-istl-devel dune-grid-devel
 %{?el6:BuildRequires: cmake28 devtoolset-3-toolchain boost148-devel}
 %{!?el6:BuildRequires: cmake gcc gcc-c++ boost-devel}
 BuildRequires:  opm-parser-devel opm-material-devel opm-output-devel
@@ -80,7 +80,7 @@ This package contains the applications for opm-grid
 # consider using -DUSE_VERSIONED_DIR=ON if backporting
 %build
 %{?el6:scl enable devtoolset-3 bash}
-%{?el6:cmake28} %{!?el6:cmake} -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%{_prefix} -DCMAKE_INSTALL_DOCDIR=share/doc/%{name}-%{version} -DUSE_RUNPATH=OFF %{?el6:-DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-3/root/usr/bin/g++ -DCMAKE_C_COMPILER=/opt/rh/devtoolset-3/root/usr/bin/gcc -DCMAKE_Fortran_COMPILER=/opt/rh/devtoolset-3/root/usr/bin/gfortran -DBOOST_LIBRARYDIR=%{_libdir}/boost148 -DBOOST_INCLUDEDIR=%{_includedir}/boost148}
+%{?el6:cmake28} %{!?el6:cmake} -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%{_prefix} -DCMAKE_INSTALL_DOCDIR=share/doc/%{name}-%{version} -DUSE_RUNPATH=OFF -DWITH_NATIVE=OFF %{?el6:-DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-3/root/usr/bin/g++ -DCMAKE_C_COMPILER=/opt/rh/devtoolset-3/root/usr/bin/gcc -DCMAKE_Fortran_COMPILER=/opt/rh/devtoolset-3/root/usr/bin/gfortran -DBOOST_LIBRARYDIR=%{_libdir}/boost148 -DBOOST_INCLUDEDIR=%{_includedir}/boost148}
 make
 
 %install


### PR DESCRIPTION
also removes (old, now incorrect) opm-core dependency for redhat packaging

Backports from 2017.04 release branch.