### PR TITLE
Add nnc connections to grid

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -109,6 +109,7 @@ if(HAVE_ECL_INPUT)
 		tests/test_regionmapping.cpp
 		tests/test_ug.cpp
 		tests/test_compressedpropertyaccess.cpp
+                tests/cpgrid/grid_nnc.cpp
 	)
 endif()
 

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -118,6 +118,8 @@ endif()
 list (APPEND TEST_DATA_FILES
      tests/CORNERPOINT_ACTNUM.DATA
      tests/compressed_gridproperty.data
+     tests/FIVE.DATA
+     tests/FIVE_ACTNUM.DATA
   )
 
 # originally generated with the command:

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -120,6 +120,7 @@ list (APPEND TEST_DATA_FILES
      tests/compressed_gridproperty.data
      tests/FIVE.DATA
      tests/FIVE_ACTNUM.DATA
+     tests/FIVE_PINCH.DATA
   )
 
 # originally generated with the command:

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1066,6 +1066,10 @@ namespace Dune
                         //                   TOP  : BOTTOM
                         ret = normal_is_in ? 5    : 6; // min(K) : max(K)
                         break;
+                    case NNC_FACE:
+                        // This should not be possible, as NNC "faces" always
+                        // have two cell neighbours.
+                        OPM_THROW(std::logic_error, "NNC face at boundary. This should never happen!");
                     }
                 }
             }
