### PR TITLE
Correct order of function parameters when commputing overlap.

### DIFF
--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -534,7 +534,7 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
     std::vector<std::set<int> > overlap;
 
     overlap.resize(cell_part.size());
-    addOverlapLayer(grid, cell_part, overlap, my_rank, false, overlap_layers);
+    addOverlapLayer(grid, cell_part, overlap, my_rank, overlap_layers, false);
     // count number of cells
     struct CellCounter
     {


### PR DESCRIPTION
Fortunately the wrong order only resulted in always using
overlap 1 due to the way the code is written.