### PR TITLE
Fixed overlap computation

### DIFF
--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -534,7 +534,7 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
     std::vector<std::set<int> > overlap;
 
     overlap.resize(cell_part.size());
-    addOverlapLayer(grid, cell_part, overlap, my_rank, overlap_layers, false);
+    addOverlapLayer(grid, cell_part, overlap, my_rank, overlap_layers, true);
     // count number of cells
     struct CellCounter
     {


### PR DESCRIPTION
PR #376 introduced a subtle bug with great percussions for parallel
runs. As said in that PR overlap_layers was at the wrong position but
the overlap was still computed correctly. The important thing was that
the last parameter evaluated to true to make the process compute the
overlap for all processes. This was needed but changed in the PR (and
I imagine that the overlap was at least not correct, maybe even not there at
all).

With this PR we set the last parameter of addOverlapLayers to true and
get rid of the excessive time step chopping experienced in parallel
runs.

No more warnings about "finding the bubble point pressure failed  for cells..."