### PR TITLE
deprecated version only if MPI_2 is not defined

### DIFF
--- a/tests/cpgrid/zoltan_test.cpp
+++ b/tests/cpgrid/zoltan_test.cpp
@@ -97,8 +97,13 @@ BOOST_AUTO_TEST_CASE(zoltan)
         Zoltan_Set_Param(zz, "PHG_EDGE_SIZE_THRESHOLD", ".35");  /* 0-remove all, 1-remove none */
 
         MPI_Errhandler handler;
+#ifdef MPI_2
+        MPI_Comm_create_errhandler(MPI_err_handler, &handler);
+        MPI_Comm_set_errhandler(MPI_COMM_WORLD, handler);
+#else
         MPI_Errhandler_create(MPI_err_handler, &handler);
         MPI_Errhandler_set(MPI_COMM_WORLD, handler);
+#endif
         MPI_Comm_size(MPI_COMM_WORLD, &procs);
         MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
 


### PR DESCRIPTION
use deprecated MPI calls only if MPI_2 is not defined