### PR TITLE
fix build of nnc test with dune 2.4

### DIFF
--- a/tests/cpgrid/grid_nnc.cpp
+++ b/tests/cpgrid/grid_nnc.cpp
@@ -25,6 +25,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <dune/common/version.hh>
 #include <dune/grid/common/mcmgmapper.hh>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
@@ -76,9 +77,23 @@ struct Fixture
         int intercount = 0;
         int bdycount = 0;
         std::vector<std::pair<int, int>> nb;
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 5)
         for (const auto& elem : elements(gv)) {
+#else
+        auto elemIt = gv.template begin<0>();
+        auto elemEnd = gv.template end<0>();
+        for (; elemIt != elemEnd; ++elemIt ) {
+            auto& elem = *elemIt;
+#endif
             ++elemcount;
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 5)
             for (const auto& inter : intersections(gv, elem)) {
+#else
+            auto interIt = gv.ibegin(elem);
+            auto interEnd = gv.iend(elem);
+            for (; interIt != interEnd; ++interIt) {
+                auto& inter = *interIt;
+#endif
                 ++intercount;
                 if (inter.boundary()) {
                     ++bdycount;


### PR DESCRIPTION
The new handy iterators are not available in dune 2.4.