### PR TITLE
Use GlobalIdSet also as local id set to make it persistent

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -172,7 +172,7 @@ namespace Dune
         /// \brief The type of the global id set.
         typedef cpgrid::GlobalIdSet GlobalIdSet;
         /// \brief The type of the local id set.
-        typedef cpgrid::GlobalIdSet LocalIdSet;
+        typedef GlobalIdSet LocalIdSet;
 
         /// \brief The type of the collective communication.
 
@@ -218,6 +218,8 @@ namespace Dune
         : public GridDefaultImplementation<3, 3, double, CpGridFamily >
     {
         friend class cpgrid::CpGridData;
+        template<int dim>
+        friend cpgrid::Entity<dim> createEntity(const CpGrid&,int,bool);
 
     public:
 
@@ -464,14 +466,14 @@ namespace Dune
         /// \brief Access to the GlobalIdSet
         const Traits::GlobalIdSet& globalIdSet() const
         {
-            return *current_view_data_->global_id_set_;
+            return global_id_set_;
         }
 
 
         /// \brief Access to the LocalIdSet
         const Traits::LocalIdSet& localIdSet() const
         {
-            return *current_view_data_->global_id_set_;
+            return global_id_set_;
         }
 
 
@@ -1393,6 +1395,10 @@ namespace Dune
          * @warning Will only update owner cells
          */
         std::shared_ptr<InterfaceMap> point_scatter_gather_interfaces_;
+        /**
+         * @brief The global id set (also used as local one).
+         */
+        cpgrid::GlobalIdSet global_id_set_;
     }; // end Class CpGrid
 
 

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -172,7 +172,7 @@ namespace Dune
         /// \brief The type of the global id set.
         typedef cpgrid::GlobalIdSet GlobalIdSet;
         /// \brief The type of the local id set.
-        typedef cpgrid::IdSet LocalIdSet;
+        typedef cpgrid::GlobalIdSet LocalIdSet;
 
         /// \brief The type of the collective communication.
 
@@ -471,7 +471,7 @@ namespace Dune
         /// \brief Access to the LocalIdSet
         const Traits::LocalIdSet& localIdSet() const
         {
-            return *current_view_data_->local_id_set_;
+            return *current_view_data_->global_id_set_;
         }
 
 

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -118,7 +118,8 @@ namespace Dune
           current_view_data_(data_.get()),
           distributed_data_(),
           cell_scatter_gather_interfaces_(new InterfaceMap),
-          point_scatter_gather_interfaces_(new InterfaceMap)
+          point_scatter_gather_interfaces_(new InterfaceMap),
+          global_id_set_(*current_view_data_)
     {}
 
 
@@ -127,7 +128,8 @@ namespace Dune
           current_view_data_(data_.get()),
           distributed_data_(),
           cell_scatter_gather_interfaces_(new InterfaceMap),
-          point_scatter_gather_interfaces_(new InterfaceMap)
+          point_scatter_gather_interfaces_(new InterfaceMap),
+          global_id_set_(*current_view_data_)
     {}
 
 
@@ -246,6 +248,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellTy
         setupRecvInterface(importList, *cell_scatter_gather_interfaces_);
 
         distributed_data_->distributeGlobalGrid(*this,*this->current_view_data_, cell_part);
+        global_id_set_.insertIdSet(*distributed_data_);
 
 
         // Compute the partition type for cell

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -29,7 +29,7 @@ namespace cpgrid
 
 CpGridData::CpGridData(const CpGridData& g)
     : index_set_(new IndexSet(*this)), local_id_set_(new IdSet(*this)),
