### PR TITLE
Fixes bugs in movement of wells when loadbalancing

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1451,6 +1451,13 @@ namespace Dune
 
     }
 
+
+    template<int dim>
+    cpgrid::Entity<dim> createEntity(const CpGrid& grid,int index,bool orientation)
+    {
+        return cpgrid::Entity<dim>(*grid.current_view_data_, index, orientation);
+    }
+
 } // namespace Dune
 
 #include <opm/grid/cpgrid/PersistentContainer.hpp>

--- a/opm/grid/common/WellConnections.cpp
+++ b/opm/grid/common/WellConnections.cpp
@@ -171,11 +171,8 @@ postProcessPartitioningForWells(std::vector<int>& parts,
                 auto exportCandidate =  exportList.begin();
 
                 for (auto movedCell = oldEnd; movedCell != add.end(); ++movedCell) {
-                    using ELValueT = decltype(*exportList.begin());
                     exportCandidate = std::lower_bound(exportCandidate, exportList.end(), *movedCell,
-                                                        [](const ELValueT& v1, const int& v2){
-                                                            return std::get<0>(v1) < v2;
-                                                        });
+                                                       Less());
                     assert(exportCandidate != exportList.end() && std::get<0>(*exportCandidate) == *movedCell);
                     std::get<1>(*exportCandidate) = new_owner;
                 }
@@ -288,12 +285,8 @@ postProcessPartitioningForWells(std::vector<int>& parts,
             for (; offset != noAdded; ++offset)
                 importList.emplace_back(cellIndexBuffer[offset], otherRank,
                                         AttributeSet::owner, -1);
-            auto compare = [](const std::tuple<int, int, char, int> &t1,
-                              const std::tuple<int, int, char, int> &t2) {
-                               return std::get<0>(t1) < std::get<0>(t2);
-                           };
             std::inplace_merge(importList.begin(), middle, importList.end(),
-                               compare);
+                               Less());
 
             // remove cells that moved to another process
             auto noRemoved = sizeBuffers[otherRank][1];

