### PR TITLE
Make dgfparser.hh compile with Clang.

### DIFF
--- a/dune/grid/polyhedralgrid/dgfparser.hh
+++ b/dune/grid/polyhedralgrid/dgfparser.hh
@@ -71,7 +71,7 @@ namespace Dune
     const typename DGFBoundaryParameter::type &
     boundaryParameter ( const Intersection &intersection ) const
     {
-        return 0.0;
+        return DGFBoundaryParameter::defaultValue();
     }
 
     template< class Entity >


### PR DESCRIPTION
This was broken by #262.

Value returned is dummy anyway, should at least match expected type. It seemed to me that the defaultValue() method would be the simplest way to ensure this.

I intend to self-merge this after Jenkins, as it is compile-critical.