### PR TITLE
Moved opm-common to Depends section of dune-module.

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -10,5 +10,5 @@ Label: 2019.10-pre
 Maintainer: atgeirr@sintef.no
 MaintainerName: Atgeirr F. Rasmussen
 Url: http://opm-project.org
-Depends: dune-common (>= 2.4) dune-geometry (>= 2.4) dune-grid (>= 2.4)
-Suggests: dune-istl (>= 2.4) opm-common
+Depends: dune-common (>= 2.4) dune-geometry (>= 2.4) dune-grid (>= 2.4) opm-common
+Suggests: dune-istl (>= 2.4)


### PR DESCRIPTION
According to our build system it is a required dependency and dune.module should be consistent with this.