--- a/opm/grid/common/WellConnections.cpp
+++ b/opm/grid/common/WellConnections.cpp
@@ -96,7 +96,7 @@ void WellConnections::init(const std::vector<OpmWellType>& wells,
 #ifdef HAVE_MPI
 std::vector<std::vector<int> >
 postProcessPartitioningForWells(std::vector<int>& parts,
-                                const std::vector<int>& globalCell,
+                                std::function<int(int)> gid,
                                 const std::vector<OpmWellType>& wells,
                                 const WellConnections& well_connections,
                                 std::vector<std::tuple<int,int,char>>& exportList,
@@ -157,7 +157,7 @@ postProcessPartitioningForWells(std::vector<int>& parts,
                 auto addOldSize = add.size(); // remember beginning of this well
 
                 for (auto connection_cell : connections) {
-                    const auto &global = globalCell[connection_cell];
+                    const auto &global = gid(connection_cell);
                     auto old_owner = parts[connection_cell];
                     if (old_owner != new_owner) // only parts might be moved
                     {

--- a/opm/grid/common/WellConnections.cpp
+++ b/opm/grid/common/WellConnections.cpp
@@ -235,17 +235,19 @@ postProcessPartitioningForWells(std::vector<int>& parts,
     ++tag;
 
     req = requests.begin();
-    std::vector<std::vector<std::size_t>> cellIndexBuffers; // receive buffers for indices of each rank.
+    std::vector<std::vector<std::size_t>> cellIndexBuffers(messages); // receive buffers for indices of each rank.
+    auto cellIndexBufferIt = cellIndexBuffers.begin();
 
     for (auto it = begin, end = cellsPerProc.end(); it != end; ++it) {
         auto otherRank = it - begin;
-        const auto &buffer = sizeBuffers[otherRank];
-        if ( buffer.size() >= 2 && (buffer[0] + buffer[1])) {
-            auto &cellIndexBuffer = cellIndexBuffers[otherRank];
-            cellIndexBuffer.resize(buffer[0] + buffer[1]);
+        const auto& sizeBuffer = sizeBuffers[otherRank];
+        if ( sizeBuffer.size() >= 2 && (sizeBuffer[0] + sizeBuffer[1])) {
+            auto &cellIndexBuffer = *cellIndexBufferIt;
+            cellIndexBuffer.resize(sizeBuffer[0] + sizeBuffer[1]);
             MPI_Irecv(cellIndexBuffer.data(), cellIndexBuffer.size(), mpiType, otherRank, tag, cc,
                       &(*req));
             ++req;
+            ++cellIndexBufferIt;
         }
     }
 

--- a/opm/grid/common/WellConnections.cpp
+++ b/opm/grid/common/WellConnections.cpp
@@ -176,6 +176,7 @@ postProcessPartitioningForWells(std::vector<int>& parts,
                     assert(exportCandidate != exportList.end() && std::get<0>(*exportCandidate) == *movedCell);
                     std::get<1>(*exportCandidate) = new_owner;
                 }
+                owner = new_owner;
             }
 
             well_indices_on_proc[owner].push_back(well_index);

--- a/opm/grid/common/WellConnections.cpp
+++ b/opm/grid/common/WellConnections.cpp
@@ -217,11 +217,11 @@ postProcessPartitioningForWells(std::vector<int>& parts,
         for (int otherRank = 0; otherRank < cc.size(); ++otherRank)
             if (otherRank != myRank) {
                 std::size_t sizes[2] = {0, 0};
-                auto candidate = addCells.find(myRank);
+                auto candidate = addCells.find(otherRank);
                 if (candidate != addCells.end())
                     sizes[0] = candidate->second.size();
 
-                candidate = removeCells.find(myRank);
+                candidate = removeCells.find(otherRank);
                 if (candidate != removeCells.end())
                     sizes[1] = candidate->second.size();
                 MPI_Send(sizes, 2, mpiType, otherRank, tag, cc);

--- a/opm/grid/common/WellConnections.cpp
+++ b/opm/grid/common/WellConnections.cpp
@@ -273,8 +273,9 @@ postProcessPartitioningForWells(std::vector<int>& parts,
     MPI_Waitall(requests.size(), requests.data(), statuses.data());
 
     // unpack data
-    int otherRank = 0;
+    auto status = statuses.begin();
     for (const auto &cellIndexBuffer : cellIndexBuffers) {
+        int otherRank = status->MPI_SOURCE;
         if (!cellIndexBuffer.empty()) {
             // add cells that moved here
             auto noAdded = sizeBuffers[otherRank][0];
@@ -300,7 +301,7 @@ postProcessPartitioningForWells(std::vector<int>& parts,
                 importList.swap(tmp);
             }
         }
-        ++otherRank;
+        ++status;
     }
 #endif
 

--- a/opm/grid/common/WellConnections.hpp
+++ b/opm/grid/common/WellConnections.hpp
@@ -23,6 +23,7 @@
 #include <set>
 #include <unordered_set>
 #include <vector>
+#include <functional>
 
 #ifdef HAVE_MPI
 #include <opm/grid/utility/platform_dependent/disable_warnings.h>
@@ -122,7 +123,7 @@ private:
 /// Computes for all processes all indices of wells that
 /// will be assigned to this process.
 /// \param parts The partition number for each cell
-/// \param globalCell The linearized cartesian index for each index
+/// \param gid Functor that turns cell index to global id.
 /// \param eclipseState The eclipse information
 /// \param well_connecton The information about the perforations of each well.
 /// \param exportList List of cells to be exported. Each entry is a tuple of the
@@ -134,7 +135,7 @@ private:
 /// \param cc Information about the parallelism together with the decomposition.
 std::vector<std::vector<int> >
 postProcessPartitioningForWells(std::vector<int>& parts,
-                                const std::vector<int>& globalCell,
+                                std::function<int(int)> gid,
                                 const std::vector<OpmWellType>&  wells,
                                 const WellConnections& well_connections,
                                 std::vector<std::tuple<int,int,char>>& exportList,

--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -104,9 +104,9 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
     int                         rank  = cc.rank();
     std::vector<int>            parts(size, rank);
     std::vector<std::vector<int> > wells_on_proc;
-    // List entry: process to export to, (global) index, attribute there (not needed?)
+    // List entry: process to export to, (global) index, process rank, attribute there (not needed?)
     std::vector<std::tuple<int,int,char>> myExportList(numExport);
-    // List entry: process to import from, global index, attribute here, local index
+    // List entry: process to import from, global index, process rank, attribute here, local index
     // (determined later)
     std::vector<std::tuple<int,int,char,int>>myImportList(numImport);
     myExportList.reserve(1.2*myExportList.size());

--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -23,6 +23,7 @@
 #include <opm/grid/common/ZoltanPartition.hpp>
 #include <opm/grid/utility/OpmParserIncludes.hpp>
 #include <opm/grid/cpgrid/CpGridData.hpp>
+#include <opm/grid/cpgrid/Entity.hpp>
 
 #if defined(HAVE_ZOLTAN) && defined(HAVE_MPI)
 namespace Dune
@@ -142,9 +143,10 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
 
     if( wells )
     {
+        auto gidGetter = [&cpgrid](int i) { return cpgrid.globalIdSet().id(createEntity<0>(cpgrid, i, true));};
         wells_on_proc =
             postProcessPartitioningForWells(parts,
-                                            cpgrid.globalCell(),
+                                            gidGetter,
                                             *wells,
                                             grid_and_wells->getWellConnections(),
                                             myExportList, myImportList,

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -26,18 +26,6 @@
 
 #include <opm/grid/utility/platform_dependent/reenable_warnings.h>
 
-namespace Dune
-{
-template<int dim>
-Dune::cpgrid::Entity<dim> createEntity(const Dune::CpGrid& grid, int index, bool orientation)
-{
-    return Dune::cpgrid::Entity<dim>(*grid.current_view_data_, index, orientation);
-}
-/*
-template Dune::cpgrid::Entity<1> createEntity<1>(const Dune::CpGrid& grid, int index, bool orientation);
-template Dune::cpgrid::Entity<3> createEntity<3>(const Dune::CpGrid& grid, int index, bool orientation);
-*/
-} // end namespace Dune
 
 #if HAVE_MPI
 class MPIError {


### PR DESCRIPTION
This fixes quite a few bugs in the code moving cells  (to keep all cells perforated by a well on one process in case the loadbalancer violates this request) .
The code has been tested with a model by @akva2 and  artifically tested by forcing all wells to be moved to the process with the highest rank. Both tests run successfully on my system.
Closes #476

The problem is that on my system usually no wells get moved ~(even with @akva2 's problem and 64 processes)~. Tested @akva2 's model with `--edge-weights-method=0` and 32 processes. Please test further.