### PR TITLE
[For testing] Enable "owners first" ordering of cells in parallel grid.

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -607,7 +607,7 @@ namespace Dune
         bool loadBalance(int overlapLayers=1)
         {
             using std::get;
-            return get<0>(scatterGrid(defaultTransEdgeWgt, false, nullptr, nullptr, overlapLayers ));
+            return get<0>(scatterGrid(defaultTransEdgeWgt, false, nullptr, nullptr, true, overlapLayers ));
         }
 
         // loadbalance is not part of the grid interface therefore we skip it.
@@ -631,7 +631,7 @@ namespace Dune
                     const double* transmissibilities = nullptr,
                     int overlapLayers=1)
         {
-            return scatterGrid(defaultTransEdgeWgt, false, wells, transmissibilities, overlapLayers);
+            return scatterGrid(defaultTransEdgeWgt, false, wells, transmissibilities, false, overlapLayers);
         }
 
         // loadbalance is not part of the grid interface therefore we skip it.
@@ -650,14 +650,16 @@ namespace Dune
         ///            adding an edge with a very high edge weight for all
         ///            possible pairs of cells in the completion set of a well.
         /// \param transmissibilities The transmissibilities used to calculate the edge weights.
+        /// \param ownersFirst Order owner cells before copy/overlap cells.
+        /// \param addCornerCells Add corner cells to the overlap layer.
         /// \param The number of layers of cells of the overlap region (default: 1).
         /// \warning May only be called once.
         std::pair<bool, std::unordered_set<std::string> >
         loadBalance(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities = nullptr, bool ownersFirst=false,
-                    int overlapLayers=1)
+                    bool addCornerCells=false, int overlapLayers=1)
         {
-            return scatterGrid(method, ownersFirst, wells, transmissibilities, overlapLayers);
+            return scatterGrid(method, ownersFirst, wells, transmissibilities, addCornerCells, overlapLayers);
         }
 
         /// \brief Distributes this grid and data over the available nodes in a distributed machine.
@@ -700,16 +702,18 @@ namespace Dune
         ///            adding an edge with a very high edge weight for all
         ///            possible pairs of cells in the completion set of a well.
         /// \param transmissibilities The transmissibilities used to calculate the edge weights.
+        /// \param ownersFirst Order owner cells before copy/overlap cells.
+        /// \param addCornerCells Add corner cells to the overlap layer.
         /// \param The number of layers of cells of the overlap region (default: 1).
         /// \warning May only be called once.
         template<class DataHandle>
         std::pair<bool, std::unordered_set<std::string> >
         loadBalance(DataHandle& data, EdgeWeightMethod method,
                     const std::vector<cpgrid::OpmWellType> * wells,
-                    const double* transmissibilities = nullptr,
-                    int overlapLayers=1)
+                    const double* transmissibilities = nullptr, bool ownersFirst=false,
+                    bool addCornerCells=false, int overlapLayers=1)
         {
-            auto ret = scatterGrid(method, wells, transmissibilities, overlapLayers);
+            auto ret = scatterGrid(method, ownersFirst, wells, transmissibilities, addCornerCells, overlapLayers);
             scatterData(data);
             return ret;
         }
@@ -1359,19 +1363,25 @@ namespace Dune
     private:
         /// \brief Scatter a global grid to all processors.
         /// \param method The edge-weighting method to be used on the Zoltan partitioner.
-        /// \param ecl Pointer to the eclipse state information. Default: null
+        /// \param ownersFirst Order owner cells before copy/overlap cells.
+        /// \param wells The wells of the eclipse If null wells will be neglected.
         ///            If this is not null then complete well information of
         ///            of the last scheduler step of the eclipse state will be
         ///            used to make sure that all the possible completion cells
         ///            of each well are stored on one process. This done by
         ///            adding an edge with a very high edge weight for all
         ///            possible pairs of cells in the completion set of a well.
