### PR TITLE
throw when a process has zero cells

### DIFF
--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -149,8 +149,14 @@ CpGrid::scatterGrid(const std::vector<const cpgrid::OpmWellType *> * wells,
         distributed_data_.reset(new cpgrid::CpGridData(new_comm));
         distributed_data_->distributeGlobalGrid(*this,*this->current_view_data_, cell_part,
                                                 overlapLayers);
-        std::cout << "After loadbalancing process " << my_num << " has " <<
-            distributed_data_->cell_to_face_.size() << " cells." << std::endl;
+        int num_cells = distributed_data_->cell_to_face_.size();
+        std::ostringstream message;
+        message << "After loadbalancing process " << my_num << " has " << num_cells << " cells.";
+        if (num_cells == 0) {
+            throw std::runtime_error(message.str() + " Aborting.");
+        } else {
+            std::cout << message.str() << "\n";
+        }
 
         // add an interface for gathering/scattering data with communication
         // forward direction will be scatter and backward gather


### PR DESCRIPTION
Exit the simulation, if load balancing results in a process with zero cells.
depends on a branch with the same name in ewoms
fixes https://github.com/OPM/opm-simulators/issues/1726