### PR TITLE
Fixing zoltan test

### DIFF
--- a/tests/cpgrid/zoltan_test.cpp
+++ b/tests/cpgrid/zoltan_test.cpp
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(zoltan)
 
         Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, grid);
 
-        BOOST_REQUIRE(grid.comm()==MPI_COMM_SELF);
+        BOOST_REQUIRE(grid.comm()==MPI_COMM_WORLD);
 
         //ZOLTAN_TRACE_ENTER(zz, yo);
         rc = Zoltan_LB_Partition(zz, /* input (all remaining fields are output) */

--- a/tests/cpgrid/zoltan_test.cpp
+++ b/tests/cpgrid/zoltan_test.cpp
@@ -115,6 +115,8 @@ BOOST_AUTO_TEST_CASE(zoltan)
 #endif
             grid.createCartesian(dims, size);
 
+        MPI_Barrier(MPI_COMM_WORLD);
+
         Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, grid);
 
         BOOST_REQUIRE(grid.comm()==MPI_COMM_WORLD);


### PR DESCRIPTION
```
BOOST_REQUIRE(grid.comm()==MPI_COMM_SELF);
```
This line never works but the test passes anyway. reported by @kjetilly . 

```
11: Test command: /usr/bin/mpiexec "-n" "1" "/home/kaib/OPM-devel/debug/opm-grid-build/bin/zoltan_test"
11: Test timeout computed to be: 1500
11: Invalid MIT-MAGIC-COOKIE-1 keyRunning 1 test case...
11: /home/kaib/OPM-devel/debug/opm-grid/tests/cpgrid/zoltan_test.cpp(120): fatal error: in "zoltan": critical check grid.comm()==(static_cast<MPI_Comm> (static_cast<void *> (&(ompi_mpi_comm_self)))) has failed
11: 
11: *** 1 failure is detected in the test module "ZoltanTests"
11: 
1/1 Test #11: zoltan ...........................   Passed    0.42 sec
```


@akva2 , not sure if this line related to what you mention that creating Zoltan with `MPI_COMM_SELF`, but in the code `zz = Zoltan_Create(MPI_COMM_WORLD);	` anyway. 

There might be something messy in this example. Maybe during discussion this PR, we can clean up the setup of the Zoltan a little bit.  


`MPI_Barrier` is because when I run this test in some cluster with two processes, one process is still creating the grid, and the other one is already beginning to partition. So `segmentation fault` and the running gets stuck. 