### PR TITLE
quell deprecation warnings with boost 1.71

### DIFF
--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -20,7 +20,12 @@
 
 #define BOOST_TEST_MODULE GeometryTests
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
 #include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 #include <opm/grid/cpgrid/Geometry.hpp>
 #include <opm/grid/cpgrid/EntityRep.hpp>
 

--- a/tests/test_cartgrid.cpp
+++ b/tests/test_cartgrid.cpp
@@ -24,7 +24,12 @@
 
 #define BOOST_TEST_MODULE CartGridTest
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
 #include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 
 /* --- our own headers --- */
 #include <opm/grid/cart_grid.h>

--- a/tests/test_geom2d.cpp
+++ b/tests/test_geom2d.cpp
@@ -7,7 +7,12 @@
 
 #define BOOST_TEST_MODULE CompGeo2DTest
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
 #include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 
 /* --- our own headers --- */
 #include <algorithm>

--- a/tests/test_repairzcorn.cpp
+++ b/tests/test_repairzcorn.cpp
@@ -25,7 +25,12 @@
 #define BOOST_TEST_MODULE TEST_RepairZCORN
 
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
 #include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 
 /* --- our own headers --- */
 

--- a/tests/test_ug.cpp
+++ b/tests/test_ug.cpp
@@ -8,7 +8,12 @@
 
 #define BOOST_TEST_MODULE TEST_UG
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
 #include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 
 /* --- our own headers --- */
 #include <algorithm>


### PR DESCRIPTION
header was relocated.