### PR TITLE
Add missing HAVE_MPI to ditribution_test.

### DIFF
--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -501,9 +501,11 @@ init_unit_test_func()
 int main(int argc, char** argv)
 {
     Dune::MPIHelper::instance(argc, argv);
+#if HAVE_MPI
     MPI_Errhandler errhandler;
     MPI_Comm_create_errhandler(MPI_err_handler, &errhandler);
     MPI_Comm_set_errhandler(MPI_COMM_WORLD, errhandler);
+#endif
     boost::unit_test::unit_test_main(&init_unit_test_func,
                                      argc, argv);
 }


### PR DESCRIPTION
Otherwise this cannot compile without MPI support.

This bug was introduced by #332. Sorry for the inconvenience.