### PR TITLE
WIP: Changed to use Well2 class from opm-common

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -615,7 +615,7 @@ namespace Dune
         /// \param The number of layers of cells of the overlap region (default: 1).
         /// \warning May only be called once.
         std::pair<bool, std::unordered_set<std::string> >
-        loadBalance(const std::vector<const cpgrid::OpmWellType *> * wells,
+        loadBalance(const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities = nullptr,
                     int overlapLayers=1)
         {
@@ -638,7 +638,7 @@ namespace Dune
         template<class DataHandle>
         std::pair<bool, std::unordered_set<std::string> >
         loadBalance(DataHandle& data,
-                    const std::vector<const cpgrid::OpmWellType *> * wells,
+                    const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities = nullptr,
                     int overlapLayers=1)
         {
@@ -1284,7 +1284,7 @@ namespace Dune
         ///            adding an edge with a very high edge weight for all
         ///            possible pairs of cells in the completion set of a well.
         std::pair<bool, std::unordered_set<std::string> >
-        scatterGrid(const std::vector<const cpgrid::OpmWellType *> * wells,
+        scatterGrid(const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities,
                     int overlapLayers);
 

--- a/opm/grid/common/WellConnections.cpp
+++ b/opm/grid/common/WellConnections.cpp
@@ -31,14 +31,14 @@ namespace Dune
 {
 namespace cpgrid
 {
-WellConnections::WellConnections(const std::vector<const OpmWellType*>& wells,
+WellConnections::WellConnections(const std::vector<OpmWellType>& wells,
                                  const std::array<int, 3>& cartesianSize,
                                  const std::vector<int>& cartesian_to_compressed)
 {
     init(wells, cartesianSize, cartesian_to_compressed);
 }
 
-void WellConnections::init(const std::vector<const OpmWellType*>& wells,
+void WellConnections::init(const std::vector<OpmWellType>& wells,
                            const std::array<int, 3>& cartesianSize,
                            const std::vector<int>& cartesian_to_compressed)
 {
@@ -49,7 +49,7 @@ void WellConnections::init(const std::vector<const OpmWellType*>& wells,
     int index=0;
     for (const auto well : wells) {
         std::set<int>& well_indices = well_indices_[index];
-        const auto& connectionSet = well->getConnections( );
+        const auto& connectionSet = well.getConnections( );
         for (size_t c=0; c<connectionSet.size(); c++) {
             const auto& connection = connectionSet.get(c);
             int i = connection.getI();
@@ -69,7 +69,7 @@ void WellConnections::init(const std::vector<const OpmWellType*>& wells,
 
 std::vector<std::vector<int> >
 postProcessPartitioningForWells(std::vector<int>& parts,
-                                const std::vector<const OpmWellType*>& wells,
+                                const std::vector<OpmWellType>& wells,
                                 const WellConnections& well_connections,
                                 std::size_t no_procs)
 {
@@ -94,7 +94,7 @@ postProcessPartitioningForWells(std::vector<int>& parts,
     // process that already has the most connections on it.
     int well_index = 0;
 
-    for (const auto* well: wells) {
+    for (const auto& well: wells) {
         const auto& connections = well_connections[well_index];
         std::map<int,std::size_t> no_connections_on_proc;
         for ( auto connection_index: connections )
@@ -113,7 +113,7 @@ postProcessPartitioningForWells(std::vector<int>& parts,
                                                 const std::pair<int,std::size_t>& p2){
                                                  return ( p1.second > p2.second );
                                              })->first;
-            std::cout << "Manually moving well " << well->name() << " to partition "
+            std::cout << "Manually moving well " << well.name() << " to partition "
                       << new_owner << std::endl;
 
             for ( auto connection_cell : connections )
@@ -136,7 +136,7 @@ postProcessPartitioningForWells(std::vector<int>& parts,
 #ifdef HAVE_MPI
 std::unordered_set<std::string>
 computeDefunctWellNames(const std::vector<std::vector<int> >& wells_on_proc,
-                        const std::vector<const OpmWellType*>& wells,
+                        const std::vector<OpmWellType>& wells,
                         const CollectiveCommunication<MPI_Comm>& cc,
                         int root)
 {
@@ -187,7 +187,7 @@ computeDefunctWellNames(const std::vector<std::vector<int> >& wells_on_proc,
     {
         if ( *defunct )
         {
-            defunct_well_names.insert(wells[defunct-defunct_wells.begin()]->name());
+            defunct_well_names.insert(wells[defunct-defunct_wells.begin()].name());
         }
     }
 #endif

--- a/opm/grid/common/WellConnections.hpp
+++ b/opm/grid/common/WellConnections.hpp
@@ -63,7 +63,7 @@ public:
     /// \param cartesian_to_compressed Mapping of cartesian index
     ///        compressed cell index. The compressed index is used
     ///        to represent the well conditions.
-    WellConnections(const std::vector<const OpmWellType*>& wells,
+    WellConnections(const std::vector<OpmWellType>& wells,
                     const std::array<int, 3>& cartesianSize,
                     const std::vector<int>& cartesian_to_compressed);
 
@@ -73,7 +73,7 @@ public:
     /// \param cartesian_to_compressed Mapping of cartesian index
     ///        compressed cell index. The compressed index is used
     ///        to represent the well conditions.
-    void init(const std::vector<const OpmWellType*>& wells,
+    void init(const std::vector<OpmWellType>& wells,
               const std::array<int, 3>& cartesianSize,
               const std::vector<int>& cartesian_to_compressed);
 
@@ -119,7 +119,7 @@ private:
 /// \param no_procs The number of processes.
 std::vector<std::vector<int> >
 postProcessPartitioningForWells(std::vector<int>& parts,
-                                const std::vector<const OpmWellType*>&  wells,
+                                const std::vector<OpmWellType>&  wells,
                                 const WellConnections& well_connections,
                                 std::size_t no_procs);
 
@@ -132,7 +132,7 @@ postProcessPartitioningForWells(std::vector<int>& parts,
 ///             information.
 std::unordered_set<std::string>
 computeDefunctWellNames(const std::vector<std::vector<int> >& wells_on_proc,
-                        const std::vector<const OpmWellType*>&  wells,
+                        const std::vector<OpmWellType>&  wells,
                         const CollectiveCommunication<MPI_Comm>& cc,
                         int root);
 #endif

--- a/opm/grid/common/ZoltanGraphFunctions.cpp
+++ b/opm/grid/common/ZoltanGraphFunctions.cpp
@@ -331,7 +331,7 @@ void getCpGridWellsEdgeList(void *graphPointer, int sizeGID, int sizeLID,
 }
 
 CombinedGridWellGraph::CombinedGridWellGraph(const CpGrid& grid,
-                                             const std::vector<const OpmWellType*> * wells,
+                                             const std::vector<OpmWellType> * wells,
                                              const double* transmissibilities,
                                              bool pretendEmptyGrid)
     : grid_(grid), transmissibilities_(transmissibilities)

--- a/opm/grid/common/ZoltanGraphFunctions.hpp
+++ b/opm/grid/common/ZoltanGraphFunctions.hpp
@@ -130,7 +130,7 @@ public:
     /// \param eclipseState The eclipse state to extract the well information from.
     /// \param pretendEmptyGrid True if we should pretend the grid and wells are empty.
     CombinedGridWellGraph(const Dune::CpGrid& grid,
-                          const std::vector<const OpmWellType*> * wells,
+                          const std::vector<OpmWellType> * wells,
                           const double* transmissibilities,
                           bool pretendEmptyGrid);
 

--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -31,7 +31,7 @@ namespace cpgrid
 {
 std::pair<std::vector<int>, std::unordered_set<std::string> >
 zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
-                               const std::vector<const OpmWellType*> * wells,
+                               const std::vector<OpmWellType> * wells,
                                const double* transmissibilities,
                                const CollectiveCommunication<MPI_Comm>& cc,
                                int root)

--- a/opm/grid/common/ZoltanPartition.hpp
+++ b/opm/grid/common/ZoltanPartition.hpp
@@ -49,7 +49,7 @@ namespace cpgrid
 ///         simulation.
 std::pair<std::vector<int>,std::unordered_set<std::string> >
 zoltanGraphPartitionGridOnRoot(const CpGrid& grid,
-                               const std::vector<const OpmWellType*> * wells,
+                               const std::vector<OpmWellType> * wells,
                                const double* transmissibilities,
                                const CollectiveCommunication<MPI_Comm>& cc,
                                int root);

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -67,7 +67,7 @@ namespace Dune
 
 
 std::pair<bool, std::unordered_set<std::string> >
-CpGrid::scatterGrid(const std::vector<const cpgrid::OpmWellType *> * wells,
+CpGrid::scatterGrid(const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities, int overlapLayers)
 {
     // Silence any unused argument warnings that could occur with various configurations.

--- a/opm/grid/utility/OpmParserIncludes.hpp
+++ b/opm/grid/utility/OpmParserIncludes.hpp
@@ -26,11 +26,11 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp>
 
 namespace Dune {
     namespace cpgrid {
-        typedef Opm::Well OpmWellType;
+        typedef Opm::Well2 OpmWellType;
         typedef Opm::EclipseState OpmEclipseStateType;
     }
 }


### PR DESCRIPTION
Change to use Well2 class from opm-common. The changes here are:

1. Pure rename `Well` &rightarrow; `Well2`
2. The new implementation uses `Well2` values or references - instead of naked pointers which were used previously.

Upstream:
https://github.com/OPM/opm-common/pull/731

Downstream:
https://github.com/OPM/opm-simulators/pull/1815