### PR TITLE
Make gatherData/scatterData const functions.

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1205,7 +1205,7 @@ namespace Dune
         /// \param handle The data handle describing the data and responsible for
         ///         gathering and scattering the data.
         template<class DataHandle>
-        void scatterData(DataHandle& handle)
+        void scatterData(DataHandle& handle) const
         {
 #if HAVE_MPI
             if(!distributed_data_)
@@ -1224,7 +1224,7 @@ namespace Dune
         /// \param handle The data handle describing the data and responsible for
         ///         gathering and scattering the data.
         template<class DataHandle>
-        void gatherData(DataHandle& handle)
+        void gatherData(DataHandle& handle) const
         {
 #if HAVE_MPI
             if(!distributed_data_)


### PR DESCRIPTION
These functions should have been const for a long time, but somehow I missed this. Currently this is need for working restart with the global grid only on one process (one can only get a const grid from
the vanguard).

Should also be uncontroversial. Will merge after a build test.