### PR TITLE
Implementation of running Zoltan in Serial

### DIFF
--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -24,6 +24,7 @@
 #include <opm/grid/utility/OpmParserIncludes.hpp>
 #include <opm/grid/cpgrid/CpGridData.hpp>
 #include <opm/grid/cpgrid/Entity.hpp>
+#include <algorithm>
 
 #if defined(HAVE_ZOLTAN) && defined(HAVE_MPI)
 namespace Dune
@@ -172,6 +173,187 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
             ++index;
         }
 #endif
+    }
+
+    std::unordered_set<std::string> defunct_well_names;
+
+    if( wells )
+    {
+        defunct_well_names = computeDefunctWellNames(wells_on_proc,
+                                                     *wells,
+                                                     cc,
+                                                     root);
+    }
+
+    return std::make_tuple(parts, defunct_well_names, myExportList, myImportList);
+}
+
+std::tuple<std::vector<int>, std::unordered_set<std::string>,
+           std::vector<std::tuple<int,int,char> >,
+           std::vector<std::tuple<int,int,char,int> > >
+zoltanSerialGraphPartitionGridOnRoot(const CpGrid& cpgrid,
+                               const std::vector<OpmWellType> * wells,
+                               const double* transmissibilities,
+                               const CollectiveCommunication<MPI_Comm>& cc,
+                               EdgeWeightMethod edgeWeightsMethod, int root)
+{
+    int rc = ZOLTAN_OK - 1;
+    struct Zoltan_Struct *zz;
+    int changes, numGidEntries = 0, numLidEntries = 0, numImport = 0, numExport = 0;
+    ZOLTAN_ID_PTR importGlobalGids = nullptr, importLocalGids = nullptr, exportGlobalGids = nullptr, exportLocalGids = nullptr;
+    int *importProcs, *importToPart, *exportProcs, *exportToPart;
+    std::shared_ptr<CombinedGridWellGraph> grid_and_wells;
+
+    if (cc.rank() == root) {
+        int argc=0;
+        char** argv = 0;
+        float ver = 0;
+
+        rc = Zoltan_Initialize(argc, argv, &ver);
+        zz = Zoltan_Create(MPI_COMM_SELF);
+        if ( rc != ZOLTAN_OK )
+        {
+            OPM_THROW(std::runtime_error, "Could not initialize Zoltan!");
+        }
+        Zoltan_Set_Param(zz, "IMBALANCE_TOL", "1.1");
+        Zoltan_Set_Param(zz, "DEBUG_LEVEL", "0");
+        Zoltan_Set_Param(zz, "LB_METHOD", "GRAPH");
+        Zoltan_Set_Param(zz, "LB_APPROACH", "PARTITION");
+        Zoltan_Set_Param(zz, "NUM_GID_ENTRIES", "1");
+        Zoltan_Set_Param(zz, "NUM_LID_ENTRIES", "1");
+        Zoltan_Set_Param(zz, "RETURN_LISTS", "ALL");
+        Zoltan_Set_Param(zz, "CHECK_GRAPH", "2");
+        Zoltan_Set_Param(zz,"EDGE_WEIGHT_DIM","0");
+        Zoltan_Set_Param(zz, "OBJ_WEIGHT_DIM", "0");
+        Zoltan_Set_Param(zz, "PHG_EDGE_SIZE_THRESHOLD", ".35");  /* 0-remove all, 1-remove none */
+
+        // For the load balancer one process has the whole grid and
+        // all others an empty partition before loadbalancing.
+        bool partitionIsEmpty     = cc.rank()!=root;
+
+        std::shared_ptr<CombinedGridWellGraph> grid_and_wells;
+
+        if( wells )
+        {
+            Zoltan_Set_Param(zz,"EDGE_WEIGHT_DIM","1");
+            grid_and_wells.reset(new CombinedGridWellGraph(cpgrid,
+                                                           wells,
+                                                           transmissibilities,
+                                                           partitionIsEmpty,
+                                                           edgeWeightsMethod));
+            Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, *grid_and_wells,
+                                                        partitionIsEmpty);
+        }
+        else
+        {
+            Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, cpgrid, partitionIsEmpty);
+        }
+
+        rc = Zoltan_LB_Partition(zz, /* input (all remaining fields are output) */
+                                 &changes,        /* 1 if partitioning was changed, 0 otherwise */
+                                 &numGidEntries,  /* Number of integers used for a global ID */
+                                 &numLidEntries,  /* Number of integers used for a local ID */
+                                 &numImport,      /* Number of vertices to be sent to me */
+                                 &importGlobalGids,  /* Global IDs of vertices to be sent to me */
+                                 &importLocalGids,   /* Local IDs of vertices to be sent to me */
+                                 &importProcs,    /* Process rank for source of each incoming vertex */
+                                 &importToPart,   /* New partition for each incoming vertex */
+                                 &numExport,      /* Number of vertices I must send to other processes*/
+                                 &exportGlobalGids,  /* Global IDs of the vertices I must send */
+                                 &exportLocalGids,   /* Local IDs of the vertices I must send */
+                                 &exportProcs,    /* Process to which I send each of the vertices */
+                                 &exportToPart);  /* Partition to which each vertex will belong */
+
+
+    }
+
+    std::vector<unsigned int> importGlobalGidsVector;
+    if (cc.rank() == root) {
+        std::vector<int> numberOfExportedVerticesPerProcess(cc.size(), 0);
+        for (int i = 0; i < numExport; ++i) {
+            numberOfExportedVerticesPerProcess[exportToPart[i]]++;
+        }
+        cc.scatter<int>(numberOfExportedVerticesPerProcess.data(), nullptr, 1, root);
+
+
+
+        std::vector<int> offsets(cc.size(), 0);
+        std::partial_sum(numberOfExportedVerticesPerProcess.begin(),
+                         numberOfExportedVerticesPerProcess.end(), offsets.begin());
+
+        std::vector<unsigned int> globalIndicesToSend(numExport, 0);
+        std::vector<int> currentIndex(cc.size(), 0);
+
+        for (int i = 0; i < numExport; ++i) {
+            globalIndicesToSend[currentIndex[exportToPart[i]]++ + offsets[i]] = exportGlobalGids[i];
+        }
+
+        cc.scatterv<unsigned int>(globalIndicesToSend.data(), numberOfExportedVerticesPerProcess.data(),
+                     offsets.data(), nullptr, 0, root);
+
+    } else {
+        cc.scatter<int>(nullptr, &numImport, 1, root);
+
+        importGlobalGidsVector.resize(numImport, 0);
+        cc.scatterv<unsigned int>(nullptr, nullptr, nullptr, importGlobalGidsVector.data(),
+                         numImport, root);
+
+        importGlobalGids = importGlobalGidsVector.data();
+
+    }
+
+    int                         size = cpgrid.numCells();
+    int                         rank  = cc.rank();
+    std::vector<int>            parts(cc.size(), rank);
+    std::vector<std::vector<int> > wells_on_proc;
+    // List entry: process to export to, (global) index, process rank, attribute there (not needed?)
+    std::vector<std::tuple<int,int,char>> myExportList(numExport);
+    // List entry: process to import from, global index, process rank, attribute here, local index
+    // (determined later)
+    std::vector<std::tuple<int,int,char,int>> myImportList(numImport);
+    myExportList.reserve(1.2*myExportList.size());
+    myImportList.reserve(1.2*myImportList.size());
+    using AttributeSet = CpGridData::AttributeSet;
+
+    for ( int i=0; i < numExport; ++i )
+    {
+        parts[exportLocalGids[i]] = exportToPart[i];
+        myExportList[i] = std::make_tuple(exportGlobalGids[i], exportProcs[i], static_cast<char>(AttributeSet::owner));
+    }
+
+    for ( int i=0; i < numImport; ++i )
+    {
+        myImportList[i] = std::make_tuple(importGlobalGids[i], importProcs[i], static_cast<char>(AttributeSet::owner),-1);
+    }
+    // Add cells that stay here to the lists. Somehow I could not persuade Zoltan to do this.
+    for ( std::size_t i = 0; i < parts.size(); ++i)
+    {
+        if ( parts[i] == rank )
+        {
+            myExportList.emplace_back(i, rank, static_cast<char>(AttributeSet::owner) );
+            myImportList.emplace_back(i, rank, static_cast<char>(AttributeSet::owner), -1 );
+        }
+    }
+
+    std::inplace_merge(myImportList.begin(), myImportList.begin() + numImport, myImportList.end());
+    std::inplace_merge(myExportList.begin(), myExportList.begin() + numExport, myExportList.end());
+    // free space allocated for zoltan.
+    if (cc.rank() == root) {
+        Zoltan_LB_Free_Part(&exportGlobalGids, &exportLocalGids, &exportProcs, &exportToPart);
+        Zoltan_LB_Free_Part(&importGlobalGids, &importLocalGids, &importProcs, &importToPart);
+        Zoltan_Destroy(&zz);
+    }
+
+    if( wells )
+    {
+        auto gidGetter = [&cpgrid](int i) { return cpgrid.globalIdSet().id(createEntity<0>(cpgrid, i, true));};
+        wells_on_proc =
+            postProcessPartitioningForWells(parts,
+                                            gidGetter,
+                                            *wells,
+                                            grid_and_wells->getWellConnections(),
+                                            myExportList, myImportList,
+                                            cc);
     }
 
     std::unordered_set<std::string> defunct_well_names;

