### PR TITLE
Make utility function UgGridHelpers::createACTNUM()

### DIFF
--- a/opm/grid/GridHelpers.hpp
+++ b/opm/grid/GridHelpers.hpp
@@ -395,6 +395,19 @@ double getCoordinate(T t, int i)
     return (*t)[i];
 }
 
+
+
+/// \brief Create Eclipse style ACTNUM array.
+///
+/// Create a vector with global cartesian number of elements,
+/// the value is 0 for inactive cells and one for active cells.
+template<class Grid>
+std::vector<int> createACTNUM(const Grid& grid){
+    const int* dims = cartDims(grid);
+    return ActiveGridCells(dims[0], dims[1], dims[2], globalCell(grid), numCells(grid)).actNum();
+}
+
+
 } // end namespace UGGridHelpers
 } // end namespace OPM
 #endif

--- a/opm/grid/utility/OpmParserIncludes.hpp
+++ b/opm/grid/utility/OpmParserIncludes.hpp
@@ -27,6 +27,8 @@
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+#include <opm/common/utility/ActiveGridCells.hpp>
+
 
 namespace Dune {
     namespace cpgrid {

--- a/tests/test_ug.cpp
+++ b/tests/test_ug.cpp
@@ -107,6 +107,16 @@ BOOST_AUTO_TEST_CASE(EqualEclipseGrid) {
 
 
     BOOST_CHECK( grid_equal( cgrid1 , cgrid2 ));
+
+    auto actnum = Opm::UgGridHelpers::createACTNUM(*cgrid1);
+    BOOST_CHECK_EQUAL( actnum.size(), 500 );
+    for (std::size_t i=0; i < 100; i++) {
+        BOOST_CHECK_EQUAL(actnum[i + 200], 1);
+        for (std::size_t j=0; j < 2; j++) {
+            BOOST_CHECK_EQUAL(actnum[i + j * 100], 0);
+            BOOST_CHECK_EQUAL(actnum[i + j * 100 + 300], 0);
+        }
+    }
     destroy_grid( cgrid2 );
 }
 
@@ -167,4 +177,7 @@ BOOST_AUTO_TEST_CASE(TOPS_Fully_Specified) {
     BOOST_CHECK(grid_equal(cgrid1, cgrid2));
 
     Opm::EclipseGrid grid = Opm::UgGridHelpers::createEclipseGrid( *cgrid1 , es1.getInputGrid( ) );
+    auto actnum = Opm::UgGridHelpers::createACTNUM(*cgrid1);
+    for (std::size_t g = 0; g < 300; g++)
+        BOOST_CHECK_EQUAL(actnum[g], 1);
 }


### PR DESCRIPTION
The functionality to map between a list of global cells (opm-grid style) and an actnum array (opm-common/Eclipses style) is required for the `FieldPropsManager`. I suggest this implementation - but it could also be located in opm-common if you feel it does not fit in opm-grid.

Also: observe that this is an away match for me - please advise if I have done things against convention.