### PR TITLE
Advertise Entity iterators using capabilities (needed for DUNE >2.7).

### DIFF
--- a/opm/grid/polyhedralgrid/capabilities.hh
+++ b/opm/grid/polyhedralgrid/capabilities.hh
@@ -41,6 +41,12 @@ namespace Dune
 
 
     template< int dim, int dimworld, int codim >
+    struct hasEntityIterator< PolyhedralGrid< dim, dimworld >, codim >
+    {
+      static const bool v = (codim == 0 || codim == 1 || codim == dim);
+    };
+
+    template< int dim, int dimworld, int codim >
     struct canCommunicate< PolyhedralGrid< dim, dimworld >, codim >
     {
         static const bool v = false;


### PR DESCRIPTION
The grid checks changed lately and now query bots
Capabilities::hasEntity and Capabilities::hasEntityIterators. This
made compilation of test_polyhedragrid fail as the template meta
program CheckIndexSet<codim> never terminated. This commit introduces
Capabilities::hasEntityIterators to fix this.

Experience compilation error was:
```            from /home/mblatt/src/dune/opm-master/opm-grid/tests/test_polyhedralgrid.cpp:16:
/home/mblatt/src/dune/opm-master/dune-grid/dune/grid/test/checkindexset.hh: In instantiation of ‘static void Dune::CheckIndexSet<Grid, GridView, OutputStream, codim, false>::checkIndexSet(const Grid&, const GridView&, OutputStream&, bool) [with Grid = Dune::PolyhedralGrid<3, 3>; GridView = Dune::GridView<Dune::PolyhedralGridViewTraits<3, 3, double, (Dune::PartitionIteratorType)4> >; OutputStream = Dune::DebugStream<1, 4>; int codim = -894]’:
/home/mblatt/src/dune/opm-master/dune-grid/dune/grid/test/checkindexset.hh:539:23:   recursively required from ‘static void Dune::CheckIndexSet<Grid, GridView, OutputStream, codim, false>::checkIndexSet(const Grid&, const GridView&, OutputStream&, bool) [with Grid = Dune::PolyhedralGrid<3, 3>; GridView = Dune::GridView<Dune::PolyhedralGridViewTraits<3, 3, double, (Dune::PartitionIteratorType)4> >; OutputStream = Dune::DebugStream<1, 4>; int codim = 1]’
/home/mblatt/src/dune/opm-master/dune-grid/dune/grid/test/checkindexset.hh:539:23:   required from ‘static void Dune::CheckIndexSet<Grid, GridView, OutputStream, codim, false>::checkIndexSet(const Grid&, const GridView&, OutputStream&, bool) [with Grid = Dune::PolyhedralGrid<3, 3>; GridView = Dune::GridView<Dune::PolyhedralGridViewTraits<3, 3, double, (Dune::PartitionIteratorType)4> >; OutputStream = Dune::DebugStream<1, 4>; int codim = 2]’
/home/mblatt/src/dune/opm-master/dune-grid/dune/grid/test/checkindexset.hh:524:23:   required from ‘static void Dune::CheckIndexSet<Grid, GridView, OutputStream, codim, hasCodim>::checkIndexSet(const Grid&, const GridView&, OutputStream&, bool) [with Grid = Dune::PolyhedralGrid<3, 3>; GridView = Dune::GridView<Dune::PolyhedralGridViewTraits<3, 3, double, (Dune::PartitionIteratorType)4> >; OutputStream = Dune::DebugStream<1, 4>; int codim = 3; bool hasCodim = true]’
/home/mblatt/src/dune/opm-master/dune-grid/dune/grid/test/checkindexset.hh:558:22:   required from ‘void Dune::checkIndexSet(const Grid&, const GridView&, OutputStream&, bool) [with Grid = Dune::PolyhedralGrid<3, 3>; GridView = Dune::GridView<Dune::PolyhedralGridViewTraits<3, 3, double, (Dune::PartitionIteratorType)4> >; OutputStream = Dune::DebugStream<1, 4>]’
/home/mblatt/src/dune/opm-master/dune-grid/dune/grid/test/gridcheck.hh:1027:24:   required from ‘void gridcheck(Grid&) [with Grid = Dune::PolyhedralGrid<3, 3>]’
/home/mblatt/src/dune/opm-master/opm-grid/tests/test_polyhedralgrid.cpp:289:25:   required from here
/home/mblatt/src/dune/opm-master/dune-grid/dune/grid/test/checkindexset.hh:535:40: fatal error: template instantiation depth exceeds maximum of 900 (use -ftemplate-depth= to increase the maximum)
       derr << "WARNING: Entities for codim " << codim
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            << " are not being tested!" << std::endl;
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
compilation terminated.
make[3]: *** [CMakeFiles/test_polyhedralgrid.dir/build.make:63: CMakeFiles/test_polyhedralgrid.dir/tests/test_polyhedralgrid.cpp.o] Error 1
make[2]: *** [CMakeFiles/Makefile2:258: CMakeFiles/test_polyhedralgrid.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:270: CMakeFiles/test_polyhedralgrid.dir/rule] Error 2
make: *** [Makefile:240: test_polyhedralgrid] Error 2
```