### PR TITLE
[WIP] Reoder cells by ijk for better linear solver convergence.

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -253,7 +253,8 @@ namespace Dune
         /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
         /// \param poreVolume pore volumes for use in MINPV processing, if asked for in deck
         void processEclipseFormat(const Opm::EclipseGrid& ecl_grid, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
-                                  const std::vector<double>& poreVolume = std::vector<double>());
+                                  const std::vector<double>& poreVolume = std::vector<double>(),
+                                  bool reorder_k_fastest = false);
 #endif
 
         /// Read the Eclipse grid format ('grdecl').
@@ -261,7 +262,8 @@ namespace Dune
         /// \param z_tolerance points along a pillar that are closer together in z
         ///        coordinate than this parameter, will be replaced by a single point.
         /// \param remove_ij_boundary if true, will remove (i, j) boundaries. Used internally.
-        void processEclipseFormat(const grdecl& input_data, double z_tolerance, bool remove_ij_boundary, bool turn_normals = false);
+        void processEclipseFormat(const grdecl& input_data, double z_tolerance, bool remove_ij_boundary, bool turn_normals = false,
+                                  bool reorder_k_fastest = false);
 
         //@}
 
@@ -323,6 +325,16 @@ namespace Dune
         void setUniqueBoundaryIds(bool uids)
         {
             current_view_data_->setUniqueBoundaryIds(uids);
+        }
+
+        /// \brief Get the lookup needed for eclipse output.
+        ///
+        /// This vector is empty if no reordering is needed
+        /// (i is the fastest index for the current ordering,
+        /// then j and then k).
+        const std::vector<int>& eclipseOuputIndexLookup()
+        {
+            return current_view_data_->output_reordering_index_;
         }
 
         // --- Dune interface below ---

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -332,7 +332,7 @@ namespace Dune
         /// This vector is empty if no reordering is needed
         /// (i is the fastest index for the current ordering,
         /// then j and then k).
-        const std::vector<int>& eclipseOuputIndexLookup()
+        const std::vector<int>& eclipseOuputIndexLookup() const
         {
             return current_view_data_->output_reordering_index_;
         }

--- a/opm/grid/cornerpoint_grid.c
+++ b/opm/grid/cornerpoint_grid.c
@@ -173,7 +173,7 @@ create_grid_cornerpoint(const struct grdecl *in, double tol)
        return NULL;
    }
 
-   process_grdecl(in, tol, &pg);
+   process_grdecl(in, tol, &pg, false);
 
    /*
     *  Convert "struct processed_grid" to "struct UnstructuredGrid".

--- a/opm/grid/cpgpreprocess/preprocess.c
+++ b/opm/grid/cpgpreprocess/preprocess.c
@@ -892,11 +892,16 @@ void process_grdecl(const struct grdecl   *in,
     */
     global_cell_index = malloc(nc * sizeof *global_cell_index);
     cellnum = 0;
