### PR TITLE
Quell warnings when building with dune 2.6

### DIFF
--- a/dune/grid/cpgrid/Entity.hpp
+++ b/dune/grid/cpgrid/Entity.hpp
@@ -36,6 +36,7 @@
 #ifndef OPM_ENTITY_HEADER
 #define OPM_ENTITY_HEADER
 
+#include <dune/common/version.hh>
 #include <dune/geometry/type.hh>
 #include <dune/grid/common/gridenums.hh>
 
@@ -174,9 +175,13 @@ namespace Dune
             /// Using the cube type for all entities now (cells and vertices).
             GeometryType type() const
             {
+#if DUNE_VERSION_NEWER(DUNE_GEOMETRY, 2, 6)
+                return Dune::GeometryTypes::cube(3 - codim);
+#else
                 GeometryType t;
                 t.makeCube(3 - codim);
                 return t;
+#endif
             }
 
             /// The count of subentities of codimension cc

--- a/dune/grid/cpgrid/Geometry.hpp
+++ b/dune/grid/cpgrid/Geometry.hpp
@@ -190,8 +190,12 @@ namespace Dune
                 // This code is modified from dune/grid/genericgeometry/mapping.hh
                 // \todo: Implement direct computation.
                 const ctype epsilon = 1e-12;
+#if DUNE_VERSION_NEWER(DUNE_GEOMETRY, 2, 6)
+                auto refElement = Dune::ReferenceElements<ctype, 3>::cube();
+#else
                 const ReferenceElement< ctype , 3 > & refElement =
                     ReferenceElements< ctype, 3 >::general(type());
