### PR TITLE
[feature][PolyhedralGrid] Allow to use coordinate type other than double.

### DIFF
--- a/dune/grid/polyhedralgrid/cartesianindexmapper.hh
+++ b/dune/grid/polyhedralgrid/cartesianindexmapper.hh
@@ -6,10 +6,10 @@
 
 namespace Dune
 {
-    template< int dim, int dimworld >
-    class CartesianIndexMapper< PolyhedralGrid< dim, dimworld > >
+    template< int dim, int dimworld, typename coord_t >
+    class CartesianIndexMapper< PolyhedralGrid< dim, dimworld, coord_t > >
     {
-        typedef PolyhedralGrid< dim, dimworld >  Grid;
+        typedef PolyhedralGrid< dim, dimworld, coord_t >  Grid;
 
         const Grid& grid_;
         const int cartesianSize_;

--- a/dune/grid/polyhedralgrid/declaration.hh
+++ b/dune/grid/polyhedralgrid/declaration.hh
@@ -6,7 +6,7 @@
 namespace Dune
 {
 
-  template< int dim, int dimworld >
+  template< int dim, int dimworld, typename coord_t = double >
   class PolyhedralGrid;
 
 } // namespace Dune

--- a/dune/grid/polyhedralgrid/geometry.hh
+++ b/dune/grid/polyhedralgrid/geometry.hh
@@ -42,16 +42,16 @@ namespace Dune
     typedef Dune::FieldVector< ctype, mydimension >    LocalCoordinate;
 
     //! type of jacobian inverse transposed
-    typedef FieldMatrix<ctype,cdim,mydim> JacobianInverseTransposed;
+    typedef FieldMatrix< ctype, cdim, mydim > JacobianInverseTransposed;
 
     //! type of jacobian transposed
     typedef FieldMatrix< ctype, mydim, cdim > JacobianTransposed;
 
 
 #if DUNE_VERSION_NEWER(DUNE_GRID,2,5)
-    typedef Dune::Impl::FieldMatrixHelper< double >  MatrixHelperType;
+    typedef Dune::Impl::FieldMatrixHelper< ctype >  MatrixHelperType;
 #else
-    typedef Dune::GenericGeometry::MatrixHelper< Dune::GenericGeometry::DuneCoordTraits<double> >  MatrixHelperType;
+    typedef Dune::GenericGeometry::MatrixHelper< Dune::GenericGeometry::DuneCoordTraits< ctype > >  MatrixHelperType;
 #endif
 
     typedef typename Grid::Traits::ExtraData  ExtraData;
@@ -140,13 +140,8 @@ namespace Dune
         // This code is modified from dune/grid/genericgeometry/mapping.hh
         // \todo: Implement direct computation.
         const ctype epsilon = 1e-12;
-#if DUNE_VERSION_NEWER(DUNE_GRID,2,3)
         const ReferenceElement< ctype , mydimension > & refElement =
           ReferenceElements< ctype, mydimension >::general(type());
-#else
-        const GenericReferenceElement< ctype , mydimension > & refElement =
-          GenericReferenceElements< ctype, mydimension >::general(type());
-#endif
 
         LocalCoordinate x = refElement.position(0,0);
         LocalCoordinate dx;

--- a/dune/grid/polyhedralgrid/grid.hh
+++ b/dune/grid/polyhedralgrid/grid.hh
@@ -15,11 +15,7 @@
 
 //- dune-grid includes
 #include <dune/grid/common/grid.hh>
-#if DUNE_VERSION_NEWER(DUNE_COMMON,2,3)
 #include <dune/common/parallel/collectivecommunication.hh>
-#else
-#include <dune/common/collectivecommunication.hh>
-#endif
 
 //- polyhedralgrid includes
 #include <dune/grid/polyhedralgrid/capabilities.hh>
@@ -42,19 +38,17 @@
 
 namespace Dune
 {
-
-
   // PolyhedralGridFamily
   // ------------
 
-  template< int dim, int dimworld >
+  template< int dim, int dimworld, typename coord_t >
   struct PolyhedralGridFamily
   {
     struct Traits
     {
-      typedef PolyhedralGrid< dim, dimworld > Grid;
+      typedef PolyhedralGrid< dim, dimworld, coord_t > Grid;
 
-      typedef double ctype;
+      typedef coord_t ctype;
 
       // type of data passed to entities, intersections, and iterators
       // for PolyhedralGrid this is just an empty place holder
@@ -125,10 +119,10 @@ namespace Dune
         typedef typename Partition< All_Partition >::LevelIterator LevelIterator;
       };
 
-      typedef PolyhedralGridIndexSet< dim, dimworld > LeafIndexSet;
-      typedef PolyhedralGridIndexSet< dim, dimworld > LevelIndexSet;
+      typedef PolyhedralGridIndexSet< dim, dimworld, ctype > LeafIndexSet;
+      typedef PolyhedralGridIndexSet< dim, dimworld, ctype > LevelIndexSet;
 
-      typedef PolyhedralGridIdSet< dim, dimworld > GlobalIdSet;
+      typedef PolyhedralGridIdSet< dim, dimworld, ctype > GlobalIdSet;
       typedef GlobalIdSet  LocalIdSet;
 
       typedef Dune::CollectiveCommunication< Grid > CollectiveCommunication;
@@ -136,8 +130,8 @@ namespace Dune
       template< PartitionIteratorType pitype >
       struct Partition
       {
-        typedef Dune::GridView< PolyhedralGridViewTraits< dim, dimworld, pitype > > LeafGridView;
-        typedef Dune::GridView< PolyhedralGridViewTraits< dim, dimworld, pitype > > LevelGridView;
+        typedef Dune::GridView< PolyhedralGridViewTraits< dim, dimworld, ctype, pitype > > LeafGridView;
+        typedef Dune::GridView< PolyhedralGridViewTraits< dim, dimworld, ctype, pitype > > LevelGridView;
       };
 
       typedef typename Partition<All_Partition>::LevelGridView LevelGridView;
@@ -147,9 +141,8 @@ namespace Dune
   };
 
 
-
   // PolyhedralGrid
-  // ------
+  // --------------
 
   /** \class PolyhedralGrid
    *  \brief identical grid wrapper
@@ -159,17 +152,17 @@ namespace Dune
    *
    *  \nosubgrouping
    */
-  template < int dim, int dimworld >
+  template < int dim, int dimworld, typename coord_t >
   class PolyhedralGrid
   /** \cond */
   : public GridDefaultImplementation
-      < dim, dimworld, double, PolyhedralGridFamily< dim, dimworld > >
+      < dim, dimworld, coord_t, PolyhedralGridFamily< dim, dimworld, coord_t > >
   /** \endcond */
   {
     typedef PolyhedralGrid< dim, dimworld > Grid;
 
     typedef GridDefaultImplementation
-      < dim, dimworld, double, PolyhedralGridFamily< dim, dimworld > > Base;
+      < dim, dimworld, coord_t, PolyhedralGridFamily< dim, dimworld, coord_t > > Base;
 
     typedef UnstructuredGrid  UnstructuredGridType;
 
@@ -182,7 +175,7 @@ namespace Dune
     };
   public:
     /** \cond */
-    typedef PolyhedralGridFamily< dim, dimworld > GridFamily;
+    typedef PolyhedralGridFamily< dim, dimworld, coord_t > GridFamily;
     /** \endcond */
 
     /** \name Traits
@@ -1283,9 +1276,9 @@ namespace Dune
   // PolyhedralGrid::Codim
   // -------------
 
-  template< int dim, int dimworld >
+  template< int dim, int dimworld, typename coord_t >
   template< int codim >
-  struct PolyhedralGrid< dim, dimworld >::Codim
+  struct PolyhedralGrid< dim, dimworld, coord_t >::Codim
   : public Base::template Codim< codim >
   {
     /** \name Entity and Entity Pointer Types

--- a/dune/grid/polyhedralgrid/gridview.hh
+++ b/dune/grid/polyhedralgrid/gridview.hh
@@ -10,7 +10,7 @@
 #include <dune/grid/common/capabilities.hh>
 #include <dune/grid/common/gridview.hh>
 
-//- dune-metagrid includes
+//- polyhedralgrid includes
 #include <dune/grid/polyhedralgrid/indexset.hh>
 #include <dune/grid/polyhedralgrid/intersection.hh>
 #include <dune/grid/polyhedralgrid/intersectioniterator.hh>
@@ -22,23 +22,23 @@ namespace Dune
   // Internal Forward Declarations
   // -----------------------------
 
-  template< int dim, int dimworld, PartitionIteratorType defaultpitype >
+  template< int dim, int dimworld, typename coord_t, PartitionIteratorType defaultpitype >
   class PolyhedralGridView;
 
-  template< int dim, int dimworld, PartitionIteratorType ptype >
+  template< int dim, int dimworld, typename coord_t, PartitionIteratorType ptype >
   struct PolyhedralGridViewTraits;
 
 
   // PolyhedralGridView
-  // ----------
+  // ------------------
 
-  template< int dim, int dimworld, PartitionIteratorType defaultpitype >
+  template< int dim, int dimworld, typename coord_t, PartitionIteratorType defaultpitype >
   class PolyhedralGridView
   {
-    typedef PolyhedralGridView< dim, dimworld, defaultpitype > This;
+    typedef PolyhedralGridView< dim, dimworld, coord_t, defaultpitype > This;
 
   public:
-    typedef PolyhedralGridViewTraits< dim, dimworld, defaultpitype > Traits;
+    typedef PolyhedralGridViewTraits< dim, dimworld, coord_t, defaultpitype > Traits;
 
     typedef typename Traits::Grid Grid;
     typedef typename Traits::IndexSet IndexSet;
@@ -146,16 +146,16 @@ namespace Dune
   };
 
   // PolyhedralGridViewTraits
-  // ----------------
+  // ------------------------
 
-  template< int dim, int dimworld, PartitionIteratorType ptype >
+  template< int dim, int dimworld, typename coord_t, PartitionIteratorType ptype >
   struct PolyhedralGridViewTraits
   {
-    typedef PolyhedralGrid< dim, dimworld > Grid;
+    typedef PolyhedralGrid< dim, dimworld, coord_t > Grid;
     static const PartitionIteratorType pitype = ptype;
 
-    typedef PolyhedralGridView< dim, dimworld, pitype > GridViewImp;
-    typedef PolyhedralGridIndexSet< Grid::dimension, Grid::dimensionworld > IndexSet;
+    typedef PolyhedralGridView< dim, dimworld, coord_t, pitype > GridViewImp;
+    typedef PolyhedralGridIndexSet< Grid::dimension, Grid::dimensionworld, coord_t > IndexSet;
 
     typedef PolyhedralGridIntersection< const Grid > IntersectionImpl;
     typedef PolyhedralGridIntersectionIterator< const Grid > IntersectionIteratorImpl;

--- a/dune/grid/polyhedralgrid/idset.hh
+++ b/dune/grid/polyhedralgrid/idset.hh
@@ -11,17 +11,17 @@ namespace Dune
   // PolyhedralGridIdSet
   // -----------
 
-  template< int dim, int dimworld >
+  template< int dim, int dimworld, typename coord_t >
   class PolyhedralGridIdSet
-      : public IdSet< PolyhedralGrid< dim, dimworld >, PolyhedralGridIdSet< dim, dimworld >, /*IdType=*/int >
+      : public IdSet< PolyhedralGrid< dim, dimworld, coord_t >, PolyhedralGridIdSet< dim, dimworld, coord_t >, /*IdType=*/int >
   {
   public:
-    typedef PolyhedralGrid<  dim, dimworld > Grid;
+    typedef PolyhedralGrid<  dim, dimworld, coord_t > Grid;
     typedef typename std::remove_const< Grid >::type::Traits Traits;
     typedef typename Traits::Index  IdType;
 
-    typedef PolyhedralGridIdSet< dim, dimworld > This;
-    typedef IdSet< Grid, PolyhedralGridIdSet< dim, dimworld >, IdType > Base;
+    typedef PolyhedralGridIdSet< dim, dimworld, coord_t > This;
+    typedef IdSet< Grid, This, IdType > Base;
 
     PolyhedralGridIdSet (const Grid& grid)
         : grid_(grid)
@@ -37,15 +37,6 @@ namespace Dune
       else
         return index;
     }
-
-#if ! DUNE_VERSION_NEWER(DUNE_GRID,2,4)
-    //! id meethod for entity and specific codim
-    template< int codim >
-    IdType id ( const typename Traits::template Codim< codim >::EntityPointer &entityPointer ) const
-    {
-      return id( *entityPointer );
-    }
-#endif
 
     //! id method of all entities
     template< class Entity >
@@ -68,9 +59,9 @@ namespace Dune
       if( codim == 0 )
         return id( entity );
       else if ( codim == 1 )
-        return id( entity.template subEntity< 1 >( i ) );
+        return id( Grid::getRealImplementation( entity ).template subEntity< 1 > ( i ) );
       else if ( codim == dim )
-        return id( entity.template subEntity< dim >( i ) );
+        return id( Grid::getRealImplementation( entity ).template subEntity< dim > ( i ) );
       else
       {
         DUNE_THROW(NotImplemented,"codimension not available");

--- a/dune/grid/polyhedralgrid/indexset.hh
+++ b/dune/grid/polyhedralgrid/indexset.hh
@@ -18,14 +18,14 @@ namespace Dune
   // PolyhedralGridIndexSet
   // --------------
 
-  template< int dim, int dimworld >
+  template< int dim, int dimworld, typename coord_t >
   class PolyhedralGridIndexSet
-      : public IndexSet< PolyhedralGrid< dim, dimworld >, PolyhedralGridIndexSet< dim, dimworld >, int >
+      : public IndexSet< PolyhedralGrid< dim, dimworld, coord_t >, PolyhedralGridIndexSet< dim, dimworld, coord_t >, int >
   {
-    typedef PolyhedralGrid<dim, dimworld> GridType;
+    typedef PolyhedralGrid<dim, dimworld, coord_t > GridType;
 
   protected:
-    typedef PolyhedralGridIndexSet< dim, dimworld > This;
+    typedef PolyhedralGridIndexSet< dim, dimworld, coord_t > This;
       typedef IndexSet< GridType, This, int > Base;
 
     typedef typename std::remove_const< GridType >::type::Traits Traits;
@@ -51,14 +51,6 @@ namespace Dune
     {
       return grid().getRealImplementation(entity).index();
     }
-
-#if ! DUNE_VERSION_NEWER(DUNE_GRID,2,4)
-    template< int cd >
-    IndexType index ( const typename Traits::template Codim< cd >::EntityPointer &entityPointer ) const
-    {
-      return index( *entityPointer );
-    }
-#endif
 
     template< class Entity >
     IndexType subIndex ( const Entity &entity, int i, unsigned int codim ) const


### PR DESCRIPTION
This PR adds a template parameter to PolyhedralGrid allowing to set the coordinate type. The default is as before double.