### PR TITLE
Chase Global "DEBUG" Macro Renaming

### DIFF
--- a/opm/grid/common/ZoltanGraphFunctions.cpp
+++ b/opm/grid/common/ZoltanGraphFunctions.cpp
@@ -221,7 +221,7 @@ void getCpGridEdgeList(void *cpGridPointer, int sizeGID, int sizeLID,
     {
         nborProc[i] = myrank;
     }
-#if defined(DEBUG) && false // The index set will not be initialized here!
+#if defined(DEBUGBUILD) && false // The index set will not be initialized here!
     // The above relies heavily on the grid not being distributed already.
     // Therefore we check here that all cells are owned by us.
     GlobalLookupIndexSet<Dune::CpGrid::ParallelIndexSet>
@@ -313,7 +313,7 @@ void getCpGridWellsEdgeList(void *graphPointer, int sizeGID, int sizeLID,
     {
         nborProc[i] = myrank;
     }
-#if defined(DEBUG) && false // The index set will not be initialized here!
+#if defined(DEBUGBUILD) && false // The index set will not be initialized here!
     // The above relies heavily on the grid not being distributed already.
     // Therefore we check here that all cells are owned by us.
     GlobalLookupIndexSet<Dune::CpGrid::ParallelIndexSet>

--- a/opm/grid/cpgpreprocess/facetopology.c
+++ b/opm/grid/cpgpreprocess/facetopology.c
@@ -47,7 +47,9 @@
 #define MIN(i,j) ((i)<(j) ? (i) : (j))
 #define MAX(i,j) ((i)>(j) ? (i) : (j))
 
-#define DEBUG 1
+#if defined(DEBUGBUILD)
+#define SELF_DEBUG 1
+#endif
 
 /*------------------------------------------------------*/
 /*                                                      */
@@ -78,7 +80,7 @@ computeFaceTopology(const int *a1, const int *a2,
     if (a2[0] > b2[0]){ mask[4] = a2[0]; } else { mask[4] = b2[0]; }
     if (a1[0] > b1[0]){ mask[6] = a1[0]; } else { mask[6] = b1[0]; }
 
-#if DEBUG
+#if SELF_DEBUG
     /* Illegal situations */
     if (mask [0] == mask[2] ||
         mask [0] == mask[4] ||
@@ -145,7 +147,7 @@ computeFaceTopology(const int *a1, const int *a2,
         }
     }
 
-#if DEBUG>1
+#if SELF_DEBUG>1
     /* Check for repeated nodes:*/
     int i;
     fprintf(stderr, "face: ");


### PR DESCRIPTION
Renamed to DEBUGBUILD to avoid conflicting with a class name.

Downstream from OPM/opm-common#1054