### PR TITLE
Make change processEclipseFormat backwards compatible.

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -277,6 +277,14 @@ namespace Dune
         void processEclipseFormat(const Opm::EclipseGrid* ecl_grid, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
                                   const std::vector<double>& poreVolume = std::vector<double>(),
                                   const Opm::NNC& = Opm::NNC());
+
+        void processEclipseFormat(const Opm::EclipseGrid& ecl_grid, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
+                                  const std::vector<double>& poreVolume = std::vector<double>(),
+                                  const Opm::NNC& nnc = Opm::NNC())
+        {
+            processEclipseFormat(&ecl_grid, periodic_extension, turn_normals,
+                                 clip_z, poreVolume, nnc);
+        }
 #endif
 
         /// Read the Eclipse grid format ('grdecl').


### PR DESCRIPTION
It used get a reference to EclipseGrid and since PR #433 it only takes a pointer to it. This is unfortunate since this code is also used by other projects such as dumux and breaks compilation of them when using master. This commit adds a processEclipseFormat using a reference to fix this.