### PR TITLE
Fixes wrong communicator in CpGrid and memory overwrite in Zoltan callback

### DIFF
--- a/opm/grid/common/ZoltanGraphFunctions.cpp
+++ b/opm/grid/common/ZoltanGraphFunctions.cpp
@@ -82,7 +82,7 @@ void getNullNumEdgesList(void *cpGridPointer, int sizeGID, int sizeLID,
     (void) sizeGID; (void) sizeLID; (void) numCells; (void) globalID;
     (void) localID; (void) numEdges; (void) cpGridPointer;
     // Pretend that there are no edges
-    numEdges = 0;
+    assert(numCells=0);
     *err = ZOLTAN_OK;
 }
 

--- a/opm/grid/common/ZoltanGraphFunctions.cpp
+++ b/opm/grid/common/ZoltanGraphFunctions.cpp
@@ -82,8 +82,10 @@ void getNullNumEdgesList(void *cpGridPointer, int sizeGID, int sizeLID,
     (void) sizeGID; (void) sizeLID; (void) numCells; (void) globalID;
     (void) localID; (void) numEdges; (void) cpGridPointer;
     // Pretend that there are no edges
-    assert(numCells=0);
-    *err = ZOLTAN_OK;
+    if (numCells!=0)
+        *err = ZOLTAN_FATAL;
+    else
+        *err = ZOLTAN_OK;
 }
 
 void getCpGridNumEdgesList(void *cpGridPointer, int sizeGID, int sizeLID,

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -32,7 +32,6 @@ CpGridData::CpGridData(const CpGridData& g)
       global_id_set_(new LevelGlobalIdSet(local_id_set_, this)), partition_type_indicator_(new PartitionTypeIndicator(*this)), ccobj_(g.ccobj_)
 {
 #if HAVE_MPI
-    ccobj_=CollectiveCommunication(MPI_COMM_SELF);
     cell_interfaces_=std::make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
 #endif
 }
@@ -43,7 +42,6 @@ CpGridData::CpGridData()
       ccobj_(Dune::MPIHelper::getCommunicator()), use_unique_boundary_ids_(false)
 {
 #if HAVE_MPI
-    ccobj_=CollectiveCommunication(MPI_COMM_SELF);
     cell_interfaces_=std::make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
 #endif
 }
@@ -65,7 +63,6 @@ CpGridData::CpGridData(CpGrid&)
     ccobj_(Dune::MPIHelper::getCommunicator()), use_unique_boundary_ids_(false)
 {
 #if HAVE_MPI
-    //ccobj_=CollectiveCommunication(MPI_COMM_SELF);
     cell_interfaces_=std::make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
 #endif
 }

--- a/tests/cpgrid/zoltan_test.cpp
+++ b/tests/cpgrid/zoltan_test.cpp
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(zoltan)
         MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
 
         Dune::CpGrid grid;
-        std::array<int, 3> dims={{1, 2, 2}};
+        std::array<int, 3> dims={{1, procs, procs}};
         std::array<double, 3> size={{ 1.0, 1.0, 1.0}};
 #ifdef ONE_TO_ALL
         if (myRank==0)
@@ -140,6 +140,10 @@ BOOST_AUTO_TEST_CASE(zoltan)
         Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, grid);
 
         BOOST_REQUIRE(grid.comm()==MPI_COMM_WORLD);
+        if (myRank != 0)
+        {
+            BOOST_REQUIRE(grid.numCells()==0);
+        }
 
         //ZOLTAN_TRACE_ENTER(zz, yo);
         rc = Zoltan_LB_Partition(zz, /* input (all remaining fields are output) */


### PR DESCRIPTION
The discussion with @GitPaean in #487 sparked this investigation. I thought that there must be a synchronisation in CpGrid::createCartesian` (rank 0 does it in line [391](https://github.com/OPM/opm-grid/blob/bea8a13fb7210b3c718b50fb508a6da7018ba477/opm/grid/cpgrid/CpGrid.cpp#L391), the others in line [336](https://github.com/OPM/opm-grid/blob/bea8a13fb7210b3c718b50fb508a6da7018ba477/opm/grid/cpgrid/CpGrid.cpp#L336). Still he was right as the communciator used was still MPI_COMM_SELF. :flushed:

Then I discovered that on nonzero ranks we might overwrite Zoltan pointers with zero (second commit fixes that). That could of course produce rather arbitrary segmentation faults and we might just be lucky on some machines/models.