### PR TITLE
Abort for zero cells before scattering grid and allow sparse tables with zero rows

### DIFF
--- a/opm/grid/common/ZoltanPartition.hpp
+++ b/opm/grid/common/ZoltanPartition.hpp
@@ -46,10 +46,13 @@ namespace cpgrid
 /// @param edgeWeightMethod The method used to calculate the weights associated
 ///             with the edges of the graph (uniform, transmissibilities, log thereof)
 /// @param root The process number that holds the global grid.
-/// @return A pair consisting of a vector that contains for each local cell of the grid the
+/// @return A tuple consisting of a vector that contains for each local cell of the original grid the
 ///         the number of the process that owns it after repartitioning,
-///         and a set of names of wells that should be defunct in a parallel
-///         simulation.
+///         a set of names of wells that should be defunct in a parallel
+///         simulation, vector containing information for each exported cell (global id
+///         of cell, process id to send to, attribute there), and a vector containing
+///         information for each imported cell (global index, process id that sends, attribute here, local index
+///         here)
 std::tuple<std::vector<int>,std::unordered_set<std::string>,
            std::vector<std::tuple<int,int,char> >,
            std::vector<std::tuple<int,int,char,int> >  >

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -230,6 +230,63 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
                                importList.end(), compareImport);
         }
 
+        int procsWithZeroCells{};
+
+        if (cc.rank()==0)
+        {
+            // Print some statistics without communication
+            std::vector<int> ownedCells(cc.size(), 0);
+            std::vector<int> overlapCells(cc.size(), 0);
+            for (const auto& entry: exportList)
+            {
+                if(std::get<2>(entry) == AttributeSet::owner)
+                {
+                    ++ownedCells[std::get<1>(entry)];
+                }
+                else
+                {
+                    ++overlapCells[std::get<1>(entry)];
+                }
+            }
+
+            for(const auto& cellsOnProc: ownedCells)
+            {
+                procsWithZeroCells += (cellsOnProc == 0);
+            }
+            std::ostringstream ostr;
+            ostr << "\nLoad balancing distributes " << data_->size(0)
+                 << " active cells on " << cc.size() << " processes as follows:\n";
+            ostr << "  rank   owned cells   overlap cells   total cells\n";
+            ostr << "--------------------------------------------------\n";
+            for (int i = 0; i < cc.size(); ++i) {
+                ostr << std::setw(6) << i
+                     << std::setw(14) << ownedCells[i]
+                     << std::setw(16) << overlapCells[i]
+                     << std::setw(14) << ownedCells[i] + overlapCells[i] << "\n";
+            }
+            ostr << "--------------------------------------------------\n";
+            ostr << "   sum";
+            auto sumOwned = std::accumulate(ownedCells.begin(), ownedCells.end(), 0);
+            ostr << std::setw(14) << sumOwned;
+            auto sumOverlap = std::accumulate(overlapCells.begin(), overlapCells.end(), 0);
+            ostr << std::setw(16) << sumOverlap;
+            ostr << std::setw(14) << (sumOwned + sumOverlap) << "\n";
+            Opm::OpmLog::info(ostr.str());
+        }
+
+        procsWithZeroCells = cc.sum(procsWithZeroCells);
+
+        if (procsWithZeroCells) {
+            if (cc.rank()==0)
+            {
+                OPM_THROW(std::runtime_error, "At least one process has zero cells. Aborting.");
+            }
+            else
+            {
+                OPM_THROW_NOLOG(std::runtime_error, "At least one process has zero cells. Aborting.");
+            }
+        }
+
         distributed_data_.reset(new cpgrid::CpGridData(cc));
         distributed_data_->setUniqueBoundaryIds(data_->uniqueBoundaryIds());
         // Just to be sure we assume that only master knows
@@ -251,61 +308,6 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
         distributed_data_->distributeGlobalGrid(*this,*this->current_view_data_, cell_part);
         global_id_set_.insertIdSet(*distributed_data_);
 
-
-        // Compute the partition type for cell
-        int owned_cells = 0;
-        int overlap_cells = 0;
-        for (const auto i : distributed_data_->cell_indexset_) {
-            if (i.local().attribute() == AttributeSet::owner) {
-                ++owned_cells;
-            } else {
-                ++overlap_cells;
-            }
-        }
-
-        // owned cells
-        std::vector<int> cc_owned_cells(cc.size(), 0);
-        cc_owned_cells[cc.rank()] = owned_cells;
-        cc.sum(cc_owned_cells.data(), cc.size());
-
-        // overlap cells
-        std::vector<int> cc_overlap_cells(cc.size(), 0);
-        cc_overlap_cells[cc.rank()] = overlap_cells;
-        cc.sum(cc_overlap_cells.data(), cc.size());
-
-        // total cells
-        const int total_cells = distributed_data_->cell_to_face_.size();
-        std::vector<int> cc_total_cells(cc.size(), 0);
-        cc_total_cells[cc.rank()] = total_cells;
-        cc.sum(cc_total_cells.data(), cc.size());
-
-        if (cc.rank() == 0) {
-            std::ostringstream ostr;
-            ostr << "\nLoad balancing distributes " << data_->size(0)
-                << " active cells on " << cc.size() << " processes as follows:\n"; 
-            ostr << "  rank   owned cells   overlap cells   total cells\n";
-            ostr << "--------------------------------------------------\n";
-            for (int i = 0; i < cc.size(); ++i) {
-                ostr << std::setw(6) << i
-                    << std::setw(14) << cc_owned_cells[i]
-                    << std::setw(16) << cc_overlap_cells[i]
-                    << std::setw(14) << cc_total_cells[i] << "\n";
-            }
-            ostr << "--------------------------------------------------\n";
-            ostr << "   sum";
-            auto sum_owned = std::accumulate(cc_owned_cells.begin(), cc_owned_cells.end(), 0);
-            ostr << std::setw(14) << sum_owned;
-            auto sum_overlap = std::accumulate(cc_overlap_cells.begin(), cc_overlap_cells.end(), 0);
-            ostr << std::setw(16) << sum_overlap;
-            auto sum_total = std::accumulate(cc_total_cells.begin(), cc_total_cells.end(), 0);
-            ostr << std::setw(14) << sum_total << "\n";
-            Opm::OpmLog::info(ostr.str());
-        }
-        for (const auto& nc : cc_owned_cells) {
-            if (nc == 0) {
-                throw std::runtime_error("At least one process has zero cells. Aborting.");
-            }
-        }
 
         current_view_data_ = distributed_data_.get();
         return std::make_pair(true, defunct_wells);


### PR DESCRIPTION
We move the printing of the loadbalancing (and the abort for zero cells) before actually distributing the grid. Hence the deadlock described in #482 should not occur any more but all processes should abort.
In addition we change SparseTable to allow for zero rows and rows with zero entries. This is the first step to simulate with partitions containing zero cells. Unfortunately there are more bugs to be resolved before this can work.

Closes #482 