### PR TITLE
Make opm-grid compilable without dune-istl.

### DIFF
--- a/opm/grid/common/GridPartitioning.cpp
+++ b/opm/grid/common/GridPartitioning.cpp
@@ -40,6 +40,7 @@
 #include <dune/istl/owneroverlapcopy.hh>
 #include "GridPartitioning.hpp"
 #include <opm/grid/CpGrid.hpp>
+#include <opm/grid/cpgrid/CpGridData.hpp>
 #include <stack>
 
 #ifdef HAVE_MPI
@@ -277,7 +278,7 @@ void addOverlapCornerCell(const CpGrid& grid, int owner,
                           const std::vector<int>& cell_part,
                           std::vector<std::tuple<int,int,char>>& exportList)
 {
-    using AttributeSet = Dune::OwnerOverlapCopyAttributeSet::AttributeSet;
+    using AttributeSet = Dune::cpgrid::CpGridData::AttributeSet;
     const CpGrid::LeafIndexSet& ix = grid.leafIndexSet();
     int my_index = ix.index(from);
     int nb_index = ix.index(neighbor);
@@ -366,7 +367,7 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
                          std::vector<std::tuple<int,int,char>>& exportList,
                          int recursion_deps)
     {
-        using AttributeSet = Dune::OwnerOverlapCopyAttributeSet::AttributeSet;
+        using AttributeSet = Dune::cpgrid::CpGridData::AttributeSet;
         const CpGrid::LeafIndexSet& ix = grid.leafIndexSet();
         for (CpGrid::LeafIntersectionIterator iit = e.ileafbegin(); iit != e.ileafend(); ++iit) {
             if ( iit->neighbor() ) {
@@ -409,7 +410,7 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
                         int layers)
     {
 #ifdef HAVE_MPI
-        using AttributeSet = Dune::OwnerOverlapCopyAttributeSet::AttributeSet;
+        using AttributeSet = Dune::cpgrid::CpGridData::AttributeSet;
         auto ownerSize = exportList.size();
         const CpGrid::LeafIndexSet& ix = grid.leafIndexSet();
         std::map<int,int> exportProcs, importProcs;

--- a/opm/grid/common/WellConnections.cpp
+++ b/opm/grid/common/WellConnections.cpp
@@ -24,7 +24,7 @@
 #include <map>
 
 #include <opm/grid/common/WellConnections.hpp>
-
+#include <opm/grid/cpgrid/CpGridData.hpp>
 #include <opm/grid/utility/OpmParserIncludes.hpp>
 
 #include <dune/common/parallel/mpitraits.hh>
@@ -114,7 +114,7 @@ postProcessPartitioningForWells(std::vector<int>& parts,
 
 #if HAVE_ECL_INPUT
     std::map<int, std::vector<int>> addCells, removeCells;
-    using AttributeSet = Dune::OwnerOverlapCopyAttributeSet::AttributeSet;
+    using AttributeSet = CpGridData::AttributeSet;
 
     if (noCells && well_connections.size()) {
 

--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -21,8 +21,8 @@
 #include <config.h>
 #endif
 #include <opm/grid/common/ZoltanPartition.hpp>
-
 #include <opm/grid/utility/OpmParserIncludes.hpp>
+#include <opm/grid/cpgrid/CpGridData.hpp>
 
 #if defined(HAVE_ZOLTAN) && defined(HAVE_MPI)
 namespace Dune
@@ -111,7 +111,7 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
     std::vector<std::tuple<int,int,char,int>>myImportList(numImport);
     myExportList.reserve(1.2*myExportList.size());
     myImportList.reserve(1.2*myImportList.size());
-    using AttributeSet = Dune::OwnerOverlapCopyAttributeSet::AttributeSet;
+    using AttributeSet = CpGridData::AttributeSet;
 
     for ( int i=0; i < numExport; ++i )
     {

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -57,7 +57,7 @@ namespace
 
 #if HAVE_MPI
 
-using AttributeSet = Dune::OwnerOverlapCopyAttributeSet::AttributeSet;
+using AttributeSet = Dune::cpgrid::CpGridData::AttributeSet;
 
 template<typename Tuple, bool first>
 void reserveInterface(const std::vector<Tuple>& list, Dune::CpGrid::InterfaceMap& interface,

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -299,6 +299,14 @@ public:
     using InterfaceMap = Communicator::InterfaceMap;
 #endif
 
+#ifdef HAVE_DUNE_ISTL
+    /// \brief The type of the set of the attributes
+    typedef Dune::OwnerOverlapCopyAttributeSet::AttributeSet AttributeSet;
+#else
+    /// \brief The type of the set of the attributes
+    enum AttributeSet{owner, overlap, copy};
+#endif
+
 private:
 
     /// \brief Adds entries to the parallel index set of the cells during grid construction
@@ -444,13 +452,6 @@ private:
     /// the zcorn values will typically be modified, and we retain a
     /// copy here to be able to create an EclipseGrid for output.
     std::vector<double> zcorn;
-
-#ifdef HAVE_DUNE_ISTL
-    typedef Dune::OwnerOverlapCopyAttributeSet::AttributeSet AttributeSet;
-#else
-    /// \brief The type of the set of the attributes
-    enum AttributeSet{owner, overlap, copy};
-#endif
 
 #if HAVE_MPI
 

--- a/opm/grid/polyhedralgrid/gridfactory.hh
+++ b/opm/grid/polyhedralgrid/gridfactory.hh
@@ -98,7 +98,7 @@ namespace Dune
 
     virtual void insertElement(const GeometryType& type,
                                const std::vector<unsigned int>& vertices,
-                               const shared_ptr<VirtualFunction<FieldVector<ctype,dimension>,FieldVector<ctype,dimensionworld> > >&)
+                               const std::shared_ptr<VirtualFunction<FieldVector<ctype,dimension>,FieldVector<ctype,dimensionworld> > >&)
     {
       std::cerr << "Warning: elementParametrization is being ignored in insertElement!" << std::endl;
       insertElement( type, vertices );


### PR DESCRIPTION
We accomplish that by making CpGridData::AttributeSet public which uses the one from dune-istl if that is found and its own implementation otherwise.

Closes #455 
Alternate to #456 