-      global_id_set_(new GlobalIdSet(local_id_set_)), partition_type_indicator_(new PartitionTypeIndicator(*this)), ccobj_(g.ccobj_)
+      global_id_set_(new LevelGlobalIdSet(local_id_set_, this)), partition_type_indicator_(new PartitionTypeIndicator(*this)), ccobj_(g.ccobj_)
 {
 #if HAVE_MPI
     ccobj_=CollectiveCommunication(MPI_COMM_SELF);
@@ -39,7 +39,7 @@ CpGridData::CpGridData(const CpGridData& g)
 
 CpGridData::CpGridData()
     : index_set_(new IndexSet(*this)), local_id_set_(new IdSet(*this)),
-      global_id_set_(new GlobalIdSet(local_id_set_)), partition_type_indicator_(new PartitionTypeIndicator(*this)),
+      global_id_set_(new LevelGlobalIdSet(local_id_set_, this)), partition_type_indicator_(new PartitionTypeIndicator(*this)),
       ccobj_(Dune::MPIHelper::getCommunicator()), use_unique_boundary_ids_(false)
 {
 #if HAVE_MPI
@@ -50,7 +50,7 @@ CpGridData::CpGridData()
 
 CpGridData::CpGridData(MPIHelper::MPICommunicator comm)
     : index_set_(new IndexSet(*this)), local_id_set_(new IdSet(*this)),
-      global_id_set_(new GlobalIdSet(local_id_set_)), partition_type_indicator_(new PartitionTypeIndicator(*this)),
+      global_id_set_(new LevelGlobalIdSet(local_id_set_, this)), partition_type_indicator_(new PartitionTypeIndicator(*this)),
       ccobj_(comm), use_unique_boundary_ids_(false)
 {
 #if HAVE_MPI
@@ -61,7 +61,7 @@ CpGridData::CpGridData(MPIHelper::MPICommunicator comm)
 
 CpGridData::CpGridData(CpGrid&)
   : index_set_(new IndexSet(*this)),   local_id_set_(new IdSet(*this)),
-    global_id_set_(new GlobalIdSet(local_id_set_)),  partition_type_indicator_(new PartitionTypeIndicator(*this)),
+    global_id_set_(new LevelGlobalIdSet(local_id_set_, this)),  partition_type_indicator_(new PartitionTypeIndicator(*this)),
     ccobj_(Dune::MPIHelper::getCommunicator()), use_unique_boundary_ids_(false)
 {
 #if HAVE_MPI
@@ -113,7 +113,7 @@ void CpGridData::populateGlobalCellIndexSet()
 #if HAVE_MPI
     cell_indexset_.beginResize();
     for (int index = 0, end = size(0); index != end ; ++index){
-        cell_indexset_.add(global_id_set_->id(EntityRep<0>(index, true)),
+        cell_indexset_.add(global_id_set_->id(Entity<0>(*this, EntityRep<0>(index, true))),
                            ParallelIndexSet::LocalIndex(index, AttributeSet::owner, true));
     }
     cell_indexset_.endResize();
@@ -560,7 +560,7 @@ struct Cell2PointsDataHandle
     using DataType = int;
     using Vector = std::vector<std::array<int,8> >;
     Cell2PointsDataHandle(const Vector& globalCell2Points,
-                          const GlobalIdSet& globalIds,
+                          const LevelGlobalIdSet& globalIds,
                           const std::vector<std::set<int> >& globalAdditionalPointIds,
                           Vector& localCell2Points,
                           std::vector<int>& flatGlobalPoints,
@@ -615,7 +615,7 @@ struct Cell2PointsDataHandle
     }
 private:
     const Vector& globalCell2Points_;
-    const GlobalIdSet& globalIds_;
+    const LevelGlobalIdSet& globalIds_;
     const std::vector<std::set<int> >& globalAdditionalPointIds_;
     Vector& localCell2Points_;
     std::vector<int>& flatGlobalPoints_;
@@ -684,7 +684,7 @@ struct SparseTableDataHandle
     using DataType = int;
     static constexpr int from = 1;
     SparseTableDataHandle(const Table& global,
-                          const GlobalIdSet& globalIds,
+                          const LevelGlobalIdSet& globalIds,
                           Table& local,
                           const std::map<int,int>& global2Local)
         : global_(global), globalIds_(globalIds), local_(local), global2Local_(global2Local)
@@ -728,7 +728,7 @@ struct SparseTableDataHandle
     }
     private:
     const Table& global_;
-    const GlobalIdSet& globalIds_;
+    const LevelGlobalIdSet& globalIds_;
     Table& local_;
     const std::map<int,int>& global2Local_;
 };
@@ -800,12 +800,12 @@ protected:
 };
 
 class C2FDataHandle
-    : public OrientedEntityTableDataHandle<GlobalIdSet,0,1>
+    : public OrientedEntityTableDataHandle<LevelGlobalIdSet,0,1>
 {
 public:
-    C2FDataHandle(const Table& global, const GlobalIdSet& globalIds, Table& local,
+    C2FDataHandle(const Table& global, const LevelGlobalIdSet& globalIds, Table& local,
                   std::vector<int>& unsignedGlobalFaceIds)
-        : OrientedEntityTableDataHandle<GlobalIdSet,0,1>(global, local, &globalIds),
+        : OrientedEntityTableDataHandle<LevelGlobalIdSet,0,1>(global, local, &globalIds),
           unsignedGlobalFaceIds_(unsignedGlobalFaceIds)
     {}
     template<class B>
@@ -1224,7 +1224,7 @@ void CpGridData::computeGeometry(CpGrid& grid,
 
 void computeFace2Point(CpGrid& grid,
                        const OrientedEntityTable<0, 1>& globalCell2Faces,
-                       const GlobalIdSet& globalIds,
+                       const LevelGlobalIdSet& globalIds,
                        const OrientedEntityTable<0, 1>& cell2Faces,
                        const Opm::SparseTable<int>& globalFace2Points,
                        Opm::SparseTable<int>& face2Points,
@@ -1300,7 +1300,7 @@ void computeFace2Cell(CpGrid& grid,
 
 std::map<int,int> computeCell2Face(CpGrid& grid,
                                     const OrientedEntityTable<0, 1>& globalCell2Faces,
-                                    const GlobalIdSet& globalIds,
+                                    const LevelGlobalIdSet& globalIds,
                                     OrientedEntityTable<0, 1>& cell2Faces,
                                     std::vector<int>& map2Global,
                                     std::size_t noCells)
@@ -1348,7 +1348,7 @@ std::map<int,int> computeCell2Face(CpGrid& grid,
 std::vector<std::set<int> > computeAdditionalFacePoints(const std::vector<std::array<int,8> >& globalCell2Points,
                                                         const OrientedEntityTable<0, 1>& globalCell2Faces,
                                                         const Opm::SparseTable<int>& globalFace2Points,
-                                                        const GlobalIdSet& globalIds)
+                                                        const LevelGlobalIdSet& globalIds)
 {
     std::vector<std::set<int> > additionalFacePoints(globalCell2Points.size());
 
@@ -1413,7 +1413,7 @@ void createInterfaceList(const typename CpGridData::InterfaceMap::value_type& pr
 
 std::map<int,int> computeCell2Point(CpGrid& grid,
                                     const std::vector<std::array<int,8> >& globalCell2Points,
-                                    const GlobalIdSet& globalIds,
+                                    const LevelGlobalIdSet& globalIds,
                                     const OrientedEntityTable<0, 1>& globalCell2Faces,
                                     const Opm::SparseTable<int>& globalFace2Points,
                                     std::vector<std::array<int,8> >& cell2Points,

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -98,7 +98,7 @@ namespace cpgrid
 
 class IndexSet;
 class IdSet;
-class GlobalIdSet;
+class LevelGlobalIdSet;
 class PartitionTypeIndicator;
 template<int,int> class Geometry;
 template<int> class Entity;
@@ -116,6 +116,8 @@ template<class T, int i> struct Mover;
 class CpGridData
 {
     template<class T, int i> friend struct mover::Mover;
+
+    friend class GlobalIdSet;
 
 private:
     CpGridData(const CpGridData& g);
@@ -433,7 +435,7 @@ private:
     /** @brief The internal local id set (not exported). */
     const cpgrid::IdSet* local_id_set_;
     /** @brief The global id set (used also as local id set). */
-    GlobalIdSet* global_id_set_;
+    LevelGlobalIdSet* global_id_set_;
     /** @brief The indicator of the partition type of the entities */
     PartitionTypeIndicator* partition_type_indicator_;
 

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -430,9 +430,9 @@ private:
     cpgrid::EntityVariable<int, 1> unique_boundary_ids_;
     /** @brief The index set of the grid (level). */
     cpgrid::IndexSet* index_set_;
-    /** @brief The local id set. */
+    /** @brief The internal local id set (not exported). */
     const cpgrid::IdSet* local_id_set_;
-    /** @brief The global id set. */
+    /** @brief The global id set (used also as local id set). */
     GlobalIdSet* global_id_set_;
     /** @brief The indicator of the partition type of the entities */
     PartitionTypeIndicator* partition_type_indicator_;

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -54,6 +54,7 @@ namespace Dune
        class IntersectionIterator;
        class HierarchicIterator;
        class CpGridData;
+       class LevelGlobalIdSet;
 
         /// @brief
         /// @todo Doc me!
@@ -67,6 +68,9 @@ namespace Dune
         template <int codim>
         class Entity : public EntityRep<codim>
         {
+            friend class LevelGlobalIdSet;
+            friend class GlobalIdSet;
+
         public:
         /// @brief
         /// @todo Doc me!
@@ -277,6 +281,7 @@ namespace Dune
         template <int codim>
         class EntityPointer : public cpgrid::Entity<codim>
         {
+            friend class LevelGlobalIdSet;
         public:
             typedef cpgrid::Entity<codim> Entity;
             typedef const Entity& Reference;

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -26,6 +26,18 @@
 
 #include <opm/grid/utility/platform_dependent/reenable_warnings.h>
 
+namespace Dune
+{
+template<int dim>
+Dune::cpgrid::Entity<dim> createEntity(const Dune::CpGrid& grid, int index, bool orientation)
+{
+    return Dune::cpgrid::Entity<dim>(*grid.current_view_data_, index, orientation);
+}
+/*
+template Dune::cpgrid::Entity<1> createEntity<1>(const Dune::CpGrid& grid, int index, bool orientation);
+template Dune::cpgrid::Entity<3> createEntity<3>(const Dune::CpGrid& grid, int index, bool orientation);
+*/
+} // end namespace Dune
 
 #if HAVE_MPI
 class MPIError {
@@ -429,16 +441,16 @@ BOOST_AUTO_TEST_CASE(compareWithSequential)
             using namespace Dune::cpgrid;
             auto face = grid.cellFace(eIt->index(), f);
             auto seqFace = seqGrid.cellFace(seqEIt->index(), f);
-            BOOST_REQUIRE(idSet.id(EntityRep<1>(face, true)) ==
-                          seqIdSet.id(EntityRep<1>(seqFace, true)));
+            BOOST_REQUIRE(idSet.id(Dune::createEntity<1>(grid, face, true)) ==
+                          seqIdSet.id(Dune::createEntity<1>(seqGrid, seqFace, true)));
             int vertices = grid.numFaceVertices(face);
             BOOST_REQUIRE(vertices == seqGrid.numFaceVertices(seqFace));
             for (int v = 0; v < vertices; ++v)
             {
                 auto vertex = grid.faceVertex(face, v);
                 auto seqVertex = seqGrid.faceVertex(seqFace, v);
-                BOOST_REQUIRE(idSet.id(EntityRep<3>(vertex, true)) ==
-                              seqIdSet.id(EntityRep<3>(seqVertex, true)));
+                BOOST_REQUIRE(idSet.id(Dune::createEntity<3>(grid, vertex, true)) ==
+                              seqIdSet.id(Dune::createEntity<3>(seqGrid, seqVertex, true)));
                 BOOST_REQUIRE(grid.vertexPosition(vertex) ==
                               seqGrid.vertexPosition(seqVertex));
             }


### PR DESCRIPTION
during grid modifications. This required for being a dune grid. The additional trait of being globally unique does not hurt us and this is the least invasive change to accomplish persistence.

Closes #454

depends on OPM/opm-simulators#2458