-    for (i = 0; i < nc; ++i) {
-        if (out->local_cell_index[i] != -1) {
-            global_cell_index[cellnum] = (int) i;
-            out->local_cell_index[i]   = cellnum;
-            cellnum++;
+    for (int i = 0; i < nx; ++i) {
+        for(int j = 0; j < ny; ++j) {
+            for(int k = 0; k < nz; ++k) {
+                int idx = linearindex(in->dims, i,j,k);
+                if (out->local_cell_index[idx] != -1) {
+                    global_cell_index[cellnum] = (int) idx;
+                    out->local_cell_index[idx]   = cellnum;
+                    cellnum++;
+                }
+            }
         }
     }
 

--- a/opm/grid/cpgpreprocess/preprocess.h
+++ b/opm/grid/cpgpreprocess/preprocess.h
@@ -104,6 +104,12 @@ extern "C" {
         int    number_of_cells;   /**< Number of active grid cells. */
         int    *local_cell_index; /**< Deceptively named local-to-global cell
                                        index mapping. */
+        int    *output_reordering_index; /**< In the case that i is not the
+                                              fastest running index this is
+                                              for reordering when doing output
+                                              that needs i running fastest, then j
+                                              and finally k. NULL if no
+                                              reordering is needed. */
     };
 
 
@@ -128,7 +134,8 @@ extern "C" {
      */
     void process_grdecl(const struct grdecl   *g  ,
                         double                 tol,
-                        struct processed_grid *out);
+                        struct processed_grid *out,
+                        int                   reorder_k_fastest);
 
     /**
      * Release memory resources acquired in previous grid processing using

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -265,18 +265,23 @@ CpGrid::scatterGrid(const std::vector<const cpgrid::OpmWellType *> * wells,
     void CpGrid::processEclipseFormat(const Opm::EclipseGrid& ecl_grid,
                                       bool periodic_extension,
                                       bool turn_normals, bool clip_z,
-                                      const std::vector<double>& poreVolume)
+                                      const std::vector<double>& poreVolume,
+                                      bool reorder_k_fastest)
     {
         current_view_data_->processEclipseFormat(ecl_grid, periodic_extension,
                                                  turn_normals, clip_z,
-                                                 poreVolume);
+                                                 poreVolume,
+                                                 reorder_k_fastest);
     }
 #endif
 
     void CpGrid::processEclipseFormat(const grdecl& input_data, double z_tolerance,
-                                      bool remove_ij_boundary, bool turn_normals)
+                                      bool remove_ij_boundary, bool turn_normals,
+                                      bool reorder_k_fastest)
     {
-        current_view_data_->processEclipseFormat(input_data, z_tolerance, remove_ij_boundary, turn_normals);
+        current_view_data_->processEclipseFormat(input_data, z_tolerance,
+                                                 remove_ij_boundary, turn_normals,
+                                                 reorder_k_fastest);
     }
 
 } // namespace Dune

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -180,7 +180,8 @@ public:
     /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
     /// \param poreVolume pore volumes for use in MINPV processing, if asked for in deck
     void processEclipseFormat(const Opm::Deck& deck, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
-                              const std::vector<double>& poreVolume = std::vector<double>());
+                              const std::vector<double>& poreVolume = std::vector<double>(),
+                              bool reorder_k_fastest=false);
 
     /// Read the Eclipse grid format ('grdecl').
     /// \param ecl_grid the high-level object from opm-parser which represents the simulation's grid
@@ -191,7 +192,8 @@ public:
     /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
     /// \param poreVolume pore volumes for use in MINPV processing, if asked for in deck
     void processEclipseFormat(const Opm::EclipseGrid& ecl_grid, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
-                              const std::vector<double>& poreVolume = std::vector<double>());
+                              const std::vector<double>& poreVolume = std::vector<double>(),
+                              bool reorder_k_fastest=false);
 #endif
 
     /// Read the Eclipse grid format ('grdecl').
@@ -199,7 +201,9 @@ public:
     /// \param z_tolerance points along a pillar that are closer together in z
     ///        coordinate than this parameter, will be replaced by a single point.
     /// \param remove_ij_boundary if true, will remove (i, j) boundaries. Used internally.
-    void processEclipseFormat(const grdecl& input_data, double z_tolerance, bool remove_ij_boundary, bool turn_normals = false);
+    void processEclipseFormat(const grdecl& input_data, double z_tolerance,
+                              bool remove_ij_boundary, bool turn_normals = false,
+                              bool reorder_k_fastest=false);
 
 
     /// @brief
@@ -413,6 +417,12 @@ private:
     /// the zcorn values will typically be modified, and we retain a
     /// copy here to be able to create an EclipseGrid for output.
     std::vector<double> zcorn;
+
+    /// This index is for looking up the correct cell indices during
+    /// eclipse output in the case that i is not the fastest running
+    /// index in ijk for our cell ordering. If size is 0 then no
+    /// reordering is needed.
+    std::vector<int> output_reordering_index_;
 
 #ifdef HAVE_DUNE_ISTL
     typedef Dune::OwnerOverlapCopyAttributeSet::AttributeSet AttributeSet;


### PR DESCRIPTION
As a result cells along a column have subsequent local cell indices. Supposably this is better for the convergence of the linear solvers. Indeed we see a 20% decrease in computation time for Norne using the
default solver. For model 2 the decrease is only 5%.

Please note that might want to consider letting users choose the ordering. That is still not possible with this PR.