### PR TITLE
Restore build of 'distribution_test' for non-MPI configurations

### DIFF
--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -501,9 +501,13 @@ init_unit_test_func()
 int main(int argc, char** argv)
 {
     Dune::MPIHelper::instance(argc, argv);
+
+#if defined(HAVE_MPI) && HAVE_MPI
     MPI_Errhandler errhandler;
     MPI_Comm_create_errhandler(MPI_err_handler, &errhandler);
     MPI_Comm_set_errhandler(MPI_COMM_WORLD, errhandler);
+#endif // HAVE_MPI
+
     boost::unit_test::unit_test_main(&init_unit_test_func,
                                      argc, argv);
 }


### PR DESCRIPTION
See @akva2's [commen](https://github.com/OPM/opm-grid/pull/332#pullrequestreview-131543620) in PR #332.