### PR TITLE
[cleanup] Removes unnecessary if clauses for unsupported DUNE versions.

### DIFF
--- a/dune/grid/common/Volumes.hpp
+++ b/dune/grid/common/Volumes.hpp
@@ -41,11 +41,7 @@
 #include <opm/grid/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/math.hh>
-#else
-#include <dune/common/misc.hh>
-#endif
 #include <dune/common/fvector.hh>
 
 #include <opm/grid/utility/platform_dependent/reenable_warnings.h>

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -21,13 +21,8 @@
 // The header below are not installed for dune-grid
 // Therefore we need to deactivate testing, if they
 // not available
-#if DUNE_VERSION_NEWER(DUNE_GRID,2,4)
 #include <dune/grid/test/checkpartition.hh>
 #include <dune/grid/test/checkcommunicate.hh>
-#else
-#include <dune/grid/test/checkpartition.cc>
-#include <dune/grid/test/checkcommunicate.cc>
-#endif
 
 #endif
 

--- a/tests/cpgrid/partition_iterator_test.cpp
+++ b/tests/cpgrid/partition_iterator_test.cpp
@@ -14,11 +14,7 @@
 
 #if HAVE_DUNE_GRID_CHECKS
 
-#if DUNE_VERSION_NEWER(DUNE_GRID,2,4)
 #include <dune/grid/test/checkpartition.hh>
-#else
-#include <dune/grid/test/checkpartition.cc>
-#endif
 
 #endif
 


### PR DESCRIPTION
We are targetting DUNE 2.4.* and 2.5.* currently. Therefore this commit removes
the if checks for lower versions to cleanup the code.