### PR TITLE
Do not use bind2nd, which is removed in C++17.

### DIFF
--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -190,8 +190,7 @@ int setupAndCountGlobalIds(const std::vector<int>& indicator, std::vector<int>& 
 {
     int count = std::count_if(indicator.begin(),
                               indicator.end(),
-                              std::bind2nd(std::less<int>(),
-                                           std::numeric_limits<int>::max()));
+                              [](int x) { return x < std::numeric_limits<int>::max(); });
     ids.resize(count);
     typedef typename std::vector<int>::const_iterator VIter;
     for(VIter ibegin=indicator.begin(), i=ibegin, iend= indicator.end();


### PR DESCRIPTION
I am curious why this passed on Jenkins?