### PR TITLE
Refactored how loadbalance exports information about parallel wells.

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -628,7 +628,10 @@ namespace Dune
         /// \param transmissibilities The transmissibilities used as the edge weights.
         /// \param overlapLayers The number of layers of cells of the overlap region (default: 1).
         /// \warning May only be called once.
-        std::pair<bool, std::unordered_set<std::string> >
+        /// \return A pair consisting of a boolean indicating whether loadbalancing actually happened and
+        ///         a vector containing a pair of name and a boolean, indicating whether this well has
+        ///         perforated cells local to the process, for all wells (sorted by name)
+        std::pair<bool, std::vector<std::pair<std::string,bool> > >
         loadBalance(const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities = nullptr,
                     int overlapLayers=1)
@@ -656,7 +659,10 @@ namespace Dune
         /// \param addCornerCells Add corner cells to the overlap layer.
         /// \param The number of layers of cells of the overlap region (default: 1).
         /// \warning May only be called once.
-        std::pair<bool, std::unordered_set<std::string> >
+        /// \return A pair consisting of a boolean indicating whether loadbalancing actually happened and
+        ///         a vector containing a pair of name and a boolean, indicating whether this well has
+        ///         perforated cells local to the process, for all wells (sorted by name)
+        std::pair<bool, std::vector<std::pair<std::string,bool> > >
         loadBalance(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities = nullptr, bool ownersFirst=false,
                     bool addCornerCells=false, int overlapLayers=1)
@@ -678,8 +684,11 @@ namespace Dune
         ///        (default: 1)
         /// \tparam DataHandle The type implementing DUNE's DataHandle interface.
         /// \warning May only be called once.
+        /// \return A pair consisting of a boolean indicating whether loadbalancing actually happened and
+        ///         a vector containing a pair of name and a boolean, indicating whether this well has
+        ///         perforated cells local to the process, for all wells (sorted by name)
         template<class DataHandle>
-        std::pair<bool, std::unordered_set<std::string> >
+        std::pair<bool, std::vector<std::pair<std::string,bool> > >
         loadBalance(DataHandle& data,
                     const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities = nullptr,
@@ -708,8 +717,11 @@ namespace Dune
         /// \param addCornerCells Add corner cells to the overlap layer.
         /// \param The number of layers of cells of the overlap region (default: 1).
         /// \warning May only be called once.
+        /// \return A pair consisting of a boolean indicating whether loadbalancing actually happened and
+        ///         a vector containing a pair of name and a boolean, indicating whether this well has
+        ///         perforated cells local to the process, for all wells (sorted by name)
         template<class DataHandle>
-        std::pair<bool, std::unordered_set<std::string> >
+        std::pair<bool, std::vector<std::pair<std::string,bool> > >
         loadBalance(DataHandle& data, EdgeWeightMethod method,
                     const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities = nullptr, bool ownersFirst=false,
@@ -1378,7 +1390,10 @@ namespace Dune
         ///                           performance of the parallel preconditioner.
         /// \param addCornerCells Add corner cells to the overlap layer.
         /// \param The number of layers of cells of the overlap region.
-        std::pair<bool, std::unordered_set<std::string> >
+        /// \return A pair consisting of a boolean indicating whether loadbalancing actually happened and
+        ///         a vector containing a pair of name and a boolean, indicating whether this well has
+        ///         perforated cells local to the process, for all wells (sorted by name)
+        std::pair<bool, std::vector<std::pair<std::string,bool> > >
         scatterGrid(EdgeWeightMethod method,
                     bool ownersFirst,
                     const std::vector<cpgrid::OpmWellType> * wells,

--- a/opm/grid/common/WellConnections.hpp
+++ b/opm/grid/common/WellConnections.hpp
@@ -142,17 +142,19 @@ postProcessPartitioningForWells(std::vector<int>& parts,
                                 std::vector<std::tuple<int,int,char,int>>& importList,
                                 const CollectiveCommunication<MPI_Comm>& cc);
 
-/// \brief Computes that names that of all wells not handled by this process
+/// \brief Computes whether wells are perforating cells on this process.
 /// \param wells_on_proc well indices assigned to each process
 /// \param eclipseState The eclipse information
 /// \param cc The communicator
 /// \param root The rank of the process that has the complete partitioning
 ///             information.
-std::unordered_set<std::string>
-computeDefunctWellNames(const std::vector<std::vector<int> >& wells_on_proc,
-                        const std::vector<OpmWellType>&  wells,
-                        const CollectiveCommunication<MPI_Comm>& cc,
-                        int root);
+/// \return Vector of pairs of well name and a boolean indicating whether the
+///         well with this name perforates cells here. Sorted by well name!
+std::vector<std::pair<std::string,bool>>
+computeParallelWells(const std::vector<std::vector<int> >& wells_on_proc,
+                     const std::vector<OpmWellType>&  wells,
+                     const CollectiveCommunication<MPI_Comm>& cc,
+                     int root);
 #endif
 } // end namespace cpgrid
 } // end namespace Dune

--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -30,7 +30,7 @@ namespace Dune
 {
 namespace cpgrid
 {
-std::tuple<std::vector<int>, std::unordered_set<std::string>,
+std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
            std::vector<std::tuple<int,int,char> >,
            std::vector<std::tuple<int,int,char,int> > >
 zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
@@ -141,6 +141,8 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
     Zoltan_LB_Free_Part(&importGlobalGids, &importLocalGids, &importProcs, &importToPart);
     Zoltan_Destroy(&zz);
 
+    std::vector<std::pair<std::string,bool>> parallel_wells;
+
     if( wells )
     {
         auto gidGetter = [&cpgrid](int i) { return cpgrid.globalIdSet().id(createEntity<0>(cpgrid, i, true));};
@@ -174,17 +176,15 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
 #endif
     }
 
-    std::unordered_set<std::string> defunct_well_names;
-
     if( wells )
     {
-        defunct_well_names = computeDefunctWellNames(wells_on_proc,
-                                                     *wells,
-                                                     cc,
-                                                     root);
+        parallel_wells = computeParallelWells(wells_on_proc,
+                                              *wells,
+                                              cc,
+                                              root);
     }
 
-    return std::make_tuple(parts, defunct_well_names, myExportList, myImportList);
+    return std::make_tuple(parts, parallel_wells, myExportList, myImportList);
 }
 }
 }

