### PR TITLE
changed: make libdune-uggrid-dev an alternative for libug-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: build-essential, debhelper (>= 9), libboost-filesystem-dev,
                libdune-istl-dev, doxygen, texlive-latex-extra,
                texlive-latex-recommended, ghostscript, libecl-dev,
                libboost-iostreams-dev, libopm-parser-dev, libsuitesparse-dev,
-               libug-dev, libopm-common-dev, libopm-material-dev,
+               libopm-common-dev, libopm-material-dev,
                libdune-geometry-dev, libtrilinos-zoltan-dev, libopenmpi-dev,
                mpi-default-bin, libopm-output-dev
 Standards-Version: 3.9.2


### PR DESCRIPTION
former is used on stretch, latter is used on xenial