### PR TITLE
quell unused parameter warnings without MPI

### DIFF
--- a/opm/grid/common/GridPartitioning.cpp
+++ b/opm/grid/common/GridPartitioning.cpp
@@ -468,7 +468,8 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
                         std::vector<std::tuple<int,int,char>>& exportList,
                         std::vector<std::tuple<int,int,char,int>>& importList,
                         const CollectiveCommunication<Dune::MPIHelper::MPICommunicator>& cc,
-                        bool addCornerCells, const double* trans, int layers)
+                        [[maybe_unused]] bool addCornerCells,
+                        [[maybe_unused]] const double* trans, int layers)
     {
 #ifdef HAVE_MPI
         using AttributeSet = Dune::cpgrid::CpGridData::AttributeSet;

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -133,10 +133,12 @@ namespace Dune
     {}
 
 
-
 std::pair<bool, std::unordered_set<std::string> >
-CpGrid::scatterGrid(EdgeWeightMethod method, bool ownersFirst, const std::vector<cpgrid::OpmWellType> * wells,
-                    const double* transmissibilities, bool addCornerCells, int overlapLayers)
+CpGrid::scatterGrid(EdgeWeightMethod method,
+                    [[maybe_unused]] bool ownersFirst,
+                    const std::vector<cpgrid::OpmWellType> * wells,
+                    const double* transmissibilities,
+                    [[maybe_unused]] bool addCornerCells, int overlapLayers)
 {
     // Silence any unused argument warnings that could occur with various configurations.
     static_cast<void>(wells);


### PR DESCRIPTION
Have to copy the macros as the OPM ones are defined in opm-material.