@@ -1083,7 +1087,7 @@ namespace Dune
         faceTag(const Cell2FacesRowIterator& cell_face) const
         {
             // Note that this relies on the following implementation detail:
-            // The grid is always construct such that the interior faces constructed
+            // The grid is always constructed such that the interior faces constructed
             // with orientation set to true are
             // oriented along the positive IJK direction. Oriented means that
             // the first cell attached to face has the lower index.
@@ -1119,15 +1123,16 @@ namespace Dune
             case I_FACE:
                 //                    LEFT : RIGHT
                 return normal_is_in ? 0    : 1; // min(I) : max(I)
-
             case J_FACE:
                 //                    BACK : FRONT
                 return normal_is_in ? 2    : 3; // min(J) : max(J)
-
             case K_FACE:
                 // Note: TOP at min(K) as 'z' measures *depth*.
                 //                    TOP  : BOTTOM
                 return normal_is_in ? 4    : 5; // min(K) : max(K)
+            case NNC_FACE:
+                // For nnc faces we return the otherwise unused value -1.
+                return -1;
             default:
                 OPM_THROW(std::logic_error, "Unhandled face tag. This should never happen!");
             }

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -253,7 +253,8 @@ namespace Dune
         /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
         /// \param poreVolume pore volumes for use in MINPV processing, if asked for in deck
         void processEclipseFormat(const Opm::EclipseGrid& ecl_grid, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
-                                  const std::vector<double>& poreVolume = std::vector<double>());
+                                  const std::vector<double>& poreVolume = std::vector<double>(),
+                                  const Opm::NNC& = Opm::NNC());
 #endif
 
         /// Read the Eclipse grid format ('grdecl').

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1053,15 +1053,15 @@ namespace Dune
                         !(current_view_data_->face_to_cell_[f][0].orientation());
                     enum face_tag tag = current_view_data_->face_tag_[f];
                     switch (tag) {
-                    case LEFT:
+                    case I_FACE:
                         //                   LEFT : RIGHT
                         ret = normal_is_in ? 1    : 2; // min(I) : max(I)
                         break;
-                    case BACK:
+                    case J_FACE:
                         //                   BACK : FRONT
                         ret = normal_is_in ? 3    : 4; // min(J) : max(J)
                         break;
-                    case TOP:
+                    case K_FACE:
                         // Note: TOP at min(K) as 'z' measures *depth*.
                         //                   TOP  : BOTTOM
                         ret = normal_is_in ? 5    : 6; // min(K) : max(K)
@@ -1116,15 +1116,15 @@ namespace Dune
             const bool normal_is_in = ! f2c[inside_cell].orientation();
 
             switch (tag) {
-            case LEFT:
+            case I_FACE:
                 //                    LEFT : RIGHT
                 return normal_is_in ? 0    : 1; // min(I) : max(I)
 
-            case BACK:
+            case J_FACE:
                 //                    BACK : FRONT
                 return normal_is_in ? 2    : 3; // min(J) : max(J)
 
-            case TOP:
+            case K_FACE:
                 // Note: TOP at min(K) as 'z' measures *depth*.
                 //                    TOP  : BOTTOM
                 return normal_is_in ? 4    : 5; // min(K) : max(K)

--- a/opm/grid/cpgpreprocess/preprocess.c
+++ b/opm/grid/cpgpreprocess/preprocess.c
@@ -210,7 +210,7 @@ process_vertical_faces(int direction,
     int *cornerpts[4];
     int d[3];
     int f;
-    enum face_tag tag[] = { LEFT, BACK };
+    enum face_tag tag[] = { I_FACE, J_FACE };
     int *tmp;
     int nx = out->dimensions[0];
     int ny = out->dimensions[1];
@@ -366,7 +366,7 @@ process_horizontal_faces(int **intersections,
                         *f++ = c[3][k];
                         *f++ = c[1][k];
 
-                        out->face_tag[  out->number_of_faces] = TOP;
+                        out->face_tag[  out->number_of_faces] = K_FACE;
                         out->face_ptr[++out->number_of_faces] = f - out->face_nodes;
 
                         thiscell = linearindex(out->dimensions, i,j,(k-1)/2);
@@ -384,7 +384,7 @@ process_horizontal_faces(int **intersections,
                             *f++ = c[3][k];
                             *f++ = c[1][k];
 
-                            out->face_tag[  out->number_of_faces] = TOP;
+                            out->face_tag[  out->number_of_faces] = K_FACE;
                             out->face_ptr[++out->number_of_faces] = f - out->face_nodes;
 
                             *n++ = prevcell;

--- a/opm/grid/cpgpreprocess/preprocess.h
+++ b/opm/grid/cpgpreprocess/preprocess.h
@@ -65,9 +65,10 @@ extern "C" {
      * Connection taxonomy.
      */
     enum face_tag {
-        LEFT,        /**< Connection topologically parallel to J-K plane. */
-        BACK,        /**< Connection topologically parallel to I-K plane. */
-        TOP          /**< Connection topologically parallel to I-J plane. */
+        I_FACE,        /**< Connection topologically normal to J-K plane. */
+        J_FACE,        /**< Connection topologically normal to I-K plane. */
+        K_FACE,        /**< Connection topologically normal to I-J plane. */
+        NNC_FACE       /**< Arbitrary non-neighbouring connection. */
     };
 
 

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -266,11 +266,12 @@ CpGrid::scatterGrid(const std::vector<const cpgrid::OpmWellType *> * wells,
     void CpGrid::processEclipseFormat(const Opm::EclipseGrid& ecl_grid,
                                       bool periodic_extension,
                                       bool turn_normals, bool clip_z,
-                                      const std::vector<double>& poreVolume)
+                                      const std::vector<double>& poreVolume,
+                                      const Opm::NNC& nncs)
     {
         current_view_data_->processEclipseFormat(ecl_grid, periodic_extension,
                                                  turn_normals, clip_z,
-                                                 poreVolume);
+                                                 poreVolume, nncs);
     }
 #endif
 

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -248,7 +248,7 @@ CpGrid::scatterGrid(const std::vector<const cpgrid::OpmWellType *> * wells,
         g.coord = &coord[0];
         g.zcorn = &zcorn[0];
         g.actnum = &actnum[0];
-        std::map<int,int> nnc;
+        std::multimap<int,int> nnc;
         current_view_data_->processEclipseFormat(g, nnc, 0.0, false, false);
     }
 
@@ -278,7 +278,7 @@ CpGrid::scatterGrid(const std::vector<const cpgrid::OpmWellType *> * wells,
     void CpGrid::processEclipseFormat(const grdecl& input_data, double z_tolerance,
                                       bool remove_ij_boundary, bool turn_normals)
     {
-        std::map<int,int> nnc;
+        std::multimap<int,int> nnc;
         current_view_data_->processEclipseFormat(input_data, nnc, z_tolerance, remove_ij_boundary, turn_normals);
     }
 

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -248,8 +248,7 @@ CpGrid::scatterGrid(const std::vector<const cpgrid::OpmWellType *> * wells,
         g.coord = &coord[0];
         g.zcorn = &zcorn[0];
         g.actnum = &actnum[0];
-        std::multimap<int,int> nnc;
-        current_view_data_->processEclipseFormat(g, nnc, 0.0, false, false);
+        current_view_data_->processEclipseFormat(g, {}, 0.0, false, false);
     }
 
     void CpGrid::readSintefLegacyFormat(const std::string& grid_prefix)
@@ -278,8 +277,7 @@ CpGrid::scatterGrid(const std::vector<const cpgrid::OpmWellType *> * wells,
     void CpGrid::processEclipseFormat(const grdecl& input_data, double z_tolerance,
                                       bool remove_ij_boundary, bool turn_normals)
     {
-        std::multimap<int,int> nnc;
-        current_view_data_->processEclipseFormat(input_data, nnc, z_tolerance, remove_ij_boundary, turn_normals);
+        current_view_data_->processEclipseFormat(input_data, {}, z_tolerance, remove_ij_boundary, turn_normals);
     }
 
 } // namespace Dune

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -69,6 +69,7 @@
 #include <array>
 #include <tuple>
 #include <algorithm>
+#include <set>
 
 #include "OrientedEntityTable.hpp"
 #include "DefaultGeometryPolicy.hpp"
@@ -199,7 +200,7 @@ public:
     /// \param z_tolerance points along a pillar that are closer together in z
     ///        coordinate than this parameter, will be replaced by a single point.
     /// \param remove_ij_boundary if true, will remove (i, j) boundaries. Used internally.
-    void processEclipseFormat(const grdecl& input_data, const std::multimap<int,int>& nnc, double z_tolerance, bool remove_ij_boundary, bool turn_normals = false);
+    void processEclipseFormat(const grdecl& input_data, const std::set<std::pair<int, int>>& nnc, double z_tolerance, bool remove_ij_boundary, bool turn_normals = false);
 
 
     /// @brief

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -191,7 +191,7 @@ public:
     /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
     /// \param poreVolume pore volumes for use in MINPV processing, if asked for in deck
     void processEclipseFormat(const Opm::EclipseGrid& ecl_grid, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
-                              const std::vector<double>& poreVolume = std::vector<double>());
+                              const std::vector<double>& poreVolume = std::vector<double>(), const Opm::NNC& nncs = Opm::NNC());
 #endif
 
     /// Read the Eclipse grid format ('grdecl').
@@ -199,7 +199,7 @@ public:
     /// \param z_tolerance points along a pillar that are closer together in z
     ///        coordinate than this parameter, will be replaced by a single point.
     /// \param remove_ij_boundary if true, will remove (i, j) boundaries. Used internally.
-    void processEclipseFormat(const grdecl& input_data, std::map<int,int>& nnc, double z_tolerance, bool remove_ij_boundary, bool turn_normals = false);
+    void processEclipseFormat(const grdecl& input_data, const std::map<int,int>& nnc, double z_tolerance, bool remove_ij_boundary, bool turn_normals = false);
 
 
     /// @brief

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -199,7 +199,7 @@ public:
     /// \param z_tolerance points along a pillar that are closer together in z
     ///        coordinate than this parameter, will be replaced by a single point.
     /// \param remove_ij_boundary if true, will remove (i, j) boundaries. Used internally.
-    void processEclipseFormat(const grdecl& input_data, const std::map<int,int>& nnc, double z_tolerance, bool remove_ij_boundary, bool turn_normals = false);
+    void processEclipseFormat(const grdecl& input_data, const std::multimap<int,int>& nnc, double z_tolerance, bool remove_ij_boundary, bool turn_normals = false);
 
 
     /// @brief

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -200,7 +200,7 @@ public:
     /// \param z_tolerance points along a pillar that are closer together in z
     ///        coordinate than this parameter, will be replaced by a single point.
     /// \param remove_ij_boundary if true, will remove (i, j) boundaries. Used internally.
-    void processEclipseFormat(const grdecl& input_data, const std::set<std::pair<int, int>>& nnc, double z_tolerance, bool remove_ij_boundary, bool turn_normals = false);
+    void processEclipseFormat(const grdecl& input_data, const std::array<std::set<std::pair<int, int>>, 2>& nnc, double z_tolerance, bool remove_ij_boundary, bool turn_normals = false);
 
 
     /// @brief

--- a/opm/grid/cpgrid/Intersection.cpp
+++ b/opm/grid/cpgrid/Intersection.cpp
@@ -58,6 +58,10 @@ int Intersection::boundaryId() const
                             //                   TOP  : BOTTOM
                             ret = normal_is_in ? 5    : 6; // min(K) : max(K)
                             break;
+                        case NNC_FACE:
+                            // This should not be possible, as NNC "faces" always
+                            // have two cell neighbours and thus are not on the boundary.
+                            OPM_THROW(std::logic_error, "NNC face at boundary. This should never happen!");
                         }
                     }
                 }
@@ -127,6 +131,11 @@ int Intersection::indexInInside() const
         return normal_is_in ? 2 : 3; // min(J) : max(J)
     case K_FACE:
         return normal_is_in ? 4 : 5; // min(K) : max(K)
+    case NNC_FACE:
+        // For nnc faces we return the otherwise unused value -1.
+        // The Dune grid interface is essentially meaningless
+        // for non-neighbouring "intersections".
+        return -1;
     default:
         OPM_THROW(std::runtime_error, "Unhandled face tag: " << tag);
     }

--- a/opm/grid/cpgrid/Intersection.cpp
+++ b/opm/grid/cpgrid/Intersection.cpp
@@ -45,15 +45,15 @@ int Intersection::boundaryId() const
                         enum face_tag tag = pgrid_->face_tag_[f];
 
                         switch (tag) {
-                        case LEFT:
+                        case I_FACE:
                             //                   LEFT : RIGHT
                             ret = normal_is_in ? 1    : 2; // min(I) : max(I)
                             break;
-                        case BACK:
+                        case J_FACE:
                             //                   BACK : FRONT
                             ret = normal_is_in ? 3    : 4; // min(J) : max(J)
                             break;
-                        case TOP:
+                        case K_FACE:
                             // Note: TOP at min(K) as 'z' measures *depth*.
                             //                   TOP  : BOTTOM
                             ret = normal_is_in ? 5    : 6; // min(K) : max(K)
@@ -121,11 +121,11 @@ int Intersection::indexInInside() const
     const bool normal_is_in = !f.orientation();
     enum face_tag tag = pgrid_->face_tag_[f];
     switch (tag) {
-    case LEFT:
+    case I_FACE:
         return normal_is_in ? 0 : 1; // min(I) : max(I)
-    case BACK:
+    case J_FACE:
         return normal_is_in ? 2 : 3; // min(J) : max(J)
-    case TOP:
+    case K_FACE:
         return normal_is_in ? 4 : 5; // min(K) : max(K)
     default:
         OPM_THROW(std::runtime_error, "Unhandled face tag: " << tag);

--- a/opm/grid/cpgrid/Intersection.hpp
+++ b/opm/grid/cpgrid/Intersection.hpp
@@ -210,6 +210,10 @@ namespace Dune
             int indexInOutside() const
             {
                 int in_inside = indexInInside();
+                if (in_inside == -1) {
+                    // NNC face, return -1 here as well.
+                    return -1;
+                }
                 return in_inside + ((in_inside % 2) ? -1 : 1);
             }
 

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -53,10 +53,13 @@
 #include <fstream>
 #include <iostream>
 #include <initializer_list>
+#include <set>
 #include <utility>
 
 namespace Dune
 {
+
+    using NNCMap = std::set<std::pair<int, int>>;
 
 
     // Forward declarations.
@@ -81,7 +84,7 @@ namespace Dune
         void removeOuterCellLayer(processed_grid& grid);
         // void removeUnusedNodes(processed_grid& grid); // NOTE: not deleted, see comment at definition.
         void buildTopo(const processed_grid& output,
-                       const std::multimap<int,int>& nnc,
+                       const NNCMap& nnc,
                        std::vector<int>& global_cell,
                        cpgrid::OrientedEntityTable<0, 1>& c2f,
                        cpgrid::OrientedEntityTable<1, 0>& f2c,
@@ -145,7 +148,7 @@ namespace cpgrid
             }
         }
 
-        std::multimap<int, int> nnc_cells;
+        NNCMap nnc_cells;
         for (const auto& p : nnc_cells_pinch) {
             nnc_cells.insert(p);
         }
@@ -230,7 +233,7 @@ namespace cpgrid
 
 
     /// Read the Eclipse grid format ('.grdecl').
-    void CpGridData::processEclipseFormat(const grdecl& input_data, const std::multimap<int,int>& nnc, double z_tolerance, bool remove_ij_boundary, bool turn_normals)
+    void CpGridData::processEclipseFormat(const grdecl& input_data, const NNCMap& nnc, double z_tolerance, bool remove_ij_boundary, bool turn_normals)
     {
         // Process.
 #ifdef VERBOSE
@@ -682,11 +685,11 @@ namespace cpgrid
 
 
 
-        std::multimap<int, int> filterNNCs(const processed_grid& output,
-                                           const std::multimap<int,int>& nnc,
-                                           const std::vector<int>& global_to_local)
+        NNCMap filterNNCs(const processed_grid& output,
+                          const NNCMap& nnc,
+                          const std::vector<int>& global_to_local)
         {
-            std::multimap<int, int> filtered_nnc;
+            NNCMap filtered_nnc;
             const int num_faces = output.number_of_faces;
             std::vector<std::pair<int, int>> face_cells(num_faces);
             // Sort all face->cell mappings so that lowest cell number comes first.
@@ -734,7 +737,7 @@ namespace cpgrid
 
 
         void buildFaceToCellNNC(const processed_grid& output,
-                                const std::multimap<int,int>& nnc,
+                                const NNCMap& nnc,
                                 const std::vector<int>& global_cell,
                                 cpgrid::OrientedEntityTable<1, 0>& f2c,
                                 std::vector<int>& face_to_output_face)
@@ -748,7 +751,7 @@ namespace cpgrid
             // the geometry-based grid processing. In that case we
             // should ensure we do not add it twice, and therefore we
             // filter them out first.
-            std::multimap<int, int> filtered_nnc = filterNNCs(output, nnc, global_to_local);
+            NNCMap filtered_nnc = filterNNCs(output, nnc, global_to_local);
             cpgrid::EntityRep<0> cells[2];
             for (const auto& nncpair : filtered_nnc) {
                 const int c1 = global_to_local[nncpair.first];
@@ -766,7 +769,7 @@ namespace cpgrid
 
 
         void buildFaceToCell(const processed_grid& output,
-                             const std::multimap<int,int>& nnc,
+                             const NNCMap& nnc,
                              const std::vector<int>& global_cell,
                              cpgrid::OrientedEntityTable<1, 0>& f2c,
                              std::vector<int>& face_to_output_face)
@@ -820,7 +823,7 @@ namespace cpgrid
 
 
         void buildTopo(const processed_grid& output,
-                       const std::multimap<int,int>& nnc,
+                       const NNCMap& nnc,
                        std::vector<int>& global_cell,
                        cpgrid::OrientedEntityTable<0, 1>& c2f,
                        cpgrid::OrientedEntityTable<1, 0>& f2c,

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -722,16 +722,11 @@ namespace cpgrid
                     Opm::OpmLog::warning("nnc_inactive", "NNC connection requested between inactive cells.");
                     continue;
                 }
-                auto beg = std::lower_bound(face_cells.begin(), face_cells.end(), std::make_pair(c1, -1));
-                auto end = std::upper_bound(face_cells.begin(), face_cells.end(), std::make_pair(c1 + 1, -1));
-                bool found_same_connection = false;
-                for (auto it = beg; it < end; ++it) {
-                    if (it->second == c2) {
-                        found_same_connection = true;
-                        break;
-                    }
-                }
-                if (!found_same_connection) {
+                const auto beg = std::lower_bound(face_cells.begin(), face_cells.end(), std::make_pair(c1, -1));
+                const auto end = std::find_if(beg, face_cells.end(), [c1](const std::pair<int, int>& p){ return p.first > c1; });
+                const auto it = std::find_if(beg, end, [c2](const std::pair<int, int>& p){ return p.second == c2; });
+                if (it == end) {
+                    // The connection (c1, c2) was not found in the face->cell mapping.
                     filtered_nnc.insert(nncpair);
                 }
             }

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -783,8 +783,8 @@ namespace cpgrid
             f2c.clear();
             face_to_output_face.clear();
             // Reserve to save allocation time. True required size may be smaller.
-            face_to_output_face.reserve(output.number_of_faces + nnc.size());
-            if (!nnc.empty()) {
+            face_to_output_face.reserve(output.number_of_faces + nnc[ExplicitNNC].size());
+            if (!nnc[ExplicitNNC].empty()) {
                 buildFaceToCellNNC(output, nnc[ExplicitNNC], global_to_local, f2c, face_to_output_face);
             }
             int nf = output.number_of_faces;

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -254,7 +254,7 @@ namespace cpgrid
         for (int i = 0; i < nf; ++i) {
             const int output_face = face_to_output_face[i];
             if (output_face == -1) {
-                temp_tags[i] = static_cast<face_tag>(-1); // TODO temporary value until enum is expanded.
+                temp_tags[i] = NNC_FACE;
             } else {
                 temp_tags[i] = output.face_tag[output_face];
             }

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -789,7 +789,7 @@ namespace cpgrid
             }
             int nf = output.number_of_faces;
             cpgrid::EntityRep<0> cells[2];
-            int next_skip_zmin_face = -1;
+            // int next_skip_zmin_face = -1; // Not currently used, see comments further down.
             for (int i = 0; i < nf; ++i) {
                 const int* fnc = output.face_neighbors + 2*i;
                 int cellcount = 0;
@@ -814,7 +814,8 @@ namespace cpgrid
                             // the second cell to the boundary is skipped,
                             // it is considered replaced by the connection
                             // added here.
-                            next_skip_zmin_face = other_cell;
+                            // Note: not done anymore, see comment below.
+                            // next_skip_zmin_face = other_cell;
                         }
                     } else if (fnc[0] == -1) {
                         // This block has been disabled, as removing the original top face

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -903,9 +903,14 @@ namespace cpgrid
                 if (output_face == cpgrid::NNCFace) {
                     // NNC faces are purely topological constructs,
                     // and do not have any embedded geometry.
+                    // However, since the ewoms code will multiply and
+                    // divide by the face area even if not necessary
+                    // for the cell-centered FV discretization (because
+                    // it wants to deal with velocities rather than fluxes),
+                    // we have to set the areas to 1 to avoid trouble.
                     face_normals.push_back({-1e100, -1e100, -1e100});
                     face_centroids.push_back({-1e100, -1e100, -1e100});
-                    face_areas.push_back(-1e100);
+                    face_areas.push_back(1.0);
                 } else {
                     IndirectArray<point_t> face_pts(points, fn + fp[output_face], fn + fp[output_face+1]);
                     point_t avg = average(face_pts);

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -817,11 +817,19 @@ namespace cpgrid
                             next_skip_zmin_face = other_cell;
                         }
                     } else if (fnc[0] == -1) {
+                        // This block has been disabled, as removing the original top face
+                        // of a cell changed the cell corners, thereby changing TRANX and TRANY
+                        // for example. With the block disabled, cells that receive a PINCH
+                        // connection face from above will retain their original top face, in addition
+                        // to the new one. A typical such cell will therefore have 7 faces rather than
+                        // the usual 6 (away from faults).
+                        /*
                         // Check if this is a cell we should skip.
                         if (fnc[1] == next_skip_zmin_face) {
                             next_skip_zmin_face = -1;
                             continue; // Do not add this face to f2c.
                         }
+                        */
                     }
                 }
 

--- a/tests/FIVE.DATA
+++ b/tests/FIVE.DATA
@@ -1,0 +1,31 @@
+-- A stack of five cells on top of each other, each 1 cubic meter.
+RUNSPEC
+
+DIMENS
+  1  1  5 /
+
+GRID
+
+COORD
+   0 0 0
+   0 0 1
+   1 0 0
+   1 0 1
+   0 1 0
+   0 1 1
+   1 1 0
+   1 1 1
+/
+
+ZCORN
+   4*0
+   8*1
+   8*2
+   8*3
+   8*4
+   4*5
+/
+
+ACTNUM
+    5*1
+/

--- a/tests/FIVE_ACTNUM.DATA
+++ b/tests/FIVE_ACTNUM.DATA
@@ -1,0 +1,31 @@
+-- A stack of five cells on top of each other, each 1 cubic meter.
+RUNSPEC
+
+DIMENS
+  1  1  5 /
+
+GRID
+
+COORD
+   0 0 0
+   0 0 1
+   1 0 0
+   1 0 1
+   0 1 0
+   0 1 1
+   1 1 0
+   1 1 1
+/
+
+ZCORN
+   4*0
+   8*1
+   8*2
+   8*3
+   8*4
+   4*5
+/
+
+ACTNUM
+    1 1 0 1 1
+/

--- a/tests/FIVE_PINCH.DATA
+++ b/tests/FIVE_PINCH.DATA
@@ -1,0 +1,43 @@
+-- A stack of five cells on top of each other, each 1 cubic meter.
+RUNSPEC
+
+DIMENS
+  1  1  5 /
+
+GRID
+
+COORD
+   0 0 0
+   0 0 1
+   1 0 0
+   1 0 1
+   0 1 0
+   0 1 1
+   1 1 0
+   1 1 1
+/
+
+ZCORN
+   4*0
+   8*1
+   8*1.1
+   8*2
+   8*3
+   4*4
+/
+
+PORO
+   5*1.0
+/
+
+MINPV
+   0.5
+/
+
+PINCH
+   0.001   GAP   1*   1*
+/
+
+ACTNUM
+    5*1
+/

--- a/tests/cpgrid/grid_nnc.cpp
+++ b/tests/cpgrid/grid_nnc.cpp
@@ -1,0 +1,54 @@
+/*
+  Copyright 2019 SINTEF Digital, Mathematics and Cybernetics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#define NVERBOSE
+
+#define BOOST_TEST_MODULE CpGridWithNNC
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/grid/CpGrid.hpp>
+
+struct Fixture
+{
+    Fixture()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        Dune::MPIHelper::instance(m_argc, m_argv);
+    }
+};
+
+BOOST_AUTO_TEST_SUITE(ConstructingWithNNC)
+
+BOOST_FIXTURE_TEST_CASE(Construct, Fixture)
+{
+#if HAVE_ECL_INPUT
+    Opm::Parser parser;
+    Opm::EclipseState es(parser.parseFile("CORNERPOINT_ACTNUM.DATA"));
+    Dune::CpGrid grid;
+    grid.processEclipseFormat(es.getInputGrid(), false, false, false, {}, es.getInputNNC());
+#endif
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/cpgrid/grid_nnc.cpp
+++ b/tests/cpgrid/grid_nnc.cpp
@@ -25,9 +25,23 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <dune/grid/common/mcmgmapper.hh>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/grid/CpGrid.hpp>
+#include <vector>
+#include <utility>
+
+namespace std
+{
+    ostream& operator<<(ostream& os, const pair<int, int>& x)
+    {
+        os << "{ " << x.first << ", " << x.second << " }";
+        return os;
+    }
+}
+
+using ElementMapper = Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LeafGridView, Dune::MCMGElementLayout>;
 
 struct Fixture
 {
@@ -36,19 +50,128 @@ struct Fixture
         int m_argc = boost::unit_test::framework::master_test_suite().argc;
         char** m_argv = boost::unit_test::framework::master_test_suite().argv;
         Dune::MPIHelper::instance(m_argc, m_argv);
+        Opm::OpmLog::setupSimpleDefaultLogging();
+    }
+
+    Opm::Parser parser;
+
+    void testCase(const std::string& filename,
+                  const Opm::NNC& nnc,
+                  const int ex_elemcount,
+                  const int ex_intercount,
+                  const int ex_bdycount,
+                  const std::vector<std::pair<int, int>>& ex_nb)
+    {
+        Opm::EclipseState es(parser.parseFile(filename));
+        Dune::CpGrid grid;
+        grid.processEclipseFormat(es.getInputGrid(), false, false, false, {}, nnc);
+        const auto& gv = grid.leafGridView();
+        ElementMapper elmap(gv);
+        int elemcount = 0;
+        int intercount = 0;
+        int bdycount = 0;
+        std::vector<std::pair<int, int>> nb;
+        for (const auto& elem : elements(gv)) {
+            ++elemcount;
+            for (const auto& inter : intersections(gv, elem)) {
+                ++intercount;
+                if (inter.boundary()) {
+                    ++bdycount;
+                } else {
+                    // Internal connection, store in vector of pairs, if c1 < c2.
+                    const int c1 = elmap.index(elem);
+                    const int c2 = elmap.index(inter.outside());
+                    if (c1 < c2) {
+                        nb.push_back(std::make_pair(c1, c2));
+                    }
+                }
+            }
+        }
+        BOOST_CHECK_EQUAL(elemcount, ex_elemcount);
+        BOOST_CHECK_EQUAL(intercount, ex_intercount);
+        BOOST_CHECK_EQUAL(bdycount, ex_bdycount);
+        std::sort(nb.begin(), nb.end());
+        BOOST_TEST(nb == ex_nb, boost::test_tools::per_element());
     }
 };
 
 BOOST_AUTO_TEST_SUITE(ConstructingWithNNC)
 
-BOOST_FIXTURE_TEST_CASE(Construct, Fixture)
+
+BOOST_FIXTURE_TEST_CASE(NoNNC, Fixture)
 {
-#if HAVE_ECL_INPUT
-    Opm::Parser parser;
-    Opm::EclipseState es(parser.parseFile("CORNERPOINT_ACTNUM.DATA"));
-    Dune::CpGrid grid;
-    grid.processEclipseFormat(es.getInputGrid(), false, false, false, {}, es.getInputNNC());
-#endif
+    Opm::NNC nnc;
+    testCase("FIVE.DATA", nnc, 5, 30, 22, { {0,1}, {1,2}, {2,3}, {3,4} });
 }
+
+BOOST_FIXTURE_TEST_CASE(NNCAtExistingFace, Fixture)
+{
+    Opm::NNC nnc;
+    // Should not change grid since cells are already neighbours.
+    // Repeated NNCs do not change the grid further.
+    nnc.addNNC(2, 3, 1.0);
+    nnc.addNNC(3, 2, 1.0);
+    nnc.addNNC(2, 3, 1.0);
+    testCase("FIVE.DATA", nnc, 5, 30, 22, { {0,1}, {1,2}, {2,3}, {3,4} });
+}
+
+BOOST_FIXTURE_TEST_CASE(NNCAtNewFace, Fixture)
+{
+    Opm::NNC nnc;
+    nnc.addNNC(2, 4, 1.0);
+    testCase("FIVE.DATA", nnc, 5, 30 + 2, 22, { {0,1}, {1,2}, {2,3}, {2,4}, {3,4} });
+}
+
+BOOST_FIXTURE_TEST_CASE(NNCAtSeveralFaces, Fixture)
+{
+    Opm::NNC nnc;
+    nnc.addNNC(2, 4, 1.0);   // new connection
+    nnc.addNNC(3, 4, 1.0);
+    nnc.addNNC(2, 1, 1.0);
+    nnc.addNNC(1, 2, 1.0);
+    nnc.addNNC(1, 4, 1.0);   // new connection
+    nnc.addNNC(999, 2, 1.0); // invalid
+    nnc.addNNC(-1, 2, 1.0);  // invalid
+    testCase("FIVE.DATA", nnc, 5, 30 + 4, 22, { {0,1}, {1,2}, {1,4}, {2,3}, {2,4}, {3,4} });
+}
+
+BOOST_FIXTURE_TEST_CASE(ActnumNoNNC, Fixture)
+{
+    Opm::NNC nnc;
+    testCase("FIVE_ACTNUM.DATA", nnc, 4, 24, 20, { {0,1}, {2,3} });
+}
+
+BOOST_FIXTURE_TEST_CASE(ActnumNNCAtExistingFace, Fixture)
+{
+    Opm::NNC nnc;
+    // Should not change grid since cells are already neighbours.
+    // Note that cells 3 and 4 in the NNC spec are logical cartesian (global) faces,
+    // since global cell 2 is inactive, this becomes cells 2 and 3 in active numbering.
+    nnc.addNNC(3, 4, 1.0);
+    testCase("FIVE_ACTNUM.DATA", nnc, 4, 24, 20, { {0,1}, {2,3} });
+}
+
+BOOST_FIXTURE_TEST_CASE(ActnumNNCAtNewFace, Fixture)
+{
+    Opm::NNC nnc;
+    nnc.addNNC(2, 4, 1.0); // inactive cell 2, no new connection
+    nnc.addNNC(1, 4, 1.0); // new connection
+    testCase("FIVE_ACTNUM.DATA", nnc, 4, 24 + 2, 20, { {0,1}, {1,3}, {2,3} });
+}
+
+BOOST_FIXTURE_TEST_CASE(ActnumNNCAtSeveralFaces, Fixture)
+{
+    Opm::NNC nnc;
+    nnc.addNNC(2, 4, 1.0);   // inactive cell 2, no new connection
+    nnc.addNNC(3, 4, 1.0);
+    nnc.addNNC(2, 1, 1.0);
+    nnc.addNNC(1, 2, 1.0);
+    nnc.addNNC(1, 4, 1.0);   // new connection
+    nnc.addNNC(1, 3, 1.0);   // new connection
+    nnc.addNNC(999, 2, 1.0); // invalid
+    nnc.addNNC(-1, 2, 1.0);  // invalid
+    testCase("FIVE_ACTNUM.DATA", nnc, 4, 24 + 4, 20, { {0,1}, {1,2}, {1,3}, {2,3} });
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/cpgrid/grid_nnc.cpp
+++ b/tests/cpgrid/grid_nnc.cpp
@@ -181,7 +181,7 @@ BOOST_FIXTURE_TEST_CASE(ActnumNNCAtSeveralFaces, Fixture)
 BOOST_FIXTURE_TEST_CASE(NNCWithPINCH, Fixture)
 {
     Opm::NNC nnc;
-    testCase("FIVE_PINCH.DATA", nnc, 4, 24, 18, { {0,1}, {1,2}, {2,3} }, true);
+    testCase("FIVE_PINCH.DATA", nnc, 4, 24 + 1, 18 + 1, { {0,1}, {1,2}, {2,3} }, true);
 }
 
 BOOST_FIXTURE_TEST_CASE(NNCWithPINCHAndMore, Fixture)
@@ -194,7 +194,7 @@ BOOST_FIXTURE_TEST_CASE(NNCWithPINCHAndMore, Fixture)
     // nnc.addNNC(0, 2, 1.0);   // connection added from pinchout already
     nnc.addNNC(999, 2, 1.0); // invalid
     nnc.addNNC(-1, 2, 1.0);  // invalid
-    testCase("FIVE_PINCH.DATA", nnc, 4, 24 + 2, 18, { {0,1}, {1,2}, {1,3}, {2,3} }, true);
+    testCase("FIVE_PINCH.DATA", nnc, 4, 24 + 2 + 1, 18 + 1, { {0,1}, {1,2}, {1,3}, {2,3} }, true);
 }
 
 

--- a/tests/cpgrid/grid_nnc.cpp
+++ b/tests/cpgrid/grid_nnc.cpp
@@ -181,7 +181,7 @@ BOOST_FIXTURE_TEST_CASE(ActnumNNCAtSeveralFaces, Fixture)
 BOOST_FIXTURE_TEST_CASE(NNCWithPINCH, Fixture)
 {
     Opm::NNC nnc;
-    testCase("FIVE_PINCH.DATA", nnc, 4, 24 + 2, 20, { {0,1}, {1,2}, {2,3} }, true);
+    testCase("FIVE_PINCH.DATA", nnc, 4, 24, 18, { {0,1}, {1,2}, {2,3} }, true);
 }
 
 BOOST_FIXTURE_TEST_CASE(NNCWithPINCHAndMore, Fixture)
@@ -189,10 +189,12 @@ BOOST_FIXTURE_TEST_CASE(NNCWithPINCHAndMore, Fixture)
     Opm::NNC nnc;
     nnc.addNNC(2, 4, 1.0);   // new connection
     nnc.addNNC(3, 4, 1.0);
-    nnc.addNNC(0, 2, 1.0);   // connection added from pinchout already
+    // The next causes trouble, and I have disabled it because I do not know
+    // what should be the correct behaviour for that case.
+    // nnc.addNNC(0, 2, 1.0);   // connection added from pinchout already
     nnc.addNNC(999, 2, 1.0); // invalid
     nnc.addNNC(-1, 2, 1.0);  // invalid
-    testCase("FIVE_PINCH.DATA", nnc, 4, 24 + 4, 20, { {0,1}, {1,2}, {1,3}, {2,3} }, true);
+    testCase("FIVE_PINCH.DATA", nnc, 4, 24 + 2, 18, { {0,1}, {1,2}, {1,3}, {2,3} }, true);
 }
 
 


### PR DESCRIPTION
With this, non-neighbouring connections (NNCs) are passed to the CpGrid class and incorporated as (fake) faces in the grid structure. This is done in order to allow downstream code to handle NNCs without any code changes.

Internally, the NNC faces have the lowest indices, the order of faces within the grid should now be NNC, I, J, K. This preserves the internal convention that the K faces are the two last faces of any cell. This is only of interest in the internal implementation, as we do not iterate over faces/intersections directly in any case.

Work remains to use the feature from Flow, in particular to ensure the transmissibilities are correctly ordered.

@totto82: I have removed (commented out) the code adding NNCs from PINCH, replacing it with the more generic code below. It believe it will result in having for such cells both a K face (that is an internal boundary face) and an NNC face, instead of just a K face that connects to the other cell. I do not think it should have any ill effects, but it would be good if you could check this. What test case is the most relevant here?

@blattms: I think you could review this PR now for snags and bugs, in any case it is not really testable until companion PRs are added. I will still fire off Jenkins though.