### PR TITLE
[bugfix] Do not MPI in processEclipseFormat.cpp

### DIFF
--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -330,10 +330,10 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
     {
         if ( current_view_data_->ccobj_.rank() != 0 )
         {
-            grdecl g;
-            g.dims[0] = g.dims[1] = g.dims[2] = 0;
-            current_view_data_->processEclipseFormat(g, {}, 0.0, false, false);
             // global grid only on rank 0
+            current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
+                                                 current_view_data_->logical_cartesian_size_.size(),
+                                                 0);
             return;
         }
 
@@ -374,6 +374,10 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
         g.zcorn = &zcorn[0];
         g.actnum = &actnum[0];
         current_view_data_->processEclipseFormat(g, {}, 0.0, false, false);
+        // global grid only on rank 0
+        current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
+                                             current_view_data_->logical_cartesian_size_.size(),
+                                             0);
     }
 
     void CpGrid::readSintefLegacyFormat(const std::string& grid_prefix)

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -250,9 +250,7 @@ namespace cpgrid
     {
         if( ccobj_.rank() != 0 )
         {
-            // We do not store any grid information
-            ccobj_.scatter(logical_cartesian_size_.data(), logical_cartesian_size_.data(), 3, 0);
-            return;
+            OPM_THROW(std::logic_error, "Processing  eclipse file only allowed on rank 0");
         }
         // Process.
 #ifdef VERBOSE
@@ -305,8 +303,7 @@ namespace cpgrid
 
         if(ccobj_.size()>1)
             populateGlobalCellIndexSet();
-        auto tmp = logical_cartesian_size_; // Probably not necessary?
-        ccobj_.scatter(tmp.data(), logical_cartesian_size_.data(), 3, 0);
+
 #ifdef VERBOSE
         std::cout << "Done with grid processing." << std::endl;
 #endif


### PR DESCRIPTION
Scatter is of course wrong and might result in segmentation faults. We are already broadcasting the stuff in the outer methods and scatter will never be called on all processes (this might have very strange side effects). Now we consistently only process eclipse on one rank and broadcast afterwards. For `CpGrid::createCartesian`, we did not do that before this PR. This PR removes MPI from processEclipseFormat.cpp


Thanks a lot to @akva2 for finding this.