### PR TITLE
Add missing loadBalance method taking data handle and egde weights.

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -686,6 +686,33 @@ namespace Dune
             return ret;
         }
 
+        /// \brief Distributes this grid over the available nodes in a distributed machine
+        ///
+        /// This will construct the corresponding graph to the grid and use the transmissibilities
+        /// specified to calculate the  weights associated with its edges. The graph will be passed
+        ///  to the load balancer.
+        /// \param data A data handle describing how to distribute attached data.
+        /// \param method The edge-weighting method to be used on the Zoltan partitioner.
+        /// \param wells The information about all possible wells. If null then
+        ///            the wells will be neglected. Otherwise the wells will be
+        ///            used to make sure that all the possible completion cells
+        ///            of each well are stored on one process. This is done by
+        ///            adding an edge with a very high edge weight for all
+        ///            possible pairs of cells in the completion set of a well.
+        /// \param transmissibilities The transmissibilities used to calculate the edge weights.
+        /// \param The number of layers of cells of the overlap region (default: 1).
+        /// \warning May only be called once.
+        template<class DataHandle>
+        std::pair<bool, std::unordered_set<std::string> >
+        loadBalance(DataHandle& data, EdgeWeightMethod method,
+                    const std::vector<cpgrid::OpmWellType> * wells,
+                    const double* transmissibilities = nullptr,
+                    int overlapLayers=1)
+        {
+            auto ret = scatterGrid(method, wells, transmissibilities, overlapLayers);
+            scatterData(data);
+            return ret;
+        }
 
         /// \brief Distributes this grid and data over the available nodes in a distributed machine.
         /// \param data A data handle describing how to distribute attached data.


### PR DESCRIPTION
The corresponding version without the data handle was there but somehow the one with the data handle was missing. That one is supposed to also distribute data attached to the grid during load balancing and will be needed and used in the future. This PR adds it.