+        /// \param transmissibilities The transmissibilities used to calculate the edge weights in
+        ///                           the Zoltan partitioner. This is done to improve the numerical
+        ///                           performance of the parallel preconditioner.
+        /// \param addCornerCells Add corner cells to the overlap layer.
+        /// \param The number of layers of cells of the overlap region.
         std::pair<bool, std::unordered_set<std::string> >
         scatterGrid(EdgeWeightMethod method,
                     bool ownersFirst,
                     const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities,
-                    int overlapLayers);
+                    bool addCornerCells, int overlapLayers);
 
         /** @brief The data stored in the grid.
          *

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1368,7 +1368,7 @@ namespace Dune
         ///            possible pairs of cells in the completion set of a well.
         std::pair<bool, std::unordered_set<std::string> >
         scatterGrid(EdgeWeightMethod method,
-		    bool ownersFirst,
+                    bool ownersFirst,
                     const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities,
                     int overlapLayers);

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -653,8 +653,8 @@ namespace Dune
         /// \param The number of layers of cells of the overlap region (default: 1).
         /// \warning May only be called once.
         std::pair<bool, std::unordered_set<std::string> >
-        loadBalance(EdgeWeightMethod method, bool ownersFirst, const std::vector<cpgrid::OpmWellType> * wells,
-                    const double* transmissibilities = nullptr,
+        loadBalance(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellType> * wells,
+                    const double* transmissibilities = nullptr, bool ownersFirst=false,
                     int overlapLayers=1)
         {
             return scatterGrid(method, ownersFirst, wells, transmissibilities, overlapLayers);

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -607,7 +607,7 @@ namespace Dune
         bool loadBalance(int overlapLayers=1)
         {
             using std::get;
-            return get<0>(scatterGrid(defaultTransEdgeWgt, nullptr, nullptr, overlapLayers ));
+            return get<0>(scatterGrid(defaultTransEdgeWgt, false, nullptr, nullptr, overlapLayers ));
         }
 
         // loadbalance is not part of the grid interface therefore we skip it.
@@ -631,7 +631,7 @@ namespace Dune
                     const double* transmissibilities = nullptr,
                     int overlapLayers=1)
         {
-            return scatterGrid(defaultTransEdgeWgt, wells, transmissibilities, overlapLayers);
+            return scatterGrid(defaultTransEdgeWgt, false, wells, transmissibilities, overlapLayers);
         }
 
         // loadbalance is not part of the grid interface therefore we skip it.
@@ -653,11 +653,11 @@ namespace Dune
         /// \param The number of layers of cells of the overlap region (default: 1).
         /// \warning May only be called once.
         std::pair<bool, std::unordered_set<std::string> >
-        loadBalance(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellType> * wells,
+        loadBalance(EdgeWeightMethod method, bool ownersFirst, const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities = nullptr,
                     int overlapLayers=1)
         {
-            return scatterGrid(method, wells, transmissibilities, overlapLayers);
+            return scatterGrid(method, ownersFirst, wells, transmissibilities, overlapLayers);
         }
 
         /// \brief Distributes this grid and data over the available nodes in a distributed machine.
@@ -1368,6 +1368,7 @@ namespace Dune
         ///            possible pairs of cells in the completion set of a well.
         std::pair<bool, std::unordered_set<std::string> >
         scatterGrid(EdgeWeightMethod method,
+		    bool ownersFirst,
                     const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities,
                     int overlapLayers);

--- a/opm/grid/common/GridPartitioning.cpp
+++ b/opm/grid/common/GridPartitioning.cpp
@@ -278,6 +278,16 @@ void addOverlapCornerCell(const CpGrid& grid, int owner,
                           const std::vector<int>& cell_part,
                           std::vector<std::tuple<int,int,char>>& exportList)
 {
+    // Add corner cells to the overlap layer. Example of a subdomain of a 4x4 grid
+    // with and without corner cells in the overlap is given below. Note that the
+    // corner cell is not needed for cell centered finite volume schemes. 
+    // I = interior cells, O = overlap cells and E = exterior cells.
+    //
+    //  With corner     Without corner
+    //  I I O E         I I O E 
+    //  I I O E         I I O E 
+    //  O O O E         O O E E
+    //  E E E E         E E E E
     using AttributeSet = Dune::cpgrid::CpGridData::AttributeSet;
     const CpGrid::LeafIndexSet& ix = grid.leafIndexSet();
     int my_index = ix.index(from);
@@ -365,7 +375,7 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
     void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Entity& e,
                          const int owner, const std::vector<int>& cell_part,
                          std::vector<std::tuple<int,int,char>>& exportList,
-                         int recursion_deps)
+                         bool addCornerCells, int recursion_deps)
     {
         using AttributeSet = Dune::cpgrid::CpGridData::AttributeSet;
         const CpGrid::LeafIndexSet& ix = grid.leafIndexSet();
@@ -381,9 +391,9 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
                     {
                         // Add another layer
                         addOverlapLayer(grid, nb_index, *(iit->outside()), owner,
-                                        cell_part, exportList, recursion_deps-1);
+                                        cell_part, exportList, addCornerCells, recursion_deps-1);
                     }
-                    else
+                    else if (addCornerCells)
                     {
                         // Add cells to the overlap that just share a corner with e.
                         for (CpGrid::LeafIntersectionIterator iit2 = iit->outside()->ileafbegin();
@@ -404,22 +414,23 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
         }
     }
 
-    void addOverlapLayerNoZeroTrans(const CpGrid& grid, int index,
+    void addOverlapLayerNoZeroTrans(const CpGrid& grid, int index, const CpGrid::Codim<0>::Entity& e,
                                     const int owner, const std::vector<int>& cell_part,
                                     std::vector<std::tuple<int,int,char>>& exportList,
-                                    int recursion_deps, const double* trans)
+                                    bool addCornerCells, int recursion_deps, const double* trans)
     {
         using AttributeSet = Dune::OwnerOverlapCopyAttributeSet::AttributeSet;
-        for (int loc_face = 0; loc_face < grid.numCellFaces(index); ++loc_face) {
-            int face = grid.cellFace(index, loc_face);
-            int faceCell0 = grid.faceCell(face, 0);
-            int faceCell1 = grid.faceCell(face, 1);
-            int otherCell = faceCell0!=index ? faceCell0 : faceCell1;
-            
-            if ( otherCell != -1 ) {
-                if ( trans[face] != 0.0 ) {
-                    int nb_index = otherCell;
-                
+        const CpGrid::LeafIndexSet& ix = grid.leafIndexSet();
+        for (CpGrid::LeafIntersectionIterator iit = e.ileafbegin(); iit != e.ileafend(); ++iit) {
+            if ( iit->neighbor() ) {
+                int faceId = iit->id();
+
+                // If the transmissibility on a cell interface is zero we do not add the neighbor cell 
+                // to the overlap layer. The reason for this is that
+                // zero transmissibility -> no flux over the face -> zero offdiagonal.
+                // This is a reservoir simulation spesific thing that reduce parallel overhead.
+                if ( trans[faceId] != 0.0 ) {
+                    int nb_index = ix.index(*(iit->outside()));
                     if ( cell_part[nb_index]!=owner )
                     {
                         // Note: multiple adds for same process are possible
@@ -428,8 +439,24 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
                         if ( recursion_deps>0 )
                         {
                             // Add another layer
-                            addOverlapLayerNoZeroTrans(grid, nb_index, owner,cell_part,
-                                                       exportList, recursion_deps-1, trans);
+                            addOverlapLayerNoZeroTrans(grid, nb_index, e, owner, cell_part,
+                                                       exportList, addCornerCells, recursion_deps-1, trans);
+                        }
+                        else if (addCornerCells)
+                        {
+                            // Add cells to the overlap that just share a corner with e.
+                            for (CpGrid::LeafIntersectionIterator iit2 = iit->outside()->ileafbegin();
+                                 iit2 != iit->outside()->ileafend(); ++iit2)
+                            {
+                                if ( iit2->neighbor() )
+                                {
+                                    int nb_index2 = ix.index(*(iit2->outside()));
+                                    if( cell_part[nb_index2]!=owner ) {
+                                        addOverlapCornerCell(grid, owner, e, *(iit2->outside()),
+                                                             cell_part, exportList);
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -441,7 +468,7 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
                         std::vector<std::tuple<int,int,char>>& exportList,
                         std::vector<std::tuple<int,int,char,int>>& importList,
                         const CollectiveCommunication<Dune::MPIHelper::MPICommunicator>& cc,
-                        const double* trans, int layers)
+                        bool addCornerCells, const double* trans, int layers)
     {
 #ifdef HAVE_MPI
         using AttributeSet = Dune::cpgrid::CpGridData::AttributeSet;
@@ -455,10 +482,10 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
             auto owner = cell_part[index];
             exportProcs.insert(std::make_pair(owner, 0));
             if ( trans ) {
-                addOverlapLayerNoZeroTrans(grid, index, owner, cell_part, exportList, layers-1, trans);
+                addOverlapLayerNoZeroTrans(grid, index, *it, owner, cell_part, exportList, addCornerCells, layers-1, trans);
             }
             else {
-                addOverlapLayer(grid, index, *it, owner, cell_part, exportList, layers-1);
+                addOverlapLayer(grid, index, *it, owner, cell_part, exportList, addCornerCells, layers-1);
             }
         }
         // remove multiple entries

--- a/opm/grid/common/GridPartitioning.cpp
+++ b/opm/grid/common/GridPartitioning.cpp
@@ -453,8 +453,12 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
             int index = ix.index(*it);
             auto owner = cell_part[index];
             exportProcs.insert(std::make_pair(owner, 0));
-            //addOverlapLayer(grid, index, *it, owner, cell_part, exportList, layers-1);
-            addOverlapLayerNoZeroTrans(grid, index, owner, cell_part, exportList, layers-1, trans);
+            if ( trans ) {
+                addOverlapLayerNoZeroTrans(grid, index, owner, cell_part, exportList, layers-1, trans);
+            }
+            else {
+                addOverlapLayer(grid, index, *it, owner, cell_part, exportList, layers-1);
+            }
         }
         // remove multiple entries
         auto compare = [](const std::tuple<int,int,char>& t1, const std::tuple<int,int,char>& t2)

--- a/opm/grid/common/GridPartitioning.cpp
+++ b/opm/grid/common/GridPartitioning.cpp
@@ -260,7 +260,7 @@ void addOverlapCornerCell(const CpGrid& grid, int owner,
         const int num_nb_subs = neighbor.subEntities(CpGrid::dimension);
         for ( int j = 0; j < num_nb_subs; j++)
         {
-            int otherpoint = ix.index(*neighbor.subEntity<CpGrid::dimension>(i));
+            int otherpoint = ix.index(*neighbor.subEntity<CpGrid::dimension>(j));
             if ( mypoint == otherpoint )
             {
                 cell_overlap[nb_index].insert(owner);
@@ -289,7 +289,7 @@ void addOverlapCornerCell(const CpGrid& grid, int owner,
         const int num_nb_subs = neighbor.subEntities(CpGrid::dimension);
         for ( int j = 0; j < num_nb_subs; j++)
         {
-            int otherpoint = ix.index(*neighbor.subEntity<CpGrid::dimension>(i));
+            int otherpoint = ix.index(*neighbor.subEntity<CpGrid::dimension>(j));
             if ( mypoint == otherpoint )
             {
                 // Note: multiple adds for same process are possible
@@ -324,7 +324,7 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
                         // Add cells to the overlap that just share a corner with e.
                         for (CpGrid::LeafIntersectionIterator iit2 = iit->outside()->ileafbegin();
                              iit2 != iit->outside()->ileafend(); ++iit2)
-                       {
+                        {
                            if ( iit2->neighbor() )
                            {
                                int nb_index2 = ix.index(*(iit2->outside()));
@@ -392,9 +392,10 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
                             if ( iit2->neighbor() )
                             {
                                 int nb_index2 = ix.index(*(iit2->outside()));
-                                if( cell_part[nb_index2]==owner ) continue;
-                                addOverlapCornerCell(grid, owner, e, *(iit2->outside()),
-                                                     cell_part, exportList);
+                                if( cell_part[nb_index2]!=owner ) {
+                                    addOverlapCornerCell(grid, owner, e, *(iit2->outside()),
+                                                         cell_part, exportList);
+                                }
                             }
                         }
                     }

--- a/opm/grid/common/GridPartitioning.hpp
+++ b/opm/grid/common/GridPartitioning.hpp
@@ -98,7 +98,7 @@ namespace Dune
                         std::vector<std::tuple<int,int,char>>& exportList,
                         std::vector<std::tuple<int,int,char,int>>& importList,
                         const CollectiveCommunication<Dune::MPIHelper::MPICommunicator>& cc,
-                        int layers = 1);
+                        const double* trans, int layers = 1);
 
 } // namespace Dune
 

--- a/opm/grid/common/GridPartitioning.hpp
+++ b/opm/grid/common/GridPartitioning.hpp
@@ -93,12 +93,14 @@ namespace Dune
     /// of global index, process rank (to import from), attribute here, local
     /// index here
     /// \param[in] cc The communication object
+    /// \param[in] addCornerCells Switch for adding corner cells to overlap layer.
+    /// \param[in] trans The transmissibilities on cell faces. When trans[i]==0, no overlap is added.
     /// \param[in] layer Number of overlap layers
     int addOverlapLayer(const CpGrid& grid, const std::vector<int>& cell_part,
                         std::vector<std::tuple<int,int,char>>& exportList,
                         std::vector<std::tuple<int,int,char,int>>& importList,
                         const CollectiveCommunication<Dune::MPIHelper::MPICommunicator>& cc,
-                        const double* trans, int layers = 1);
+                        bool addCornerCells, const double* trans, int layers = 1);
 
 } // namespace Dune
 

--- a/opm/grid/common/ZoltanGraphFunctions.hpp
+++ b/opm/grid/common/ZoltanGraphFunctions.hpp
@@ -155,7 +155,7 @@ public:
 
     double logTransmissibilityWeights(int face_index) const
     {
-        double trans = transmissibilities_[face_index]; 
+        double trans = transmissibilities_ ?  transmissibilities_[face_index] : 1; 
         return trans == 0.0 ? 0.0 : 1.0 + std::log(trans) - log_min_;
     }
 
@@ -167,7 +167,7 @@ public:
     double edgeWeight(int face_index) const
     {
         if (edgeWeightsMethod_ == uniformEdgeWgt)
-            return transmissibilities_[face_index] == 0.0 ? 0.0 : 1.0;
+            return 1.0;
         else if (edgeWeightsMethod_ == defaultTransEdgeWgt)
             return transmissibility(face_index);
         else if (edgeWeightsMethod_ == logTransEdgeWgt)
@@ -199,16 +199,21 @@ private:
     {
         double min_val = std::numeric_limits<float>::max();
 
-        for (int face = 0; face < getGrid().numFaces(); ++face)
-        {
-            double trans = transmissibilities_[face];
-            if (trans > 0)
+        if (transmissibilities_) {
+            for (int face = 0; face < getGrid().numFaces(); ++face)
             {
-                if (trans < min_val)
-                    min_val = trans;
+                double trans = transmissibilities_[face];
+                if (trans > 0)
+                {
+                    if (trans < min_val)
+                        min_val = trans;
+                }
             }
+            log_min_ = std::log(min_val);
         }
-        log_min_ = std::log(min_val);
+        else {
+            log_min_ = 0.0;
+        }
     }
 
     const Dune::CpGrid& grid_;

--- a/opm/grid/common/ZoltanGraphFunctions.hpp
+++ b/opm/grid/common/ZoltanGraphFunctions.hpp
@@ -135,7 +135,7 @@ public:
                           const std::vector<OpmWellType> * wells,
                           const double* transmissibilities,
                           bool pretendEmptyGrid,
-			  EdgeWeightMethod edgeWeightsMethod);
+                          EdgeWeightMethod edgeWeightsMethod);
 
     /// \brief Access the grid.
     const Dune::CpGrid& getGrid() const
@@ -167,7 +167,7 @@ public:
     double edgeWeight(int face_index) const
     {
         if (edgeWeightsMethod_ == uniformEdgeWgt)
-            return 1.0;
+            return transmissibilities_[face_index] == 0.0 ? 0.0 : 1.0;
         else if (edgeWeightsMethod_ == defaultTransEdgeWgt)
             return transmissibility(face_index);
         else if (edgeWeightsMethod_ == logTransEdgeWgt)
@@ -197,18 +197,18 @@ private:
 
     void findMaxMinTrans()
     {
-	double min_val = std::numeric_limits<float>::max();
-		
-	for (int face = 0; face < getGrid().numFaces(); ++face)
-	{
-	    double trans = transmissibilities_[face];
-	    if (trans > 0)
-	    {
-		if (trans < min_val)
-		    min_val = trans;		
-	    }
-	}	
-	log_min_ = std::log(min_val);
+        double min_val = std::numeric_limits<float>::max();
+
+        for (int face = 0; face < getGrid().numFaces(); ++face)
+        {
+            double trans = transmissibilities_[face];
+            if (trans > 0)
+            {
+                if (trans < min_val)
+                    min_val = trans;
+            }
+        }
+        log_min_ = std::log(min_val);
     }
 
     const Dune::CpGrid& grid_;

--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -77,7 +77,7 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
                                                        wells,
                                                        transmissibilities,
                                                        partitionIsEmpty,
-						       edgeWeightsMethod));
+                                                       edgeWeightsMethod));
         Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, *grid_and_wells,
                                                     partitionIsEmpty);
     }

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -134,7 +134,7 @@ namespace Dune
 
 std::pair<bool, std::unordered_set<std::string> >
 CpGrid::scatterGrid(EdgeWeightMethod method, bool ownersFirst, const std::vector<cpgrid::OpmWellType> * wells,
-                    const double* transmissibilities, int overlapLayers)
+                    const double* transmissibilities, bool addCornerCells, int overlapLayers)
 {
     // Silence any unused argument warnings that could occur with various configurations.
     static_cast<void>(wells);
@@ -199,7 +199,8 @@ CpGrid::scatterGrid(EdgeWeightMethod method, bool ownersFirst, const std::vector
         // first create the overlap
         // map from process to global cell indices in overlap
         std::map<int,std::set<int> > overlap;
-        auto noImportedOwner = addOverlapLayer(*this, cell_part, exportList, importList, cc, transmissibilities);
+        auto noImportedOwner = addOverlapLayer(*this, cell_part, exportList, importList, cc, addCornerCells,
+                                               transmissibilities);
         // importList contains all the indices that will be here.
         auto compareImport = [](const std::tuple<int,int,char,int>& t1,
                                 const std::tuple<int,int,char,int>&t2)

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -196,12 +196,10 @@ CpGrid::scatterGrid(EdgeWeightMethod method, bool ownersFirst, const std::vector
         // }
 #endif
 
-        //bool ownersFirst = false;
-
         // first create the overlap
         // map from process to global cell indices in overlap
         std::map<int,std::set<int> > overlap;
-        auto noImportedOwner = addOverlapLayer(*this, cell_part, exportList, importList, cc);
+        auto noImportedOwner = addOverlapLayer(*this, cell_part, exportList, importList, cc, transmissibilities);
         // importList contains all the indices that will be here.
         auto compareImport = [](const std::tuple<int,int,char,int>& t1,
                                 const std::tuple<int,int,char,int>&t2)

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -133,7 +133,7 @@ namespace Dune
 
 
 std::pair<bool, std::unordered_set<std::string> >
-CpGrid::scatterGrid(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellType> * wells,
+CpGrid::scatterGrid(EdgeWeightMethod method, bool ownersFirst, const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities, int overlapLayers)
 {
     // Silence any unused argument warnings that could occur with various configurations.
@@ -196,7 +196,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellTy
         // }
 #endif
 
-        bool ownersFirst = false;
+        //bool ownersFirst = false;
 
         // first create the overlap
         // map from process to global cell indices in overlap


### PR DESCRIPTION
Enable an "owners first" ordering by adding an argument in the loadBalance function. 

In addition, a new addOverlapLayerNoZeroTrans method is added. In this method ghost cells will not be added if the transmissibility on the interface between the interior and potential overlap cell is 0. 

Since the transmissibility is zero, the neighbour cell is not needed, and by not adding this cell, we can avoid some parallel overhead.

This PR require changes in opm-simulators. 