--- a/opm/grid/common/ZoltanPartition.hpp
+++ b/opm/grid/common/ZoltanPartition.hpp
@@ -48,12 +48,13 @@ namespace cpgrid
 /// @param root The process number that holds the global grid.
 /// @return A tuple consisting of a vector that contains for each local cell of the original grid the
 ///         the number of the process that owns it after repartitioning,
-///         a set of names of wells that should be defunct in a parallel
-///         simulation, vector containing information for each exported cell (global id
+///         a vector containing a pair of name  and a boolean indicating whether this well has
+///         perforated cells local to the process of all wells,
+///         vector containing information for each exported cell (global id
 ///         of cell, process id to send to, attribute there), and a vector containing
 ///         information for each imported cell (global index, process id that sends, attribute here, local index
 ///         here)
-std::tuple<std::vector<int>,std::unordered_set<std::string>,
+std::tuple<std::vector<int>,std::vector<std::pair<std::string,bool>>,
            std::vector<std::tuple<int,int,char> >,
            std::vector<std::tuple<int,int,char,int> >  >
 zoltanGraphPartitionGridOnRoot(const CpGrid& grid,

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -133,7 +133,7 @@ namespace Dune
     {}
 
 
-std::pair<bool, std::unordered_set<std::string> >
+std::pair<bool, std::vector<std::pair<std::string,bool> > >
 CpGrid::scatterGrid(EdgeWeightMethod method,
                     [[maybe_unused]] bool ownersFirst,
                     const std::vector<cpgrid::OpmWellType> * wells,
@@ -149,7 +149,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
     {
         std::cerr<<"There is already a distributed version of the grid."
                  << " Maybe scatterGrid was called before?"<<std::endl;
-        return std::make_pair(false, std::unordered_set<std::string>());
+        return std::make_pair(false, std::vector<std::pair<std::string,bool> >());
     }
 
 #if HAVE_MPI
@@ -162,7 +162,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
             cpgrid::zoltanGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0);
         using std::get;
         auto cell_part = std::get<0>(part_and_wells);
-        auto defunct_wells = std::get<1>(part_and_wells);
+        auto wells_on_proc = std::get<1>(part_and_wells);
         auto exportList = std::get<2>(part_and_wells);
         auto importList = std::get<3>(part_and_wells);
 #else
@@ -310,19 +310,19 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
 
 
         current_view_data_ = distributed_data_.get();
-        return std::make_pair(true, defunct_wells);
+        return std::make_pair(true, wells_on_proc);
     }
     else
     {
         std::cerr << "CpGrid::scatterGrid() only makes sense in a parallel run. "
                   << "This run only uses one process.\n";
-        return std::make_pair(false, std::unordered_set<std::string>());
+        return std::make_pair(false, std::vector<std::pair<std::string,bool>>());
     }
 #else // #if HAVE_MPI
     std::cerr << "CpGrid::scatterGrid() is non-trivial only with "
               << "MPI support and if the target Dune platform is "
               << "sufficiently recent.\n";
-    return std::make_pair(false, std::unordered_set<std::string>());
+    return std::make_pair(false, std::vector<std::pair<std::string,bool>>());
 #endif
 }
 


### PR DESCRIPTION
Previously, we exported an unordered map containing all names of wells that are not present in the local part of the grid.

As we envision to have wells that are distributed across multiple processors, this information does not seem to be enough. We need
to be able to set up communication for each well. To do this we need to find out who handles perforations of each well.

We now export a full list of well name together with a boolean indicating whether it perforates local cells (vector of pair of string and bool).

Needs a downstream PR: OPM/opm-simulators#2802