### PR TITLE
Stop wasting space when working around VariableSizeCommunicator bug.

### DIFF
--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -116,8 +116,9 @@ public:
         /// \brief The maximum data items allowed per cell (DUNE < 2.5.2)
         ///
         /// Due to a bug in DUNE < 2.5.2 we need to limit this when
-        /// communicating. 16 should be big enough for OPM
-        MAX_DATA_PER_CELL = 16
+        /// communicating. 1 is big enough for OPM as we always use
+        /// one block for all unknowns.
+        MAX_DATA_PER_CELL = 1
 #else
         /// \brief The maximum data items allowed per cell (DUNE < 2.5.2)
         ///


### PR DESCRIPTION
In OPM we always use one vector block with all unknowns and send this. Ergo we only send 1 datum and not more (previous threshold was 16). The only place where we send more is during grid distribution. But for that case we already compute the correct buffer size and this change has no effect.

This is a follow up to #318. Tested with SPE 10 Model 2. #316 is still fixed with this.