### PR TITLE
Use wells

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -214,9 +214,6 @@ namespace Dune
         : public GridDefaultImplementation<3, 3, double, CpGridFamily >
     {
 
-        // defined in OpmParserIncludes in case opm-parser is not available
-        typedef cpgrid::OpmEclipseStateType  OpmEclipseStateType;
-
     public:
 
         // --- Typedefs ---
@@ -617,11 +614,11 @@ namespace Dune
         /// \param The number of layers of cells of the overlap region (default: 1).
         /// \warning May only be called once.
         std::pair<bool, std::unordered_set<std::string> >
-        loadBalance(const OpmEclipseStateType* ecl,
+        loadBalance(const std::vector<const cpgrid::OpmWellType *> * wells,
                     const double* transmissibilities = nullptr,
                     int overlapLayers=1)
         {
-            return scatterGrid(ecl, transmissibilities, overlapLayers);
+            return scatterGrid(wells, transmissibilities, overlapLayers);
         }
 
         /// \brief Distributes this grid and data over the available nodes in a distributed machine.
@@ -640,11 +637,11 @@ namespace Dune
         template<class DataHandle>
         std::pair<bool, std::unordered_set<std::string> >
         loadBalance(DataHandle& data,
-                    const OpmEclipseStateType* ecl,
+                    const std::vector<const cpgrid::OpmWellType *> * wells,
                     const double* transmissibilities = nullptr,
                     int overlapLayers=1)
         {
-            auto ret = loadBalance(ecl, transmissibilities, overlapLayers);
+            auto ret = loadBalance(wells, transmissibilities, overlapLayers);
             scatterData(data);
             return ret;
         }
@@ -1281,7 +1278,8 @@ namespace Dune
         ///            adding an edge with a very high edge weight for all
         ///            possible pairs of cells in the completion set of a well.
         std::pair<bool, std::unordered_set<std::string> >
-        scatterGrid(const OpmEclipseStateType* ecl, const double* transmissibilities,
+        scatterGrid(const std::vector<const cpgrid::OpmWellType *> * wells,
+                    const double* transmissibilities,
                     int overlapLayers);
 
         /** @brief The data stored in the grid.

--- a/dune/grid/common/WellConnections.hpp
+++ b/dune/grid/common/WellConnections.hpp
@@ -58,22 +58,22 @@ public:
     WellConnections() = default;
 
     /// \brief Constructor
-    /// \param eclipseState The eclipse information
+    /// \param schedule The eclipse information
     /// \param cartesianSize The logical cartesian size of the grid.
     /// \param cartesian_to_compressed Mapping of cartesian index
     ///        compressed cell index. The compressed index is used
     ///        to represent the well conditions.
-    WellConnections(const OpmEclipseStateType& eclipseState,
+    WellConnections(const std::vector<const OpmWellType*>& wells,
                     const std::array<int, 3>& cartesianSize,
                     const std::vector<int>& cartesian_to_compressed);
 
     /// \brief Initialze the data of the container
-    /// \param eclipseState The eclipse information
+    /// \param schedule The eclipse information
     /// \param cartesianSize The logical cartesian size of the grid.
     /// \param cartesian_to_compressed Mapping of cartesian index
     ///        compressed cell index. The compressed index is used
     ///        to represent the well conditions.
-    void init(const OpmEclipseStateType& eclipseState,
+    void init(const std::vector<const OpmWellType*>& wells,
               const std::array<int, 3>& cartesianSize,
               const std::vector<int>& cartesian_to_compressed);
 
@@ -119,7 +119,7 @@ private:
 /// \param no_procs The number of processes.
 std::vector<std::vector<int> >
 postProcessPartitioningForWells(std::vector<int>& parts,
-                                const OpmEclipseStateType& eclipseState,
+                                const std::vector<const OpmWellType*>&  wells,
                                 const WellConnections& well_connections,
                                 std::size_t no_procs);
 
@@ -132,7 +132,7 @@ postProcessPartitioningForWells(std::vector<int>& parts,
 ///             information.
 std::unordered_set<std::string>
 computeDefunctWellNames(const std::vector<std::vector<int> >& wells_on_proc,
-                        const OpmEclipseStateType& eclipseState,
+                        const std::vector<const OpmWellType*>&  wells,
                         const CollectiveCommunication<MPI_Comm>& cc,
                         int root);
 #endif

--- a/dune/grid/common/ZoltanGraphFunctions.cpp
+++ b/dune/grid/common/ZoltanGraphFunctions.cpp
@@ -331,7 +331,7 @@ void getCpGridWellsEdgeList(void *graphPointer, int sizeGID, int sizeLID,
 }
 
 CombinedGridWellGraph::CombinedGridWellGraph(const CpGrid& grid,
-                                             const Opm::EclipseState* eclipseState,
+                                             const std::vector<const OpmWellType*> * wells,
                                              const double* transmissibilities,
                                              bool pretendEmptyGrid)
     : grid_(grid), transmissibilities_(transmissibilities)
@@ -350,7 +350,7 @@ CombinedGridWellGraph::CombinedGridWellGraph(const CpGrid& grid,
     {
         cartesian_to_compressed[grid.globalCell()[i]] = i;
     }
-    well_indices_.init(*eclipseState, cpgdim, cartesian_to_compressed);
+    well_indices_.init(*wells, cpgdim, cartesian_to_compressed);
     std::vector<int>().swap(cartesian_to_compressed); // free memory.
     addCompletionSetToGraph();
 }

--- a/dune/grid/common/ZoltanGraphFunctions.hpp
+++ b/dune/grid/common/ZoltanGraphFunctions.hpp
@@ -130,7 +130,7 @@ public:
     /// \param eclipseState The eclipse state to extract the well information from.
     /// \param pretendEmptyGrid True if we should pretend the grid and wells are empty.
     CombinedGridWellGraph(const Dune::CpGrid& grid,
-                          const Opm::EclipseState*,
+                          const std::vector<const OpmWellType*> * wells,
                           const double* transmissibilities,
                           bool pretendEmptyGrid);
 

--- a/dune/grid/common/ZoltanPartition.cpp
+++ b/dune/grid/common/ZoltanPartition.cpp
@@ -31,7 +31,7 @@ namespace cpgrid
 {
 std::pair<std::vector<int>, std::unordered_set<std::string> >
 zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
-                               const Opm::EclipseState* eclipseState,
+                               const std::vector<const OpmWellType*> * wells,
                                const double* transmissibilities,
                                const CollectiveCommunication<MPI_Comm>& cc,
                                int root)
@@ -69,11 +69,11 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
 
     std::shared_ptr<CombinedGridWellGraph> grid_and_wells;
 
-    if( eclipseState )
+    if( wells )
     {
         Zoltan_Set_Param(zz,"EDGE_WEIGHT_DIM","1");
         grid_and_wells.reset(new CombinedGridWellGraph(cpgrid,
-                                                       eclipseState,
+                                                       wells,
                                                        transmissibilities,
                                                        partitionIsEmpty));
         Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, *grid_and_wells,
@@ -108,11 +108,11 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
         parts[exportLocalGids[i]] = exportProcs[i];
     }
 
-    if( eclipseState && partitionIsWholeGrid )
+    if( wells && partitionIsWholeGrid )
     {
         wells_on_proc =
             postProcessPartitioningForWells(parts,
-                                            *eclipseState,
+                                            *wells,
                                             grid_and_wells->getWellConnections(),
                                             cc.size());
 
@@ -144,10 +144,10 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
 
     std::unordered_set<std::string> defunct_well_names;
 
-    if( eclipseState )
+    if( wells )
     {
         defunct_well_names = computeDefunctWellNames(wells_on_proc,
-                                                     *eclipseState,
+                                                     *wells,
                                                      cc,
                                                      root);
     }

--- a/dune/grid/common/ZoltanPartition.hpp
+++ b/dune/grid/common/ZoltanPartition.hpp
@@ -49,10 +49,10 @@ namespace cpgrid
 ///         simulation.
 std::pair<std::vector<int>,std::unordered_set<std::string> >
 zoltanGraphPartitionGridOnRoot(const CpGrid& grid,
-                                    const Opm::EclipseState* eclipseState,
-                                    const double* transmissibilities,
-                                    const CollectiveCommunication<MPI_Comm>& cc,
-                                    int root);
+                               const std::vector<const OpmWellType*> * wells,
+                               const double* transmissibilities,
+                               const CollectiveCommunication<MPI_Comm>& cc,
+                               int root);
 }
 }
 #endif // HAVE_ZOLTAN

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -67,11 +67,11 @@ namespace Dune
 
 
 std::pair<bool, std::unordered_set<std::string> >
-CpGrid::scatterGrid(const OpmEclipseStateType* ecl,
+CpGrid::scatterGrid(const std::vector<const cpgrid::OpmWellType *> * wells,
                     const double* transmissibilities, int overlapLayers)
 {
     // Silence any unused argument warnings that could occur with various configurations.
-    static_cast<void>(ecl);
+    static_cast<void>(wells);
     static_cast<void>(transmissibilities);
     static_cast<void>(overlapLayers);
 #if HAVE_MPI
@@ -87,7 +87,7 @@ CpGrid::scatterGrid(const OpmEclipseStateType* ecl,
     int my_num=cc.rank();
 #ifdef HAVE_ZOLTAN
     auto part_and_wells =
-        cpgrid::zoltanGraphPartitionGridOnRoot(*this, ecl, transmissibilities, cc, 0);
+        cpgrid::zoltanGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, 0);
     int num_parts = cc.size();
     using std::get;
     auto cell_part = std::get<0>(part_and_wells);
@@ -108,19 +108,19 @@ CpGrid::scatterGrid(const OpmEclipseStateType* ecl,
 
     std::unordered_set<std::string> defunct_wells;
 
-    if ( ecl )
+    if ( wells )
     {
-        cpgrid::WellConnections well_connections(*ecl,
+        cpgrid::WellConnections well_connections(*wells,
                                                  cpgdim,
                                                  cartesian_to_compressed);
 
         auto wells_on_proc =
             cpgrid::postProcessPartitioningForWells(cell_part,
-                                                    *ecl,
+                                                    *wells,
                                                     well_connections,
                                                     cc.size());
         defunct_wells = cpgrid::computeDefunctWellNames(wells_on_proc,
-                                                        *ecl,
+                                                        *wells,
                                                         cc,
                                                         0);
     }

--- a/opm/grid/utility/OpmParserIncludes.hpp
+++ b/opm/grid/utility/OpmParserIncludes.hpp
@@ -26,14 +26,12 @@
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
 
 namespace Dune {
     namespace cpgrid {
+        typedef Opm::Well OpmWellType;
         typedef Opm::EclipseState OpmEclipseStateType;
     }
 }
@@ -41,6 +39,7 @@ namespace Dune {
 
 namespace Dune {
     namespace cpgrid {
+        typedef int OpmWellType;
         typedef int OpmEclipseStateType;
     }
 }


### PR DESCRIPTION
With this PR the load-balance & scatter operations on the grid take `std::vector< const Well*>` argument instead of an `EclipseState` argument. The direct motivation is downstream of: https://github.com/OPM/opm-parser/pull/1138
