### PR TITLE
Avoid use of property.iget()

### DIFF
--- a/opm/grid/utility/CompressedPropertyAccess.hpp
+++ b/opm/grid/utility/CompressedPropertyAccess.hpp
@@ -333,7 +333,7 @@ namespace Opm {
                 operator[](const size_type i) const
                 {
                     if (x_) {
-                        return x_->iget(i);
+                        return x_->getData()[i];
                     }
                     else {
                         return dflt_;


### PR DESCRIPTION
Followup to: https://github.com/OPM/opm-common/pull/1051