### PR TITLE
Construct VariableSizeCommunicator with a sufficient buffer for sending at once

### DIFF
--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -580,8 +580,8 @@ void CpGridData::communicateCodim(DataHandle& data, CommunicationDirection dir,
     {
         OPM_THROW(std::logic_error,
                   "You triggered a bug in the communication of DUNE"
-                   << " as yu tried to send more than " << MAX_DATA_PER_CELL
-                   << " values per cell/point. PLease define MAX_DATA_COMMUNICATED_PER_ENTITY"
+                   << " as you tried to send more than " << MAX_DATA_PER_CELL
+                   << " values per cell/point. Please define MAX_DATA_COMMUNICATED_PER_ENTITY"
                    << " to a high enough value when compiling.");
     }
 #endif

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -516,7 +516,7 @@ void CpGridData::communicateCodim(DataHandle& data, CommunicationDirection dir,
         return;
     }
     Entity2IndexDataHandle<DataHandle, codim> data_wrapper(*this, data);
-    std::size_t max_entries = 0;
+    std::size_t max_interface_entries = 0;
     // Work around a bug/deadlock in DUNE <=2.5.1 which happens if the
     // buffer cannot hold all data that needs to be send.
     // https://gitlab.dune-project.org/core/dune-common/merge_requests/416
@@ -526,11 +526,11 @@ void CpGridData::communicateCodim(DataHandle& data, CommunicationDirection dir,
     for (const auto& pair: interface )
     {
         using std::max;
-        max_entries = max(max_entries, pair.second.first.size());
-        max_entries = max(max_entries, pair.second.second.size());
+        max_interface_entries = max(max_interface_entries, pair.second.first.size());
+        max_interface_entries = max(max_interface_entries, pair.second.second.size());
     }
     VariableSizeCommunicator<> comm(ccobj_, interface,
-                                    max_entries * MAX_DATA_PER_CELL);
+                                    max_interface_entries * MAX_DATA_PER_CELL);
 #endif
 
     if(dir==ForwardCommunication)

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -111,6 +111,21 @@ private:
     CpGridData(const CpGridData& g);
 
 public:
+    enum{
+#ifndef MAX_DATA_COMMUNICATED_PER_ENTITY
+        /// \brief The maximum data items allowed per cell (DUNE < 2.5.2)
+        ///
+        /// Due to a bug in DUNE < 2.5.2 we need to limit this when
+        /// communicating. 16 should be big enough for OPM
+        MAX_DATA_PER_CELL = 16
+#else
+        /// \brief The maximum data items allowed per cell (DUNE < 2.5.2)
+        ///
+        /// Due to a bug in DUNE < 2.5.2 we need to limit this when
+        /// communicating. Uses the define MAX_DATA_COMMUNICATED_PER_ENTITY.
+        MAX_DATA_PER_CELL = MAX_DATA_COMMUNICATED_PER_ENTITY
+#endif
+    };
     /// Constructor
     /// \param grid  The grid that we are the data of.
     explicit CpGridData(CpGrid& grid);
@@ -515,7 +530,9 @@ void CpGridData::communicateCodim(DataHandle& data, CommunicationDirection dir,
         max_entries = max(max_entries, pair.second.second.size());
     }
     VariableSizeCommunicator<> comm(ccobj_, interface,
-                                    max_entries*16); // 16 should be big enough.
+                                    max_entries * MAX_DATA_PER_CELL);
+#endif
+
     if(dir==ForwardCommunication)
         comm.forward(data_wrapper);
     else


### PR DESCRIPTION
Otherwise the message will be chopped into several sends and for DUNE version
less than 2.5.2 the code will deadlock because of a bug. We assume that we will
never send more than 16 values per cell and use it to calculate an upper bound
for the message size. This is send passed to the constructor of
VariableSizeCommunicator to ensure that the message is never chopped into
multiple ones.

Fixes #316. 

The number 16 is up for debate. 4 should probably suffice too (for polymer) or can there be more?

Please test.