### PR TITLE
Prevent unused variable warning for Dune > 2.5.2

### DIFF
--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -518,7 +518,6 @@ void CpGridData::communicateCodim(DataHandle& data, CommunicationDirection dir,
         return;
     }
     Entity2IndexDataHandle<DataHandle, codim> data_wrapper(*this, data);
-    std::size_t max_interface_entries = 0;
 
 #if DUNE_VERSION_NEWER_REV(DUNE_GRID, 2, 5, 2)
     VariableSizeCommunicator<> comm(ccobj_, interface);
@@ -529,6 +528,7 @@ void CpGridData::communicateCodim(DataHandle& data, CommunicationDirection dir,
     // For this we calculate an upper barrier of the number of
     // data items to be send manually and use it to construct a
     // VariableSizeCommunicator with sufficient buffer.
+    std::size_t max_interface_entries = 0;
 #ifndef NDEBUG
     std::size_t max_items = 0;
 #endif


### PR DESCRIPTION
In that case there is no need to calculate the maximum entries
of an interface. Therefore we move the declaration of variable
max_interface_entries into the compile time if branch where it
is actually used.