### PR TITLE
Send CMake error if we are configuring with MPI but without ZOLTAN.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,10 @@ macro (config_hook)
 	list (APPEND ${project}_CONFIG_IMPL_VARS
 		HAVE_DUNE_GRID_CHECKS
 		)
+	if(NOT ZOLTAN_FOUND AND MPI_C_FOUND)
+		message(SEND_ERROR "opm-grid with MPI support requires the package ZOLTAN."
+			"Please install it (e.g. from http://www.cs.sandia.gov/zoltan/.)")
+	endif(NOT ZOLTAN_FOUND AND MPI_C_FOUND)
 endmacro (config_hook)
 
 macro (prereqs_hook)


### PR DESCRIPTION
At least for more complex models our loadbalancing without ZOLTAN
is not good enough and may lead to cryptic error message and abortion
of the problem. Therefore this commit resorts to give a good error
message during the CMake run that makes clear that the user needs ZOLTAN.

See OPM/opm-simulators#1910 for support requests that this change will prevent.