+#endif
                 LocalCoordinate x = refElement.position(0,0);
                 LocalCoordinate dx;
                 do {

--- a/dune/grid/cpgrid/Geometry.hpp
+++ b/dune/grid/cpgrid/Geometry.hpp
@@ -219,9 +219,13 @@ namespace Dune
             /// but we use the singular type for intersections.
             GeometryType type() const
             {
+#if DUNE_VERSION_NEWER(DUNE_GEOMETRY, 2, 6)
+                return Dune::GeometryTypes::cube(mydimension);
+#else
                 GeometryType t;
                 t.makeCube(mydimension);
                 return t;
+#endif
             }
 
             /// The number of corners of this convex polytope.
@@ -383,9 +387,13 @@ namespace Dune
             /// We use the singular type (None) for intersections.
             GeometryType type() const
             {
+#if DUNE_VERSION_NEWER(DUNE_GEOMETRY, 2, 6)
+                return Dune::GeometryTypes::none(mydimension);
+#else
                 GeometryType t;
                 t.makeNone(mydimension);
                 return t;
+#endif
             }
 
             /// The number of corners of this convex polytope.
@@ -510,9 +518,13 @@ namespace Dune
             /// Using the cube type for vertices.
             GeometryType type() const
             {
+#if DUNE_VERSION_NEWER(DUNE_GEOMETRY, 2, 6)
+                return Dune::GeometryTypes::cube(mydimension);
+#else
                 GeometryType t;
                 t.makeCube(mydimension);
                 return t;
+#endif
             }
 
             /// A vertex is defined by a single corner.

--- a/dune/grid/cpgrid/Indexsets.hpp
+++ b/dune/grid/cpgrid/Indexsets.hpp
@@ -66,11 +66,16 @@ namespace Dune
             IndexSet(const CpGridData& grid)
                 : grid_(grid)
             {
+#if DUNE_VERSION_NEWER(DUNE_GEOMETRY, 2, 6)
+                geom_types_[0].emplace_back(Dune::GeometryTypes::cube(3));
+                geom_types_[3].emplace_back(Dune::GeometryTypes::cube(0));
+#else
                 GeometryType t;
                 t.makeCube(3);
                 geom_types_[0].push_back(t);
                 t.makeCube(0);
                 geom_types_[3].push_back(t);
+#endif
             }
 
             /// \brief Destructor.

--- a/dune/grid/polyhedralgrid/grid.hh
+++ b/dune/grid/polyhedralgrid/grid.hh
@@ -3,6 +3,7 @@
 #ifndef DUNE_POLYHEDRALGRID_GRID_HH
 #define DUNE_POLYHEDRALGRID_GRID_HH
 
+#include <array>
 #include <set>
 #include <vector>
 
@@ -11,7 +12,6 @@
 
 //- dune-common includes
 #include <dune/common/version.hh>
-#include <dune/common/array.hh>
 
 //- dune-grid includes
 #include <dune/grid/common/grid.hh>
@@ -1109,7 +1109,7 @@ namespace Dune
       // sort vertices such that they comply with the dune cube reference element
       if( grid_.cell_facetag )
       {
-        typedef Dune::array<int, 3> KeyType;
+        typedef std::array<int, 3> KeyType;
         std::map< const KeyType, const int > vertexFaceTags;
         const int vertexFacePattern [8][3] = {
                                 { 0, 2, 4 }, // vertex 0

--- a/examples/finitevolume/finitevolume.cc
+++ b/examples/finitevolume/finitevolume.cc
@@ -35,6 +35,7 @@ typedef Dune::CpGrid GridType;
 // the time loop function working for all types of grids
 //===============================================================
 
+#if ! DUNE_VERSION_NEWER(DUNE_GEOMETRY, 2, 6)
 //! Parameter for mapper class
 template<int dim>
 struct P0Layout
@@ -44,13 +45,18 @@ struct P0Layout
         return gt.dim() == dim;
     }
 };
+#endif
 
 template<class G>
 void timeloop(const G& grid, double tend)
 {
     // make a mapper for codim 0 entities in the leaf grid
+#if DUNE_VERSION_NEWER(DUNE_GEOMETRY, 2, 6)
+    Dune::LeafMultipleCodimMultipleGeomTypeMapper<G> mapper(grid, Dune::mcmgElementLayout());
+#else
     Dune::LeafMultipleCodimMultipleGeomTypeMapper<G,P0Layout>
     mapper(grid);
+#endif
 
     // allocate a vector for the concentration
     std::vector<double> c(mapper.size());

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -264,9 +264,13 @@ BOOST_AUTO_TEST_CASE(distribute)
         typedef GridView :: Codim<0> :: Iterator LeafIterator ;
         for (LeafIterator it = gridView.begin<0>();
              it != gridView.end<0>(); ++it) {
+#if DUNE_VERSION_NEWER(DUNE_GEOMETRY, 2, 6)
+            auto ref = Dune::ReferenceElements<Dune::CpGrid::ctype,3>::cube();
+#else
             Dune::GeometryType gt = it->type () ;
             const Dune::ReferenceElement<Dune::CpGrid::ctype, 3>& ref=
                 Dune::ReferenceElements<Dune::CpGrid::ctype, 3>::general(gt);
+#endif
 
             cell_indices.push_back(ix.index(*it));
             cell_centers.push_back(it->geometry().center());
@@ -318,9 +322,13 @@ BOOST_AUTO_TEST_CASE(distribute)
 
         for (Dune::CpGrid::Codim<0>::LeafIterator it = grid.leafbegin<0>();
              it != grid.leafend<0>(); ++it) {
+#if DUNE_VERSION_NEWER(DUNE_GEOMETRY, 2, 6)
+            auto ref = Dune::ReferenceElements<Dune::CpGrid::ctype,3>::cube();
+#else
             Dune::GeometryType gt = it->type () ;
             const Dune::ReferenceElement<Dune::CpGrid::ctype, 3>& ref=
                 Dune::ReferenceElements<Dune::CpGrid::ctype, 3>::general(gt);
+#endif
 
             BOOST_REQUIRE(cell_indices[cell_index]==ix1.index(*it));
             BOOST_REQUIRE(cell_centers[cell_index++]==it->geometry().center());


### PR DESCRIPTION
This suppresses warnings when building with dune 2.6.

The last commit is a build fix (only triggered from simulators); it can possibly be made unconditional, i wasn't immediately sure about the dune 2.4 status.