### PR TITLE
Allow compilation of parallel tests with DUNE 2.3.

### DIFF
--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -25,6 +25,9 @@
 #include <dune/grid/test/checkpartition.hh>
 #include <dune/grid/test/checkcommunicate.hh>
 #else
+// checkpartition.cc in dune-grid uses dune_static_assert but never includes
+// the header in version 2.3.1
+#include <dune/common/static_assert.hh>
 #include <dune/grid/test/checkpartition.cc>
 #include <dune/grid/test/checkcommunicate.cc>
 #endif

--- a/tests/cpgrid/partition_iterator_test.cpp
+++ b/tests/cpgrid/partition_iterator_test.cpp
@@ -17,6 +17,9 @@
 #if DUNE_VERSION_NEWER(DUNE_GRID,2,4)
 #include <dune/grid/test/checkpartition.hh>
 #else
+// checkpartition.cc in dune-grid uses dune_static_assert but never includes
+// the header in version 2.3.1
+#include <dune/common/static_assert.hh>
 #include <dune/grid/test/checkpartition.cc>
 #endif
 


### PR DESCRIPTION
In that version checkpartition.cc uses dune_static_assert but
never includes the header dune/common/static_assert.hh that defines
it. Therefore we now do this ourselves for DUNE 2.3.

I guess some previous commit must have stripped an include of header that
implicitly included static_assert.hh. Otherwise compilation would have failed.
(Or nobody using 2.3 compiled the tests.)

Unless #278 is merged this is needed on my system. Note that a merge of this requires a change in #277.