### PR TITLE
suppress unused variable warnings from compiler

### DIFF
--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -457,6 +457,7 @@ BOOST_AUTO_TEST_CASE(cellGatherScatterWithMPI)
 #else
     (void) scatter_handle;
     (void) gather_handle;
+    (void) bid_handle;
 #endif
 }
 


### PR DESCRIPTION
like was done for the other vars here.