### PR TITLE
adding functions to access and recover the current view of CpGrid

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -1238,6 +1238,18 @@ namespace Dune
         {
             current_view_data_=distributed_data_.get();
         }
+
+        /// \brief return the curent view
+        cpgrid::CpGridData* const currentView() const
+        {
+            return current_view_data_;
+        }
+
+        /// \brief set the the view
+        void setView(cpgrid::CpGridData* const view)
+        {
+            current_view_data_ = view;
+        }
         //@}
 
 #if HAVE_MPI


### PR DESCRIPTION
currentView() and setView()

The motivation please see OPM/ewoms#283.  I do see this expose `current_view_data_` to outside. Please let me know if it is something welcome. If not, I will be satisfied in the current implementation in OPM/ewoms#283. 