### PR TITLE
Pass a pointer to the EclipseGrid to CpGrid::processEclipseGrid.

### DIFF
--- a/examples/grdecl2vtu.cpp
+++ b/examples/grdecl2vtu.cpp
@@ -142,7 +142,7 @@ try
     {
         const int* actnum = deck.hasKeyword("ACTNUM") ? deck.getKeyword("ACTNUM").getIntData().data() : nullptr;
         Opm::EclipseGrid ecl_grid(deck , actnum);
-        grid.processEclipseFormat(ecl_grid, false);
+        grid.processEclipseFormat(&ecl_grid, false);
     }
 
     VTKWriter<CpGrid::LeafGridView> vtkwriter(grid.leafGridView());

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -267,13 +267,14 @@ namespace Dune
 #if HAVE_ECL_INPUT
         /// Read the Eclipse grid format ('grdecl').
         /// \param ecl_grid the high-level object from opm-parser which represents the simulation's grid
+        ///        In a parallel run this may be a nullptr on all ranks but rank zero.
         /// \param periodic_extension if true, the grid will be (possibly) refined, so that
         ///        intersections/faces along i and j boundaries will match those on the other
         ///        side. That is, i- faces will match i+ faces etc.
         /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
         /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
         /// \param poreVolume pore volumes for use in MINPV processing, if asked for in deck
-        void processEclipseFormat(const Opm::EclipseGrid& ecl_grid, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
+        void processEclipseFormat(const Opm::EclipseGrid* ecl_grid, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
                                   const std::vector<double>& poreVolume = std::vector<double>(),
                                   const Opm::NNC& = Opm::NNC());
 #endif

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -341,7 +341,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellTy
 
 
 #if HAVE_ECL_INPUT
-    void CpGrid::processEclipseFormat(const Opm::EclipseGrid& ecl_grid,
+    void CpGrid::processEclipseFormat(const Opm::EclipseGrid* ecl_grid,
                                       bool periodic_extension,
                                       bool turn_normals, bool clip_z,
                                       const std::vector<double>& poreVolume,

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -190,13 +190,14 @@ public:
 
     /// Read the Eclipse grid format ('grdecl').
     /// \param ecl_grid the high-level object from opm-parser which represents the simulation's grid
+    ///        In a parallel run this may be a nullptr on all ranks but rank zero.
     /// \param periodic_extension if true, the grid will be (possibly) refined, so that
     ///        intersections/faces along i and j boundaries will match those on the other
     ///        side. That is, i- faces will match i+ faces etc.
     /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
     /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
     /// \param poreVolume pore volumes for use in MINPV processing, if asked for in deck
-    void processEclipseFormat(const Opm::EclipseGrid& ecl_grid, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
+    void processEclipseFormat(const Opm::EclipseGrid* ecl_grid, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
                               const std::vector<double>& poreVolume = std::vector<double>(), const Opm::NNC& nncs = Opm::NNC());
 #endif
 

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -113,7 +113,7 @@ namespace cpgrid
 {
 
 #if HAVE_ECL_INPUT
-    void CpGridData::processEclipseFormat(const Opm::EclipseGrid& ecl_grid, bool periodic_extension, bool turn_normals, bool clip_z,
+    void CpGridData::processEclipseFormat(const Opm::EclipseGrid* ecl_grid_ptr, bool periodic_extension, bool turn_normals, bool clip_z,
                                           const std::vector<double>& poreVolume, const Opm::NNC& nncs)
     {
         if (ccobj_.rank() != 0 ) {
@@ -121,6 +121,10 @@ namespace cpgrid
             return;
         }
 
+        if (!ecl_grid_ptr)
+            OPM_THROW(std::logic_error, "We need a valid pointer to an eclipse grid on rank 0!");
+
+        const Opm::EclipseGrid& ecl_grid = *ecl_grid_ptr;
         std::vector<double> coordData = ecl_grid.getCOORD();
         std::vector<int> actnumData = ecl_grid.getACTNUM();
 

--- a/tests/cpgrid/grid_nnc.cpp
+++ b/tests/cpgrid/grid_nnc.cpp
@@ -79,7 +79,7 @@ struct Fixture
         }
 #endif
         Dune::CpGrid grid;
-        grid.processEclipseFormat(es.getInputGrid(), false, false, false, porv, nnc);
+        grid.processEclipseFormat(&es.getInputGrid(), false, false, false, porv, nnc);
         const auto& gv = grid.leafGridView();
 #if DUNE_VERSION_NEWER(DUNE_GRID, 2,6)
         ElementMapper elmap(gv, Dune::mcmgElementLayout());

--- a/tests/test_cpgrid.cpp
+++ b/tests/test_cpgrid.cpp
@@ -171,7 +171,7 @@ int main(int argc, char** argv )
     const int* actnum = deck.hasKeyword("ACTNUM") ? deck.getKeyword("ACTNUM").getIntData().data() : nullptr;
     Opm::EclipseGrid ecl_grid(deck , actnum);
 
-    grid.processEclipseFormat(ecl_grid, false, false, false, porv);
+    grid.processEclipseFormat(&ecl_grid, false, false, false, porv);
     testGrid( grid, "CpGrid_ecl", 8, 27 );
 #endif
 


### PR DESCRIPTION
... instead of a reference This is needed as we only want to read the
full deck and construct the EclipseGrid only on the master process
with rank 0. Hence all other ranks will pass a nullptr to this
function. This will be possible with this move from a reference to a
pointer.