### PR TITLE
Add iterator for SparseTable to support range-for.

### DIFF
--- a/opm/grid/utility/SparseTable.hpp
+++ b/opm/grid/utility/SparseTable.hpp
@@ -182,6 +182,49 @@ namespace Opm
             return mutable_row_type(start_ptr + row_start_[row], start_ptr + row_start_[row + 1]);
         }
 
+        /// Iterator for iterating over the container as a whole,
+        /// i.e. row by row.
+        class Iterator
+        {
+        public:
+            Iterator(const SparseTable& table, const int begin_row_index)
+                : table_(table)
+                , row_index_(begin_row_index)
+            {
+            }
+            Iterator& operator++()
+            {
+                ++row_index_;
+                return *this;
+            }
+            row_type operator*() const
+            {
+                return table_[row_index_];
+            }
+            bool operator==(const Iterator& other)
+            {
+                assert(&table_ == &other.table_);
+                return row_index_ == other.row_index_;
+            }
+            bool operator!=(const Iterator& other)
+            {
+                return !(*this == other);
+            }
+        private:
+            const SparseTable& table_;
+            int row_index_;
+        };
+
+        /// Iterator access.
+        Iterator begin() const
+        {
+            return Iterator(*this, 0);
+        }
+        Iterator end() const
+        {
+            return Iterator(*this, size());
+        }
+
         /// Equality.
         bool operator==(const SparseTable& other) const
         {

--- a/tests/test_sparsetable.cpp
+++ b/tests/test_sparsetable.cpp
@@ -59,6 +59,7 @@ BOOST_AUTO_TEST_CASE(construction_and_queries)
     // 3 4 5 6
     // 7 8 9
     // ----------------
+    std::vector<std::vector<int>> expected = { {0}, {}, {1, 2}, {3, 4, 5, 6}, {7, 8, 9} };
     const int num_elem = 10;
     const int elem[num_elem] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
     const int num_rows = 5;
@@ -115,6 +116,14 @@ BOOST_AUTO_TEST_CASE(construction_and_queries)
 
     // Need at least one row.
     BOOST_CHECK_THROW(const SparseTable<int> st5(elem, elem + num_elem, rowsizes, rowsizes), std::exception);
+
+    // Test iteration over rows with a range-for loop.
+    int row_index = 0;
+    for (const auto& row : st2) {
+        BOOST_CHECK_EQUAL(row.size(), expected[row_index].size());
+        ++row_index;
+    }
+
 
     // Tests that only run in debug mode.
 #ifndef NDEBUG


### PR DESCRIPTION
Simplifies working with SparseTable in some contexts. Includes test.