### PR TITLE
Use 2 for MAX_DATA_PER_CELL to run grid checks.

### DIFF
--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -117,8 +117,9 @@ public:
         ///
         /// Due to a bug in DUNE < 2.5.2 we need to limit this when
         /// communicating. 1 is big enough for OPM as we always use
-        /// one block for all unknowns.
-        MAX_DATA_PER_CELL = 1
+        /// one block for all unknowns, but some DUNE's grid checks
+        /// actually need 2. So 2 it is.
+        MAX_DATA_PER_CELL = 2
 #else
         /// \brief The maximum data items allowed per cell (DUNE < 2.5.2)
         ///


### PR DESCRIPTION
While one is enough for OPM these checks need at least 2. Otherwise our tests, compiled with with -DDEBUG, will throw an exception when run.