### PR TITLE
Hold global grid only on process (2nd try, rebased on current master)

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -32,6 +32,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/grid/cpgrid/Intersection.cpp
   opm/grid/cpgrid/CpGridData.cpp
   opm/grid/cpgrid/CpGrid.cpp
+  opm/grid/cpgrid/DataHandleWrappers.cpp
   opm/grid/cpgrid/GridHelpers.cpp
   opm/grid/cpgrid/PartitionTypeIndicator.cpp
   opm/grid/cpgrid/processEclipseFormat.cpp
@@ -152,6 +153,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/grid/common/p2pcommunicator_impl.hh
   opm/grid/cpgrid/CartesianIndexMapper.hpp
   opm/grid/cpgrid/CpGridData.hpp
+  opm/grid/cpgrid/DataHandleWrappers.hpp
   opm/grid/cpgrid/DefaultGeometryPolicy.hpp
   opm/grid/cpgrid/dgfparser.hh
   opm/grid/cpgrid/Entity2IndexDataHandle.hpp
@@ -216,6 +218,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/grid/utility/RegionMapping.hpp
   opm/grid/utility/SparseTable.hpp
   opm/grid/utility/StopWatch.hpp
+  opm/grid/utility/VariableSizeCommunicator.hpp
   opm/grid/utility/VelocityInterpolation.hpp
   opm/grid/utility/WachspressCoord.hpp
   opm/grid/utility/ErrorMacros.hpp

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -50,7 +50,11 @@
 #include <dune/common/version.hh>
 
 #if HAVE_MPI
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
 #include <dune/common/parallel/variablesizecommunicator.hh>
+#else
+#include <opm/grid/utility/VariableSizeCommunicator.hpp>
+#endif
 #endif
 
 #include <dune/grid/common/capabilities.hh>
@@ -227,6 +231,7 @@ namespace Dune
     class CpGrid
         : public GridDefaultImplementation<3, 3, double, CpGridFamily >
     {
+        friend class cpgrid::CpGridData;
 
     public:
 
@@ -242,6 +247,8 @@ namespace Dune
 
         /// Default constructor
         CpGrid();
+
+        CpGrid(MPIHelper::MPICommunicator comm);
 
         /// \name IO routines
         //@{
@@ -1210,7 +1217,8 @@ namespace Dune
 #if HAVE_MPI
             if(!distributed_data_)
                 OPM_THROW(std::runtime_error, "Moving Data only allowed with a load balanced grid!");
-            distributed_data_->scatterData(handle, data_.get(), distributed_data_.get(), cellScatterGatherInterface());
+            distributed_data_->scatterData(handle, data_.get(), distributed_data_.get(), cellScatterGatherInterface(),
+                                           pointScatterGatherInterface());
 #else
             // Suppress warnings for unused argument.
             (void) handle;
@@ -1236,8 +1244,13 @@ namespace Dune
 #endif
         }
 #if HAVE_MPI
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
         /// \brief The type of the map describing communication interfaces.
-        typedef VariableSizeCommunicator<>::InterfaceMap InterfaceMap;
+        using InterfaceMap = VariableSizeCommunicator<>::InterfaceMap;
+#else
+        /// \brief The type of the map describing communication interfaces.
+        using InterfaceMap = Opm::VariableSizeCommunicator<>::InterfaceMap;
+#endif
 #else
         // bogus definition for the non parallel type. VariableSizeCommunicator not
         // availabe
@@ -1246,7 +1259,7 @@ namespace Dune
         typedef std::map<int, std::list<int> > InterfaceMap;
 #endif
 
-        /// \brief Get an interface for gathering/scattering data with communication.
+        /// \brief Get an interface for gathering/scattering data attached to cells with communication.
         ///
         /// Scattering means sending data from the indices of the global grid on
         /// process 0 to the distributed grid on all ranks independent of the grid.
@@ -1279,6 +1292,13 @@ namespace Dune
             return *cell_scatter_gather_interfaces_;
         }
 
+        /// \brief Get an interface for gathering/scattering data attached to points with communication.
+        /// \see cellScatterGatherInterface
+        const InterfaceMap& pointScatterGatherInterface() const
+        {
+            return *point_scatter_gather_interfaces_;
+        }
+
         /// \brief Switch to the global view.
         void switchToGlobalView()
         {
@@ -1288,6 +1308,8 @@ namespace Dune
         /// \brief Switch to the distributed view.
         void switchToDistributedView()
         {
+            if (! distributed_data_)
+                OPM_THROW(std::logic_error, "No distributed view available in grid");
             current_view_data_=distributed_data_.get();
         }
         //@}
@@ -1351,6 +1373,12 @@ namespace Dune
          * @warning Will only update owner cells
          */
         std::shared_ptr<InterfaceMap> cell_scatter_gather_interfaces_;
+        /*
+         * @brief Interface for scattering and gathering point data.
+         *
+         * @warning Will only update owner cells
+         */
+        std::shared_ptr<InterfaceMap> point_scatter_gather_interfaces_;
     }; // end Class CpGrid
 
 

--- a/opm/grid/common/GridPartitioning.cpp
+++ b/opm/grid/common/GridPartitioning.cpp
@@ -456,6 +456,12 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
                   { return std::get<0>(t1) < std::get<0>(t2);});
         return importOwnerSize;
 #else
+        (void) grid;
+        (void) cell_part;
+        (void) exportList;
+        (void) importList;
+        (void) cc;
+        (void) layers;
         DUNE_THROW(InvalidStateException, "MPI is missing from the system");
 
         return 0;

--- a/opm/grid/common/GridPartitioning.cpp
+++ b/opm/grid/common/GridPartitioning.cpp
@@ -37,10 +37,14 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <dune/istl/owneroverlapcopy.hh>
 #include "GridPartitioning.hpp"
 #include <opm/grid/CpGrid.hpp>
 #include <stack>
 
+#ifdef HAVE_MPI
+#include "mpi.h"
+#endif
 namespace Dune
 {
 
@@ -325,6 +329,137 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
             }
             addOverlapLayer(grid, index, *it, owner, cell_part, cell_overlap, layers-1);
         }
-}
+    }
+
+    void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Entity& e,
+                         const int owner, const std::vector<int>& cell_part,
+                         std::vector<std::tuple<int,int,char>>& exportList,
+                         int recursion_deps)
+    {
+        using AttributeSet = Dune::OwnerOverlapCopyAttributeSet::AttributeSet;
+        const CpGrid::LeafIndexSet& ix = grid.leafIndexSet();
+        for (CpGrid::LeafIntersectionIterator iit = e.ileafbegin(); iit != e.ileafend(); ++iit) {
+            if ( iit->neighbor() ) {
+                int nb_index = ix.index(*(iit->outside()));
+                if ( cell_part[nb_index]!=owner )
+                {
+                    // Note: multiple adds for same process are possible
+                    exportList.emplace_back(nb_index, owner, AttributeSet::overlap);
+                    exportList.emplace_back(index, cell_part[nb_index],  AttributeSet::overlap);
+                    if ( recursion_deps>0 )
+                    {
+                        // Add another layer
+                        addOverlapLayer(grid, nb_index, *(iit->outside()), owner,
+                                        cell_part, exportList, recursion_deps-1);
+                    }
+                }
+            }
+        }
+    }
+
+    int addOverlapLayer(const CpGrid& grid, const std::vector<int>& cell_part,
+                        std::vector<std::tuple<int,int,char>>& exportList,
+                        std::vector<std::tuple<int,int,char,int>>& importList,
+                        const CollectiveCommunication<Dune::MPIHelper::MPICommunicator>& cc,
+                        int layers)
+    {
+#ifdef HAVE_MPI
+        using AttributeSet = Dune::OwnerOverlapCopyAttributeSet::AttributeSet;
+        auto ownerSize = exportList.size();
+        const CpGrid::LeafIndexSet& ix = grid.leafIndexSet();
+        std::map<int,int> exportProcs, importProcs;
+
+        for (CpGrid::Codim<0>::LeafIterator it = grid.leafbegin<0>();
+             it != grid.leafend<0>(); ++it) {
+            int index = ix.index(*it);
+            auto owner = cell_part[index];
+            exportProcs.insert(std::make_pair(owner, 0));
+            addOverlapLayer(grid, index, *it, owner, cell_part, exportList, layers-1);
+        }
+        // remove multiple entries
+        auto compare = [](const std::tuple<int,int,char>& t1, const std::tuple<int,int,char>& t2)
+                       {
+                           return (std::get<0>(t1) < std::get<0>(t2)) ||
+                                                    ( ! (std::get<0>(t2) < std::get<0>(t1))
+                                                      && (std::get<1>(t1) < std::get<1>(t2)) );
+                       };
+
+        auto ownerEnd = exportList.begin() + ownerSize;
+        std::sort(ownerEnd, exportList.end(), compare);
+
+        auto newEnd = std::unique(ownerEnd, exportList.end());
+        exportList.resize(newEnd - exportList.begin());
+
+        for(const auto& entry: importList)
+            importProcs.insert(std::make_pair(std::get<1>(entry), 0));
+        //count entries to send
+        std::for_each(ownerEnd, exportList.end(),
+                      [&exportProcs](const std::tuple<int,int,char>& t){ ++exportProcs[std::get<1>(t)];});
+
+        // communicate number of entries
+        std::vector<MPI_Request> requests(importProcs.size());
+        auto req = requests.begin();
+        int tag = 23872949;
+        for(auto&& proc : importProcs)
+        {
+            MPI_Irecv(&(proc.second), 1, MPI_INT, proc.first, tag, cc, &(*req));
+            ++req;
+        }
+
+        for(const auto& proc: exportProcs)
+        {
+            MPI_Send(&(proc.second), 1, MPI_INT, proc.first, tag, cc);
+        }
+        std::vector<MPI_Status> statuses(requests.size());
+        MPI_Waitall(requests.size(), requests.data(), statuses.data());
+
+        // Communicate overlap entries
+        ++tag;
+        std::vector<std::vector<int> > receiveBuffers(importProcs.size());
+        auto buffer = receiveBuffers.begin();
+        req = requests.begin();
+
+        for(auto&& proc: importProcs)
+        {
+            buffer->resize(proc.second);
+            MPI_Irecv(buffer->data(), proc.second, MPI_INT, proc.first, tag, cc, &(*req));
+            ++req; ++buffer;
+        }
+
+        for(const auto& proc: exportProcs)
+        {
+            std::vector<int> sendBuffer;
+            sendBuffer.reserve(proc.second);
+            std::for_each(ownerEnd, exportList.end(),
+                          [&sendBuffer, &proc](const std::tuple<int,int,char>& t)
+                          {
+                              if ( std::get<1>(t) == proc.first )
+                                  sendBuffer.push_back(std::get<0>(t));
+                          });
+            MPI_Send(sendBuffer.data(), proc.second, MPI_INT, proc.first, tag, cc);
+        }
+
+        std::inplace_merge(exportList.begin(), ownerEnd, exportList.end());
+
+        MPI_Waitall(requests.size(), requests.data(), statuses.data());
+        buffer = receiveBuffers.begin();
+        auto importOwnerSize = importList.size();
+
+        for(const auto& proc: importProcs)
+        {
+            for(const auto& index: *buffer)
+                importList.emplace_back(index, proc.first, AttributeSet::overlap, -1);
+            ++buffer;
+        }
+        std::sort(importList.begin() + importOwnerSize, importList.end(),
+                  [](const std::tuple<int,int,char,int>& t1, const std::tuple<int,int,char,int>& t2)
+                  { return std::get<0>(t1) < std::get<0>(t2);});
+        return importOwnerSize;
+#else
+        DUNE_THROW(InvalidStateException, "MPI is missing from the system");
+
+        return 0;
+#endif
+    }
 } // namespace Dune
 

--- a/opm/grid/common/GridPartitioning.hpp
+++ b/opm/grid/common/GridPartitioning.hpp
@@ -40,7 +40,9 @@
 #include <vector>
 #include <array>
 #include <set>
+#include <tuple>
 
+#include <dune/common/parallel/mpihelper.hh>
 namespace Dune
 {
 
@@ -69,18 +71,34 @@ namespace Dune
                    bool recursive = false,
                    bool ensureConnectivity = true);
 
-/// \brief Adds a layer of overlap cells to a partitioning.
-/// \param[in] grid The grid that is partitioned.
-/// \param[in] cell_part a vector containing each cells partition number.
-/// \param[out] cell_overlap a vector of sets that contains for each cell all
-///             the partition numbers that it is an overlap cell of.
-/// \param[in] mypart The partition number of the processor.
-/// \param[in] all Whether to compute the overlap for all partions or just the
-///            one associated by mypart.
-     void addOverlapLayer(const CpGrid& grid,
-                          const std::vector<int>& cell_part,
-                          std::vector<std::set<int> >& cell_overlap,
-                          int mypart, int overlapLayers, bool all=false);
+    /// \brief Adds a layer of overlap cells to a partitioning.
+    /// \param[in] grid The grid that is partitioned.
+    /// \param[in] cell_part a vector containing each cells partition number.
+    /// \param[out] cell_overlap a vector of sets that contains for each cell all
+    ///             the partition numbers that it is an overlap cell of.
+    /// \param[in] mypart The partition number of the processor.
+    /// \param[in] all Whether to compute the overlap for all partions or just the
+    ///            one associated by mypart.
+    void addOverlapLayer(const CpGrid& grid,
+                         const std::vector<int>& cell_part,
+                         std::vector<std::set<int> >& cell_overlap,
+                         int mypart, int overlapLayers, bool all=false);
+
+    /// \brief Adds a layer of overlap cells to a partitioning.
+    /// \param[in] grid The grid that is partitioned.
+    /// \param[in] cell_part a vector containing each cells partition number.
+    /// \param[inout] exportList List indices to export, each entry is a tuple
+    /// of global index, process rank (to export to), attribute on remote.
+    /// \param[inout] importList List indices to import, each entry is a tuple
+    /// of global index, process rank (to import from), attribute here, local
+    /// index here
+    /// \param[in] cc The communication object
+    /// \param[in] layer Number of overlap layers
+    int addOverlapLayer(const CpGrid& grid, const std::vector<int>& cell_part,
+                        std::vector<std::tuple<int,int,char>>& exportList,
+                        std::vector<std::tuple<int,int,char,int>>& importList,
+                        const CollectiveCommunication<Dune::MPIHelper::MPICommunicator>& cc,
+                        int layers = 1);
 
 } // namespace Dune
 

--- a/opm/grid/common/WellConnections.cpp
+++ b/opm/grid/common/WellConnections.cpp
@@ -27,6 +27,32 @@
 
 #include <opm/grid/utility/OpmParserIncludes.hpp>
 
