### PR TITLE
WIP: The eclipse gride preprocessing is not allowed to deactivate cells

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -268,7 +268,8 @@ namespace Dune
         /// \param poreVolume pore volumes for use in MINPV processing, if asked for in deck
         void processEclipseFormat(const Opm::EclipseGrid& ecl_grid, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
                                   const std::vector<double>& poreVolume = std::vector<double>(),
-                                  const Opm::NNC& = Opm::NNC());
+                                  const Opm::NNC& = Opm::NNC(),
+                                  bool allow_deactivate_cells = false);
 #endif
 
         /// Read the Eclipse grid format ('grdecl').

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -273,11 +273,12 @@ CpGrid::scatterGrid(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellTy
                                       bool periodic_extension,
                                       bool turn_normals, bool clip_z,
                                       const std::vector<double>& poreVolume,
-                                      const Opm::NNC& nncs)
+                                      const Opm::NNC& nncs,
+                                      bool allow_deactivate_cells)
     {
         current_view_data_->processEclipseFormat(ecl_grid, periodic_extension,
                                                  turn_normals, clip_z,
-                                                 poreVolume, nncs);
+                                                 poreVolume, nncs, allow_deactivate_cells);
     }
 #endif
 

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -191,8 +191,11 @@ public:
     /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
     /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
     /// \param poreVolume pore volumes for use in MINPV processing, if asked for in deck
+    /// \param allow_deactivate_cells By default the active/inactive cells should be fully initialized in the EclipseGrid,
+    ///        but if this parameter is set to true the function is allowed to deactivate cells.
     void processEclipseFormat(const Opm::EclipseGrid& ecl_grid, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
-                              const std::vector<double>& poreVolume = std::vector<double>(), const Opm::NNC& nncs = Opm::NNC());
+                              const std::vector<double>& poreVolume = std::vector<double>(), const Opm::NNC& nncs = Opm::NNC(),
+                              bool allow_deactivate_cells = false);
 #endif
 
     /// Read the Eclipse grid format ('grdecl').

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -112,6 +112,21 @@ namespace Dune
 namespace cpgrid
 {
 
+namespace {
+
+void assert_active_cells(const grdecl& grdecl_grid, const Opm::EclipseGrid& ecl_grid) {
+// #ifndef NDEBUG
+    const auto& ecl_actnum = ecl_grid.getACTNUM();
+    for (std::size_t g = 0; g < ecl_grid.getCartesianSize(); g++) {
+        if (ecl_actnum[g] != grdecl_grid.actnum[g])
+            throw std::logic_error("Cells have been deactivated in the grid processing - should not happen");
+    }
+// #endif
+}
+
+}
+
+
 #if HAVE_ECL_INPUT
     void CpGridData::processEclipseFormat(const Opm::EclipseGrid& ecl_grid, bool periodic_extension, bool turn_normals, bool clip_z,
                                           const std::vector<double>& poreVolume, const Opm::NNC& nncs)
@@ -227,10 +242,13 @@ namespace cpgrid
             addOuterCellLayer(g, new_coord, new_zcorn, new_actnum, new_g);
             // Make the grid.
             processEclipseFormat(new_g, nnc_cells, z_tolerance, true, turn_normals);
+            assert_active_cells(new_g, ecl_grid);
         } else {
             // Make the grid.
             processEclipseFormat(g, nnc_cells, z_tolerance, false, turn_normals);
+            assert_active_cells(g, ecl_grid);
         }
+
     }
 #endif // #if HAVE_ECL_INPUT
 

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -129,7 +129,7 @@ void assert_active_cells(const grdecl& grdecl_grid, const Opm::EclipseGrid& ecl_
 
 #if HAVE_ECL_INPUT
     void CpGridData::processEclipseFormat(const Opm::EclipseGrid& ecl_grid, bool periodic_extension, bool turn_normals, bool clip_z,
-                                          const std::vector<double>& poreVolume, const Opm::NNC& nncs)
+                                          const std::vector<double>& poreVolume, const Opm::NNC& nncs, bool allow_deactivate_cells)
     {
         std::vector<double> coordData = ecl_grid.getCOORD();
 
@@ -242,11 +242,15 @@ void assert_active_cells(const grdecl& grdecl_grid, const Opm::EclipseGrid& ecl_
             addOuterCellLayer(g, new_coord, new_zcorn, new_actnum, new_g);
             // Make the grid.
             processEclipseFormat(new_g, nnc_cells, z_tolerance, true, turn_normals);
-            assert_active_cells(new_g, ecl_grid);
+            if (!allow_deactivate_cells) {
+                assert_active_cells(new_g, ecl_grid);
+            }
         } else {
             // Make the grid.
             processEclipseFormat(g, nnc_cells, z_tolerance, false, turn_normals);
-            assert_active_cells(g, ecl_grid);
+            if (!allow_deactivate_cells) {
+                assert_active_cells(g, ecl_grid);
+            }
         }
 
     }


### PR DESCRIPTION
Related to: https://github.com/OPM/opm-common/pull/1059

Observe that the uglyness in the second commit is to support opm-upscaling: https://github.com/OPM/opm-upscaling/pull/279