### PR TITLE
Edge weight methods

### DIFF
--- a/opm/grid/common/ZoltanGraphFunctions.cpp
+++ b/opm/grid/common/ZoltanGraphFunctions.cpp
@@ -290,7 +290,7 @@ void getCpGridWellsEdgeList(void *graphPointer, int sizeGID, int sizeLID,
                     if ( wellEdges.find(otherCell) == wellEdges.end() )
                     {
                         nborGID[idx] = globalID[otherCell];
-                        ewgts[idx++] = graph.transmissibility(face);
+                        ewgts[idx++] = graph.edgeWeight(face);
                     }
                     continue;
                 }
@@ -298,7 +298,7 @@ void getCpGridWellsEdgeList(void *graphPointer, int sizeGID, int sizeLID,
             if ( wellEdges.find(otherCell) == wellEdges.end() )
             {
                 nborGID[idx] = globalID[otherCell];
-                ewgts[idx++] = graph.transmissibility(face);
+                ewgts[idx++] = graph.edgeWeight(face);
             }
         }
 #ifndef NDEBUG
@@ -333,8 +333,9 @@ void getCpGridWellsEdgeList(void *graphPointer, int sizeGID, int sizeLID,
 CombinedGridWellGraph::CombinedGridWellGraph(const CpGrid& grid,
                                              const std::vector<OpmWellType> * wells,
                                              const double* transmissibilities,
-                                             bool pretendEmptyGrid)
-    : grid_(grid), transmissibilities_(transmissibilities)
+                                             bool pretendEmptyGrid, 
+					     int edgeWeightsMethod)
+    : grid_(grid), transmissibilities_(transmissibilities), edgeWeightsMethod_(edgeWeightsMethod)
 {
     if ( pretendEmptyGrid )
     {
@@ -353,6 +354,9 @@ CombinedGridWellGraph::CombinedGridWellGraph(const CpGrid& grid,
     well_indices_.init(*wells, cpgdim, cartesian_to_compressed);
     std::vector<int>().swap(cartesian_to_compressed); // free memory.
     addCompletionSetToGraph();
+
+    if (edgeWeightsMethod == 2)
+	findMaxMinTrans();
 }
 
 void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz, const Dune::CpGrid& grid,

--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -34,7 +34,7 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
                                const std::vector<OpmWellType> * wells,
                                const double* transmissibilities,
                                const CollectiveCommunication<MPI_Comm>& cc,
-                               int root)
+                               int edgeWeightsMethod, int root)
 {
     int rc = ZOLTAN_OK - 1;
     float ver = 0;
@@ -50,7 +50,7 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
     {
         OPM_THROW(std::runtime_error, "Could not initialize Zoltan!");
     }
-
+    Zoltan_Set_Param(zz, "IMBALANCE_TOL", "1.1");
     Zoltan_Set_Param(zz, "DEBUG_LEVEL", "0");
     Zoltan_Set_Param(zz, "LB_METHOD", "GRAPH");
     Zoltan_Set_Param(zz, "LB_APPROACH", "PARTITION");
@@ -75,7 +75,8 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
         grid_and_wells.reset(new CombinedGridWellGraph(cpgrid,
                                                        wells,
                                                        transmissibilities,
-                                                       partitionIsEmpty));
+                                                       partitionIsEmpty,
+						       edgeWeightsMethod));
         Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, *grid_and_wells,
                                                     partitionIsEmpty);
     }

--- a/opm/grid/common/ZoltanPartition.hpp
+++ b/opm/grid/common/ZoltanPartition.hpp
@@ -52,7 +52,7 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& grid,
                                const std::vector<OpmWellType> * wells,
                                const double* transmissibilities,
                                const CollectiveCommunication<MPI_Comm>& cc,
-                               int root);
+                               int edgeWeightsMethod, int root);
 }
 }
 #endif // HAVE_ZOLTAN

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -67,7 +67,7 @@ namespace Dune
 
 
 std::pair<bool, std::unordered_set<std::string> >
-CpGrid::scatterGrid(const std::vector<cpgrid::OpmWellType> * wells,
+CpGrid::scatterGrid(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities, int overlapLayers)
 {
     // Silence any unused argument warnings that could occur with various configurations.
@@ -87,7 +87,7 @@ CpGrid::scatterGrid(const std::vector<cpgrid::OpmWellType> * wells,
     int my_num=cc.rank();
 #ifdef HAVE_ZOLTAN
     auto part_and_wells =
-        cpgrid::zoltanGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, 0);
+        cpgrid::zoltanGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0);
     int num_parts = cc.size();
     using std::get;
     auto cell_part = std::get<0>(part_and_wells);


### PR DESCRIPTION
Added options for allowing different edge-weights in the Zoltan partitioner. Added a new loadBalance method in CpGrid class that accepts an additional parameter:
int edgeWeightsMethod. 

If edgeWeightsMethod=0, non-well edge-weights are set to 1.0, if edgeWeightsMethod=1 the current transmissibility approach is used, and if edgeWeightsMethod=2 a logarithmic transmissibility edge-weighting strategy is used. Default is edgeWeightsMethod=1.

The alternative strategies produce partitioning results with lower edge-cut, fewer overlap/ghost cells and less communication overhead. However, the impact on parallel linear solver performance is negative. 