+#include <dune/common/parallel/mpitraits.hh>
+#include <dune/istl/owneroverlapcopy.hh>
+
+namespace
+{
+
+struct Less
+{
+    template<typename T>
+    bool operator()( const T& t1, const T& t2 )
+    {
+        return std::get<0>(t1) < std::get<0>(t2);
+    }
+    template<typename T>
+    bool operator()( const T& t, int i )
+    {
+        return std::get<0>(t) < i;
+    }
+    template<typename T>
+    bool operator()( int i, const T& t )
+    {
+        return i < std::get<0>(t);
+    }
+};
+}
+
 namespace Dune
 {
 namespace cpgrid
@@ -67,65 +93,230 @@ void WellConnections::init(const std::vector<OpmWellType>& wells,
 #endif
 }
 
+#ifdef HAVE_MPI
 std::vector<std::vector<int> >
 postProcessPartitioningForWells(std::vector<int>& parts,
+                                const std::vector<int>& globalCell,
                                 const std::vector<OpmWellType>& wells,
                                 const WellConnections& well_connections,
-                                std::size_t no_procs)
+                                std::vector<std::tuple<int,int,char>>& exportList,
+                                std::vector<std::tuple<int,int,char,int>>& importList,
+                                const CollectiveCommunication<MPI_Comm>& cc)
 {
+    auto no_procs = cc.size();
+    auto noCells = parts.size();
+    const auto& mpiType =  MPITraits<std::size_t>::getType();
+    std::vector<std::size_t> cellsPerProc(no_procs);
+    cc.allgather(&noCells, 1, cellsPerProc.data());
+
     // Contains for each process the indices of the wells assigned to it.
     std::vector<std::vector<int> > well_indices_on_proc(no_procs);
 
 #if HAVE_ECL_INPUT
-    if( ! well_connections.size() )
-    {
-        // No wells to be processed
-        return well_indices_on_proc;
-    }
+    std::map<int, std::vector<int>> addCells, removeCells;
+    using AttributeSet = Dune::OwnerOverlapCopyAttributeSet::AttributeSet;
 
-    // prevent memory allocation
-    for(auto& well_indices : well_indices_on_proc)
-    {
-        well_indices.reserve(wells.size());
-    }
+    if (noCells && well_connections.size()) {
 
-    // Check that all connections of a well have ended up on one process.
-    // If that is not the case for well then move them manually to the
-    // process that already has the most connections on it.
-    int well_index = 0;
-
-    for (const auto& well: wells) {
-        const auto& connections = well_connections[well_index];
-        std::map<int,std::size_t> no_connections_on_proc;
-        for ( auto connection_index: connections )
-        {
-            ++no_connections_on_proc[parts[connection_index]];
+        // prevent memory allocation
+        for (auto &well_indices : well_indices_on_proc) {
+            well_indices.reserve(wells.size());
         }
 
-        int owner = no_connections_on_proc.begin()->first;
+        // Check that all connections of a well have ended up on one process.
+        // If that is not the case for well then move them manually to the
+        // process that already has the most connections on it.
+        int well_index = 0;
 
-        if ( no_connections_on_proc.size() > 1 )
-        {
-            // partition with the most connections on it becomes new owner
-            int new_owner = std::max_element(no_connections_on_proc.begin(),
-                                             no_connections_on_proc.end(),
-                                             [](const std::pair<int,std::size_t>& p1,
-                                                const std::pair<int,std::size_t>& p2){
-                                                 return ( p1.second > p2.second );
-                                             })->first;
-            std::cout << "Manually moving well " << well.name() << " to partition "
-                      << new_owner << std::endl;
-
-            for ( auto connection_cell : connections )
-            {
-                parts[connection_cell] = new_owner;
+        for (const auto &well : wells) {
+            const auto &connections = well_connections[well_index];
+            std::map<int, std::size_t> no_connections_on_proc;
+            for (auto connection_index : connections) {
+                ++no_connections_on_proc[parts[connection_index]];
             }
 
-            owner = new_owner;
-        }
+            int owner = no_connections_on_proc.begin()->first;
 
-        well_indices_on_proc[owner].push_back(well_index);
-        ++well_index;
+            if (no_connections_on_proc.size() > 1) {
+                // partition with the most connections on it becomes new owner
+                int new_owner =
+                    std::max_element(no_connections_on_proc.begin(),
+                                     no_connections_on_proc.end(),
+                                     [](const std::pair<int, std::size_t> &p1,
+                                        const std::pair<int, std::size_t> &p2) {
+                                         return (p1.second > p2.second);
+                                     })
+                    ->first;
+                std::cout << "Manually moving well " << well.name()
+                          << " to partition " << new_owner << std::endl;
+
+                std::vector<int> globalConnections;
+                globalConnections.reserve(connections.size());
+                std::map<int, std::vector<int>> tmpRemove;
+                auto &add = addCells[new_owner];
+                auto oldEnd = add.end();
+                std::vector<int> myConnections;
+                myConnections.reserve(connections.size());
+                for (auto connection_cell : connections) {
+                    const auto &global = globalCell[connection_cell];
+                    auto old_owner = parts[connection_cell];
+                    if (old_owner != cc.rank()) //otherwise there is not entry
+                        removeCells[old_owner].push_back(global);
+                    else
+                        myConnections.push_back(global);
+                    parts[connection_cell] = new_owner;
+                    if (new_owner != cc.rank()) // no entry assumed for rank
+                        add.push_back(global);
+                }
+                std::sort(myConnections.begin(), myConnections.end());
+                std::sort(oldEnd, add.end());
+                exportList.reserve(exportList.size()+myConnections.size()); // We might store new entries
+                auto start  = exportList.begin();
+                auto middle = exportList.end();
+
+                for (auto movedCell = oldEnd; oldEnd != add.end(); ++movedCell) {
+                    auto myCandidate = std::lower_bound(myConnections.begin(), myConnections.end(), *movedCell);
+                    if (myCandidate == myConnections.end()){
+                        auto candidate = std::lower_bound(start, middle, *movedCell, Less());
+                        assert(candidate != exportList.end());
+                        std::get<1>(*candidate) = new_owner;
+                        start = candidate;
+                    } else {
+                        // entry was not yet in the list. add it at the end.
+                        exportList.emplace_back(*movedCell, new_owner, AttributeSet::owner);
+                    }
+                }
+                std::sort(middle, exportList.end(), Less());
+                std::inplace_merge(exportList.begin(), middle, exportList.end(), Less());
+            }
+
+            well_indices_on_proc[owner].push_back(well_index);
+            ++well_index;
+        }
+        auto sorter = [](std::pair<const int, std::vector<int>> &pair) {
+                          auto &vec = pair.second;
+                          std::sort(vec.begin(), vec.end());
+                      };
+        std::for_each(addCells.begin(), addCells.end(), sorter);
+        std::for_each(removeCells.begin(), removeCells.end(), sorter);
+    }
+
+    // setup receives for each process that owns cells of the original grid
+    auto noSource = std::count_if(cellsPerProc.begin(), cellsPerProc.end(),
+                                  [](const std::size_t &i) { return i > 0; }) -
+        (parts.size() > 0);
+    std::vector<MPI_Request> requests(noSource, MPI_REQUEST_NULL);
+    std::vector<std::vector<std::size_t>> sizeBuffers(cc.size());
+    auto begin = cellsPerProc.begin();
+    auto req = requests.begin();
+    int tag = 782372873;
+    auto myRank = cc.rank();
+
+    for (auto it = begin, end = cellsPerProc.end(); it != end; ++it) {
+        auto otherRank = it - begin;
+        if (otherRank != myRank && *it > 0 ) {
+            sizeBuffers[otherRank].resize(2);
+            MPI_Irecv(sizeBuffers[otherRank].data(), 2, mpiType, otherRank, tag, cc, &(*req));
+            ++req;
+        }
+    }
+
+    // Send the sizes
+    if (!parts.empty()) {
+        for (int otherRank = 0; otherRank < cc.size(); ++otherRank)
+            if (otherRank != myRank) {
+                std::size_t sizes[2] = {0, 0};
+                auto candidate = addCells.find(myRank);
+                if (candidate != addCells.end())
+                    sizes[0] = candidate->second.size();
+
+                candidate = removeCells.find(myRank);
+                if (candidate != removeCells.end())
+                    sizes[1] = candidate->second.size();
+                MPI_Send(sizes, 2, mpiType, otherRank, tag, cc);
+            }
+    }
+    std::vector<MPI_Status> statuses(requests.size());
+    MPI_Waitall(requests.size(), requests.data(), statuses.data());
+
+    auto messages = std::count_if(
+                                  sizeBuffers.begin(), sizeBuffers.end(),
+                                  [](const std::vector<std::size_t> &v) { return v.size() ? v[0] + v[1] : 0; });
+    requests.resize(messages);
+    ++tag;
+
+    req = requests.begin();
+    std::vector<std::vector<std::size_t>> cellIndexBuffers; // receive buffers for indices of each rank.
+
+    for (auto it = begin, end = cellsPerProc.end(); it != end; ++it) {
+        auto otherRank = it - begin;
+        const auto &buffer = sizeBuffers[otherRank];
+        if ( otherRank != myRank && buffer.size() >= 2 && (buffer[0] + buffer[1])) {
+            auto &cellIndexBuffer = cellIndexBuffers[otherRank];
+            cellIndexBuffer.resize(buffer[0] + buffer[1]);
+            MPI_Irecv(cellIndexBuffer.data(), cellIndexBuffer.size(), mpiType, otherRank, tag, cc,
+                      &(*req));
+            ++req;
+        }
+    }
+
+    // Send data if we have cells.
+    if (!parts.empty()) {
+        for (int otherRank = 0; otherRank < cc.size(); ++otherRank)
+            if (otherRank != myRank) {
+                std::vector<std::size_t> buffer;
+                auto candidate = addCells.find(otherRank);
+                if (candidate != addCells.end())
+                    buffer.insert(buffer.end(), candidate->second.begin(),
+                                  candidate->second.end());
+
+                candidate = removeCells.find(otherRank);
+                if (candidate != removeCells.end())
+                    buffer.insert(buffer.end(), candidate->second.begin(),
+                                  candidate->second.end());
+
+                if (!buffer.empty()) {
+                    MPI_Send(buffer.data(), buffer.size(), mpiType, otherRank, tag, cc);
+                }
+            }
+    }
+    statuses.resize(messages);
+    // Wait for the messages
+    MPI_Waitall(requests.size(), requests.data(), statuses.data());
+
+    // unpack data
+    int otherRank = 0;
+    for (const auto &cellIndexBuffer : cellIndexBuffers) {
+        if (!cellIndexBuffer.empty()) {
+            // add cells that moved here
+            auto noAdded = sizeBuffers[otherRank][0];
+            importList.reserve(importList.size() + noAdded);
+            auto middle = importList.end();
+            std::vector<std::tuple<int, int, char>> addToImport;
+            std::size_t offset = 0;
+            for (; offset != noAdded; ++offset)
+                importList.emplace_back(cellIndexBuffer[offset], otherRank,
+                                        AttributeSet::owner, -1);
+            auto compare = [](const std::tuple<int, int, char, int> &t1,
+                              const std::tuple<int, int, char, int> &t2) {
+                               return std::get<0>(t1) < std::get<0>(t2);
+                           };
+            std::inplace_merge(importList.begin(), middle, importList.end(),
+                               compare);
+
+            // remove cells that moved to another process
+            auto noRemoved = sizeBuffers[otherRank][1];
+            if (noRemoved) {
+                std::vector<std::tuple<int, int, char, int>> tmp(importList.size());
+                auto newEnd =
+                    std::set_difference(importList.begin(), importList.end(),
+                                        cellIndexBuffer.begin() + noAdded,
+                                        cellIndexBuffer.end(), tmp.begin(), Less());
+                tmp.resize(newEnd - tmp.begin());
+                importList.swap(tmp);
+            }
+        }
+        ++otherRank;
     }
 #endif
 
@@ -133,7 +324,6 @@ postProcessPartitioningForWells(std::vector<int>& parts,
 
 }
 
-#ifdef HAVE_MPI
 std::unordered_set<std::string>
 computeDefunctWellNames(const std::vector<std::vector<int> >& wells_on_proc,
                         const std::vector<OpmWellType>& wells,
@@ -145,6 +335,7 @@ computeDefunctWellNames(const std::vector<std::vector<int> >& wells_on_proc,
 
 #if HAVE_ECL_INPUT
     std::vector<int> my_well_indices;
+    std::vector<std::string> globalWellNames;
     const int well_information_tag = 267553;
 
     if( root == cc.rank() )
@@ -163,6 +354,31 @@ computeDefunctWellNames(const std::vector<std::vector<int> >& wells_on_proc,
         }
         std::vector<MPI_Status> stats(reqs.size());
         MPI_Waitall(reqs.size(), reqs.data(), stats.data());
+        // Broadcast well names
+        // 1. Compute packed size and broadcast
+        std::size_t sizes[2] = {wells.size(),0};
+        int wellMessageSize = 0;
+        MPI_Pack_size(2, MPITraits<std::size_t>::getType(), cc, &wellMessageSize);
+        for(const auto& well: wells)
+        {
+            int size;
+            MPI_Pack_size(well.name().size() + 1, MPI_CHAR, cc, &size); // +1 for '\0' delimiter
+            sizes[1] += well.name().size() + 1;
+            wellMessageSize += size;
+        }
+        MPI_Bcast(&wellMessageSize, 1, MPI_INT, root, cc);
+        // 2. Send number of wells and their names in one message
+        globalWellNames.reserve(wells.size());
+        std::vector<char> buffer(wellMessageSize);
+        int pos = 0;
+        MPI_Pack(&sizes, 2, MPITraits<std::size_t>::getType(), buffer.data(), wellMessageSize, &pos, cc);
+        for(const auto& well: wells)
+        {
+            MPI_Pack(well.name().c_str(), well.name().size()+1, MPI_CHAR, buffer.data(),
+                     wellMessageSize, &pos, cc); // +1 for '\0' delimiter
+            globalWellNames.push_back(well.name());
+        }
+        MPI_Bcast(buffer.data(), wellMessageSize, MPI_PACKED, root, cc);
     }
     else
     {
@@ -173,6 +389,27 @@ computeDefunctWellNames(const std::vector<std::vector<int> >& wells_on_proc,
         my_well_indices.resize(msg_size);
         MPI_Recv(my_well_indices.data(), msg_size, MPI_INT, root,
                  well_information_tag, cc, &stat);
+
+        // 1. receive broadcasted message Size
+        int wellMessageSize;
+        MPI_Bcast(&wellMessageSize, 1, MPI_INT, root, cc);
+
+        // 2. Receive number of wells and their names in one message
+        globalWellNames.reserve(wells.size());
+        std::vector<char> buffer(wellMessageSize);
+        MPI_Bcast(buffer.data(), wellMessageSize, MPI_PACKED, root, cc);
+        std::size_t sizes[2];
+        int pos = 0;
+        MPI_Unpack(buffer.data(), wellMessageSize, &pos, &sizes, 2, MPITraits<std::size_t>::getType(), cc);
+        // unpack all string at once
+        std::vector<char> cstr(sizes[1]);
+        MPI_Unpack(buffer.data(), wellMessageSize, &pos, cstr.data(), sizes[1], MPI_CHAR, cc);
+        pos = 0;
+        for(std::size_t i = 0; i < sizes[0]; ++i)
+        {
+            globalWellNames.emplace_back(cstr.data()+pos);
+            pos += globalWellNames.back().size() + 1; // +1 because of '\0' delimiter
+        }
     }
 
     // Compute defunct wells in parallel run.
@@ -187,7 +424,7 @@ computeDefunctWellNames(const std::vector<std::vector<int> >& wells_on_proc,
     {
         if ( *defunct )
         {
-            defunct_well_names.insert(wells[defunct-defunct_wells.begin()].name());
+            defunct_well_names.insert(globalWellNames[defunct-defunct_wells.begin()]);
         }
     }
 #endif

--- a/opm/grid/common/WellConnections.hpp
+++ b/opm/grid/common/WellConnections.hpp
@@ -109,21 +109,32 @@ private:
     std::vector<std::set<int> > well_indices_;
 };
 
+
+#ifdef HAVE_MPI
 /// \brief Computes wells assigned to processes.
 ///
 /// Computes for all processes all indices of wells that
 /// will be assigned to this process.
 /// \param parts The partition number for each cell
+/// \param globalCell The linearized cartesian index for each index
 /// \param eclipseState The eclipse information
-/// \param well_connecton The informatio about the perforations of each well.
-/// \param no_procs The number of processes.
+/// \param well_connecton The information about the perforations of each well.
+/// \param exportList List of cells to be exported. Each entry is a tuple of the
+///                   global cell index, the process rank to export to, and the
+///                   attribute on that rank (assumed to be owner)
+/// \param exportList List of cells to be imported. Each entry is a tuple of the
+///                   global cell index, the process rank that exports it, and the
+///                   attribute on this rank (assumed to be owner)
+/// \param cc Information about the parallelism together with the decomposition.
 std::vector<std::vector<int> >
 postProcessPartitioningForWells(std::vector<int>& parts,
+                                const std::vector<int>& globalCell,
                                 const std::vector<OpmWellType>&  wells,
                                 const WellConnections& well_connections,
-                                std::size_t no_procs);
+                                std::vector<std::tuple<int,int,char>>& exportList,
+                                std::vector<std::tuple<int,int,char,int>>& importList,
+                                const CollectiveCommunication<MPI_Comm>& cc);
 
-#ifdef HAVE_MPI
 /// \brief Computes that names that of all wells not handled by this process
 /// \param wells_on_proc well indices assigned to each process
 /// \param eclipseState The eclipse information

--- a/opm/grid/common/ZoltanPartition.hpp
+++ b/opm/grid/common/ZoltanPartition.hpp
@@ -50,7 +50,9 @@ namespace cpgrid
 ///         the number of the process that owns it after repartitioning,
 ///         and a set of names of wells that should be defunct in a parallel
 ///         simulation.
-std::pair<std::vector<int>,std::unordered_set<std::string> >
+std::tuple<std::vector<int>,std::unordered_set<std::string>,
+           std::vector<std::tuple<int,int,char> >,
+           std::vector<std::tuple<int,int,char,int> >  >
 zoltanGraphPartitionGridOnRoot(const CpGrid& grid,
                                const std::vector<OpmWellType> * wells,
                                const double* transmissibilities,

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -52,6 +52,63 @@
 #include <fstream>
 #include <iostream>
 
+namespace
+{
+
+#if HAVE_MPI
+
+using AttributeSet = Dune::OwnerOverlapCopyAttributeSet::AttributeSet;
+
+template<typename Tuple, bool first>
+void reserveInterface(const std::vector<Tuple>& list, Dune::CpGrid::InterfaceMap& interface,
+                      const std::integral_constant<bool, first>&)
+{
+    std::map<int, std::size_t> proc_to_no_cells;
+    for(const auto& entry: list)
+    {
+        ++proc_to_no_cells[std::get<1>(entry)];
+    }
+    for(const auto& proc: proc_to_no_cells)
+    {
+        auto& entry = interface[proc.first];
+        if ( first )
+            entry.first.reserve(proc.second);
+        else
+            entry.second.reserve(proc.second);
+    }
+}
+
+void setupSendInterface(const std::vector<std::tuple<int, int, char> >& list, Dune::CpGrid::InterfaceMap& interface)
+{
+    reserveInterface(list, interface, std::integral_constant<bool, true>());
+    int cellIndex=-1;
+    int oldIndex = std::numeric_limits<int>::max();
+    for(const auto& entry: list)
+    {
+        auto index = std::get<0>(entry);
+        assert(oldIndex == std::numeric_limits<int>::max() || index >= oldIndex);
+
+        if (index != oldIndex )
+        {
+            oldIndex = index;
+            ++cellIndex;
+        }
+        interface[std::get<1>(entry)].first.add(cellIndex);
+    }
+}
+
+void setupRecvInterface(const std::vector<std::tuple<int, int, char, int> >& list, Dune::CpGrid::InterfaceMap& interface)
+{
+    reserveInterface(list, interface, std::integral_constant<bool, false>());
+    for(const auto& entry: list)
+    {
+        auto index = std::get<3>(entry);
+        interface[std::get<1>(entry)].second.add(index);
+    }
+}
+#endif // HAVE_MPI
+}
+
 namespace Dune
 {
 
@@ -59,10 +116,18 @@ namespace Dune
         : data_( new cpgrid::CpGridData(*this)),
           current_view_data_(data_.get()),
           distributed_data_(),
-          cell_scatter_gather_interfaces_(new InterfaceMap)
+          cell_scatter_gather_interfaces_(new InterfaceMap),
+          point_scatter_gather_interfaces_(new InterfaceMap)
     {}
 
 
+    CpGrid::CpGrid(MPIHelper::MPICommunicator  comm)
+        : data_( new cpgrid::CpGridData(comm)),
+          current_view_data_(data_.get()),
+          distributed_data_(),
+          cell_scatter_gather_interfaces_(new InterfaceMap),
+          point_scatter_gather_interfaces_(new InterfaceMap)
+    {}
 
 
 
@@ -75,7 +140,6 @@ CpGrid::scatterGrid(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellTy
     static_cast<void>(transmissibilities);
     static_cast<void>(overlapLayers);
     static_cast<void>(method);
-#if HAVE_MPI
     if(distributed_data_)
     {
         std::cerr<<"There is already a distributed version of the grid."
@@ -83,73 +147,105 @@ CpGrid::scatterGrid(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellTy
         return std::make_pair(false, std::unordered_set<std::string>());
     }
 
-    CollectiveCommunication cc(MPI_COMM_WORLD);
+#if HAVE_MPI
+    auto& cc = data_->ccobj_;
 
-    int my_num=cc.rank();
+    if (cc.size() > 1)
+    {
+        int my_num=cc.rank();
 #ifdef HAVE_ZOLTAN
-    auto part_and_wells =
-        cpgrid::zoltanGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0);
-    int num_parts = cc.size();
-    using std::get;
-    auto cell_part = std::get<0>(part_and_wells);
-    auto defunct_wells = std::get<1>(part_and_wells);
+        auto part_and_wells =
+            cpgrid::zoltanGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0);
+        using std::get;
+        auto cell_part = std::get<0>(part_and_wells);
+        auto defunct_wells = std::get<1>(part_and_wells);
+        auto exportList = std::get<2>(part_and_wells);
+        auto importList = std::get<3>(part_and_wells);
 #else
-    std::vector<int> cell_part(current_view_data_->global_cell_.size());
-    int  num_parts=-1;
-    std::array<int, 3> initial_split;
-    initial_split[1]=initial_split[2]=std::pow(cc.size(), 1.0/3.0);
-    initial_split[0]=cc.size()/(initial_split[1]*initial_split[2]);
-    partition(*this, initial_split, num_parts, cell_part, false, false);
-    const auto& cpgdim =  logicalCartesianSize();
-    std::vector<int> cartesian_to_compressed(cpgdim[0]*cpgdim[1]*cpgdim[2], -1);
-    for( int i=0; i < numCells(); ++i )
-    {
-        cartesian_to_compressed[globalCell()[i]] = i;
-    }
+        OPM_THROW(std::runtime_error, "Parallel runs depend on ZOLTAN. Please install!");
+        // std::vector<int> cell_part(current_view_data_->global_cell_.size());
+        // int  num_parts=-1;
+        // std::array<int, 3> initial_split;
+        // initial_split[1]=initial_split[2]=std::pow(cc.size(), 1.0/3.0);
+        // initial_split[0]=cc.size()/(initial_split[1]*initial_split[2]);
+        // partition(*this, initial_split, num_parts, cell_part, false, false);
+        // const auto& cpgdim =  logicalCartesianSize();
+        // std::vector<int> cartesian_to_compressed(cpgdim[0]*cpgdim[1]*cpgdim[2], -1);
+        // for( int i=0; i < numCells(); ++i )
+        // {
+        //     cartesian_to_compressed[globalCell()[i]] = i;
+        // }
 
-    std::unordered_set<std::string> defunct_wells;
+        // std::unordered_set<std::string> defunct_wells;
 
-    if ( wells )
-    {
-        cpgrid::WellConnections well_connections(*wells,
-                                                 cpgdim,
-                                                 cartesian_to_compressed);
+        // if ( wells )
+        // {
+        //     cpgrid::WellConnections well_connections(*wells,
+        //                                              cpgdim,
+        //                                              cartesian_to_compressed);
 
-        auto wells_on_proc =
-            cpgrid::postProcessPartitioningForWells(cell_part,
-                                                    *wells,
-                                                    well_connections,
-                                                    cc.size());
-        defunct_wells = cpgrid::computeDefunctWellNames(wells_on_proc,
-                                                        *wells,
-                                                        cc,
-                                                        0);
-    }
+        //     auto wells_on_proc =
+        //         cpgrid::postProcessPartitioningForWells(cell_part,
+        //                                                 *wells,
+        //                                                 well_connections,
+        //                                                 cc.size());
+        //     defunct_wells = cpgrid::computeDefunctWellNames(wells_on_proc,
+        //                                                     *wells,
+        //                                                     cc,
+        //                                                     0);
+        // }
 #endif
 
-    MPI_Comm new_comm = MPI_COMM_NULL;
+        bool ownersFirst = false;
 
-    if(num_parts < cc.size())
-    {
-        std::vector<int> ranks(num_parts);
-        for(int i=0; i<num_parts; ++i)
-            ranks[i]=i;
-        MPI_Group new_group;
-        MPI_Group old_group;
-        MPI_Comm_group(cc, &old_group);
-        MPI_Group_incl(old_group, num_parts, &(ranks[0]), &new_group);
+        // first create the overlap
+        // map from process to global cell indices in overlap
+        std::map<int,std::set<int> > overlap;
+        auto noImportedOwner = addOverlapLayer(*this, cell_part, exportList, importList, cc);
+        // importList contains all the indices that will be here.
+        auto compareImport = [](const std::tuple<int,int,char,int>& t1,
+                                const std::tuple<int,int,char,int>&t2)
+                             {
+                                 return std::get<0>(t1) < std::get<0>(t2);
+                             };
 
-        // Not all procs take part in the parallel computation
-        MPI_Comm_create(cc, new_group, &new_comm);
-        cc=CollectiveCommunication(new_comm);
-    }else{
-        new_comm = cc;
-    }
-    if(my_num<cc.size())
-    {
-        distributed_data_.reset(new cpgrid::CpGridData(new_comm));
-        distributed_data_->distributeGlobalGrid(*this,*this->current_view_data_, cell_part,
-                                                overlapLayers);
+        if ( ! ownersFirst )
+        {
+            // merge owner and overlap sorted by global index
+            std::inplace_merge(importList.begin(), importList.begin()+noImportedOwner,
+                               importList.end(), compareImport);
+        }
+        // assign local indices
+        int localIndex = 0;
+        for(auto&& entry: importList)
+            std::get<3>(entry) = localIndex++;
+
+        if ( ownersFirst )
+        {
+            // merge owner and overlap sorted by global index
+            std::inplace_merge(importList.begin(), importList.begin()+noImportedOwner,
+                               importList.end(), compareImport);
+        }
+
+        distributed_data_.reset(new cpgrid::CpGridData(cc));
+        distributed_data_->setUniqueBoundaryIds(data_->uniqueBoundaryIds());
+        // Just to be sure we assume that only master knows
+        cc.broadcast(&distributed_data_->use_unique_boundary_ids_, 1, 0);
+
+        // Create indexset
+        distributed_data_->cell_indexset_.beginResize();
+        for(const auto& entry: importList)
+        {
+            distributed_data_->cell_indexset_.add(std::get<0>(entry), ParallelIndexSet::LocalIndex(std::get<3>(entry), AttributeSet(std::get<2>(entry)), true));
+        }
+        distributed_data_->cell_indexset_.endResize();
+        // add an interface for gathering/scattering data with communication
+        // forward direction will be scatter and backward gather
+        // Interface will communicate from owner to all
+        setupSendInterface(exportList, *cell_scatter_gather_interfaces_);
+        setupRecvInterface(importList, *cell_scatter_gather_interfaces_);
+
+        distributed_data_->distributeGlobalGrid(*this,*this->current_view_data_, cell_part);
         int num_cells = distributed_data_->cell_to_face_.size();
         std::ostringstream message;
         message << "After loadbalancing process " << my_num << " has " << num_cells << " cells.";
@@ -159,54 +255,15 @@ CpGrid::scatterGrid(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellTy
             std::cout << message.str() << "\n";
         }
 
-        // add an interface for gathering/scattering data with communication
-        // forward direction will be scatter and backward gather
-        cell_scatter_gather_interfaces_.reset(new InterfaceMap);
-
-        auto rank = distributed_data_->ccobj_.rank();
-
-        if ( rank == 0)
-        {
-            std::map<int, std::size_t> proc_to_no_cells;
-            for(auto cell_owner = cell_part.begin(); cell_owner != cell_part.end();
-                ++cell_owner)
-            {
-                ++proc_to_no_cells[*cell_owner];
-            }
-
-            for(const auto& proc_no_cells : proc_to_no_cells)
-            {
-                (*cell_scatter_gather_interfaces_)[proc_no_cells.first]
-                    .first.reserve(proc_no_cells.second);
-            }
-
-            std::size_t cell_index = 0;
-
-            for(auto cell_owner = cell_part.begin(); cell_owner != cell_part.end();
-                ++cell_owner, ++cell_index)
-            {
-                auto& indices = (*cell_scatter_gather_interfaces_)[*cell_owner];
-                indices.first.add(cell_index);
-            }
-
-        }
-
-        (*cell_scatter_gather_interfaces_)[0].second
-            .reserve(distributed_data_->cell_indexset_.size());
-
-        for( auto& index: distributed_data_->cell_indexset_)
-        {
-            typedef typename cpgrid::CpGridData::AttributeSet AttributeSet;
-            if ( index.local().attribute() == AttributeSet::owner)
-            {
-                auto& indices = (*cell_scatter_gather_interfaces_)[0];
-                indices.second.add(index.local());
-            }
-        }
+        current_view_data_ = distributed_data_.get();
+        return std::make_pair(true, defunct_wells);
     }
-    current_view_data_ = distributed_data_.get();
-    return std::make_pair(true, defunct_wells);
-
+    else
+    {
+        std::cerr << "CpGrid::scatterGrid() only makes sense in a parallel run. "
+                  << "This run only uses one process.\n";
+        return std::make_pair(false, std::unordered_set<std::string>());
+    }
 #else // #if HAVE_MPI
     std::cerr << "CpGrid::scatterGrid() is non-trivial only with "
               << "MPI support and if the target Dune platform is "
@@ -219,6 +276,15 @@ CpGrid::scatterGrid(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellTy
     void CpGrid::createCartesian(const std::array<int, 3>& dims,
                                  const std::array<double, 3>& cellsize)
     {
+        if ( current_view_data_->ccobj_.rank() != 0 )
+        {
+            grdecl g;
+            g.dims[0] = g.dims[1] = g.dims[2] = 0;
+            current_view_data_->processEclipseFormat(g, {}, 0.0, false, false);
+            // global grid only on rank 0
+            return;
+        }
+
         // Make the grdecl format arrays.
         // Pillar coords.
         std::vector<double> coord;
@@ -261,10 +327,16 @@ CpGrid::scatterGrid(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellTy
     void CpGrid::readSintefLegacyFormat(const std::string& grid_prefix)
     {
         current_view_data_->readSintefLegacyFormat(grid_prefix);
+        current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
+                                             current_view_data_->logical_cartesian_size_.size(),
+                                             0);
     }
     void CpGrid::writeSintefLegacyFormat(const std::string& grid_prefix) const
     {
         current_view_data_->writeSintefLegacyFormat(grid_prefix);
+        current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
+                                             current_view_data_->logical_cartesian_size_.size(),
+                                             0);
     }
 
 
@@ -278,6 +350,9 @@ CpGrid::scatterGrid(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellTy
         current_view_data_->processEclipseFormat(ecl_grid, periodic_extension,
                                                  turn_normals, clip_z,
                                                  poreVolume, nncs);
+        current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
+                                             current_view_data_->logical_cartesian_size_.size(),
+                                             0);
     }
 #endif
 
@@ -285,6 +360,9 @@ CpGrid::scatterGrid(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellTy
                                       bool remove_ij_boundary, bool turn_normals)
     {
         current_view_data_->processEclipseFormat(input_data, {}, z_tolerance, remove_ij_boundary, turn_normals);
+        current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
+                                             current_view_data_->logical_cartesian_size_.size(),
+                                             0);
     }
 
 } // namespace Dune

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -1392,7 +1392,7 @@ void createInterfaceList(const typename CpGridData::InterfaceMap::value_type& pr
         for (const auto& point: cell2Points[cellList[c]])
             tmpPoints.push_back(local2Global(point));
 
-        for (const auto& point: additionalPoints[c])
+        for (const auto& point: additionalPoints[cellList[c]])
             tmpPoints.push_back(point); // is already a global id
     }
 

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -3,6 +3,7 @@
 #include <map>
 #include <vector>
 #include"CpGridData.hpp"
+#include"DataHandleWrappers.hpp"
 #include"Intersection.hpp"
 #include"Entity.hpp"
 #include"OrientedEntityTable.hpp"
@@ -18,6 +19,7 @@
 #include <opm/grid/utility/SparseTable.hpp>
 
 #include <opm/grid/utility/platform_dependent/reenable_warnings.h>
+#include <opm/grid/CpGrid.hpp>
 
 namespace Dune
 {
@@ -46,15 +48,16 @@ CpGridData::CpGridData()
 #endif
 }
 
-#if HAVE_MPI
-CpGridData::CpGridData(MPI_Comm comm)
+CpGridData::CpGridData(MPIHelper::MPICommunicator comm)
     : index_set_(new IndexSet(*this)), local_id_set_(new IdSet(*this)),
       global_id_set_(new GlobalIdSet(local_id_set_)), partition_type_indicator_(new PartitionTypeIndicator(*this)),
       ccobj_(comm), use_unique_boundary_ids_(false)
 {
+#if HAVE_MPI
     cell_interfaces_=std::make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
-}
 #endif
+}
+
 
 CpGridData::CpGridData(CpGrid&)
   : index_set_(new IndexSet(*this)),   local_id_set_(new IdSet(*this)),
@@ -62,7 +65,7 @@ CpGridData::CpGridData(CpGrid&)
     ccobj_(Dune::MPIHelper::getCommunicator()), use_unique_boundary_ids_(false)
 {
 #if HAVE_MPI
-    ccobj_=CollectiveCommunication(MPI_COMM_SELF);
+    //ccobj_=CollectiveCommunication(MPI_COMM_SELF);
     cell_interfaces_=std::make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
 #endif
 }
@@ -103,6 +106,18 @@ CpGridData::~CpGridData()
     delete local_id_set_;
     delete global_id_set_;
     delete partition_type_indicator_;
+}
+
+void CpGridData::populateGlobalCellIndexSet()
+{
+#if HAVE_MPI
+    cell_indexset_.beginResize();
+    for (int index = 0, end = size(0); index != end ; ++index){
+        cell_indexset_.add(global_id_set_->id(EntityRep<0>(index, true)),
+                           ParallelIndexSet::LocalIndex(index, AttributeSet::owner, true));
+    }
+    cell_indexset_.endResize();
+#endif
 }
 
 void CpGridData::computeUniqueBoundaryIds()
@@ -225,6 +240,678 @@ int getIndex(T i)
 {
     return i->index();
 }
+
+template<class C>
+struct DefaultContainerHandle
+{
+    using DataType = typename C::value_type;
+
+    DefaultContainerHandle(const C& gatherCont, C& scatterCont)
+        : gatherCont_(gatherCont), scatterCont_(scatterCont)
+    {}
+    bool fixedsize(std::size_t, std::size_t)
+    {
+        return true;
+    }
+    bool contains(std::size_t, std::size_t codim)
+    {
+        return codim == 0;
+    }
+    template<class T>
+    std::size_t size(const T&)
+    {
+        return 1;
+    }
+    template<class B, class T>
+    void gather(B& buffer, const T& t)
+    {
+        buffer.write(gatherCont_[t.index()]);
+    }
+    template<class B, class T>
+    void scatter(B& buffer, const T& t, std::size_t)
+    {
+        buffer.read(scatterCont_[t.index()]);
+    }
+private:
+    const C& gatherCont_;
+    C& scatterCont_;
+};
+
+/// \brief Handle for face tag, normal and boundary id
+struct FaceTagNormalBIdHandle
+{
+    using DataType = std::tuple<face_tag,FieldVector<double, 3>,int>;
+    using TagContainer = EntityVariable<enum face_tag, 1>;
+    using BIdContainer = EntityVariable<int, 1>;
+    using NormalContainer = SignedEntityVariable<FieldVector<double, 3>, 1>;
+
+    FaceTagNormalBIdHandle(const TagContainer& gatherTags, const NormalContainer& gatherNormals, const BIdContainer& gatherBIds,
+                           TagContainer& scatterTags,  NormalContainer& scatterNormals, BIdContainer& scatterBIds)
+        : gatherTags_(gatherTags), gatherNormals_(gatherNormals), gatherBIds_(gatherBIds),
+          scatterTags_(scatterTags), scatterNormals_(scatterNormals), scatterBIds_(scatterBIds)
+    {}
+    bool fixedsize(int, int)
+    {
+        return true;
+    }
+    bool contains(std::size_t dim, std::size_t codim)
+    {
+        return dim==3 && codim == 1;
+    }
+    template<class T>
+    std::size_t size(const T&)
+    {
+        return 1;
+    }
+    template<class B, class T>
+    void gather(B& buffer, const T& t)
+    {
+        if ( t.orientation() )
+        {
+            buffer.write(DataType(gatherTags_[t], gatherNormals_[t],
+                                  gatherBIds_[t]));
+        }
+        else
+        {
+            auto normal = -gatherNormals_[t];
+            buffer.write(DataType(gatherTags_[t], normal,
+                                  gatherBIds_[t]));
+        }
+    }
+    template<class B, class T>
+    void scatter(B& buffer, T& t, std::size_t )
+    {
+        DataType tmp;
+        buffer.read(tmp);
+        scatterTags_[t]=std::get<0>(tmp);
+        scatterNormals_.get(t.index()) = std::get<1>(tmp);
+        scatterBIds_[t] = std::get<2>(tmp);
+    }
+private:
+    const TagContainer& gatherTags_;
+    const NormalContainer& gatherNormals_;
+    const BIdContainer& gatherBIds_;
+    TagContainer& scatterTags_;
+    NormalContainer& scatterNormals_;
+    BIdContainer& scatterBIds_;
+};
+/// \brief Handle for face tag, normal and boundary id
+struct FaceTagNormalHandle
+{
+    using DataType = std::tuple<face_tag,FieldVector<double, 3> >;
+    using TagContainer = EntityVariable<enum face_tag, 1>;
+    using NormalContainer = SignedEntityVariable<FieldVector<double, 3>, 1>;
+
+    FaceTagNormalHandle(const TagContainer& gatherTags, const NormalContainer& gatherNormals,
+                        TagContainer& scatterTags,  NormalContainer& scatterNormals)
+        : gatherTags_(gatherTags), gatherNormals_(gatherNormals),
+          scatterTags_(scatterTags), scatterNormals_(scatterNormals)
+    {}
+    bool fixedsize(int, int)
+    {
+        return true;
+    }
+    bool contains(std::size_t dim, std::size_t codim)
+    {
+        return dim==3 && codim == 1;
+    }
+    template<class T>
+    std::size_t size(const T&)
+    {
+        return 4; // 3 coordinates + 1 volume
+    }
+    template<class B, class T>
+    void gather(B& buffer, const T& t)
+    {
+        if ( t.orientation() )
+        {
+            buffer.write(std::make_tuple(gatherTags_[t], gatherNormals_[t]));
+        }
+        else
+        {
+            auto normal = - gatherNormals_[t];
+            buffer.write(std::make_tuple(gatherTags_[t], normal));
+        }
+    }
+    template<class B, class T>
+    void scatter(B& buffer, T& t, std::size_t )
+    {
+        DataType tmp;
+        buffer.read(tmp);
+        scatterTags_[t]=std::get<0>(tmp);
+        scatterNormals_.get(t.index()) = std::get<1>(tmp);
+    }
+private:
+    const TagContainer& gatherTags_;
+    const NormalContainer& gatherNormals_;
+    TagContainer& scatterTags_;
+    NormalContainer& scatterNormals_;
+};
+struct PointGeometryHandle
+{
+    using DataType = double;
+    using Container = EntityVariable<cpgrid::Geometry<0, 3>, 3>;
+
+    PointGeometryHandle(const Container& gatherCont, Container& scatterCont)
+        : gatherPoints_(gatherCont), scatterPoints_(scatterCont)
+    {}
+    bool fixedsize(int, int)
+    {
+        return true;
+    }
+    bool contains(std::size_t dim, std::size_t codim)
+    {
+        return dim==3 && codim == 3;
+    }
+    template<class T>
+    std::size_t size(const T&)
+    {
+        return 3;
+    }
+    template<class B, class T>
+    typename std::enable_if<T::codimension != 3, void>::type
+    gather(B&, const T&)
+    {
+        OPM_THROW(std::logic_error, "This should never throw!");
+    }
+    template<class B>
+    void gather(B& buffer, const EntityRep<3>& t)
+    {
+        auto& geom = gatherPoints_[t];
+        for (int i = 0; i < 3; i++)
+            buffer.write(geom.center()[i]);
+    }
+    template<class B, class T>
+    typename std::enable_if<T::codimension != 3, void>::type
+    scatter(B&, const T&, std::size_t )
+    {
+        OPM_THROW(std::logic_error, "This should never throw!");
+    }
+    template<class B>
+    void scatter(B& buffer, const EntityRep<3>& t, std::size_t )
+    {
+        using Vector = typename Geometry<0, 3>::GlobalCoordinate;
+        Vector pos;
+
+        for (int i = 0; i < 3; i++)
+            buffer.read(pos[i]);
+        scatterPoints_[t] = Geometry<0, 3>(pos);
+    }
+private:
+    const Container& gatherPoints_;
+    Container& scatterPoints_;
+};
+
+struct FaceGeometryHandle
+{
+    using DataType = double;
+    using Geom = Geometry<2, 3>;
+    using Container = EntityVariable<Geom, 1>;
+
+    FaceGeometryHandle(const Container& gatherCont, Container& scatterCont)
+        : gatherPoints_(gatherCont), scatterPoints_(scatterCont)
+    {}
+    bool fixedsize(int, int)
+    {
+        return true;
+    }
+    bool contains(std::size_t dim, std::size_t codim)
+    {
+        return dim==3 && codim == 1;
+    }
+    template<class T>
+    std::size_t size(const T&)
+    {
+        return 4; // 3 coordinates + 1 volume
+    }
+    template<class B, class T>
+    void gather(B& buffer, const T& t)
+    {
+        auto& geom = gatherPoints_[t];
+        for (int i = 0; i < 3; i++)
+            buffer.write(geom.center()[i]);
+        buffer.write(geom.volume());
+    }
+    template<class B, class T>
+    void scatter(B& buffer, const T& t, std::size_t )
+    {
+        using Vector = typename Geom::GlobalCoordinate;
+        Vector pos;
+        double vol;
+
+        for (int i = 0; i < 3; i++)
+            buffer.read(pos[i]);
+
+        buffer.read(vol);
+        scatterPoints_[t] = Geom(pos, vol);
+    }
+private:
+    const Container& gatherPoints_;
+    Container& scatterPoints_;
+};
+
+
+struct CellGeometryHandle
+{
+    using DataType = double;
+    using Geom = Geometry<3, 3>;
+    using Container = EntityVariable<Geom, 0>;
+
+    CellGeometryHandle(const Container& gatherCont, Container& scatterCont,
+                       const EntityVariable<cpgrid::Geometry<0, 3>, 3>& pointGeom,
+                       const std::vector< std::array<int,8> >& cell2Points)
+        : gatherCont_(gatherCont), scatterCont_(scatterCont), pointGeom_(pointGeom),
+          cell2Points_(cell2Points)
+    {}
+    bool fixedsize(int, int)
+    {
+        return true;
+    }
+    bool contains(std::size_t dim, std::size_t codim)
+    {
+        return dim==3 && codim == 0;
+    }
+    template<class T>
+    std::size_t size(const T&)
+    {
+        return 4; // 3 coordinates + 1 volume
+    }
+    template<class B, class T>
+    typename std::enable_if<T::codimension != 0, void>::type
+    gather(B&, const T&)
+    {
+        OPM_THROW(std::logic_error, "This should never throw!");
+    }
+    template<class B>
+    void gather(B& buffer, const EntityRep<0>& t)
+    {
+        auto& geom = gatherCont_[t];
+        for (int i = 0; i < 3; i++)
+            buffer.write(geom.center()[i]);
+        buffer.write(geom.volume());
+    }
+    template<class B, class T>
+    typename std::enable_if<T::codimension != 0, void>::type
+    scatter(B&, const T&, std::size_t)
+    {
+        OPM_THROW(std::logic_error, "This should never throw!");
+    }
+    template<class B>
+    void scatter(B& buffer, const EntityRep<0>& t, std::size_t )
+    {
+        using Vector = typename Geom::GlobalCoordinate;
+        Vector pos;
+        double vol;
+
+        for (int i = 0; i < 3; i++)
+            buffer.read(pos[i]);
+
+        buffer.read(vol);
+        scatterCont_[t] = Geom(pos, vol, pointGeom_, cell2Points_[t.index()].data());
+    }
+private:
+    const Container& gatherCont_;
+    Container& scatterCont_;
+    const EntityVariable<cpgrid::Geometry<0, 3>, 3>& pointGeom_;
+    const std::vector< std::array<int,8> >& cell2Points_;
+};
+
+struct Cell2PointsDataHandle
+{
+    using DataType = int;
+    using Vector = std::vector<std::array<int,8> >;
+    Cell2PointsDataHandle(const Vector& globalCell2Points,
+                          const GlobalIdSet& globalIds,
+                          const std::vector<std::set<int> >& globalAdditionalPointIds,
+                          Vector& localCell2Points,
+                          std::vector<int>& flatGlobalPoints,
+                          std::vector<std::set<int> >& additionalPointIds)
+        : globalCell2Points_(globalCell2Points), globalIds_(globalIds), globalAdditionalPointIds_(globalAdditionalPointIds),
+          localCell2Points_(localCell2Points), flatGlobalPoints_(flatGlobalPoints), additionalPointIds_(additionalPointIds)
+    {}
+    bool fixedsize(int, int)
+    {
+        return false;
+    }
+    bool contains(std::size_t dim, std::size_t codim)
+    {
+        return dim==3 && codim == 0;
+    }
+    template<class T>
+    std::size_t size(const T& t)
+    {
+        return 8+globalAdditionalPointIds_[t.index()].size();
+    }
+    template<class B, class T>
+    void gather(B& buffer, const T& t)
+    {
+        std::size_t i = t.index();
+        assert(i < globalCell2Points_.size());
+        const auto& points = globalCell2Points_[i];
+        std::for_each(points.begin(), points.end(),
+                      [&buffer, this](const int& point){
+                          buffer.write(globalIds_.id(EntityRep<3>(point, true)));});
+        for (const auto& point: globalAdditionalPointIds_[i])
+        {
+            buffer.write(point);
+        }
+    }
+    template<class B, class T>
+    void scatter(B& buffer, const T& t, std::size_t s)
+    {
+        auto i = t.index();
+        auto& points = localCell2Points_[i];
+        std::for_each(points.begin(), points.end(),
+                      [&buffer, this](int& point){
+                          buffer.read(point);
+                          this->flatGlobalPoints_.push_back(point);
+                      });
+        for (std::size_t p = 8; p < s; ++p)
+        {
+            int pi{};
+            buffer.read(pi);
+            this->flatGlobalPoints_.push_back(pi);
+            additionalPointIds_[i].insert(pi);
+        }
+    }
+private:
+    const Vector& globalCell2Points_;
+    const GlobalIdSet& globalIds_;
+    const std::vector<std::set<int> >& globalAdditionalPointIds_;
+    Vector& localCell2Points_;
+    std::vector<int>& flatGlobalPoints_;
+    std::vector<std::set<int> >& additionalPointIds_;
+};
+
+template<class Table, int from>
+struct RowSizeDataHandle
+{
+    using DataType = int;
+    RowSizeDataHandle(const Table& global,
+                      std::vector<int>& noEntries)
+        : global_(global), noEntries_(noEntries)
+    {}
+    bool fixedsize(int, int)
+    {
+        return true;
+    }
+    template<class T>
+    std::size_t size(const T&)
+    {
+        return 1;
+    }
+    bool contains(std::size_t dim, std::size_t codim)
+    {
+        return dim==3 && codim == from;
+    }
+    template<class B, class T>
+    typename std::enable_if<T::codimension != from, void>::type
+    gather(B&, const T&)
+    {
+        OPM_THROW(std::logic_error, "This should never throw. Only available for other codims.");
+    }
+    template<class B>
+    void gather(B& buffer, const EntityRep<from>& t)
+    {
+        buffer.write(global_.rowSize(t));
+    }
+    template<class B, class T>
+    void scatter(B& buffer, const T& t, std::size_t)
+    {
+        buffer.read(noEntries_[t.index()]);
+    }
+private:
+    const Table& global_;
+    std::vector<int>& noEntries_;
+};
+
+template<int from>
+struct SparseTableEntity
+{
+    SparseTableEntity(const Opm::SparseTable<int>& table)
+        : table_(table)
+    {}
+    int rowSize(const EntityRep<from>& index) const
+    {
+        return table_.rowSize(index.index());
+    }
+private:
+    const Opm::SparseTable<int>& table_;
+};
+
+struct SparseTableDataHandle
+{
+    using Table = Opm::SparseTable<int>;
+    using DataType = int;
+    static constexpr int from = 1;
+    SparseTableDataHandle(const Table& global,
+                          const GlobalIdSet& globalIds,
+                          Table& local,
+                          const std::map<int,int>& global2Local)
+        : global_(global), globalIds_(globalIds), local_(local), global2Local_(global2Local)
+    {}
+    bool fixedsize(int, int)
+    {
+        return false;
+    }
+    bool contains(std::size_t dim, std::size_t codim)
+    {
+        return dim==3 && codim == from;
+    }
+    template<class T>
+    std::size_t size(const T& t)
+    {
+        return global_.rowSize(t.index());
+    }
+    template<class B, class T>
+    void gather(B& buffer, const T& t)
+    {
+        const auto& entries = global_[t.index()];
+        std::for_each(entries.begin(), entries.end(), [&buffer, this](const DataType& i){buffer.write(globalIds_.id(EntityRep<3>(i, true)));});
+    }
+    template<class B, class T>
+    void scatter(B& buffer, const T& t, std::size_t )
+    {
+        const auto& entries = local_[t.index()];
+        for (auto&& point : entries)
+        {
+            int i{};
+            buffer.read(i);
+            if ( point != std::numeric_limits<int>::max() )
+            {
+                // face already processed
+                continue;
+            }
+            auto candidate = global2Local_.find(i);
+            assert(candidate != global2Local_.end());
+            point = candidate->second;
+        }
+    }
+    private:
+    const Table& global_;
+    const GlobalIdSet& globalIds_;
+    Table& local_;
+    const std::map<int,int>& global2Local_;
+};
+
+template<class IdSet, int from, int to>
+struct OrientedEntityTableDataHandle
+{
+    using DataType = int;
+    using Table = OrientedEntityTable<from, to>;
+    using ToEntity = typename Table::ToType;
+    using FromEntity = typename Table::FromType;
+    OrientedEntityTableDataHandle(const Table& global, Table& local,
+                                  const IdSet* globalIds = nullptr)
+        : global_(global), local_(local), globalIds_(globalIds)
+    {}
+    bool fixedsize(int, int)
+    {
+        return false;
+    }
+    bool contains(std::size_t dim, std::size_t codim)
+    {
+        return dim==3 && codim == from;
+    }
+    template<class T>
+    typename std::enable_if<T::codimension != 0, std::size_t>::type
+    size(const T&)
+    {
+        OPM_THROW(std::logic_error, "This should never throw!");
+        return 0;
+    }
+    std::size_t size(const FromEntity& t)
+    {
+        return global_.rowSize(t);
+    }
+    template<class B, class T>
+    typename std::enable_if<T::codimension != 0, void>::type
+    gather(B&, const T&)
+    {
+        OPM_THROW(std::logic_error, "This should never throw!");
+    }
+    template<class B>
+    void gather(B& buffer, const FromEntity& t)
+    {
+        const auto& entries = global_[t];
+        if (globalIds_)
+        {
+            std::for_each(entries.begin(), entries.end(),
+                          [&buffer, this](const ToEntity& i){
+                              int id = globalIds_->id(i);
+                              if (!i.orientation())
+                                  id = ~id;
+                              buffer.write(id);});
+        }
+        else
+        {
+            std::for_each(entries.begin(), entries.end(), [&buffer](const ToEntity& i){buffer.write(i.signedIndex());});
+        }
+    }
+    template<class B, class T>
+    typename std::enable_if<T::codimension != 0, void>::type
+    scatter(B&, const T&, std::size_t)
+    {
+        OPM_THROW(std::logic_error, "This should never throw!");
+    }
+protected:
+    const Table& global_;
+    Table& local_;
+    const IdSet* globalIds_;
+};
+
+class C2FDataHandle
+    : public OrientedEntityTableDataHandle<GlobalIdSet,0,1>
+{
+public:
+    C2FDataHandle(const Table& global, const GlobalIdSet& globalIds, Table& local,
+                  std::vector<int>& unsignedGlobalFaceIds)
+        : OrientedEntityTableDataHandle<GlobalIdSet,0,1>(global, local, &globalIds),
+          unsignedGlobalFaceIds_(unsignedGlobalFaceIds)
+    {}
+    template<class B>
+    void scatter(B& buffer, const FromEntity& t, std::size_t)
+    {
+        auto entries = local_.row(t);
+        int i{};
+        for (auto&& entry : entries)
+        {
+            buffer.read(i);
+            if ( i < 0 )
+            {
+                entry = ToEntity(~i, false);
+                unsignedGlobalFaceIds_.push_back(~i);
+            }
+            else
+            {
+                entry = ToEntity(i, true);
+                unsignedGlobalFaceIds_.push_back(i);
+            }
+        }
+    }
+    template<class B, class T>
+    typename std::enable_if<T::codimension != 0, void>::type
+    scatter(B&, const T&, std::size_t)
+    {
+        OPM_THROW(std::logic_error, "This should never throw!");
+    }
+private:
+    std::vector<int>& unsignedGlobalFaceIds_;
+};
+
+template<class IndexSet>
+struct IndexSet2IdSet
+{
+    IndexSet2IdSet(const IndexSet& indexSet)
+    {
+        map_.resize(indexSet.size());
+        for (const auto& entry: indexSet)
+            map_[entry.local()] = entry.global();
+    }
+    template<class T>
+    int id(const T& t) const
+    {
+        return map_[t.index()];
+    }
+
+    std::vector<int> map_;
+};
+
+template<class IndexSet>
+class F2CDataHandle
+    : public OrientedEntityTableDataHandle<IndexSet2IdSet<IndexSet>,1,0>
+{
+public:
+    using Table = typename OrientedEntityTableDataHandle<IndexSet2IdSet<IndexSet>,1,0>::Table;
+    using FromEntity = typename OrientedEntityTableDataHandle<IndexSet2IdSet<IndexSet>,1,0>::FromEntity;
+    using ToEntity = typename OrientedEntityTableDataHandle<IndexSet2IdSet<IndexSet>,1,0>::ToEntity;
+
+    F2CDataHandle(const Table& global, Table& local,
+                  const IndexSet2IdSet<IndexSet>& gatherLocal2Global,
+                  const IndexSet& global2Local)
+        : OrientedEntityTableDataHandle<IndexSet2IdSet<IndexSet>,1,0>(global, local, &gatherLocal2Global),
+          global2Local_(global2Local)
+    {}
+    template<class B>
+    void scatter(B& buffer, const FromEntity& t, std::size_t )
+    {
+        auto entries = this->local_.row(t);
+        int i{};
+        for (auto&& entry : entries)
+        {
+            buffer.read(i);
+            if (entry.index() != std::numeric_limits<int>::max())
+            {
+                // face already processed, continue to save map lookup
+                continue;
+            }
+            bool orientation = true;
+            if ( i < 0 )
+            {
+                i = ~i;
+                orientation = false;
+            }
+            using IndexPair = typename IndexSet::IndexPair;
+            auto candidate = std::lower_bound(global2Local_.begin(), global2Local_.end(),
+                                          IndexPair(i),
+                                          [](const IndexPair& p1,
+                                             const IndexPair& p2){
+                                              return p1.global() < p2.global();});
+            if (candidate == global2Local_.end() || i != candidate->global())
+            {
+                // mark cell as being stored elsewhere
+                i = std::numeric_limits<int>::max();
+            }
+            else
+            {
+                i = candidate->local();
+            }
+            entry = ToEntity(i, orientation);
+        }
+    }
+private:
+    const IndexSet& global2Local_;
+};
 
 template<class T>
 struct AttributeDataHandle
@@ -512,387 +1199,384 @@ void createInterfaces(std::vector<std::map<int,char> >& attributes,
 
 }
 
+void CpGridData::computeGeometry(CpGrid& grid,
+                                 const DefaultGeometryPolicy&  globalGeometry,
+                                 const OrientedEntityTable<0, 1>& globalCell2Faces,
+                                 DefaultGeometryPolicy& geometry,
+                                 const OrientedEntityTable<0, 1>& cell2Faces,
+                                 const std::vector< std::array<int,8> >& cell2Points)
+{
+    FaceGeometryHandle faceGeomHandle(globalGeometry.geomVector(std::integral_constant<int,1>()),
+                                      geometry.geomVector(std::integral_constant<int,1>()));
+    FaceViaCellHandleWrapper<FaceGeometryHandle>
+        wrappedFaceGeomHandle(faceGeomHandle, globalCell2Faces, cell2Faces);
+    grid.scatterData(wrappedFaceGeomHandle);
+
+    PointGeometryHandle pointGeomHandle(globalGeometry.geomVector(std::integral_constant<int,3>()),
+                                             geometry.geomVector(std::integral_constant<int,3>()));
+    grid.scatterData(pointGeomHandle);
+
+    CellGeometryHandle cellGeomHandle(globalGeometry.geomVector(std::integral_constant<int,0>()),
+                                      geometry.geomVector(std::integral_constant<int,0>()),
+                                      geometry.geomVector(std::integral_constant<int,3>()),
+                                      cell2Points);
+    grid.scatterData(cellGeomHandle);
+}
+
+void computeFace2Point(CpGrid& grid,
+                       const OrientedEntityTable<0, 1>& globalCell2Faces,
+                       const GlobalIdSet& globalIds,
+                       const OrientedEntityTable<0, 1>& cell2Faces,
+                       const Opm::SparseTable<int>& globalFace2Points,
+                       Opm::SparseTable<int>& face2Points,
+                       const std::map<int,int>& global2local,
+                       std::size_t noFaces)
+{
+    std::vector<int> rowSizes(noFaces);
+    using EntityTable = SparseTableEntity<1>;
+    using RowSizeDataHandle = RowSizeDataHandle<EntityTable, 1>;
+    EntityTable wrappedGlobal(globalFace2Points);
+    RowSizeDataHandle rowSizeHandle(wrappedGlobal, rowSizes);
+    FaceViaCellHandleWrapper<RowSizeDataHandle>
+        wrappedSizeHandle(rowSizeHandle, globalCell2Faces, cell2Faces);
+    grid.scatterData(wrappedSizeHandle);
+    face2Points.allocate(rowSizes.begin(), rowSizes.end());
+    // Use entity with index INT_MAX to mark unprocessed row entries
+    for (int row = 0, size = face2Points.size(); row < size; ++row)
+    {
+        for (auto&& point : face2Points[row])
+        {
+            point = std::numeric_limits<int>::max();
+        }
+    }
+    SparseTableDataHandle handle(globalFace2Points, globalIds, face2Points, global2local);
+    FaceViaCellHandleWrapper<SparseTableDataHandle>
+        wrappedHandle(handle, globalCell2Faces, cell2Faces);
+    grid.scatterData(wrappedHandle);
+}
+
+template<class IndexSet>
+void computeFace2Cell(CpGrid& grid,
+                      const OrientedEntityTable<0, 1>& globalCell2Faces,
+                      const OrientedEntityTable<0, 1>& cell2Faces,
+                      const OrientedEntityTable<1, 0>& globalFace2Cells,
+                      OrientedEntityTable<1, 0>& face2Cells,
+                      const IndexSet& global2local,
+                      const IndexSet& globalIndexSet,
+                      std::size_t noFaces)
+{
+    std::vector<int> rowSizes(noFaces);
+    using Table = OrientedEntityTable<1,0>;
+    RowSizeDataHandle<Table,1> rowSizeHandle(globalFace2Cells, rowSizes);
+    FaceViaCellHandleWrapper<RowSizeDataHandle<Table,1> > wrappedSizeHandle(rowSizeHandle,
+                                                                        globalCell2Faces, cell2Faces);
+    grid.scatterData(wrappedSizeHandle);
+    face2Cells.allocate(rowSizes.begin(), rowSizes.end());
+    // Use entity with index INT_MAX to mark unprocessed row entries
+    for (int row = 0, size = face2Cells.size(); row < size; ++row)
+    {
+        for (auto&& face : face2Cells.row(EntityRep<1>(row, true)))
+        {
+            face = EntityRep<0>(std::numeric_limits<int>::max(), true);
+        }
+    }
+    IndexSet2IdSet<IndexSet> local2Global(globalIndexSet);
+    F2CDataHandle<IndexSet> entryHandle(globalFace2Cells, face2Cells, local2Global, global2local);
+    FaceViaCellHandleWrapper<F2CDataHandle<IndexSet> > wrappedEntryHandle(entryHandle,
+                                                                          globalCell2Faces, cell2Faces);
+    grid.scatterData(wrappedEntryHandle);
+#ifndef NDEBUG
+    for (int row = 0, size = face2Cells.size(); row < size; ++row)
+    {
+        bool oneValid = false;
+        for (auto&& face : face2Cells.row(EntityRep<1>(row, true)))
+        {
+            oneValid = oneValid || face.index() != std::numeric_limits<int>::max();
+        }
+        assert(oneValid);
+    }
+#endif
+}
+
+
+std::map<int,int> computeCell2Face(CpGrid& grid,
+                                    const OrientedEntityTable<0, 1>& globalCell2Faces,
+                                    const GlobalIdSet& globalIds,
+                                    OrientedEntityTable<0, 1>& cell2Faces,
+                                    std::vector<int>& map2Global,
+                                    std::size_t noCells)
+{
+    std::vector<int> rowSizes(noCells);
+    using Table = OrientedEntityTable<0,1>;
+    RowSizeDataHandle<Table,0> rowSizeHandle(globalCell2Faces, rowSizes);
+    grid.scatterData(rowSizeHandle);
+    cell2Faces.allocate(rowSizes.begin(), rowSizes.end());
+    map2Global.reserve((noCells*6)*1.1);
+    C2FDataHandle handle(globalCell2Faces, globalIds, cell2Faces,
+                         map2Global);
+    grid.scatterData(handle);
+    // make map2Global a map from local index to global id
+    std::sort(map2Global.begin(),map2Global.end());
+    auto newEnd = std::unique(map2Global.begin(),map2Global.end());
+    map2Global.resize(newEnd - map2Global.begin());
+    // Convert face ids to local ones
+    std::map<int, int> map2Local;
+    auto current_global = map2Global.begin();
+    int localId = 0;
+    // \todo improve since we are inserting values by sorted keys.
+    std::generate_n(std::inserter(map2Local, map2Local.begin()),
+                    newEnd - current_global,
+                    [&localId, &current_global](){ return std::make_pair(*(current_global++), localId++); });
+    // translate global to local ids
+    for (int row = 0, size = cell2Faces.size(); row < size; ++row)
+    {
+        for (auto&& face : cell2Faces.row(EntityRep<0>(row, true)))
+        {
+            auto index = face.signedIndex();
+            if (index < 0 )
+            {
+                face = EntityRep<1>(map2Local[~index], false);
+            }
+            else
+            {
+                face = EntityRep<1>(map2Local[index], true);
+            }
+        }
+    }
+    return map2Local;
+}
+
+std::vector<std::set<int> > computeAdditionalFacePoints(const std::vector<std::array<int,8> >& globalCell2Points,
+                                                        const OrientedEntityTable<0, 1>& globalCell2Faces,
+                                                        const Opm::SparseTable<int>& globalFace2Points,
+                                                        const GlobalIdSet& globalIds)
+{
+    std::vector<std::set<int> > additionalFacePoints(globalCell2Points.size());
+
+    for ( std::size_t c = 0; c < globalCell2Points.size(); ++c)
+    {
+        const auto& points = globalCell2Points[c];
+        for(const auto& face: globalCell2Faces[EntityRep<0>(c, true)])
+            for(const auto& point: globalFace2Points[face.index()])
+            {
+                auto candidate = std::find(points.begin(), points.end(), point);
+                if(candidate == points.end())
+                    // point is not a corner of the cell
+                    additionalFacePoints[c].insert(globalIds.id(EntityRep<3>(point,true)));
+            }
+    }
+    return additionalFacePoints;
+}
+
+template<bool send, class Map2Global, class Map2Local>
+void createInterfaceList(const typename CpGridData::InterfaceMap::value_type& procCellLists,
+                         const std::vector<std::array<int,8> >& cell2Points,
+                         const std::vector<std::set<int> >& additionalPoints,
+                         const Map2Global& local2Global,
+                         Map2Local& map2Local,
+                         typename CpGridData::InterfaceMap::mapped_type& pointLists
+)
+{
+    const auto& cellList = send? procCellLists.second.first : procCellLists.second.second;
+
+    // Create list of global ids from cell lists
+    std::vector<int> tmpPoints;
+    std::size_t noAdditional{};
+    for (auto const& addPoints: additionalPoints)
+        noAdditional += addPoints.size();
+
+    tmpPoints.reserve(cell2Points.size()*8+noAdditional);
+
+    for (std::size_t c = 0; c < cellList.size(); ++c)
+    {
+        for (const auto& point: cell2Points[cellList[c]])
+            tmpPoints.push_back(local2Global(point));
+
+        for (const auto& point: additionalPoints[c])
+            tmpPoints.push_back(point); // is already a global id
+    }
+
+    // sort list and make it unique
+    std::sort(tmpPoints.begin(), tmpPoints.end());
+    auto newEnd = std::unique(tmpPoints.begin(), tmpPoints.end());
+    tmpPoints.resize(newEnd - tmpPoints.begin());
+
+    // map entries to local indices
+    for ( auto&& point: tmpPoints)
+        point = map2Local[point];
+
+    auto& pointList = send ? pointLists.first : pointLists.second;
+    pointList.reserve(tmpPoints.size());
+
+    for ( auto && point: tmpPoints)
+        pointList.add(point);
+}
+
+std::map<int,int> computeCell2Point(CpGrid& grid,
+                                    const std::vector<std::array<int,8> >& globalCell2Points,
+                                    const GlobalIdSet& globalIds,
+                                    const OrientedEntityTable<0, 1>& globalCell2Faces,
+                                    const Opm::SparseTable<int>& globalFace2Points,
+                                    std::vector<std::array<int,8> >& cell2Points,
+                                    std::vector<int>& map2Global,
+                                    std::size_t noCells,
+                                    const typename CpGridData::InterfaceMap& cellInterfaces,
+                                    typename CpGridData::InterfaceMap& pointInterfaces
+                                    )
+{
+    cell2Points.resize(noCells);
+    map2Global.reserve(noCells*8*1.1);
+    auto globalAdditionalPoints = computeAdditionalFacePoints(globalCell2Points, globalCell2Faces,
+                                                              globalFace2Points,
+                                                              globalIds);
+    std::vector<std::set<int> > additionalPoints(noCells);
+    Cell2PointsDataHandle handle(globalCell2Points, globalIds,
+                                 globalAdditionalPoints,
+                                 cell2Points,
+                                 map2Global,
+                                 additionalPoints);
+    grid.scatterData(handle);
+    // make map2Global a map from local index to global id
+    std::sort(map2Global.begin(),map2Global.end());
+    auto newEnd = std::unique(map2Global.begin(),map2Global.end());
+    map2Global.resize(newEnd - map2Global.begin());
+    // Convert point ids to local ones
+    std::map<int, int> map2Local;
+    auto current_global = map2Global.begin();
+    int localId = 0;
+    // \todo improve since we are inserting values by sorted keys.
+    std::generate_n(std::inserter(map2Local, map2Local.begin()),
+                    newEnd - current_global,
+                    [&localId, &current_global](){ return std::make_pair(*(current_global++), localId++); });
+    for (auto&& points : cell2Points)
+    {
+        for (auto&& point : points)
+        {
+            point = map2Local[point];
+        }
+    }
+
+    // Create interfaces for point communication
+
+    for ( const auto& procCellLists: cellInterfaces)
+    {
+        // The send list
+        ReversePointGlobalIdSet globalMap2Local(globalIds);
+        createInterfaceList<true>(procCellLists, globalCell2Points,
+                                  globalAdditionalPoints,
+                                  [&globalIds](int i){
+                                      return globalIds.id(EntityRep<3>(i, true));
+                                  },
+                                  globalMap2Local,
+                                  pointInterfaces[procCellLists.first]);
+        globalMap2Local.release();
+        // The receive list
+        createInterfaceList<false>(procCellLists, cell2Points,
+                                   additionalPoints,
+                                   [&map2Global](int i)
+                                   {
+                                       return map2Global[i];
+                                   },
+                                   map2Local,
+                                   pointInterfaces[procCellLists.first]);
+    }
+    return map2Local;
+}
+
 #endif // #if HAVE_MPI
 
-
-void CpGridData::distributeGlobalGrid(const CpGrid& grid,
+void CpGridData::distributeGlobalGrid(CpGrid& grid,
                                       const CpGridData& view_data,
-                                      const std::vector<int>& cell_part,
-                                      int overlap_layers)
+                                      const std::vector<int>& /* cell_part */)
 {
 #if HAVE_MPI
-    Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator>& ccobj=ccobj_;
-    int my_rank=ccobj.rank();
-#if 0
-    int size=ccobj.size();
-    typedef std::vector<int>::const_iterator Iterator;
-    for(Iterator i=cell_part.begin(); i!= cell_part.end(); ++i)
-        if(*i>=size)
-            OPM_THROW(std::runtime_error, "rank for cell is too big");
-#endif // #ifdef DEBUG
-    // vector with the set of ranks that
-    std::vector<std::set<int> > overlap;
-
-    overlap.resize(cell_part.size());
-    addOverlapLayer(grid, cell_part, overlap, my_rank, overlap_layers, true);
-    // count number of cells
-    struct CellCounter
-    {
-        int myrank;
-        int count;
-        typedef std::set<int>::const_iterator NeighborIterator;
-        std::set<int> neighbors;
-        typedef Dune::ParallelLocalIndex<AttributeSet> Index;
-        ParallelIndexSet* indexset;
-        std::vector<int> global2local;
-        /**
-         * @brief Adds an index with flag owner to the index set.
-         *
-         * An index is added if the rank is our rank.
-         * @param i The global index
-         * @param rank The rank that owns the index.
-         */
-        void operator() (int i, int rank)
-        {
-            if(rank==myrank)
-            {
-                global2local.push_back(count);
-                indexset->add(i, Index(count++, AttributeSet::owner, true));
-            }else
-                global2local.push_back(std::numeric_limits<int>::max());
-        }
-        /**
-         * @brief Adds an index that is present on more than one processor to the index set.
-         * @param i The global index.
-         * @param ov The set of ranks where the index is in the overlap
-         * region.
-         * @param rank The rank that owns this index.
-         */
-        void operator() (int i, const std::set<int>& ov, int rank)
-        {
-            if(rank==myrank)
-            {
-                global2local.push_back(count);
-                indexset->add(i, Index(count++, AttributeSet::owner, true));
-                neighbors.insert(ov.begin(), ov.end());
-            }
-            else
-            {
-                std::set<int>::const_iterator iter=
-                    ov.find(myrank);
-                if(iter!=ov.end())
-                {
-                    global2local.push_back(count);
-                    indexset->add(i, Index(count++, AttributeSet::copy, true));
-                    neighbors.insert(ov.begin(), iter);
-                    neighbors.insert(++iter, ov.end());
-                }
-                else
-                    global2local.push_back(std::numeric_limits<int>::max());
-            }
-        }
-    } cell_counter;
-    cell_counter.myrank=my_rank;
-    cell_counter.count=0;
-    cell_counter.global2local.reserve(cell_part.size());
-    cell_counter.indexset=&cell_indexset_;
-    // set up the index set.
-    cell_counter.indexset->beginResize();
-    typedef std::vector<std::set<int> >::const_iterator OIterator;
-    std::vector<int>::const_iterator ci=cell_part.begin();
-    for(OIterator end=overlap.end(), begin=overlap.begin(), i=begin; i!=end; ++i, ++ci)
-    {
-        if(i->size())
-            // Cell is shared between different processors
-            cell_counter(i-begin, *i, *ci);
-        else
-            // cell is not shared
-            cell_counter(i-begin, *ci);
-    }
-    cell_counter.indexset->endResize();
     // setup the remote indices.
-    typedef RemoteIndexListModifier<RemoteIndices::ParallelIndexSet, RemoteIndices::Allocator,
-                                    false> Modifier;
-    typedef RemoteIndices::RemoteIndex RemoteIndex;
     cell_remote_indices_.setIndexSets(cell_indexset_, cell_indexset_, ccobj_);
-
-
-    // Create a map of ListModifiers
-    if(cell_counter.neighbors.size()){ //extra scope to call destructor of the Modifiers
-        std::map<int,Modifier> modifiers;
-        for(CellCounter::NeighborIterator n=cell_counter.neighbors.begin(), end=cell_counter.neighbors.end();
-            n != end; ++n)
-            modifiers.insert(std::make_pair(*n, cell_remote_indices_.getModifier<false,false>(*n)));
-        // Insert remote indices. For each entry in the index set, see wether there are overlap occurences and add them.
-        for(ParallelIndexSet::const_iterator i=cell_indexset_.begin(), end=cell_indexset_.end();
-            i!=end; ++i)
-        {
-            if(i->local().attribute()!=AttributeSet::owner)
-            {
-                std::map<int,Modifier>::iterator mod=modifiers.find(cell_part[i->global()]);
-                assert(mod!=modifiers.end());
-                mod->second.insert(RemoteIndex(AttributeSet::owner,&(*i)));
-            }
-            else
-            {
-                typedef std::set<int>::const_iterator SIter;
-                SIter mine =overlap[i->global()].find(my_rank);
-                for(SIter iter=overlap[i->global()].begin(); iter!=mine; ++iter)
-                {
-                    std::map<int,Modifier>::iterator mod=modifiers.find(*iter);
-                    assert(mod!=modifiers.end());
-                    mod->second.insert(RemoteIndex(AttributeSet::copy, &(*i)));
-                }
-                SIter end2=overlap[i->global()].end();
-                if(mine!=end2)
-                    for(++mine; mine!=end2; ++mine)
-                    {
-                        std::map<int,Modifier>::iterator mod=modifiers.find(*mine);
-                        assert(mod!=modifiers.end());
-                        mod->second.insert(RemoteIndex(AttributeSet::copy, &(*i)));
-                    }
-            }
-        }
-    }
-    else
-    {
-        // Force update of the sync counter in the remote indices.
-        cell_remote_indices_.getModifier<false,false>(0);
-    }
+    cell_remote_indices_.template rebuild<false>(); // We could probably also compute this on our own, like before?
 
     // We can identify existing cells with the help of the index set.
     // Now we need to compute the existing faces and points. Either exist
     // if they are reachable from an existing cell.
     // We use std::numeric_limits<int>::max() to indicate non-existent entities.
-    std::vector<int> face_indicator(view_data.geometry_.geomVector<1>().size(),
-                                    std::numeric_limits<int>::max());
-    std::vector<int> point_indicator(view_data.geometry_.geomVector<3>().size(),
-                                     std::numeric_limits<int>::max());
-    for(ParallelIndexSet::iterator i=cell_indexset_.begin(), end=cell_indexset_.end();
-            i!=end; ++i)
-    {
-        typedef boost::iterator_range<const EntityRep<1>*>::iterator RowIter;
-        int row_index=i->global();
-        // Somehow g++-4.4 does not find functions of father even if we
-        // change inheritance of OrientedEntityTable to public.
-        // Therfore we use an ugly cast to base class here.
-        const Opm::SparseTable<EntityRep<1> >& c2f=view_data.cell_to_face_;
-        for(RowIter f=c2f[row_index].begin(), fend=c2f[row_index].end();
-            f!=fend; ++f)
-        {
-            int findex=f->index();
-            --face_indicator[findex];
-            // points reachable from a cell exist, too.
-            for(auto p=view_data.face_to_point_[findex].begin(),
-                    pend=view_data.face_to_point_[findex].end(); p!=pend; ++p)
-            {
-                assert(*p >= 0);
-                --point_indicator[*p];
-            }
-        }
-    }
-
-
-    // renumber  face and point indicators
-    std::for_each(face_indicator.begin(), face_indicator.end(), AssignAndIncrement());
-    std::for_each(point_indicator.begin(), point_indicator.end(), AssignAndIncrement());
-
     std::vector<int> map2GlobalFaceId;
-    int noExistingFaces = setupAndCountGlobalIds<1>(face_indicator, map2GlobalFaceId,
-                                                    *view_data.local_id_set_);
     std::vector<int> map2GlobalPointId;
-    int noExistingPoints = setupAndCountGlobalIds<3>(point_indicator, map2GlobalPointId,
-                                                     *view_data.local_id_set_);
+    std::map<int,int> point_indicator =
+        computeCell2Point(grid, view_data.cell_to_point_, *view_data.global_id_set_, view_data.cell_to_face_,
+                          view_data.face_to_point_, cell_to_point_,
+                          map2GlobalPointId, cell_indexset_.size(),
+                          *grid.cell_scatter_gather_interfaces_,
+                          *grid.point_scatter_gather_interfaces_);
+
+    // create global ids array for cells. The parallel index set uses the global id
+    // as the global index.
     std::vector<int> map2GlobalCellId(cell_indexset_.size());
-    for(ParallelIndexSet::const_iterator i=cell_indexset_.begin(), end=cell_indexset_.end();
-        i!=end; ++i)
+    for(const auto& i: cell_indexset_)
     {
-        map2GlobalCellId[i->local()]=view_data.local_id_set_->id(EntityRep<0>(i->global(), true));
+        map2GlobalCellId[i.local()]=i.global();
     }
+
+    std::map<int,int> face_indicator =
+        computeCell2Face(grid, view_data.cell_to_face_, *view_data.global_id_set_, cell_to_face_,
+                         map2GlobalFaceId, cell_indexset_.size());
+
+    auto noExistingPoints = map2GlobalPointId.size();
+    auto noExistingFaces = map2GlobalFaceId.size();
 
     global_id_set_->swap(map2GlobalCellId, map2GlobalFaceId, map2GlobalPointId);
 
-    // Create the topology information. This is stored in sparse matrix like data structures.
-    // First conunt the size of the nonzeros of the cell_to_face data.
-    int data_size=0;
-    for(auto i=cell_indexset_.begin(), end=cell_indexset_.end();
-        i!=end; ++i)
-    {
-        const Opm::SparseTable<EntityRep<1> >& c2f=view_data.cell_to_face_;
-        data_size+=c2f.rowSize(i->global());
-    }
+    computeFace2Cell(grid, view_data.cell_to_face_, cell_to_face_,
+                     view_data.face_to_cell_, face_to_cell_, cell_indexset_, view_data.cell_indexset_, noExistingFaces);
+    computeFace2Point(grid,  view_data.cell_to_face_, *view_data.global_id_set_, cell_to_face_,
+                      view_data.face_to_point_, face_to_point_, point_indicator,
+                      noExistingFaces);
 
-    //- cell_to_face_ : extract owner/overlap rows from cell_to_face_
-    // Construct the sparse matrix like data structure.
-    //OrientedEntityTable<0, 1> cell_to_face;
-    cell_to_face_.reserve(cell_indexset_.size(), data_size);
-    cell_to_point_.resize(cell_indexset_.size());
-
-    for(auto i=cell_indexset_.begin(), end=cell_indexset_.end();
-        i!=end; ++i)
-    {
-        typedef boost::iterator_range<const EntityRep<1>*>::const_iterator RowIter;
-        const Opm::SparseTable<EntityRep<1> >& c2f=view_data.cell_to_face_;
-        auto row=c2f[i->global()];
-        // create the new row, i.e. copy orientation and use new face indicator.
-        std::vector<EntityRep<1> > new_row(row.size());
-        std::vector<EntityRep<1> >::iterator  nface=new_row.begin();
-        for(RowIter face=row.begin(), fend=row.end(); face!=fend; ++face, ++nface)
-            nface->setValue(face_indicator[face->index()], face->orientation());
-        // Append the new row to the matrix
-        cell_to_face_.appendRow(new_row.begin(), new_row.end());
-        for(int j=0; j<8; ++j)
-            cell_to_point_[i->local()][j]=point_indicator[view_data.cell_to_point_[i->global()][j]];
-    }
-
-    // Calculate the number of nonzeros needed for the face_to_cell sparse matrix
-    // To speed things up, we only use an upper limit here.
-    data_size=0;
-    const Opm::SparseTable<EntityRep<0> >& f2c=view_data.face_to_cell_;
-    for(auto f=face_indicator.begin(), fend=face_indicator.end(); f!=fend; ++f)
-        if(*f<std::numeric_limits<int>::max())
-            data_size += f2c.rowSize(*f);
-
-    face_to_cell_.reserve(f2c.size(), data_size);
-
-    //- face_to cell_ : extract rows that connect to an existent cell
-    std::vector<int> cell_indicator(view_data.cell_to_face_.size(),
-                                    std::numeric_limits<int>::max());
-    for(auto i=cell_indexset_.begin(), end=cell_indexset_.end(); i!=end; ++i)
-        cell_indicator[i->global()]=i->local();
-
-    for(auto begin=face_indicator.begin(), f=begin, fend=face_indicator.end(); f!=fend; ++f)
-    {
-        if(*f<std::numeric_limits<int>::max())
-        {
-            // face does exist
-            std::vector<EntityRep<0> > new_row;
-            auto old_row = f2c[f-begin];
-            new_row.reserve(old_row.size());
-            // push back connected existent cells.
-            // for those cells we use the new cell_indicator and copy the
-            // orientation of the old cell.
-            for(auto cell = old_row.begin(), cend=old_row.end();cell!=cend; ++cell)
-            {
-                // The statement below results in all faces having two neighbours
-                // except for those at the domain boundary.
-                // Note that along the front partition there are invalid neighbours
-                // marked with index std::numeric_limits<int>::max()
-                // Still they inherit the orientation to make CpGrid::faceCell happy
-                new_row.push_back(EntityRep<0>(cell_indicator[cell->index()],
-                                                   cell->orientation()));
-            }
-            face_to_cell_.appendRow(new_row.begin(), new_row.end());
-        }
-    }
-
-    // Compute the number of non zeros of the face_to_point matrix.
-    data_size=0;
-    for(auto f=face_indicator.begin(), fend=face_indicator.end(); f!=fend; ++f)
-        if(*f<std::numeric_limits<int>::max())
-            data_size += view_data.face_to_point_.rowSize(*f);
-
-    face_to_point_.reserve(view_data.face_to_point_.size(), data_size);
-
-    //- face_to_point__ : extract row associated with existing faces_
-    for(auto begin=face_indicator.begin(), f=begin, fend=face_indicator.end(); f!=fend; ++f)
-    {
-        if(*f<std::numeric_limits<int>::max())
-        {
-            // face does exist
-            std::vector<int> new_row;
-            auto old_row = view_data.face_to_point_[f-begin];
-            new_row.reserve(old_row.size());
-            for(auto point = old_row.begin(), pend=old_row.end(); point!=pend; ++point)
-            {
-                assert(point_indicator[*point]<std::numeric_limits<int>::max());
-                new_row.push_back(point_indicator[*point]);
-            }
-            face_to_point_.appendRow(new_row.begin(), new_row.end());
-        }
-    }
 
     logical_cartesian_size_=view_data.logical_cartesian_size_;
 
     // Set up the new topology arrays
-    // Count the existing points and allocate space
-    EntityVariable<cpgrid::Geometry<0, 3>, 3>& point_geom = geometry_.geomVector(std::integral_constant<int,3>());
-    const std::vector<cpgrid::Geometry<0, 3> >& global_point_geom=view_data.geomVector<3>();
-    point_geom.reserve(noExistingPoints);
+    geometry_.geomVector(std::integral_constant<int,1>()).resize(noExistingFaces);
+    geometry_.geomVector(std::integral_constant<int,0>()).resize(cell_to_face_.size());
+    geometry_.geomVector(std::integral_constant<int,3>()).resize(noExistingPoints);
 
-    // Now copy the point geometries that do exist.
-    for (auto begin = point_indicator.begin(), pi = begin,  end = point_indicator.end(); pi != end;
-        ++pi)
-    {
-        if (*pi < std::numeric_limits<int>::max())
-        {
-            point_geom.emplace_back(global_point_geom[pi - begin]);
-        }
-    }
+    computeGeometry(grid, view_data.geometry_, view_data.cell_to_face_,
+                    geometry_, cell_to_face_, cell_to_point_);
 
-
-    EntityVariable<cpgrid::Geometry<3, 3>, 0>& cell_geom = geometry_.geomVector(std::integral_constant<int,0>());
-    std::vector<cpgrid::Geometry<3, 3> > tmp_cell_geom(cell_indexset_.size());
-    auto global_cell_geom=view_data.geomVector<0>();
     global_cell_.resize(cell_indexset_.size());
-    cell_geom.resize(cell_indexset_.size());
-    // Copy the existing cells.
-    for (auto i = cell_indexset_.begin(), end = cell_indexset_.end(); i != end; ++i)
+
+    // communicate global cell
+    DefaultContainerHandle<std::vector<int> > indexHandle(view_data.global_cell_, global_cell_);
+    grid.scatterData(indexHandle);
+
+    // Scatter face tags, normals, and boundary ids.
+    auto noBids = view_data.unique_boundary_ids_.size();
+    bool hasBids = ccobj_.max(noBids);
+    face_tag_.resize(noExistingFaces);
+    face_normals_.resize(noExistingFaces);
+
+    if (hasBids)
     {
-        const auto& geom = global_cell_geom.get(i->global());
-        cell_geom.get(i->local()) = Geometry<3,3>(geom.center(), geom.volume(),
-                                                  point_geom,
-                                                  cell_to_point_[i->local()].data());
-        global_cell_[i->local()]=view_data.global_cell_[i->global()];
+        unique_boundary_ids_.resize(noExistingFaces);
+        FaceTagNormalBIdHandle faceHandle(view_data.face_tag_, view_data.face_normals_, view_data.unique_boundary_ids_,
+                                          face_tag_, face_normals_, unique_boundary_ids_);
+        FaceViaCellHandleWrapper<FaceTagNormalBIdHandle>
+        wrappedFaceHandle(faceHandle, view_data.cell_to_face_, cell_to_face_);
+        grid.scatterData(wrappedFaceHandle);
+    }
+    else
+    {
+        FaceTagNormalHandle faceHandle(view_data.face_tag_, view_data.face_normals_,
+                                       face_tag_, face_normals_);
+        FaceViaCellHandleWrapper<FaceTagNormalHandle>
+        wrappedFaceHandle(faceHandle, view_data.cell_to_face_, cell_to_face_);
+        grid.scatterData(wrappedFaceHandle);
     }
 
-    // count the existing faces, renumber, and allocate space.
-    EntityVariable<cpgrid::Geometry<2, 3>, 1>&  face_geom = geometry_.geomVector(std::integral_constant<int,1>());
-    face_geom.reserve(noExistingFaces);
-    std::vector<enum face_tag> tmp_face_tag(noExistingFaces);
-    std::vector<PointType> tmp_face_normals(noExistingFaces);
-    const std::vector<cpgrid::Geometry<2, 3> >& global_face_geom=view_data.geomVector<1>();
-    const std::vector<enum face_tag>& global_face_tag=view_data.face_tag_;
-    const std::vector<PointType>& global_face_normals=view_data.face_normals_;
-
-    // Now copy the face geometries that do exist.
-    auto ft = tmp_face_tag.begin();
-    auto fn = tmp_face_normals.begin();
-    for (auto begin = face_indicator.begin(), fi = begin,  end = face_indicator.end(); fi != end;
-        ++fi)
-    {
-        if (*fi < std::numeric_limits<int>::max())
-        {
-            face_geom.push_back(global_face_geom[fi-begin]);
-            *ft=global_face_tag[fi-begin];
-            *fn=global_face_normals[fi-begin];
-            ++ft; ++fn;
-        }
-    }
-    static_cast<std::vector<PointType>&>(face_normals_).swap(tmp_face_normals);
-    static_cast<std::vector<enum face_tag>&>(face_tag_).swap(tmp_face_tag);
-
-    // - unique_boundary_ids_ : extract the ones that correspond existent faces
-    if(view_data.unique_boundary_ids_.size())
-    {
-        // Unique boundary ids are inherited from the global grid.
-        auto id=view_data.unique_boundary_ids_.begin();
-        unique_boundary_ids_.reserve(view_data.face_to_cell_.size());
-        for(auto f=face_indicator.begin(), fend=face_indicator.end(); f!=fend; ++f, ++id)
-        {
-            if(*f<std::numeric_limits<int>::max())
-            {
-                unique_boundary_ids_.push_back(*id);
-            }
-        }
-    }
     // Compute the partition type for cell
     partition_type_indicator_->cell_indicator_.resize(cell_indexset_.size());
-    for(ParallelIndexSet::const_iterator i=cell_indexset_.begin(), end=cell_indexset_.end();
-            i!=end; ++i)
+    for(const auto i: cell_indexset_)
     {
-        partition_type_indicator_->cell_indicator_[i->local()]=
-            i->local().attribute()==AttributeSet::owner?
+        partition_type_indicator_->cell_indicator_[i.local()]=
+            i.local().attribute()==AttributeSet::owner?
             InteriorEntity:OverlapEntity;
     }
 
@@ -939,22 +1623,9 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
     // are also present on other processes and with what attribute.
     const auto& all_all_cell_interface = std::get<All_All_Interface>(cell_interfaces_);
 
-    // Work around a bug/deadlock in DUNE <=2.5.1 which happens if the
-    // buffer cannot hold all data that needs to be send.
-    // https://gitlab.dune-project.org/core/dune-common/merge_requests/416
-    // For this we calculate an upper barrier of the number of
-    // data items to be send manually and use it to construct a
-    // VariableSizeCommunicator with sufficient buffer.
-    std::size_t max_entries = 0;
-    for (const auto& pair: all_all_cell_interface.interfaces() )
-    {
-        using std::max;
-        max_entries = max(max_entries, pair.second.first.size());
-        max_entries = max(max_entries, pair.second.second.size());
-    }
-    Dune::VariableSizeCommunicator<> comm(all_all_cell_interface.communicator(),
-                                          all_all_cell_interface.interfaces(),
-                                          max_entries*8*sizeof(int));
+    Communicator comm(all_all_cell_interface.communicator(),
+                     all_all_cell_interface.interfaces());
+
     /*
       // code deactivated, because users cannot access face indices and therefore
       // communication on faces makes no sense!
@@ -985,8 +1656,6 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
 #else // #if HAVE_MPI
     static_cast<void>(grid);
     static_cast<void>(view_data);
-    static_cast<void>(cell_part);
-    static_cast<void>(overlap_layers);
 #endif
 }
 

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -60,7 +60,11 @@
 #include <dune/common/parallel/indexset.hh>
 #include <dune/common/parallel/interface.hh>
 #include <dune/common/parallel/plocalindex.hh>
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
 #include <dune/common/parallel/variablesizecommunicator.hh>
+#else
+#include <opm/grid/utility/VariableSizeCommunicator.hpp>
+#endif
 #include <dune/grid/common/gridenums.hh>
 
 #include <opm/grid/utility/platform_dependent/reenable_warnings.h>
@@ -78,6 +82,7 @@
 #include <opm/grid/utility/OpmParserIncludes.hpp>
 
 #include "Entity2IndexDataHandle.hpp"
+#include "DataHandleWrappers.hpp"
 #include "GlobalIdMapping.hpp"
 
 namespace Dune
@@ -132,12 +137,12 @@ public:
     /// Constructor
     /// \param grid  The grid that we are the data of.
     explicit CpGridData(CpGrid& grid);
-#if HAVE_MPI
+
     /// Constructor for parallel grid data.
     /// \param comm The MPI communicator
     /// Default constructor.
-    CpGridData(MPI_Comm comm);
-#endif
+    explicit CpGridData(MPIHelper::MPICommunicator comm);
+
     /// Constructor
     CpGridData();
     /// Destructor
@@ -264,10 +269,9 @@ public:
     /// \brief Redistribute a global grid.
     ///
     /// The whole grid must be available on all processors.
-    void distributeGlobalGrid(const CpGrid& grid,
+    void distributeGlobalGrid(CpGrid& grid,
                               const CpGridData& view_data,
-                              const std::vector<int>& cell_part,
-                              int overlap_layers);
+                              const std::vector<int>& cell_part);
 
     /// \brief communicate objects for all codims on a given level
     /// \param data The data handle describing the data. Has to adhere to the
@@ -277,7 +281,23 @@ public:
     template<class DataHandle>
     void communicate(DataHandle& data, InterfaceType iftype, CommunicationDirection dir);
 
+#if HAVE_MPI
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+    /// \brief The type of the  Communicator.
+    using Communicator = VariableSizeCommunicator<>;
+#else
+    /// \brief The type of the Communicator.
+    using Communicator = Opm::VariableSizeCommunicator<>;
+#endif
+
+    /// \brief The type of the map describing communication interfaces.
+    using InterfaceMap = Communicator::InterfaceMap;
+#endif
+
 private:
+
+    /// \brief Adds entries to the parallel index set of the cells during grid construction
+    void populateGlobalCellIndexSet();
 
 #if HAVE_MPI
 
@@ -301,9 +321,6 @@ private:
     void gatherCodimData(DataHandle& data, CpGridData* global_data,
                          CpGridData* distributed_data);
 
-    /// \brief The type of the interface map for communication.
-    typedef VariableSizeCommunicator<>::InterfaceMap InterfaceMap;
-
     /// \brief Scatter data from a global grid representation
     /// to a distributed representation of the same grid.
     /// \param data A data handle for getting or setting the data
@@ -312,7 +329,8 @@ private:
     /// \tparam DataHandle The type of the data handle used.
     template<class DataHandle>
     void scatterData(DataHandle& data, CpGridData* global_data,
-                     CpGridData* distributed_data, const InterfaceMap& inf);
+                     CpGridData* distributed_data, const InterfaceMap& cell_inf,
+                     const InterfaceMap& point_inf);
 
     /// \brief Scatter data specific to given codimension from a global grid representation
     /// to a distributed representation of the same grid.
@@ -348,7 +366,16 @@ private:
     template<int codim, class DataHandle>
     void communicateCodim(Entity2IndexDataHandle<DataHandle, codim>& data, CommunicationDirection dir,
                           const InterfaceMap& interface);
+
 #endif
+
+    void computeGeometry(CpGrid& grid,
+                         const DefaultGeometryPolicy&  globalGeometry,
+                         const OrientedEntityTable<0, 1>& globalCell2Faces,
+                         DefaultGeometryPolicy& geometry,
+                         const OrientedEntityTable<0, 1>& cell2Faces,
+                         const std::vector< std::array<int,8> >& cell2Points);
+
     // Representing the topology
     /** @brief Container for lookup of the faces attached to each cell. */
     cpgrid::OrientedEntityTable<0, 1> cell_to_face_;
@@ -505,85 +532,7 @@ template<int codim, class DataHandle>
 void CpGridData::communicateCodim(Entity2IndexDataHandle<DataHandle, codim>& data_wrapper, CommunicationDirection dir,
                                   const InterfaceMap& interface)
 {
-    if ( interface.empty() )
-    {
-        // The communication interface is empty, do nothing.
-        // Otherwise we will produce a memory error in
-        // VariableSizeCommunicator prior to DUNE 2.4
-        return;
-    }
-
-#if DUNE_VERSION_NEWER_REV(DUNE_GRID, 2, 5, 2)
-    VariableSizeCommunicator<> comm(ccobj_, interface);
-#else
-    // Work around a bug/deadlock in DUNE <=2.5.1 which happens if the
-    // buffer cannot hold all data that needs to be send.
-    // https://gitlab.dune-project.org/core/dune-common/merge_requests/416
-    // For this we calculate an upper barrier of the number of
-    // data items to be send manually and use it to construct a
-    // VariableSizeCommunicator with sufficient buffer.
-    std::size_t max_interface_entries = 0;
-#ifndef NDEBUG
-    std::size_t max_items = 0;
-#endif
-
-    for (const auto& pair: interface )
-    {
-        using std::max;
-        max_interface_entries = max(max_interface_entries, pair.second.first.size());
-        max_interface_entries = max(max_interface_entries, pair.second.second.size());
-
-#ifndef NDEBUG
-        if ( data_wrapper.fixedsize() )
-        {
-            const auto& interface_send = pair.second.first;
-
-            if ( interface_send.size() )
-            {
-                max_items = std::max(max_items, data_wrapper.size(interface_send[0]));
-            }
-
-            const auto& interface_recv = pair.second.second;
-
-            if ( interface_recv.size() )
-            {
-                max_items = std::max(max_items, data_wrapper.size(interface_recv[0]));
-            }
-        }
-        else
-        {
-            const auto& interface_send = pair.second.first;
-
-            for ( std::size_t i = 0, end = interface_send.size(); i < end; ++i)
-            {
-                max_items = std::max(max_items, data_wrapper.size(interface_send[i]));
-            }
-
-            const auto& interface_recv = pair.second.second;
-
-            for ( std::size_t i = 0, end = interface_recv.size(); i < end; ++i)
-            {
-                max_items = std::max(max_items, data_wrapper.size(interface_recv[i]));
-            }
-        }
-#endif
-    }
-
-#ifndef NDEBUG
-    max_items = ccobj_.max(max_items);
-
-    if ( max_items > MAX_DATA_PER_CELL)
-    {
-        OPM_THROW(std::logic_error,
-                  "You triggered a bug in the communication of DUNE"
-                   << " as you tried to send more than " << MAX_DATA_PER_CELL
-                   << " values per cell/point. Please define MAX_DATA_COMMUNICATED_PER_ENTITY"
-                   << " to a high enough value when compiling.");
-    }
-#endif
-    VariableSizeCommunicator<> comm(ccobj_, interface,
-                                    max_interface_entries * MAX_DATA_PER_CELL);
-#endif
+    Communicator comm(ccobj_, interface);
 
     if(dir==ForwardCommunication)
         comm.forward(data_wrapper);
@@ -745,17 +694,19 @@ struct Mover<DataHandle,3> : public BaseMover<DataHandle>
 
 template<class DataHandle>
 void CpGridData::scatterData(DataHandle& data, CpGridData* global_data,
-                             CpGridData* distributed_data, const InterfaceMap& inf)
+                             CpGridData* distributed_data, const InterfaceMap& cell_inf,
+                             const InterfaceMap& point_inf)
 {
 #if HAVE_MPI
     if(data.contains(3,0))
     {
         Entity2IndexDataHandle<DataHandle, 0> data_wrapper(*global_data, *distributed_data, data);
-        communicateCodim<0>(data_wrapper, ForwardCommunication, inf);
+        communicateCodim<0>(data_wrapper, ForwardCommunication, cell_inf);
     }
     if(data.contains(3,3))
     {
-        scatterCodimData<3>(data, global_data, distributed_data);
+        Entity2IndexDataHandle<DataHandle, 3> data_wrapper(*global_data, *distributed_data, data);
+        communicateCodim<3>(data_wrapper, ForwardCommunication, point_inf);
     }
 #endif
 }

--- a/opm/grid/cpgrid/DataHandleWrappers.cpp
+++ b/opm/grid/cpgrid/DataHandleWrappers.cpp
@@ -1,0 +1,3 @@
+#include "DataHandleWrappers.hpp"
+
+bool Dune::cpgrid::PointViaCellWarner::printWarn = true;

--- a/opm/grid/cpgrid/DataHandleWrappers.hpp
+++ b/opm/grid/cpgrid/DataHandleWrappers.hpp
@@ -1,0 +1,245 @@
+//===========================================================================
+//
+// File: DataHandleWrappers.hpp
+//
+// Created: Mon Nov 4 2013
+//
+// Author(s): Markus Blatt <markus@dr-blatt.de>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+/**
+  Copyright 2019 Equinor AS.
+
+  This file is part of The Open Porous Media project  (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_DATAHANDLEWRAPPERS_HEADER
+#define OPM_DATAHANDLEWRAPPERS_HEADER
+
+#include <array>
+#include <vector>
+#include <iostream>
+
+#include "OrientedEntityTable.hpp"
+#include "EntityRep.hpp"
+
+namespace Dune
+{
+namespace cpgrid
+{
+
+/// \brief A data handle to send data attached to faces via cell communication
+///
+/// With it we can use the cell communication to also communicate data attached
+/// to faces.
+/// \warning As we send all faces of cell most of the faces will be send twice
+/// which will temporarily waste some space and bandwidth.
+///
+/// \tparam Handle The type of the data handle to wrap. It must gather and scatter
+///         only for codim-1 entities.
+/// \warning The wrapped data handle must not used the last argument of
+/// its' scatter method since this numer will be incorrect in most cases!
+template<class Handle>
+struct FaceViaCellHandleWrapper
+{
+    using DataType = typename Handle::DataType;
+    using C2FTable = OrientedEntityTable<0, 1>;
+
+    /// \brief Constructs the data handle
+    ///
+    /// \param handle Handle object wrapped and used for actual gather/scatter
+    /// \param c2pGather Table to determine points when gathering
+    /// \param c2p Table to determine points when scattering
+    FaceViaCellHandleWrapper(Handle& handle,
+                             const C2FTable& c2fGather,
+                             const C2FTable& c2f)
+        : handle_(handle), c2fGather_(c2fGather), c2f_(c2f)
+    {}
+    bool fixedsize(int, int)
+    {
+        return false; // as the faces per cell differ
+    }
+    template<class T>
+    typename std::enable_if<T::codimension != 0, std::size_t>::type
+    size(const T&)
+    {
+        OPM_THROW(std::logic_error, "This should never throw! We only know sizes for cells");
+        return 1;
+    }
+    std::size_t size(const EntityRep<0>& t)
+    {
+        const auto& faces = c2fGather_[t];
+        std::size_t size{};
+        for (const auto& face : faces)
+        {
+            size += handle_.size(face);
+        }
+        return size;
+    }
+    bool contains(std::size_t dim, std::size_t codim)
+    {
+        return dim==3 && codim == 0;
+    }
+    template<class B, class T>
+    typename std::enable_if<T::codimension != 0, void>::type
+    gather(B&, const T&)
+    {
+        OPM_THROW(std::logic_error, "This should never throw! We can only gather cell values and indicate that");
+    }
+    template<class B>
+    void gather(B& buffer, const EntityRep<0>& t)
+    {
+        const auto& faces = c2fGather_[t];
+        for (const auto& face : faces)
+        {
+            handle_.gather(buffer, face);
+        }
+    }
+    template<class B, class T>
+    typename std::enable_if<T::codimension != 0, void>::type
+    scatter(B&, const T&, std::size_t)
+    {
+        OPM_THROW(std::logic_error, "This should never throw! We can only gather cell values and indicate that");
+    }
+    template<class B>
+    void scatter(B& buffer, const EntityRep<0>& t, std::size_t)
+    {
+        const auto& faces = c2f_[t];
+        for (const auto& face : faces)
+        {
+            // Note that the size (last parameter) is not correct here.
+            // Therefore this handle needs to know how many data items
+            // to expect. Not usable outside of CpGrid.
+            handle_.scatter(buffer, face, 1);
+        }
+    }
+private:
+    Handle& handle_;
+    const C2FTable& c2fGather_, c2f_;
+};
+
+struct PointViaCellWarner
+{
+    static bool printWarn;
+    void warn()
+    {
+        if (printWarn)
+        {
+            std::cerr << "Communication of variable data attached to points is "
+                      << "not fully supported. Your code/handle must not use the"
+                      << "last parameter of "
+                      << "DataHandle::scatter(B& buffer, E& entity, int size) "
+                      << "as it will not be correct!";
+            printWarn =false;
+        }
+    }
+};
+
+/// \brief A data handle to send data attached to points via cell communication
+///
+/// With it we can use the cell communication to also communicate data attached
+/// to faces.
+/// \warning As we send all points of cell most of the points will be send six times
+/// which will temporarily waste some space and bandwidth.
+///
+/// \tparam Handle The type of the data handle to wrap. It must gather and scatter
+///         only for codim-3 entities.
+template<class Handle>
+struct PointViaCellHandleWrapper : public PointViaCellWarner
+{
+    using DataType = typename Handle::DataType;
+    using C2PTable = std::vector< std::array<int,8> >;
+
+    /// \brief Constructs the data handle
+    ///
+    /// \param handle Handle object wrapped and used for actual gather/scatter
+    /// \param c2pGather Table to determine points when gathering
+    /// \param c2p Table to determine points when scattering
+    PointViaCellHandleWrapper(Handle& handle,
+                             const C2PTable& c2pGather,
+                             const C2PTable& c2p)
+        : handle_(handle), c2pGather_(c2pGather), c2p_(c2p)
+    {}
+    bool fixedsize(int i, int j)
+    {
+        if( ! handle_.fixedsize(i, j))
+        {
+            this->warn();
+        }
+        return handle_.fixedsize(i, j);
+    }
+    template<class T>
+    typename std::enable_if<T::codimension != 0, std::size_t>::type
+    size(const T&)
+    {
+        OPM_THROW(std::logic_error, "This should never throw! We only know sizes for cells");
+        return 1;
+    }
+    std::size_t size(const EntityRep<0>& t)
+    {
+        const auto& points = c2pGather_[t.index()];
+        std::size_t size{};
+        for (const auto& point : points)
+        {
+            size += handle_.size(EntityRep<3>(point, true));
+        }
+        return size;
+    }
+    bool contains(std::size_t dim, std::size_t codim)
+    {
+        return dim==3 && codim == 0;
+    }
+    template<class B, class T>
+    typename std::enable_if<T::codimension != 0, void>::type
+    gather(B&, const T&)
+    {
+        OPM_THROW(std::logic_error, "This should never throw! We can only gather cell values and indicate that");
+    }
+    template<class B>
+    void gather(B& buffer, const EntityRep<0>& t)
+    {
+        const auto& points = c2pGather_[t.index()];
+        for (const auto& point : points)
+        {
+            handle_.gather(buffer, EntityRep<3>(point, true));
+        }
+    }
+    template<class B, class T>
+    typename std::enable_if<T::codimension != 0, void>::type
+    scatter(B&, const T&, std::size_t)
+    {
+        OPM_THROW(std::logic_error, "This should never throw! We can only gather cell values and indicate that");
+    }
+    template<class B>
+    void scatter(B& buffer, const EntityRep<0>& t, std::size_t s)
+    {
+        const auto& points = c2p_[t.index()];
+        for (const auto& point : points)
+        {
+            handle_.scatter(buffer, EntityRep<3>(point, true), s/8);
+        }
+    }
+private:
+    Handle& handle_;
+    const C2PTable& c2pGather_, c2p_;
+};
+
+} // end namespace cpgrid
+} // end namespace Dune
+#endif

--- a/opm/grid/cpgrid/EntityRep.hpp
+++ b/opm/grid/cpgrid/EntityRep.hpp
@@ -128,6 +128,11 @@ namespace Dune
                 return entityrep_ < 0 ? ~entityrep_ : entityrep_;
             }
 
+            /// @brief The signed index that also tells us the orientation
+            int signedIndex() const
+            {
+                return entityrep_;
+            }
             /// @brief Returns true if the entity has positive orientation.
             /// Not a Dune interface method.
             ///
@@ -267,6 +272,13 @@ namespace Dune
             /// @param e Entity representation.
             /// @return a const reference to the varable, at e.
             const T& operator[](const EntityRep<codim>& e) const
+            {
+                return EntityVariableBase<T>::get(e.index());
+            }
+            /// @brief Random access to the variable through an EntityRep.
+            /// @param e Entity representation.
+            /// @return a mutable reference to the varable, at e.
+            T& operator[](const EntityRep<codim>& e)
             {
                 return EntityVariableBase<T>::get(e.index());
             }

--- a/opm/grid/cpgrid/Indexsets.hpp
+++ b/opm/grid/cpgrid/Indexsets.hpp
@@ -41,6 +41,7 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 #include "GlobalIdMapping.hpp"
 #include "Intersection.hpp"
 
+#include <unordered_map>
 namespace Dune
 {
     namespace cpgrid
@@ -203,6 +204,7 @@ namespace Dune
 
         class IdSet
         {
+            friend class ReversePointGlobalIdSet;
         public:
             typedef int IdType;
 
@@ -262,6 +264,7 @@ namespace Dune
         class GlobalIdSet : public GlobalIdMapping
         {
             friend class CpGridData;
+            friend class ReversePointGlobalIdSet;
         public:
             typedef int IdType;
 
@@ -310,6 +313,42 @@ namespace Dune
             const IdSet* idSet_;
         };
 
+    class ReversePointGlobalIdSet
+    {
+    public:
+        ReversePointGlobalIdSet(const GlobalIdSet& idSet)
+        {
+            if(idSet.idSet_)
+            {
+                grid_ = &(idSet.idSet_->grid_);
+            }
+            else
+            {
+                mapping_.reset(new std::unordered_map<int,int>);
+                int localId = 0;
+                for (const  auto& globalId: idSet.template getMapping<3>())
+                    (*mapping_)[globalId] = localId++;
+            }
+        }
+        int operator[](int i) const
+        {
+            if (mapping_)
+            {
+                return(*mapping_)[i];
+            }
+            else
+            {
+                return i - grid_->size(0) - grid_->size(1) - grid_->size(2);
+            }
+        }
+        void release()
+        {
+            mapping_.reset(nullptr);
+        }
+    private:
+        std::unique_ptr<std::unordered_map<int,int> > mapping_;
+        const CpGridData* grid_;
+    };
 
     } // namespace cpgrid
 } // namespace Dune

--- a/opm/grid/cpgrid/OrientedEntityTable.hpp
+++ b/opm/grid/cpgrid/OrientedEntityTable.hpp
@@ -88,6 +88,43 @@ namespace Dune
         };
 
 
+        /// @brief A class used as a row type for  OrientedEntityTable.
+        /// @tparam codim_to Codimension.
+        template <int codim_to>
+        class MutableOrientedEntityRange : private Opm::SparseTable< EntityRep<codim_to> >::mutable_row_type
+        {
+        public:
+            typedef EntityRep<codim_to> ToType;
+            typedef ToType* ToTypePtr;
+            typedef typename Opm::SparseTable<ToType>::mutable_row_type R;
+
+            /// @brief Default constructor yielding an empty range.
+            MutableOrientedEntityRange()
+                : R(ToTypePtr(0), ToTypePtr(0)), orientation_(true)
+            {
+            }
+            /// @brief Constructor taking a row type and an orientation.
+            /// @param R Row type
+            /// @param orientation True if positive orientation.
+            MutableOrientedEntityRange(const R& r, bool orientation)
+                : R(r), orientation_(orientation)
+            {
+            }
+            int size () const { return R::size(); }
+            using R::empty;
+            using R::begin;
+            using R::end;
+            /// @brief Random access operator.
+            /// @param subindex Column index.
+            /// @return Entity representation.
+            ToType operator[](int subindex) const
+            {
+                ToType erep = R::operator[](subindex);
+                return orientation_ ? erep : erep.opposite();
+            }
+        private:
+            bool orientation_;
+        };
 
 
         /// @brief Represents the topological relationships between
@@ -107,6 +144,7 @@ namespace Dune
             typedef EntityRep<codim_to> ToType;
             typedef OrientedEntityRange<codim_to> row_type; // ??? doxygen henter doc fra Opm::SparseTable
             typedef Opm::SparseTable<ToType> super_t;
+            typedef typename super_t::mutable_row_type mutable_row_type;
 
             /// Default constructor.
             OrientedEntityTable()
@@ -136,6 +174,7 @@ namespace Dune
             using super_t::dataSize;
             using super_t::clear;
             using super_t::appendRow;
+            using super_t::allocate;
 
             /// @brief Given an entity e of codimension codim_from,
             /// returns the number of neighbours of codimension codim_to.
@@ -156,6 +195,15 @@ namespace Dune
                 return row_type(super_t::operator[](e.index()), e.orientation());
             }
 
+            /// @brief Given an entity e of codimension codim_from, returns a
+            /// row (an indirect container) containing its neighbour
+            /// entities of codimension codim_to.
+            /// @param e Entity representation.
+            /// @return A row of the table.
+            mutable_row_type row(const FromType& e)
+            {
+                return super_t::operator[](e.index());
+            }
             /// @brief Elementwise equality.
             /// @param other The other element
             /// @return Returns true if \b this and the \b other element are equal.

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -116,8 +116,12 @@ namespace cpgrid
     void CpGridData::processEclipseFormat(const Opm::EclipseGrid& ecl_grid, bool periodic_extension, bool turn_normals, bool clip_z,
                                           const std::vector<double>& poreVolume, const Opm::NNC& nncs)
     {
-        std::vector<double> coordData = ecl_grid.getCOORD();
+        if (ccobj_.rank() != 0 ) {
+            // Store global grid only on rank 0
+            return;
+        }
 
+        std::vector<double> coordData = ecl_grid.getCOORD();
         std::vector<int> actnumData = ecl_grid.getACTNUM();
 
         // Mutable because grdecl::zcorn is non-const.
@@ -241,6 +245,12 @@ namespace cpgrid
     /// Read the Eclipse grid format ('.grdecl').
     void CpGridData::processEclipseFormat(const grdecl& input_data, const NNCMaps& nnc, double z_tolerance, bool remove_ij_boundary, bool turn_normals)
     {
+        if( ccobj_.rank() != 0 )
+        {
+            // We do not store any grid information
+            ccobj_.scatter(logical_cartesian_size_.data(), logical_cartesian_size_.data(), 3, 0);
+            return;
+        }
         // Process.
 #ifdef VERBOSE
         std::cout << "Processing eclipse data." << std::endl;
@@ -290,6 +300,10 @@ namespace cpgrid
 
         computeUniqueBoundaryIds();
 
+        if(ccobj_.size()>1)
+            populateGlobalCellIndexSet();
+        auto tmp = logical_cartesian_size_; // Probably not necessary?
+        ccobj_.scatter(tmp.data(), logical_cartesian_size_.data(), 3, 0);
 #ifdef VERBOSE
         std::cout << "Done with grid processing." << std::endl;
 #endif

--- a/opm/grid/cpgrid/readSintefLegacyFormat.cpp
+++ b/opm/grid/cpgrid/readSintefLegacyFormat.cpp
@@ -65,6 +65,10 @@ namespace Dune
     /// Read the Sintef legacy grid format ('topogeom').
     void cpgrid::CpGridData::readSintefLegacyFormat(const std::string& grid_prefix)
     {
+        if ( ccobj_.rank() != 0 )
+            // global grid only on rank 0
+            return;
+
         std::string topofilename = grid_prefix + "-topo.dat";
         {
             std::ifstream file(topofilename.c_str());
@@ -97,6 +101,9 @@ namespace Dune
             }
         }
         computeUniqueBoundaryIds();
+
+        if(ccobj_.size()>1)
+            populateGlobalCellIndexSet();
     }
 
 

--- a/opm/grid/utility/VariableSizeCommunicator.hpp
+++ b/opm/grid/utility/VariableSizeCommunicator.hpp
@@ -1,0 +1,1228 @@
+// -*- tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+// vi: set et ts=4 sw=2 sts=2:
+
+// This file is copied from file dune/common/variablesizecommunicator.hh
+// of dune-common as of commit 30e78443884f7730229e6c59b14406051d71c032.
+// It is needed as we need an important bugfix (commit 30e78443884)
+// that is not included in DUNE
+// versions below 2.8. We have moved the classes to the Opm namespace.
+// The file's main author is Markus Blatt. Others have only contributed
+// minor fixes proposed by compilers, and codespell to prevent unused warnings
+// and variables or improved documentation.
+/*
+Copyright 2013-2018 Dr. Blatt - HPC-Simulation-Software & Services
+Copyright 2013-2017 Statoil ASA
+*/
+#ifndef OPM_COMMON_PARALLEL_VARIABLESIZECOMMUNICATOR_HH // Still fits the line!
+#define OPM_COMMON_PARALLEL_VARIABLESIZECOMMUNICATOR_HH
+
+#if HAVE_MPI
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <memory>
+#include <utility>
+#include <vector>
+#include <algorithm>
+
+#include <mpi.h>
+
+#include <dune/common/parallel/interface.hh>
+#include <dune/common/parallel/mpitraits.hh>
+#include <dune/common/unused.hh>
+
+/**
+ * @addtogroup Common_Parallel
+ *
+ * @{
+ */
+/**
+ * @file
+ * @brief A communicator that only needs to know the number of elements per
+ * index at the sender side.
+ * @author Markus Blatt
+ * @}
+ */
+namespace Opm
+{
+
+namespace
+{
+/**
+ * @brief A message buffer.
+ * @tparam T The type of data that the buffer will hold.
+ */
+template<class T, class Allocator=std::allocator<T> >
+class MessageBuffer
+{
+public:
+  /**
+   * @brief Constructs a message.
+   * @param size The number of elements that buffer should hold,
+   */
+  explicit MessageBuffer(int size)
+    : buffer_(new T[size]), size_(size), position_(0)
+  {}
+  /**
+   * @brief Copy constructor.
+   * @param o The instance to copy.
+   */
+  explicit MessageBuffer(const MessageBuffer& o)
+  : buffer_(new T[o.size_]), size_(o.size_), position_(o.position_)
+  {
+  }
+  /** @brief Destructor. */
+  ~MessageBuffer()
+  {
+    delete[] buffer_;
+  }
+  /**
+   * @brief Write an item to the buffer.
+   * @param data The data item to write.
+   */
+  void write(const T& data)
+  {
+    assert(position_<size_);
+    buffer_[position_++]=data;
+  }
+
+  /**
+   * @brief Reads a data item from the buffer
+   * @param[out] data Reference to where to store the read data.
+   */
+  void read(T& data)
+  {
+    assert(position_<size_);
+    data=buffer_[position_++];
+  }
+
+  /**
+   * @brief Reset the buffer.
+   *
+   * On return the buffer will be positioned at the start again.
+   */
+  void reset()
+  {
+    position_=0;
+  }
+
+  /**
+   * @brief Test whether the whole buffer was read.
+   * @return True if we read or wrot until the end of the buffer.
+   */
+  bool finished()
+  {
+    return position_==size_;
+  }
+
+  /**
+   * @brief Tests whether the buffer has enough space left to read/write data.
+   * @param notItems The number of items to read or write.
+   * @return True if there is enough space for noItems items.
+   */
+  bool hasSpaceForItems(int noItems)
+  {
+    return position_+noItems<=size_;
+  }
+  /**
+   * @brief Get the size of the buffer.
+   * @return The number of elements the buffer can hold.
+   */
+  std::size_t size() const
+  {
+    return size_;
+  }
+  std::size_t position() const
+  {
+    return position_;
+  }
+  /**
+   * @brief Converts the buffer to a C array.
+   * @return The underlying C array.
+   */
+  operator T*()
+  {
+    return buffer_;
+  }
+
+private:
+  /**
+   * @brief Pointer to the current insertion point of the buffer.
+   */
+  T* buffer_;
+  /**
+   * @brief The size of the buffer
+   */
+  std::size_t size_;
+  /**
+   * @brief The current position in the buffer.
+   */
+  std::size_t position_;
+};
+
+using Dune::InterfaceInformation;
+using Dune::Interface;
+
+/**
+ * @brief A tracker for the current position in a communication interface.
+ */
+class InterfaceTracker
+{
+public:
+  /**
+   * @brief Constructor.
+   * @param rank The other rank that the interface communicates with.
+   * @param info A list of local indices belonging to this interface.
+   */
+  InterfaceTracker(int rank, InterfaceInformation info, std::size_t fixedsize=0,
+                   bool allocateSizes=false)
+    : fixedSize(fixedsize),rank_(rank), index_(), interface_(info), sizes_()
+  {
+    if(allocateSizes)
+    {
+      sizes_.resize(info.size());
+    }
+  }
+
+  /**
+   * @brief Moves to the next index in the interface.
+   */
+  void moveToNextIndex()
+  {
+    index_++;
+    assert(index_<=interface_.size());
+    skipZeroIndices();
+  }
+  /**
+   * @brief Increment index various times.
+   * @param i The number of times to increment.
+   */
+  void increment(std::size_t i)
+  {
+    index_+=i;
+    assert(index_<=interface_.size());
+  }
+  /**
+   * @brief Checks whether all indices have been visited.
+   * @return True if all indices have been visited.
+   */
+  bool finished() const
+  {
+    return index_==interface_.size();
+  }
+
+  void skipZeroIndices()
+  {
+    // skip indices with size zero!
+    while(sizes_.size() && index_!=interface_.size() &&!size())
+      ++index_;
+  }
+
+  /**
+   * @brief Get the current local index of the interface.
+   * @return The current local index of the interface.
+   */
+  std::size_t index() const
+  {
+    return interface_[index_];
+  }
+  /**
+   * @brief Get the size at the current index.
+   */
+  std::size_t size() const
+  {
+    assert(sizes_.size());
+    return sizes_[index_];
+  }
+  /**
+   * @brief Get a pointer to the array with the sizes.
+   */
+  std::size_t* getSizesPointer()
+  {
+    return &sizes_[0];
+  }
+  /**
+   * @brief Returns whether the interface is empty.
+   * @return True if there are no entries in the interface.
+   */
+  bool empty() const
+  {
+    return !interface_.size();
+  }
+
+  /**
+   * @brief Checks whether there are still indices waiting to be processed.
+   * @return True if there are still indices waiting to be processed.
+   */
+  std::size_t indicesLeft() const
+  {
+    return interface_.size()-index_;
+  }
+  /**
+   * @brief The number of data items per index if it is fixed, 0 otherwise.
+   */
+  std::size_t fixedSize;
+  /**
+   * @brief Get the process rank that this communication interface is with.
+   */
+  int rank() const
+  {
+    return rank_;
+  }
+  /**
+   * @brief Get the offset to the first index.
+   */
+  std::size_t offset() const
+  {
+    return index_;
+  }
+private:
+  /** @brief The process rank that this communication interface is with. */
+  int rank_;
+  /** @brief The other rank that this interface communcates with. */
+  std::size_t index_;
+  /** @brief The list of local indices of this interface. */
+  InterfaceInformation interface_;
+  std::vector<std::size_t> sizes_;
+};
+
+
+} // end unnamed namespace
+
+/**
+ * @addtogroup Common_Parallel
+ *
+ * @{
+ */
+/**
+ * @brief A buffered communicator where the amount of data sent does not have to be known a priori.
+ *
+ * In contrast to BufferedCommunicator the amount of data is determined by the container
+ * whose entries are sent and not known at the receiving side a priori.
+ *
+ * Note that there is no global index-space, only local index-spaces on each
+ * rank.  Note also that each rank has two index-spaces, one used for
+ * gathering/sending, and one used for scattering/receiving.  These may be the
+ * identical, but they do not have to be.
+ *
+ * For data send from rank A to rank B, the order that rank A inserts its
+ * indices into its send-interface for rank B has to be the same order that
+ * rank B inserts its matching indices into its receive interface for rank A.
+ * (This is because the `VariableSizeCommunicator` has no concept of a global
+ * index-space, so the order used to insert the indices into the interfaces is
+ * the only clue it has to know which source index should be communicated to
+ * which target index.)
+ *
+ * It is permissible for a rank to communicate with itself, i.e. it can define
+ * send- and receive-interfaces to itself.  These interfaces do not need to
+ * contain the same indices, as the local send index-space can be different
+ * from the local receive index-space.  This is useful for repartitioning or
+ * for aggregating in AMG.
+ *
+ * Do not assume that gathering to an index happens before scattering to the
+ * same index in the same communication, as `VariableSizeCommunicator` assumes
+ * they are from different index-spaces.  This is a pitfall if you want do
+ * communicate a vector in-place, e.g. to sum up partial results from
+ * different ranks.  Instead, have separate source and target vectors and copy
+ * the source vector to the target vector before communicating.
+ */
+template<class Allocator=std::allocator<std::pair<InterfaceInformation,InterfaceInformation> > >
+class VariableSizeCommunicator
+{
+public:
+  /**
+     * @brief The type of the map from process number to InterfaceInformation for
+     * sending and receiving to and from it.
+     */
+  typedef std::map<int,std::pair<InterfaceInformation,InterfaceInformation>,
+                   std::less<int>,
+                   typename Allocator::template rebind<std::pair<const int,std::pair<InterfaceInformation,InterfaceInformation> > >::other> InterfaceMap;
+
+#ifndef DUNE_PARALLEL_MAX_COMMUNICATION_BUFFER_SIZE
+  /**
+   * @brief Creates a communicator with the default maximum buffer size.
+   *
+   * The default size ist either what the macro DUNE_MAX_COMMUNICATION_BUFFER_SIZE
+   * is set to or 32768 if is not set.
+   */
+  VariableSizeCommunicator(MPI_Comm comm, const InterfaceMap& inf)
+    : maxBufferSize_(32768), interface_(&inf)
+  {
+    MPI_Comm_dup(comm, &communicator_);
+  }
+  /**
+   * @brief Creates a communicator with the default maximum buffer size.
+   * @param inf The communication interface.
+   */
+  VariableSizeCommunicator(const Interface& inf)
+  : maxBufferSize_(32768), interface_(&inf.interfaces())
+  {
+    MPI_Comm_dup(inf.communicator(), &communicator_);
+  }
+#else
+  /**
+   * @brief Creates a communicator with the default maximum buffer size.
+   *
+   * The default size ist either what the macro DUNE_MAX_COMMUNICATION_BUFFER_SIZE
+   * is set to or 32768 if is not set.
+   */
+  VariableSizeCommunicator(MPI_Comm comm, InterfaceMap& inf)
+    : maxBufferSize_(DUNE_PARALLEL_MAX_COMMUNICATION_BUFFER_SIZE),
+      interface_(&inf)
+  {
+    MPI_Comm_dup(comm, &communicator_);
+  }
+  /**
+   * @brief Creates a communicator with the default maximum buffer size.
+   * @param inf The communication interface.
+   */
+  VariableSizeCommunicator(const Interface& inf)
+  : maxBufferSize_(DUNE_PARALLEL_MAX_COMMUNICATION_BUFFER_SIZE),
+    interface_(&inf.interfaces())
+  {
+    MPI_Comm_dup(inf.communicator(), &communicator_);
+  }
+#endif
+  /**
+  * @brief Creates a communicator with a specific maximum buffer size.
+  * @param comm The MPI communicator to use.
+  * @param inf The communication interface.
+  * @param max_buffer_size The maximum buffer size allowed.
+  */
+  VariableSizeCommunicator(MPI_Comm comm, const InterfaceMap& inf, std::size_t max_buffer_size)
+    : maxBufferSize_(max_buffer_size), interface_(&inf)
+  {
+    MPI_Comm_dup(comm, &communicator_);
+  }
+
+  /**
+  * @brief Creates a communicator with a specific maximum buffer size.
+  * @param inf The communication interface.
+  * @param max_buffer_size The maximum buffer size allowed.
+  */
+  VariableSizeCommunicator(const Interface& inf, std::size_t max_buffer_size)
+    : maxBufferSize_(max_buffer_size), interface_(&inf.interfaces())
+  {
+    MPI_Comm_dup(inf.communicator(), &communicator_);
+  }
+
+  ~VariableSizeCommunicator()
+  {
+    MPI_Comm_free(&communicator_);
+  }
+
+
+  /**
+   * @brief Communicate forward.
+   *
+   * @tparam DataHandle The type of the handle describing the data. This type has to adhere
+   * to the following interface:
+   * \code{.cpp}
+   * // returns whether the number of data items per entry is fixed
+   * bool fixedsize();
+   * // get the number of data items for an entry with index i
+   * std::size_t size(std::size_t i);
+   * // gather the data at index i
+   * template<class MessageBuffer>
+   * void gather(MessageBuffer& buf, std::size_t  i);
+   * // scatter the n data items to index i
+   * template<class MessageBuffer>
+   * void scatter(MessageBuffer& buf, std::size_t i, std::size_t n);
+   * \endcode
+   * @param handle A handle responsible for describing the data, gathering, and scattering it.
+   */
+  template<class DataHandle>
+  void forward(DataHandle& handle)
+  {
+    communicate<true>(handle);
+  }
+
+  /**
+   * @brief Communicate backwards.
+   *
+   * @tparam DataHandle The type of the handle describing the data. This type has to adhere
+   * to the following interface:
+   * \code{.cpp}
+   * // returns whether the number of data items per entry is fixed
+   * bool fixedsize();
+   * // get the number of data items for an entry with index i
+   * std::size_t size(std::size_t i);
+   * // gather the data at index i
+   * template<class MessageBuffer>
+   * void gather(MessageBuffer& buf, std::size_t  i);
+   * // scatter the n data items to index i
+   * template<class MessageBuffer>
+   * void scatter(MessageBuffer& buf, std::size_t i, std::size_t n);
+   * \endcode
+   * @param handle A handle responsible for describing the data, gathering, and scattering it.
+   */
+  template<class DataHandle>
+  void backward(DataHandle& handle)
+  {
+    communicate<false>(handle);
+  }
+
+private:
+  template<bool FORWARD, class DataHandle>
+  void communicateSizes(DataHandle& handle,
+                        std::vector<InterfaceTracker>& recv_trackers);
+
+  /**
+   * @brief Communicates data according to the interface.
+   * @tparam forward If true sends data forwards, otherwise backwards along the interface.
+   * @tparame DataHandle The type of the data handle @see forward for a description of the interface.
+   * @param handle The handle describing the data and responsible for gather and scatter operations.
+   */
+  template<bool forward,class DataHandle>
+  void communicate(DataHandle& handle);
+  /**
+   * @brief Initialize the trackers along the interface for the communication.
+   * @tparam FORWARD If true we send in the forward direction.
+   * @tparam DataHandle DataHandle The type of the data handle.
+   * @param handle The handle describing the data and responsible for gather
+   * and scatter operations.
+   * @param[out] send_trackers The trackers for the sending side.
+   * @param[out] recv_trackers The trackers for the receiving side.
+   */
+  template<bool FORWARD, class DataHandle>
+  void setupInterfaceTrackers(DataHandle& handle,
+                              std::vector<InterfaceTracker>& send_trackers,
+                              std::vector<InterfaceTracker>& recv_trackers);
+  /**
+   * @brief Communicate data with a fixed amount of data per entry.
+   * @tparam FORWARD If true we send in the forward direction.
+   * @tparam DataHandle DataHandle The type of the data handle.
+   * @param handle The handle describing the data and responsible for gather
+   * and scatter operations.
+   */
+  template<bool FORWARD, class DataHandle>
+  void communicateFixedSize(DataHandle& handle);
+   /**
+   * @brief Communicate data with a variable amount of data per entry.
+   * @tparam FORWARD If true we send in the forward direction.
+   * @tparam DataHandle DataHandle The type of the data handle.
+   * @param handle The handle describing the data and responsible for gather
+   * and scatter operations.
+   */
+  template<bool FORWARD, class DataHandle>
+  void communicateVariableSize(DataHandle& handle);
+  /**
+   * @brief The maximum size if the buffers used for gather and scatter.
+   *
+   * @note If this process has n neighbours, then a maximum of 2n buffers of this size
+   * is allocate. Memory needed will be n*sizeof(std::size_t)+n*sizeof(Datahandle::DataType)
+   */
+  std::size_t maxBufferSize_;
+  /**
+   * @brief description of the interface.
+   *
+   * This is a map of the neighboring process number to a pair of local index lists.
+   * The first is a list of indices to gather data for sending from and the second is a list of
+   * indices to scatter received data to during forward.
+   */
+  const InterfaceMap* interface_;
+  /**
+   * @brief The communicator.
+   *
+   * This is a cloned communicator to ensure there are no interferences.
+   */
+  MPI_Comm communicator_;
+};
+
+/** @} */
+namespace
+{
+/**
+ *  @brief A data handle for comunicating the sizes of variable sized data.
+ */
+template<class DataHandle>
+class SizeDataHandle
+{
+public:
+  typedef std::size_t DataType;
+
+  SizeDataHandle(DataHandle& data,
+                 std::vector<InterfaceTracker>& trackers)
+    : data_(data), trackers_(trackers), index_()
+  {}
+  bool fixedsize()
+  {
+    return true;
+  }
+  std::size_t size(std::size_t i)
+  {
+    DUNE_UNUSED_PARAMETER(i);
+    return 1;
+  }
+  template<class B>
+  void gather(B& buf, int  i)
+  {
+    buf.write(data_.size(i));
+  }
+  void setReceivingIndex(std::size_t i)
+  {
+    index_=i;
+  }
+  std::size_t* getSizesPointer()
+  {
+    return trackers_[index_].getSizesPointer();
+  }
+
+private:
+  DataHandle& data_;
+  std::vector<InterfaceTracker>& trackers_;
+  int index_;
+};
+
+template<class T>
+void setReceivingIndex(T&, int)
+{}
+
+template<class T>
+void setReceivingIndex(SizeDataHandle<T>& t, int i)
+{
+  t.setReceivingIndex(i);
+}
+
+
+/**
+ * @brief Template meta program for choosing then send or receive interface
+ * information based on the direction.
+ * @tparam FORWARD If true the communication happens in the forward direction.
+ */
+template<bool FORWARD>
+struct InterfaceInformationChooser
+{
+  /**
+   * @brief Get the interface information for the sending side.
+   */
+  static const InterfaceInformation&
+  getSend(const std::pair<InterfaceInformation,InterfaceInformation>& info)
+  {
+    return info.first;
+  }
+
+  /**
+   * @brief Get the interface information for the receiving side.
+   */
+  static const InterfaceInformation&
+  getReceive(const std::pair<InterfaceInformation,InterfaceInformation>& info)
+  {
+    return info.second;
+  }
+};
+
+template<>
+struct InterfaceInformationChooser<false>
+{
+  static const InterfaceInformation&
+  getSend(const std::pair<InterfaceInformation,InterfaceInformation>& info)
+  {
+    return info.second;
+  }
+
+  static const InterfaceInformation&
+  getReceive(const std::pair<InterfaceInformation,InterfaceInformation>& info)
+  {
+    return info.first;
+  }
+};
+
+/**
+ * @brief A functor that packs entries into the message buffer.
+ * @tparam DataHandle The type of the data handle that describes
+ * the communicated data.
+ */
+template<class DataHandle>
+struct PackEntries
+{
+
+  int operator()(DataHandle& handle, InterfaceTracker& tracker,
+                 MessageBuffer<typename DataHandle::DataType>& buffer,
+                 int i) const
+  {
+    DUNE_UNUSED_PARAMETER(i);
+    return operator()(handle,tracker,buffer);
+  }
+
+  /**
+   * @brief packs data.
+   * @param handle The handle describing the data and the gather and scatter operations.
+   * @param tracker The tracker of the interface to tell us where we are.
+   * @param buffer The buffer to use for packing.
+   * @return The number data entries that we packed.
+   */
+  int operator()(DataHandle& handle, InterfaceTracker& tracker,
+                 MessageBuffer<typename DataHandle::DataType>& buffer) const
+  {
+    if(tracker.fixedSize) // fixed size if variable is >0!
+    {
+
+      std::size_t noIndices=std::min(buffer.size()/tracker.fixedSize, tracker.indicesLeft());
+      for(std::size_t i=0; i< noIndices; ++i)
+      {
+        handle.gather(buffer, tracker.index());
+        tracker.moveToNextIndex();
+      }
+      return noIndices*tracker.fixedSize;
+    }
+    else
+    {
+      int packed=0;
+      tracker.skipZeroIndices();
+      while(!tracker.finished())
+        if(buffer.hasSpaceForItems(handle.size(tracker.index())))
+        {
+          assert(std::size_t(packed) == buffer.position());
+          handle.gather(buffer, tracker.index());
+          packed+=handle.size(tracker.index());
+          assert(std::size_t(packed) <= buffer.size());
+          assert(std::size_t(packed) == buffer.position());
+          tracker.moveToNextIndex();
+        }
+        else
+          break;
+      return packed;
+    }
+  }
+};
+
+/**
+ * @brief A functor that unpacks entries from the message buffer.
+ * @tparam DataHandle The type of the data handle that describes
+ * the communicated data.
+ */
+template<class DataHandle>
+struct UnpackEntries{
+
+  /**
+   * @brief packs data.
+   * @param handle The handle describing the data and the gather and scatter operations.
+   * @param tracker The tracker of the interface to tell us where we are.
+   * @param buffer The buffer to use for packing.
+   * @return The number data entries that we packed.
+   */
+  bool operator()(DataHandle& handle, InterfaceTracker& tracker,
+                  MessageBuffer<typename DataHandle::DataType>& buffer,
+                  int count=0)
+  {
+    if(tracker.fixedSize) // fixed size if variable is >0!
+    {
+      std::size_t noIndices=std::min(buffer.size()/tracker.fixedSize, tracker.indicesLeft());
+
+      for(std::size_t i=0; i< noIndices; ++i)
+      {
+        handle.scatter(buffer, tracker.index(), tracker.fixedSize);
+        tracker.moveToNextIndex();
+      }
+      return tracker.finished();
+    }
+    else
+    {
+      assert(count);
+      for(int unpacked=0;unpacked<count;)
+      {
+        assert(!tracker.finished());
+        assert(buffer.hasSpaceForItems(tracker.size()));
+        handle.scatter(buffer, tracker.index(), tracker.size());
+        unpacked+=tracker.size();
+        tracker.moveToNextIndex();
+      }
+      return tracker.finished();
+    }
+  }
+};
+
+
+/**
+ * @brief A functor that unpacks std::size_t from the message buffer.
+ */
+template<class DataHandle>
+struct UnpackSizeEntries{
+
+  /**
+   * @brief packs data.
+   * @param handle The handle describing the data and the gather and scatter operations.
+   * @param tracker The tracker of the interface to tell us where we are.
+   * @param buffer The buffer to use for packing.
+   * @return The number data entries that we packed.
+   */
+  bool operator()(SizeDataHandle<DataHandle>& handle, InterfaceTracker& tracker,
+                  MessageBuffer<typename SizeDataHandle<DataHandle>::DataType>& buffer) const
+  {
+    std::size_t noIndices=std::min(buffer.size(), tracker.indicesLeft());
+    std::copy(static_cast<std::size_t*>(buffer), static_cast<std::size_t*>(buffer)+noIndices,
+              handle.getSizesPointer()+tracker.offset());
+    tracker.increment(noIndices);
+    return noIndices;
+  }
+   bool operator()(SizeDataHandle<DataHandle>& handle, InterfaceTracker& tracker,
+                   MessageBuffer<typename SizeDataHandle<DataHandle>::DataType>& buffer, int) const
+  {
+    return operator()(handle,tracker,buffer);
+  }
+};
+
+/**
+ * @brief Sends the size in case of communicating a fixed amount of data per entry.
+ * @param[in] send_trackers The trackers for the sending side.
+ * @param[out] send_requests The request for the asynchronous send operations.
+ * @param[in] recv_trackers The trackers for the receiving side.
+ * @param[out] recv_requests The request for the asynchronous receive operations.
+ */
+void sendFixedSize(std::vector<InterfaceTracker>& send_trackers,
+                   std::vector<MPI_Request>& send_requests,
+                   std::vector<InterfaceTracker>& recv_trackers,
+                   std::vector<MPI_Request>& recv_requests,
+                   MPI_Comm communicator)
+{
+  typedef std::vector<InterfaceTracker>::iterator TIter;
+  std::vector<MPI_Request>::iterator mIter=recv_requests.begin();
+
+  for(TIter iter=recv_trackers.begin(), end=recv_trackers.end(); iter!=end;
+      ++iter, ++mIter)
+  {
+    MPI_Irecv(&(iter->fixedSize), 1, Dune::MPITraits<std::size_t>::getType(),
+              iter->rank(), 933881, communicator, &(*mIter));
+  }
+
+  // Send our size to all neighbours using non-blocking synchronous communication.
+  std::vector<MPI_Request>::iterator mIter1=send_requests.begin();
+  for(TIter iter=send_trackers.begin(), end=send_trackers.end();
+      iter!=end;
+      ++iter, ++mIter1)
+  {
+    MPI_Issend(&(iter->fixedSize), 1, Dune::MPITraits<std::size_t>::getType(),
+               iter->rank(), 933881, communicator, &(*mIter1));
+  }
+}
+
+
+/**
+ * @brief Functor for setting up send requests.
+ * @tparam DataHandle The type of the data handle for describing the data.
+ */
+template<class DataHandle>
+struct SetupSendRequest{
+  void operator()(DataHandle& handle,
+                  InterfaceTracker& tracker,
+                  MessageBuffer<typename DataHandle::DataType>& buffer,
+                  MPI_Request& request,
+                  MPI_Comm comm) const
+  {
+    buffer.reset();
+    int size=PackEntries<DataHandle>()(handle, tracker, buffer);
+    // Skip indices of zero size.
+    while(!tracker.finished() &&  !handle.size(tracker.index()))
+      tracker.moveToNextIndex();
+    if(size)
+    {
+      assert(std::size_t(size) <= buffer.size());
+      MPI_Issend(buffer, size, Dune::MPITraits<typename DataHandle::DataType>::getType(),
+                 tracker.rank(), 933399, comm, &request);
+    }
+  }
+};
+
+
+/**
+ * @brief Functor for setting up receive requests.
+ * @tparam DataHandle The type of the data handle for describing the data.
+ */
+template<class DataHandle>
+struct SetupRecvRequest{
+  void operator()(DataHandle& /*handle*/,
+                  InterfaceTracker& tracker,
+                  MessageBuffer<typename DataHandle::DataType>& buffer,
+                  MPI_Request& request,
+                  MPI_Comm comm) const
+  {
+    buffer.reset();
+    if(tracker.indicesLeft())
+      MPI_Irecv(buffer, buffer.size(), Dune::MPITraits<typename DataHandle::DataType>::getType(),
+                tracker.rank(), 933399, comm, &request);
+  }
+};
+
+/**
+ * @brief A functor that does nothing.
+ */
+template<class DataHandle>
+struct NullPackUnpackFunctor
+{
+  int operator()(DataHandle&, InterfaceTracker&,
+                 MessageBuffer<typename DataHandle::DataType>&, int)
+  {
+    return 0;
+  }
+  int operator()(DataHandle&, InterfaceTracker&,
+                 MessageBuffer<typename DataHandle::DataType>&)
+  {
+    return 0;
+  }
+};
+
+/**
+ * @brief Check whether some of the requests finished and continue send/receive operation.
+ * @tparam DataHandle The type of the data handle describing the data.
+ * @tparam BufferFunctor A functor that packs or unpacks data from the buffer.
+ * E.g. NullPackUnpackFunctor.
+ * @tparam CommunicationFuntor A functor responsible for continuing the communication.
+ * @param handle The data handle describing the data.
+ * @param trackers The trackers indicating the current position in the communication.
+ * @param requests The requests to test whether they finished.
+ * @param requests2 The requests to use for setting up the continuing communication. Might
+ * be the same as requests.
+ * @param comm The MPI communicator to use.
+ * @param buffer_func The functor that does the packing or unpacking of the data.
+ */
+template<class DataHandle, class BufferFunctor, class CommunicationFunctor>
+std::size_t checkAndContinue(DataHandle& handle,
+                             std::vector<InterfaceTracker>& trackers,
+                             std::vector<MPI_Request>& requests,
+                             std::vector<MPI_Request>& requests2,
+                             std::vector<MessageBuffer<typename DataHandle::DataType> >& buffers,
+                             MPI_Comm comm,
+                             BufferFunctor buffer_func,
+                             CommunicationFunctor comm_func,
+                             bool valid=true,
+                             bool getCount=false)
+{
+  std::size_t size=requests.size();
+  std::vector<MPI_Status> statuses(size);
+  int no_completed;
+  std::vector<int> indices(size, -1); // the indices for which the communication finished.
+
+  MPI_Testsome(size, &(requests[0]), &no_completed, &(indices[0]), &(statuses[0]));
+  indices.resize(no_completed);
+  for(std::vector<int>::iterator index=indices.begin(), end=indices.end();
+      index!=end; ++index)
+  {
+    InterfaceTracker& tracker=trackers[*index];
+    setReceivingIndex(handle, *index);
+    if(getCount)
+    {
+      // Get the number of entries received
+      int count;
+      MPI_Get_count(&(statuses[index-indices.begin()]),
+                    Dune::MPITraits<typename DataHandle::DataType>::getType(),
+                    &count);
+      // Communication completed, we can reuse the buffers, e.g. unpack or repack
+      buffer_func(handle, tracker, buffers[*index], count);
+    }else
+      buffer_func(handle, tracker, buffers[*index]);
+    tracker.skipZeroIndices();
+    if(!tracker.finished()){
+      // Maybe start another communication.
+      comm_func(handle, tracker, buffers[*index], requests2[*index], comm);
+      tracker.skipZeroIndices();
+      if(valid)
+      --no_completed; // communication not finished, decrement counter for finished ones.
+    }
+  }
+  return no_completed;
+
+}
+
+/**
+ * @brief Receive the size per data entry and set up requests for receiving the data.
+ * @tparam DataHandle The type of the data handle.
+ * @param trackers The trackers indicating the indices where we send and from which rank.
+ * @param size_requests The requests for receiving the size.
+ * @param data_requests The requests for sending the data.
+ * @param buffers The buffers to use for sending.
+ * @param comm The mpi communicator to use.
+ */
+template<class DataHandle>
+std::size_t receiveSizeAndSetupReceive(DataHandle& handle,
+                                       std::vector<InterfaceTracker>& trackers,
+                                       std::vector<MPI_Request>& size_requests,
+                                       std::vector<MPI_Request>& data_requests,
+                                       std::vector<MessageBuffer<typename DataHandle::DataType> >& buffers,
+                                       MPI_Comm comm)
+{
+  return checkAndContinue(handle, trackers, size_requests, data_requests, buffers, comm,
+                   NullPackUnpackFunctor<DataHandle>(), SetupRecvRequest<DataHandle>(), false);
+}
+
+/**
+ * @brief Check whether send request completed and continue sending if necessary.
+ * @tparam DataHandle The type of the data handle.
+ * @param trackers The trackers indicating the indices where we send and from which rank.
+ * @param requests The requests for the asynchronous communication.
+ * @param buffers The buffers to use for sending.
+ * @param comm The mpi communicator to use.
+ */
+template<class DataHandle>
+std::size_t checkSendAndContinueSending(DataHandle& handle,
+                                        std::vector<InterfaceTracker>& trackers,
+                                        std::vector<MPI_Request>& requests,
+                                        std::vector<MessageBuffer<typename DataHandle::DataType> >& buffers,
+                                        MPI_Comm comm)
+{
+  return checkAndContinue(handle, trackers, requests, requests, buffers, comm,
+                          NullPackUnpackFunctor<DataHandle>(), SetupSendRequest<DataHandle>());
+}
+
+/**
+ * @brief Check whether receive request completed and continue receiving if necessary.
+ * @tparam DataHandle The type of the data handle.
+ * @param trackers The trackers indicating the indices where we receive and from which rank.
+ * @param requests The requests for the asynchronous communication.
+ * @param buffers The buffers to use for receiving.
+ * @param comm The mpi communicator to use.
+ */
+template<class DataHandle>
+std::size_t checkReceiveAndContinueReceiving(DataHandle& handle,
+                                             std::vector<InterfaceTracker>& trackers,
+                                             std::vector<MPI_Request>& requests,
+                                             std::vector<MessageBuffer<typename DataHandle::DataType> >& buffers,
+                                             MPI_Comm comm)
+{
+  return checkAndContinue(handle, trackers, requests, requests, buffers, comm,
+                          UnpackEntries<DataHandle>(), SetupRecvRequest<DataHandle>(),
+                          true, !handle.fixedsize());
+}
+
+
+bool validRecvRequests(const std::vector<MPI_Request> reqs)
+{
+  for(std::vector<MPI_Request>::const_iterator i=reqs.begin(), end=reqs.end();
+      i!=end; ++i)
+    if(*i!=MPI_REQUEST_NULL)
+      return true;
+  return false;
+}
+
+/**
+ * @brief Sets up all the send requests for the data.
+ * @tparam DataHandle The type of the data handle.
+ * @tparam Functor The type of the functor to set up the request.
+ * @param handle The data handle describing the data.
+ * @param trackers The trackers for the communication interfaces.
+ * @param buffers The buffers for the comunication. One for each neighbour.
+ * @param requests The send requests for each neighbour.
+ * @param setupFunctor The functor responsible for setting up the request.
+ */
+template<class DataHandle, class Functor>
+std::size_t setupRequests(DataHandle& handle,
+                   std::vector<InterfaceTracker>& trackers,
+                   std::vector<MessageBuffer<typename DataHandle::DataType> >& buffers,
+                   std::vector<MPI_Request>& requests,
+                   const Functor& setupFunctor,
+                   MPI_Comm communicator)
+{
+  typedef typename std::vector<InterfaceTracker>::iterator TIter;
+  typename std::vector<MessageBuffer<typename DataHandle::DataType> >::iterator
+    biter=buffers.begin();
+  typename std::vector<MPI_Request>::iterator riter=requests.begin();
+  std::size_t complete=0;
+  for(TIter titer=trackers.begin(), end=trackers.end(); titer!=end; ++titer, ++biter, ++riter)
+  {
+    setupFunctor(handle, *titer, *biter, *riter, communicator);
+    complete+=titer->finished();
+  }
+  return complete;
+}
+} // end unnamed namespace
+
+template<class Allocator>
+template<bool FORWARD, class DataHandle>
+void VariableSizeCommunicator<Allocator>::setupInterfaceTrackers(DataHandle& handle,
+                            std::vector<InterfaceTracker>& send_trackers,
+                            std::vector<InterfaceTracker>& recv_trackers)
+{
+  if(interface_->size()==0)
+    return;
+  send_trackers.reserve(interface_->size());
+  recv_trackers.reserve(interface_->size());
+
+  int fixedsize=0;
+  if(handle.fixedsize())
+    ++fixedsize;
+
+
+  typedef typename InterfaceMap::const_iterator IIter;
+  for(IIter inf=interface_->begin(), end=interface_->end(); inf!=end; ++inf)
+  {
+
+    if(handle.fixedsize() && InterfaceInformationChooser<FORWARD>::getSend(inf->second).size())
+      fixedsize=handle.size(InterfaceInformationChooser<FORWARD>::getSend(inf->second)[0]);
+    assert(!handle.fixedsize()||fixedsize>0);
+    send_trackers.push_back(InterfaceTracker(inf->first,
+                                             InterfaceInformationChooser<FORWARD>::getSend(inf->second), fixedsize));
+    recv_trackers.push_back(InterfaceTracker(inf->first,
+                                             InterfaceInformationChooser<FORWARD>::getReceive(inf->second), fixedsize, fixedsize==0));
+  }
+}
+
+template<class Allocator>
+template<bool FORWARD, class DataHandle>
+void VariableSizeCommunicator<Allocator>::communicateFixedSize(DataHandle& handle)
+{
+  std::vector<MPI_Request> size_send_req(interface_->size());
+  std::vector<MPI_Request> size_recv_req(interface_->size());
+
+  std::vector<InterfaceTracker> send_trackers;
+  std::vector<InterfaceTracker> recv_trackers;
+  setupInterfaceTrackers<FORWARD>(handle,send_trackers, recv_trackers);
+  sendFixedSize(send_trackers,  size_send_req, recv_trackers, size_recv_req, communicator_);
+
+  std::vector<MPI_Request> data_send_req(interface_->size(), MPI_REQUEST_NULL);
+  std::vector<MPI_Request> data_recv_req(interface_->size(), MPI_REQUEST_NULL);
+  typedef typename DataHandle::DataType DataType;
+  std::vector<MessageBuffer<DataType> > send_buffers(interface_->size(), MessageBuffer<DataType>(maxBufferSize_)),
+    recv_buffers(interface_->size(), MessageBuffer<DataType>(maxBufferSize_));
+
+
+  setupRequests(handle, send_trackers, send_buffers, data_send_req,
+                SetupSendRequest<DataHandle>(), communicator_);
+
+  std::size_t no_size_to_recv,  no_to_send, no_to_recv, old_size;
+  no_size_to_recv = no_to_send = no_to_recv = old_size = interface_->size();
+
+  // Skip empty interfaces.
+  typedef typename std::vector<InterfaceTracker>::const_iterator Iter;
+  for(Iter i=recv_trackers.begin(), end=recv_trackers.end(); i!=end; ++i)
+    if(i->empty())
+       --no_to_recv;
+  for(Iter i=send_trackers.begin(), end=send_trackers.end(); i!=end; ++i)
+    if(i->empty())
+      --no_to_send;
+
+  while(no_size_to_recv+no_to_send+no_to_recv)
+  {
+    // Receive the fixedsize and setup receives accordingly
+    if(no_size_to_recv)
+      no_size_to_recv -= receiveSizeAndSetupReceive(handle,recv_trackers, size_recv_req,
+                                                  data_recv_req, recv_buffers,
+                                                  communicator_);
+
+    // Check send completion and initiate other necessary sends
+    if(no_to_send)
+      no_to_send -= checkSendAndContinueSending(handle, send_trackers, data_send_req,
+                                              send_buffers, communicator_);
+    if(validRecvRequests(data_recv_req))
+      // Receive data and setup new unblocking receives if necessary
+      no_to_recv -= checkReceiveAndContinueReceiving(handle, recv_trackers, data_recv_req,
+                                                     recv_buffers, communicator_);
+  }
+
+  // Wait for completion of sending the size.
+  //std::vector<MPI_Status> statuses(interface_->size(), MPI_STATUSES_IGNORE);
+  MPI_Waitall(size_send_req.size(), &(size_send_req[0]), MPI_STATUSES_IGNORE);
+
+}
+
+template<class Allocator>
+template<bool FORWARD, class DataHandle>
+void VariableSizeCommunicator<Allocator>::communicateSizes(DataHandle& handle,
+                                                           std::vector<InterfaceTracker>& data_recv_trackers)
+{
+  std::vector<InterfaceTracker> send_trackers;
+  std::vector<InterfaceTracker> recv_trackers;
+  std::size_t size = interface_->size();
+  std::vector<MPI_Request> send_requests(size, MPI_REQUEST_NULL);
+  std::vector<MPI_Request> recv_requests(size, MPI_REQUEST_NULL);
+  std::vector<MessageBuffer<std::size_t> >
+    send_buffers(size, MessageBuffer<std::size_t>(maxBufferSize_)),
+    recv_buffers(size, MessageBuffer<std::size_t>(maxBufferSize_));
+  SizeDataHandle<DataHandle> size_handle(handle,data_recv_trackers);
+  setupInterfaceTrackers<FORWARD>(size_handle,send_trackers, recv_trackers);
+  setupRequests(size_handle, send_trackers, send_buffers, send_requests,
+                                SetupSendRequest<SizeDataHandle<DataHandle> >(), communicator_);
+  setupRequests(size_handle, recv_trackers, recv_buffers, recv_requests,
+                SetupRecvRequest<SizeDataHandle<DataHandle> >(), communicator_);
+
+  // Count valid requests that we have to wait for.
+  auto valid_req_func =
+    [](const MPI_Request& req) { return req != MPI_REQUEST_NULL; };
+
+  auto size_to_send = std::count_if(send_requests.begin(), send_requests.end(),
+                                    valid_req_func);
+  auto size_to_recv = std::count_if(recv_requests.begin(), recv_requests.end(),
+                                    valid_req_func);
+
+  while(size_to_send+size_to_recv)
+  {
+    if(size_to_send)
+      size_to_send -=
+        checkSendAndContinueSending(size_handle, send_trackers, send_requests,
+                                    send_buffers, communicator_);
+    if(size_to_recv)
+      // Could have done this using checkSendAndContinueSending
+      // But the call below is more efficient as UnpackSizeEntries
+      // uses std::copy.
+      size_to_recv -=
+        checkAndContinue(size_handle, recv_trackers, recv_requests, recv_requests,
+                         recv_buffers, communicator_, UnpackSizeEntries<DataHandle>(),
+                         SetupRecvRequest<SizeDataHandle<DataHandle> >());
+  }
+}
+
+template<class Allocator>
+template<bool FORWARD, class DataHandle>
+void VariableSizeCommunicator<Allocator>::communicateVariableSize(DataHandle& handle)
+{
+
+  std::vector<InterfaceTracker> send_trackers;
+  std::vector<InterfaceTracker> recv_trackers;
+  setupInterfaceTrackers<FORWARD>(handle, send_trackers, recv_trackers);
+
+  std::vector<MPI_Request> send_requests(interface_->size(), MPI_REQUEST_NULL);
+  std::vector<MPI_Request> recv_requests(interface_->size(), MPI_REQUEST_NULL);
+  typedef typename DataHandle::DataType DataType;
+  std::vector<MessageBuffer<DataType> >
+    send_buffers(interface_->size(), MessageBuffer<DataType>(maxBufferSize_)),
+    recv_buffers(interface_->size(), MessageBuffer<DataType>(maxBufferSize_));
+
+  communicateSizes<FORWARD>(handle, recv_trackers);
+  // Setup requests for sending and receiving.
+  setupRequests(handle, send_trackers, send_buffers, send_requests,
+                SetupSendRequest<DataHandle>(), communicator_);
+  setupRequests(handle, recv_trackers, recv_buffers, recv_requests,
+                SetupRecvRequest<DataHandle>(), communicator_);
+
+  // Determine number of valid requests.
+  auto valid_req_func =
+    [](const MPI_Request& req) { return req != MPI_REQUEST_NULL;};
+
+  auto no_to_send = std::count_if(send_requests.begin(), send_requests.end(),
+                             valid_req_func);
+  auto no_to_recv = std::count_if(recv_requests.begin(), recv_requests.end(),
+                             valid_req_func);
+  while(no_to_send+no_to_recv)
+  {
+    // Check send completion and initiate other necessary sends
+    if(no_to_send)
+      no_to_send -= checkSendAndContinueSending(handle, send_trackers, send_requests,
+                                              send_buffers, communicator_);
+    if(no_to_recv)
+      // Receive data and setup new unblocking receives if necessary
+      no_to_recv -= checkReceiveAndContinueReceiving(handle, recv_trackers, recv_requests,
+                                                     recv_buffers, communicator_);
+  }
+}
+
+template<class Allocator>
+template<bool FORWARD, class DataHandle>
+void VariableSizeCommunicator<Allocator>::communicate(DataHandle& handle)
+{
+  if( interface_->size() == 0)
+    // Simply return as otherwise we will index an empty container
+    // either for MPI_Wait_all or MPI_Test_some.
+    return;
+
+  if(handle.fixedsize())
+    communicateFixedSize<FORWARD>(handle);
+  else
+    communicateVariableSize<FORWARD>(handle);
+}
+} // end namespace Dune
+
+#endif // HAVE_MPI
+
+#endif

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -287,6 +287,164 @@ public:
     }
 };
 
+class CopyCellValues
+{
+public:
+    CopyCellValues(std::vector<int>& cont)
+        : cont_(cont)
+    {}
+
+    typedef int DataType;
+    bool fixedsize(int /*dim*/, int /*codim*/)
+    {
+        return true;
+    }
+
+    template<class T>
+    std::size_t size(const T&)
+    {
+        return 1;
+    }
+    template<class B, class T>
+    void gather(B& buffer, const T& t)
+    {
+        buffer.write(cont_[t.index()]);
+    }
+    template<class B, class T>
+    void scatter(B& buffer, const T& t, std::size_t s)
+    {
+        for(std::size_t i=0; i<s; ++i)
+        {
+            buffer.read(cont_[t.index()]);
+        }
+    }
+    bool contains(int dim, int codim)
+    {
+        return dim==3 && codim==0;
+    }
+private:
+    std::vector<int>& cont_;
+};
+
+BOOST_AUTO_TEST_CASE(testDistributedComm)
+{
+    Dune::CpGrid grid;
+    std::array<int, 3> dims={{8, 4, 2}};
+    std::array<double, 3> size={{ 8.0, 4.0, 2.0}};
+    //grid.setUniqueBoundaryIds(true); // set and compute unique boundary ids.
+    grid.createCartesian(dims, size);
+    grid.loadBalance();
+#ifdef HAVE_DUNE_ISTL
+    using AttributeSet = Dune::OwnerOverlapCopyAttributeSet::AttributeSet;
+#else
+    /// \brief The type of the set of the attributes
+    enum AttributeSet{owner, overlap, copy};
+#endif
+    std::vector<int> cont(grid.size(0), 1);
+    const auto& indexSet = grid.getCellIndexSet();
+    for ( const auto index: indexSet)
+        if (index.local().attribute() != AttributeSet::owner )
+            cont[index.local()] = -1;
+
+    CopyCellValues handle(cont);
+    grid.communicate(handle, Dune::InteriorBorder_All_Interface,
+                     Dune::ForwardCommunication);
+
+    for ( const auto index: indexSet)
+        BOOST_REQUIRE(cont[index.local()] == 1);
+}
+
+BOOST_AUTO_TEST_CASE(compareWithSequential)
+{
+#if HAVE_MPI
+    Dune::CpGrid grid;
+    Dune::CpGrid seqGrid(MPI_COMM_SELF);
+    std::array<int, 3> dims={{8, 4, 2}};
+    std::array<double, 3> size={{ 8.0, 4.0, 2.0}};
+    grid.setUniqueBoundaryIds(true); // set and compute unique boundary ids.
+    seqGrid.setUniqueBoundaryIds(true);
+    grid.createCartesian(dims, size);
+    grid.loadBalance();
+    seqGrid.createCartesian(dims, size);
+
+    auto idSet = grid.globalIdSet(), seqIdSet = seqGrid.globalIdSet();
+
+    using GridView = Dune::CpGrid::LeafGridView;
+    using ElementIterator = GridView::Codim<0>::Iterator;
+    GridView gridView(grid.leafGridView());
+    GridView seqGridView(seqGrid.leafGridView());
+
+    ElementIterator endEIt = gridView.end<0>();
+    ElementIterator seqEndEIt = seqGridView.end<0>();
+    ElementIterator seqEIt = seqGridView.begin<0>();
+    const auto& gc = grid.globalCell();
+    const auto& seqGc = seqGrid.globalCell();
+    int i{}, seqI{};
+    BOOST_REQUIRE(gc.size() == std::size_t(grid.size(0)));
+
+    for (ElementIterator eIt = gridView.begin<0>(); eIt != endEIt; ++eIt, ++i) {
+        // find corresponding cell in global grid
+        auto id = idSet.id(*eIt);
+        while (seqIdSet.id(*seqEIt) < id && seqEIt != seqEndEIt)
+        {
+            ++seqI;
+            ++seqEIt;
+        }
+        BOOST_REQUIRE(id == seqIdSet.id(seqEIt));
+        BOOST_REQUIRE(gc[eIt->index()] == seqGc[seqEIt->index()]);
+        const auto& geom = eIt->geometry();
+        const auto& seqGeom = seqEIt-> geometry();
+        BOOST_REQUIRE(geom.center() == seqGeom.center());
+        BOOST_REQUIRE(geom.volume() == seqGeom.volume());
+
+        int ii{};
+
+        for (auto iit=gridView.ibegin(*eIt), siit = seqGridView.ibegin(*seqEIt),
+                 endiit = gridView.iend(*eIt); iit!=endiit; ++iit, ++siit, ++ii)
+            {
+                if (iit.boundary())
+                {
+                    BOOST_REQUIRE(iit.boundarySegmentIndex() == siit.boundarySegmentIndex());
+                    BOOST_REQUIRE(iit.boundaryId() == siit.boundaryId());
+                }
+                BOOST_REQUIRE(iit->geometry().center() == siit->geometry().center());
+                BOOST_REQUIRE(iit->geometry().volume() == siit->geometry().volume());
+                BOOST_REQUIRE(iit.boundary() == siit.boundary());
+                BOOST_REQUIRE(iit.outerNormal({0, 0}) == siit.outerNormal({0, 0}));
+                BOOST_REQUIRE(idSet.id(*iit.inside()) == seqIdSet.id(*siit.inside()));
+                if (iit->neighbor())
+                {
+                    assert(siit->neighbor());
+                    BOOST_REQUIRE(idSet.id(*iit.outside()) == seqIdSet.id(*siit.outside()));
+                }
+            }
+
+        // to reach all points we need to loop over subentities
+        int faces = grid.numCellFaces(eIt->index());
+        BOOST_REQUIRE(faces == seqGrid.numCellFaces(seqEIt.index()));
+        for (int f = 0; f < faces; ++f)
+        {
+            using namespace Dune::cpgrid;
+            auto face = grid.cellFace(eIt->index(), f);
+            auto seqFace = seqGrid.cellFace(seqEIt->index(), f);
+            BOOST_REQUIRE(idSet.id(EntityRep<1>(face, true)) ==
+                          seqIdSet.id(EntityRep<1>(seqFace, true)));
+            int vertices = grid.numFaceVertices(face);
+            BOOST_REQUIRE(vertices == seqGrid.numFaceVertices(seqFace));
+            for (int v = 0; v < vertices; ++v)
+            {
+                auto vertex = grid.faceVertex(face, v);
+                auto seqVertex = seqGrid.faceVertex(seqFace, v);
+                BOOST_REQUIRE(idSet.id(EntityRep<3>(vertex, true)) ==
+                              seqIdSet.id(EntityRep<3>(seqVertex, true)));
+                BOOST_REQUIRE(grid.vertexPosition(vertex) ==
+                              seqGrid.vertexPosition(seqVertex));
+            }
+        }
+    }
+#endif
+}
+
 BOOST_AUTO_TEST_CASE(distribute)
 {
 
@@ -306,7 +464,7 @@ BOOST_AUTO_TEST_CASE(distribute)
 
     grid.createCartesian(dims, size);
 #if HAVE_MPI
-    BOOST_REQUIRE(grid.comm()==MPI_COMM_SELF);
+    BOOST_REQUIRE(grid.comm()==MPI_COMM_WORLD);
 #endif
     std::vector<int> cell_indices, face_indices, point_indices;
     std::vector<Dune::CpGrid::Traits::Codim<0>::Geometry::GlobalCoordinate > cell_centers, face_centers, point_centers;

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -328,6 +328,7 @@ private:
 
 BOOST_AUTO_TEST_CASE(testDistributedComm)
 {
+#if HAVE_MPI
     Dune::CpGrid grid;
     std::array<int, 3> dims={{8, 4, 2}};
     std::array<double, 3> size={{ 8.0, 4.0, 2.0}};
@@ -352,6 +353,7 @@ BOOST_AUTO_TEST_CASE(testDistributedComm)
 
     for ( const auto index: indexSet)
         BOOST_REQUIRE(cont[index.local()] == 1);
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(compareWithSequential)


### PR DESCRIPTION
This is a corrected and rebased version of #405. Due to the non-linear history there there have been
some glitches during rebasing it which could only be removed get rid of some merges there and cherry-picking them back.

This is now a working version of have the global grid only on one process in parallel. Tested on SPE, and norne. Tests on model2 still running.

Needs OPM/opm-simulators#2161 as otherwise wells will be ignored on non-root processes.