### PR TITLE
Reduce the value of MPI tags to avoid crash

### DIFF
--- a/opm/grid/common/GridPartitioning.cpp
+++ b/opm/grid/common/GridPartitioning.cpp
@@ -444,7 +444,7 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
         // communicate number of entries
         std::vector<MPI_Request> requests(importProcs.size());
         auto req = requests.begin();
-        int tag = 23872949;
+        int tag = 2387;
         for(auto&& proc : importProcs)
         {
             MPI_Irecv(&(proc.second), 1, MPI_INT, proc.first, tag, cc, &(*req));

--- a/opm/grid/common/WellConnections.cpp
+++ b/opm/grid/common/WellConnections.cpp
@@ -209,7 +209,7 @@ postProcessPartitioningForWells(std::vector<int>& parts,
     std::vector<std::vector<std::size_t>> sizeBuffers(cc.size());
     auto begin = cellsPerProc.begin();
     auto req = requests.begin();
-    int tag = 782372873;
+    int tag = 7823;
     auto myRank = cc.rank();
 
     for (auto it = begin, end = cellsPerProc.end(); it != end; ++it) {


### PR DESCRIPTION
Parallel flow crashes on my computer due to too large MPI tag values in the MPI_send calls in the files changed in this PR.

According to https://github.com/lanl/SNAP/issues/6, the lowest allowed upper bound for MPI tags is  32767. Changed the tags to reflect this.