--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -31,6 +31,22 @@ namespace Dune
 {
 namespace cpgrid
 {
+
+namespace {
+void setDefaultZoltanParameters(Zoltan_Struct* zz) {
+    Zoltan_Set_Param(zz, "IMBALANCE_TOL", "1.1");
+    Zoltan_Set_Param(zz, "DEBUG_LEVEL", "0");
+    Zoltan_Set_Param(zz, "LB_METHOD", "GRAPH");
+    Zoltan_Set_Param(zz, "LB_APPROACH", "PARTITION");
+    Zoltan_Set_Param(zz, "NUM_GID_ENTRIES", "1");
+    Zoltan_Set_Param(zz, "NUM_LID_ENTRIES", "1");
+    Zoltan_Set_Param(zz, "RETURN_LISTS", "ALL");
+    Zoltan_Set_Param(zz, "CHECK_GRAPH", "2");
+    Zoltan_Set_Param(zz,"EDGE_WEIGHT_DIM","0");
+    Zoltan_Set_Param(zz, "OBJ_WEIGHT_DIM", "0");
+    Zoltan_Set_Param(zz, "PHG_EDGE_SIZE_THRESHOLD", ".35");  /* 0-remove all, 1-remove none */
+}
+}
 std::tuple<std::vector<int>, std::unordered_set<std::string>,
            std::vector<std::tuple<int,int,char> >,
            std::vector<std::tuple<int,int,char,int> > >
@@ -54,17 +70,7 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
     {
         OPM_THROW(std::runtime_error, "Could not initialize Zoltan!");
     }
-    Zoltan_Set_Param(zz, "IMBALANCE_TOL", "1.1");
-    Zoltan_Set_Param(zz, "DEBUG_LEVEL", "0");
-    Zoltan_Set_Param(zz, "LB_METHOD", "GRAPH");
-    Zoltan_Set_Param(zz, "LB_APPROACH", "PARTITION");
-    Zoltan_Set_Param(zz, "NUM_GID_ENTRIES", "1");
-    Zoltan_Set_Param(zz, "NUM_LID_ENTRIES", "1");
-    Zoltan_Set_Param(zz, "RETURN_LISTS", "ALL");
-    Zoltan_Set_Param(zz, "CHECK_GRAPH", "2");
-    Zoltan_Set_Param(zz,"EDGE_WEIGHT_DIM","0");
-    Zoltan_Set_Param(zz, "OBJ_WEIGHT_DIM", "0");
-    Zoltan_Set_Param(zz, "PHG_EDGE_SIZE_THRESHOLD", ".35");  /* 0-remove all, 1-remove none */
+    setDefaultZoltanParameters(zz);
 
     // For the load balancer one process has the whole grid and
     // all others an empty partition before loadbalancing.
@@ -215,18 +221,9 @@ zoltanSerialGraphPartitionGridOnRoot(const CpGrid& cpgrid,
         {
             OPM_THROW(std::runtime_error, "Could not initialize Zoltan!");
         }
-        Zoltan_Set_Param(zz, "IMBALANCE_TOL", "1.1");
-        Zoltan_Set_Param(zz, "DEBUG_LEVEL", "0");
-        Zoltan_Set_Param(zz, "LB_METHOD", "GRAPH");
-        Zoltan_Set_Param(zz, "LB_APPROACH", "PARTITION");
-        Zoltan_Set_Param(zz, "NUM_GID_ENTRIES", "1");
-        Zoltan_Set_Param(zz, "NUM_LID_ENTRIES", "1");
-        Zoltan_Set_Param(zz, "RETURN_LISTS", "ALL");
-        Zoltan_Set_Param(zz, "CHECK_GRAPH", "2");
-        Zoltan_Set_Param(zz,"EDGE_WEIGHT_DIM","0");
-        Zoltan_Set_Param(zz, "OBJ_WEIGHT_DIM", "0");
+
+        setDefaultZoltanParameters(zz);
         Zoltan_Set_Param(zz, "NUM_GLOBAL_PARTS", std::to_string(cc.size()).c_str());
-        Zoltan_Set_Param(zz, "PHG_EDGE_SIZE_THRESHOLD", ".35");  /* 0-remove all, 1-remove none */
 
         // For the load balancer one process has the whole grid and
         // all others an empty partition before loadbalancing.

--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -40,6 +40,10 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
                                const CollectiveCommunication<MPI_Comm>& cc,
                                EdgeWeightMethod edgeWeightsMethod, int root)
 {
+    {
+        std::ofstream outfile("ran_mpi.txt");
+        outfile << "ran mpi" << std::endl;
+    }
     int rc = ZOLTAN_OK - 1;
     float ver = 0;
     struct Zoltan_Struct *zz;
@@ -197,6 +201,10 @@ zoltanSerialGraphPartitionGridOnRoot(const CpGrid& cpgrid,
                                const CollectiveCommunication<MPI_Comm>& cc,
                                EdgeWeightMethod edgeWeightsMethod, int root)
 {
+    {
+        std::ofstream outfile("ran_mpi.txt");
+        outfile << "ran mpi" << std::endl;
+    }
     int rc = ZOLTAN_OK - 1;
     struct Zoltan_Struct *zz;
     int changes, numGidEntries = 0, numLidEntries = 0, numImport = 0, numExport = 0;
@@ -273,7 +281,9 @@ zoltanSerialGraphPartitionGridOnRoot(const CpGrid& cpgrid,
         for (int i = 0; i < numExport; ++i) {
             numberOfExportedVerticesPerProcess[exportToPart[i]]++;
         }
-        cc.scatter<int>(numberOfExportedVerticesPerProcess.data(), nullptr, 1, root);
+
+        int dummyForRoot = 0;
+        cc.scatter<int>(numberOfExportedVerticesPerProcess.data(), &dummyForRoot, 1, root);
 
 
 
@@ -288,8 +298,9 @@ zoltanSerialGraphPartitionGridOnRoot(const CpGrid& cpgrid,
             globalIndicesToSend[currentIndex[exportToPart[i]]++ + offsets[i]] = exportGlobalGids[i];
         }
 
+        std::vector<unsigned int> dummyIndicesForRoot(numExport, 0);
         cc.scatterv<unsigned int>(globalIndicesToSend.data(), numberOfExportedVerticesPerProcess.data(),
-                     offsets.data(), nullptr, 0, root);
+                     offsets.data(), dummyIndicesForRoot.data(), 0, root);
 
     } else {
         cc.scatter<int>(nullptr, &numImport, 1, root);

--- a/opm/grid/common/ZoltanPartition.hpp
+++ b/opm/grid/common/ZoltanPartition.hpp
@@ -61,6 +61,40 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& grid,
                                const double* transmissibilities,
                                const CollectiveCommunication<MPI_Comm>& cc,
                                EdgeWeightMethod edgeWeightsMethod, int root);
+
+/// \brief Partition a CpGrid using Zoltan
+///
+/// This function will extract Zoltan's graph information
+/// from the grid, and the wells and use it to partition the grid.
+/// In case the global grid is available on all processes, it
+/// will nevertheless only use the information on the root process
+/// to partition it as Zoltan cannot identify this situation.
+/// @param grid The grid to partition
+/// @param wells The wells of the eclipse If null wells will be neglected.
+/// @param transmissibilities The transmissibilities associated with the
+///             faces
+/// @paramm cc  The MPI communicator to use for the partitioning.
+///             The will be partitioned among the partiticipating processes.
+/// @param edgeWeightMethod The method used to calculate the weights associated
+///             with the edges of the graph (uniform, transmissibilities, log thereof)
+/// @param root The process number that holds the global grid.
+/// @return A tuple consisting of a vector that contains for each local cell of the original grid the
+///         the number of the process that owns it after repartitioning,
+///         a set of names of wells that should be defunct in a parallel
+///         simulation, vector containing information for each exported cell (global id
+///         of cell, process id to send to, attribute there), and a vector containing
+///         information for each imported cell (global index, process id that sends, attribute here, local index
+///         here)
+///
+/// @note This function will only do *serial* partioning.
+std::tuple<std::vector<int>,std::unordered_set<std::string>,
+           std::vector<std::tuple<int,int,char> >,
+           std::vector<std::tuple<int,int,char,int> >  >
+zoltanSerialGraphPartitionGridOnRoot(const CpGrid& grid,
+                               const std::vector<OpmWellType> * wells,
+                               const double* transmissibilities,
+                               const CollectiveCommunication<MPI_Comm>& cc,
+                               EdgeWeightMethod edgeWeightsMethod, int root);
 }
 }
 #endif // HAVE_ZOLTAN

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -159,7 +159,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
     {
 #ifdef HAVE_ZOLTAN
         auto part_and_wells =
-            cpgrid::zoltanGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0);
+            cpgrid::zoltanSerialGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0);
         using std::get;
         auto cell_part = std::get<0>(part_and_wells);
         auto defunct_wells = std::get<1>(part_and_wells);


### PR DESCRIPTION
On several clusters, we have experienced issues with running Zoltan for partitioning graphs of 3D Cartesian grids. This does not seem to be an isssue of OPM, but rather an issue of Zoltan, since one can reproduce the issue with a standalone example.

 A simple workaround is to  run Zoltan in serial. This pull request enables running Zoltan in serial, and fixes several observed crashes (Segmentation faults) on HPC clusters.