### PR TITLE
Serial partitioning

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -609,7 +609,7 @@ namespace Dune
         bool loadBalance(int overlapLayers=1)
         {
             using std::get;
-            return get<0>(scatterGrid(defaultTransEdgeWgt, false, nullptr, nullptr, true, overlapLayers ));
+            return get<0>(scatterGrid(defaultTransEdgeWgt, false, nullptr, false, nullptr, true, overlapLayers ));
         }
 
         // loadbalance is not part of the grid interface therefore we skip it.
@@ -636,7 +636,7 @@ namespace Dune
                     const double* transmissibilities = nullptr,
                     int overlapLayers=1)
         {
-            return scatterGrid(defaultTransEdgeWgt, false, wells, transmissibilities, false, overlapLayers);
+            return scatterGrid(defaultTransEdgeWgt, false, wells, false, transmissibilities, false, overlapLayers);
         }
 
         // loadbalance is not part of the grid interface therefore we skip it.
@@ -667,7 +667,7 @@ namespace Dune
                     const double* transmissibilities = nullptr, bool ownersFirst=false,
                     bool addCornerCells=false, int overlapLayers=1)
         {
-            return scatterGrid(method, ownersFirst, wells, transmissibilities, addCornerCells, overlapLayers);
+            return scatterGrid(method, ownersFirst, wells, false, transmissibilities, addCornerCells, overlapLayers);
         }
 
         /// \brief Distributes this grid and data over the available nodes in a distributed machine.
@@ -712,6 +712,7 @@ namespace Dune
         ///            of each well are stored on one process. This is done by
         ///            adding an edge with a very high edge weight for all
         ///            possible pairs of cells in the completion set of a well.
+        /// \param serialPartitioning If true, the partitioning will be done on a single process.
         /// \param transmissibilities The transmissibilities used to calculate the edge weights.
         /// \param ownersFirst Order owner cells before copy/overlap cells.
         /// \param addCornerCells Add corner cells to the overlap layer.
@@ -724,10 +725,11 @@ namespace Dune
         std::pair<bool, std::vector<std::pair<std::string,bool> > >
         loadBalance(DataHandle& data, EdgeWeightMethod method,
                     const std::vector<cpgrid::OpmWellType> * wells,
+                    bool serialPartitioning,
                     const double* transmissibilities = nullptr, bool ownersFirst=false,
                     bool addCornerCells=false, int overlapLayers=1)
         {
-            auto ret = scatterGrid(method, ownersFirst, wells, transmissibilities, addCornerCells, overlapLayers);
+            auto ret = scatterGrid(method, ownersFirst, wells, serialPartitioning, transmissibilities, addCornerCells, overlapLayers);
             scatterData(data);
             return ret;
         }
@@ -1397,6 +1399,7 @@ namespace Dune
         scatterGrid(EdgeWeightMethod method,
                     bool ownersFirst,
                     const std::vector<cpgrid::OpmWellType> * wells,
+                    bool serialPartitioning,
                     const double* transmissibilities,
                     bool addCornerCells, int overlapLayers);
 

--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -24,12 +24,131 @@
 #include <opm/grid/utility/OpmParserIncludes.hpp>
 #include <opm/grid/cpgrid/CpGridData.hpp>
 #include <opm/grid/cpgrid/Entity.hpp>
+#include <algorithm>
 
 #if defined(HAVE_ZOLTAN) && defined(HAVE_MPI)
 namespace Dune
 {
 namespace cpgrid
 {
+
+namespace {
+void setDefaultZoltanParameters(Zoltan_Struct* zz) {
+    Zoltan_Set_Param(zz, "IMBALANCE_TOL", "1.1");
+    Zoltan_Set_Param(zz, "DEBUG_LEVEL", "0");
+    Zoltan_Set_Param(zz, "LB_METHOD", "GRAPH");
+    Zoltan_Set_Param(zz, "LB_APPROACH", "PARTITION");
+    Zoltan_Set_Param(zz, "NUM_GID_ENTRIES", "1");
+    Zoltan_Set_Param(zz, "NUM_LID_ENTRIES", "1");
+    Zoltan_Set_Param(zz, "RETURN_LISTS", "ALL");
+    Zoltan_Set_Param(zz, "CHECK_GRAPH", "2");
+    Zoltan_Set_Param(zz,"EDGE_WEIGHT_DIM","0");
+    Zoltan_Set_Param(zz, "OBJ_WEIGHT_DIM", "0");
+    Zoltan_Set_Param(zz, "PHG_EDGE_SIZE_THRESHOLD", ".35");  /* 0-remove all, 1-remove none */
+}
+
+
+std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
+           std::vector<std::tuple<int,int,char> >,
+           std::vector<std::tuple<int,int,char,int> > >
+makeImportAndExportLists(const CpGrid& cpgrid,
+                         const CollectiveCommunication<MPI_Comm>& cc,
+                         const std::vector<OpmWellType> * wells,
+                         const CombinedGridWellGraph& gridAndWells,
+                         int root,
+                         int numExport,
+                         int numImport,
+                         const ZOLTAN_ID_PTR exportLocalGids,
+                         const ZOLTAN_ID_PTR exportGlobalGids,
+                         const int* exportToPart,
+                         const ZOLTAN_ID_PTR importGlobalGids) {
+    int                         size = cpgrid.numCells();
+    int                         rank  = cc.rank();
+    std::vector<int>            parts(size, rank);
+    std::vector<std::vector<int> > wellsOnProc;
+
+    // List entry: process to export to, (global) index, process rank, attribute there (not needed?)
+    std::vector<std::tuple<int,int,char>> myExportList(numExport);
+    // List entry: process to import from, global index, process rank, attribute here, local index
+    // (determined later)
+    std::vector<std::tuple<int,int,char,int>> myImportList(numImport);
+    myExportList.reserve(1.2*myExportList.size());
+    myImportList.reserve(1.2*myImportList.size());
+    using AttributeSet = CpGridData::AttributeSet;
+
+    for ( int i=0; i < numExport; ++i )
+    {
+        parts[exportLocalGids[i]] = exportToPart[i];
+        myExportList[i] = std::make_tuple(exportGlobalGids[i], exportToPart[i], static_cast<char>(AttributeSet::owner));
+    }
+
+    for ( int i=0; i < numImport; ++i )
+    {
+        myImportList[i] = std::make_tuple(importGlobalGids[i], root, static_cast<char>(AttributeSet::owner),-1);
+    }
+
+
+    // Add cells that stay here to the lists. Somehow I could not persuade Zoltan to do this.
+    for ( std::size_t i = 0; i < parts.size(); ++i)
+    {
+        if ( parts[i] == rank )
+        {
+            myExportList.emplace_back(i, rank, static_cast<char>(AttributeSet::owner) );
+            myImportList.emplace_back(i, rank, static_cast<char>(AttributeSet::owner), -1 );
+        }
+    }
+    std::inplace_merge(myImportList.begin(), myImportList.begin() + numImport, myImportList.end());
+    std::inplace_merge(myExportList.begin(), myExportList.begin() + numExport, myExportList.end());
+
+
+
+
+    if( wells )
+    {
+        auto gidGetter = [&cpgrid](int i) { return cpgrid.globalIdSet().id(createEntity<0>(cpgrid, i, true));};
+        wellsOnProc =
+            postProcessPartitioningForWells(parts,
+                                            gidGetter,
+                                            *wells,
+                                            gridAndWells.getWellConnections(),
+                                            myExportList, myImportList,
+                                            cc);
+
+
+#ifndef NDEBUG
+        int index = 0;
+        for( auto well : gridAndWells.getWellsGraph() )
+        {
+            int part=parts[index];
+            std::set<std::pair<int,int> > cells_on_other;
+            for( auto vertex : well )
+            {
+                if( part != parts[vertex] )
+                {
+                    cells_on_other.insert(std::make_pair(vertex, parts[vertex]));
+                }
+            }
+            if ( cells_on_other.size() )
+            {
+                OPM_THROW(std::domain_error, "Well is distributed between processes, which should not be the case!");
+            }
+            ++index;
+        }
+#endif
+    }
+
+    std::vector<std::pair<std::string,bool>> parallel_wells;
+    if( wells )
+    {
+        parallel_wells = computeParallelWells(wellsOnProc,
+                                              *wells,
+                                              cc,
+                                              root);
+    }
+    return std::make_tuple(parts, parallel_wells, myExportList, myImportList);
+}
+} // anon namespace
+
 std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
            std::vector<std::tuple<int,int,char> >,
            std::vector<std::tuple<int,int,char,int> > >
@@ -53,33 +172,23 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
     {
         OPM_THROW(std::runtime_error, "Could not initialize Zoltan!");
     }
-    Zoltan_Set_Param(zz, "IMBALANCE_TOL", "1.1");
-    Zoltan_Set_Param(zz, "DEBUG_LEVEL", "0");
-    Zoltan_Set_Param(zz, "LB_METHOD", "GRAPH");
-    Zoltan_Set_Param(zz, "LB_APPROACH", "PARTITION");
-    Zoltan_Set_Param(zz, "NUM_GID_ENTRIES", "1");
-    Zoltan_Set_Param(zz, "NUM_LID_ENTRIES", "1");
-    Zoltan_Set_Param(zz, "RETURN_LISTS", "ALL");
-    Zoltan_Set_Param(zz, "CHECK_GRAPH", "2");
-    Zoltan_Set_Param(zz,"EDGE_WEIGHT_DIM","0");
-    Zoltan_Set_Param(zz, "OBJ_WEIGHT_DIM", "0");
-    Zoltan_Set_Param(zz, "PHG_EDGE_SIZE_THRESHOLD", ".35");  /* 0-remove all, 1-remove none */
+    setDefaultZoltanParameters(zz);
 
     // For the load balancer one process has the whole grid and
     // all others an empty partition before loadbalancing.
     bool partitionIsEmpty     = cc.rank()!=root;
 
-    std::shared_ptr<CombinedGridWellGraph> grid_and_wells;
+    std::shared_ptr<CombinedGridWellGraph> gridAndWells;
 
     if( wells )
     {
         Zoltan_Set_Param(zz,"EDGE_WEIGHT_DIM","1");
-        grid_and_wells.reset(new CombinedGridWellGraph(cpgrid,
+        gridAndWells.reset(new CombinedGridWellGraph(cpgrid,
                                                        wells,
                                                        transmissibilities,
                                                        partitionIsEmpty,
                                                        edgeWeightsMethod));
-        Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, *grid_and_wells,
+        Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, *gridAndWells,
                                                     partitionIsEmpty);
     }
     else
@@ -101,90 +210,165 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
                              &exportLocalGids,   /* Local IDs of the vertices I must send */
                              &exportProcs,    /* Process to which I send each of the vertices */
                              &exportToPart);  /* Partition to which each vertex will belong */
-    int                         size = cpgrid.numCells();
-    int                         rank  = cc.rank();
-    std::vector<int>            parts(size, rank);
-    std::vector<std::vector<int> > wells_on_proc;
-    // List entry: process to export to, (global) index, process rank, attribute there (not needed?)
-    std::vector<std::tuple<int,int,char>> myExportList(numExport);
-    // List entry: process to import from, global index, process rank, attribute here, local index
-    // (determined later)
-    std::vector<std::tuple<int,int,char,int>>myImportList(numImport);
-    myExportList.reserve(1.2*myExportList.size());
-    myImportList.reserve(1.2*myImportList.size());
-    using AttributeSet = CpGridData::AttributeSet;
 
-    for ( int i=0; i < numExport; ++i )
-    {
-        parts[exportLocalGids[i]] = exportProcs[i];
-        myExportList[i] = std::make_tuple(exportGlobalGids[i], exportProcs[i], static_cast<char>(AttributeSet::owner));
-    }
-
-    for ( int i=0; i < numImport; ++i )
-    {
-        myImportList[i] = std::make_tuple(importGlobalGids[i], importProcs[i], static_cast<char>(AttributeSet::owner),-1);
-    }
-    // Add cells that stay here to the lists. Somehow I could not persuade Zoltan to do this.
-    for ( std::size_t i = 0; i < parts.size(); ++i)
-    {
-        if ( parts[i] == rank )
-        {
-            myExportList.emplace_back(i, rank, static_cast<char>(AttributeSet::owner) );
-            myImportList.emplace_back(i, rank, static_cast<char>(AttributeSet::owner), -1 );
-        }
-    }
-
-    std::inplace_merge(myImportList.begin(), myImportList.begin() + numImport, myImportList.end());
-    std::inplace_merge(myExportList.begin(), myExportList.begin() + numExport, myExportList.end());
-    // free space allocated for zoltan.
+    auto importExportLists = makeImportAndExportLists(cpgrid,
+                                     cc,
+                                     wells,
+                                     *gridAndWells,
+                                     root,
+                                     numExport,
+                                     numImport,
+                                     exportLocalGids,
+                                     exportGlobalGids,
+                                     exportProcs,
+                                     importGlobalGids);
     Zoltan_LB_Free_Part(&exportGlobalGids, &exportLocalGids, &exportProcs, &exportToPart);
     Zoltan_LB_Free_Part(&importGlobalGids, &importLocalGids, &importProcs, &importToPart);
     Zoltan_Destroy(&zz);
 
-    std::vector<std::pair<std::string,bool>> parallel_wells;
+    return importExportLists;
+}
 
-    if( wells )
-    {
-        auto gidGetter = [&cpgrid](int i) { return cpgrid.globalIdSet().id(createEntity<0>(cpgrid, i, true));};
-        wells_on_proc =
-            postProcessPartitioningForWells(parts,
-                                            gidGetter,
-                                            *wells,
-                                            grid_and_wells->getWellConnections(),
-                                            myExportList, myImportList,
-                                            cc);
+std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
+           std::vector<std::tuple<int,int,char> >,
+           std::vector<std::tuple<int,int,char,int> > >
+zoltanSerialGraphPartitionGridOnRoot(const CpGrid& cpgrid,
+                               const std::vector<OpmWellType> * wells,
+                               const double* transmissibilities,
+                               const CollectiveCommunication<MPI_Comm>& cc,
+                               EdgeWeightMethod edgeWeightsMethod, int root)
+{
+    int rc = ZOLTAN_OK - 1;
+    struct Zoltan_Struct *zz;
+    int changes, numGidEntries = 0, numLidEntries = 0, numImport = 0, numExport = 0;
+    ZOLTAN_ID_PTR importGlobalGids = nullptr, importLocalGids = nullptr, exportGlobalGids = nullptr, exportLocalGids = nullptr;
+    int *importProcs, *importToPart, *exportProcs, *exportToPart;
+    std::shared_ptr<CombinedGridWellGraph> gridAndWells;
+    MPI_Barrier(cc);
+    if (cc.rank() == root) {
+        int argc=0;
+        char** argv = 0;
+        float ver = 0;
 
-#ifndef NDEBUG
-        int index = 0;
-        for( auto well : grid_and_wells->getWellsGraph() )
+        rc = Zoltan_Initialize(argc, argv, &ver);
+        zz = Zoltan_Create(MPI_COMM_SELF);
+        if ( rc != ZOLTAN_OK )
         {
-            int part=parts[index];
-            std::set<std::pair<int,int> > cells_on_other;
-            for( auto vertex : well )
-            {
-                if( part != parts[vertex] )
-                {
-                    cells_on_other.insert(std::make_pair(vertex, parts[vertex]));
-                }
-            }
-            if ( cells_on_other.size() )
-            {
-                OPM_THROW(std::domain_error, "Well is distributed between processes, which should not be the case!");
-            }
-            ++index;
+            OPM_THROW(std::runtime_error, "Could not initialize Zoltan!");
         }
-#endif
+
+        setDefaultZoltanParameters(zz);
+        Zoltan_Set_Param(zz, "NUM_GLOBAL_PARTS", std::to_string(cc.size()).c_str());
+
+        // For the load balancer one process has the whole grid and
+        // all others an empty partition before loadbalancing.
+        bool partitionIsEmpty     = cc.rank()!=root;
+
+        if( wells )
+        {
+            Zoltan_Set_Param(zz,"EDGE_WEIGHT_DIM","1");
+            gridAndWells.reset(new CombinedGridWellGraph(cpgrid,
+                                                           wells,
+                                                           transmissibilities,
+                                                           partitionIsEmpty,
+                                                           edgeWeightsMethod));
+            Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, *gridAndWells,
+                                                        partitionIsEmpty);
+        }
+        else
+        {
+            Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, cpgrid, partitionIsEmpty);
+        }
+
+        rc = Zoltan_LB_Partition(zz, /* input (all remaining fields are output) */
+                                 &changes,        /* 1 if partitioning was changed, 0 otherwise */
+                                 &numGidEntries,  /* Number of integers used for a global ID */
+                                 &numLidEntries,  /* Number of integers used for a local ID */
+                                 &numImport,      /* Number of vertices to be sent to me */
+                                 &importGlobalGids,  /* Global IDs of vertices to be sent to me */
+                                 &importLocalGids,   /* Local IDs of vertices to be sent to me */
+                                 &importProcs,    /* Process rank for source of each incoming vertex */
+                                 &importToPart,   /* New partition for each incoming vertex */
+                                 &numExport,      /* Number of vertices I must send to other processes*/
+                                 &exportGlobalGids,  /* Global IDs of the vertices I must send */
+                                 &exportLocalGids,   /* Local IDs of the vertices I must send */
+                                 &exportProcs,    /* Process to which I send each of the vertices */
+                                 &exportToPart);  /* Partition to which each vertex will belong */
+
+        // This is very important: by default, zoltan sets numImport to -1,
+        // as we are only running Zoltan in serial.
+        // In order to make sense of the rest of  the code, this must be set
+        // to 0.
+        numImport = 0;
+
+
+    }
+    MPI_Barrier(cc);
+    std::vector<unsigned int> importGlobalGidsVector;
+    if (cc.rank() == root) {
+        std::vector<int> numberOfExportedVerticesPerProcess(cc.size(), 0);
+        for (int i = 0; i < numExport; ++i) {
+            numberOfExportedVerticesPerProcess[exportToPart[i]]++;
+        }
+        int dummyForRoot = 0;
+        cc.scatter<int>(numberOfExportedVerticesPerProcess.data(), &dummyForRoot, 1, root);
+
+
+        std::vector<int> offsets(cc.size() + 1, 0);
+        std::partial_sum(numberOfExportedVerticesPerProcess.begin(),
+                         numberOfExportedVerticesPerProcess.end(), offsets.begin() + 1);
+        std::vector<unsigned int> globalIndicesToSend(numExport, 0);
+        std::vector<int> currentIndex(cc.size(), 0);
+        for (int i = 0; i < numExport; ++i) {
+            if (exportToPart[i] >= currentIndex.size()) {
+                OPM_THROW(std::runtime_error, "Something wrong with Zoltan decomposition. "
+                          << "Debug information: exportToPart[i] = "
+                          << exportToPart[i] << ", " << "currentIndex.size() = " << currentIndex.size());
+            }
+            const auto index = currentIndex[exportToPart[i]]++ + offsets[exportToPart[i]];
+
+            if (index >= globalIndicesToSend.size()) {
+                OPM_THROW(std::runtime_error, "Something wrong with Zoltan decomposition. "
+                          << "index " << index << ", " << "globalIndicesToSend.size() = "
+                          << globalIndicesToSend.size()
+                          << "\n\noffsets[exportToPart[i]] = " << offsets[exportToPart[i]]
+                          << "\n\ncurrentIndex[exportToPart[i]] = "<< currentIndex[exportToPart[i]]
+                          <<"\n\nexportToPart[i] = " << exportToPart[i]);
+            }
+
+            globalIndicesToSend[index] = exportGlobalGids[i];
+        }
+        std::vector<unsigned int> dummyIndicesForRoot(numExport, 0);
+        cc.scatterv<unsigned int>(globalIndicesToSend.data(), numberOfExportedVerticesPerProcess.data(),
+                     offsets.data(), dummyIndicesForRoot.data(), 0, root);
+    } else {
+        cc.scatter<int>(nullptr, &numImport, 1, root);
+        importGlobalGidsVector.resize(numImport, 0);
+        cc.scatterv<unsigned int>(nullptr, nullptr, nullptr, importGlobalGidsVector.data(),
+                         numImport, root);
+        importGlobalGids = importGlobalGidsVector.data();
     }
 
-    if( wells )
-    {
-        parallel_wells = computeParallelWells(wells_on_proc,
-                                              *wells,
-                                              cc,
-                                              root);
+    auto importExportLists = makeImportAndExportLists(cpgrid,
+                                 cc,
+                                 wells,
+                                 *gridAndWells,
+                                 root,
+                                 numExport,
+                                 numImport,
+                                 exportLocalGids,
+                                 exportGlobalGids,
+                                 exportToPart,
+                                 importGlobalGids);
+
+    // free space allocated for zoltan.
+    if (cc.rank() == root) {
+        Zoltan_LB_Free_Part(&exportGlobalGids, &exportLocalGids, &exportProcs, &exportToPart);
+        Zoltan_LB_Free_Part(&importGlobalGids, &importLocalGids, &importProcs, &importToPart);
+        Zoltan_Destroy(&zz);
     }
 
-    return std::make_tuple(parts, parallel_wells, myExportList, myImportList);
+    return importExportLists;
 }
 }
 }

--- a/opm/grid/common/ZoltanPartition.hpp
+++ b/opm/grid/common/ZoltanPartition.hpp
@@ -62,6 +62,40 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& grid,
                                const double* transmissibilities,
                                const CollectiveCommunication<MPI_Comm>& cc,
                                EdgeWeightMethod edgeWeightsMethod, int root);
+
+/// \brief Partition a CpGrid using Zoltan
+///
+/// This function will extract Zoltan's graph information
+/// from the grid, and the wells and use it to partition the grid.
+/// In case the global grid is available on all processes, it
+/// will nevertheless only use the information on the root process
+/// to partition it as Zoltan cannot identify this situation.
+/// @param grid The grid to partition
+/// @param wells The wells of the eclipse If null wells will be neglected.
+/// @param transmissibilities The transmissibilities associated with the
+///             faces
+/// @paramm cc  The MPI communicator to use for the partitioning.
+///             The will be partitioned among the partiticipating processes.
+/// @param edgeWeightMethod The method used to calculate the weights associated
+///             with the edges of the graph (uniform, transmissibilities, log thereof)
+/// @param root The process number that holds the global grid.
+/// @return A tuple consisting of a vector that contains for each local cell of the original grid the
+///         the number of the process that owns it after repartitioning,
+///         a set of names of wells that should be defunct in a parallel
+///         simulation, vector containing information for each exported cell (global id
+///         of cell, process id to send to, attribute there), and a vector containing
+///         information for each imported cell (global index, process id that sends, attribute here, local index
+///         here)
+///
+/// @note This function will only do *serial* partioning.
+std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
+           std::vector<std::tuple<int,int,char> >,
+           std::vector<std::tuple<int,int,char,int> >  >
+zoltanSerialGraphPartitionGridOnRoot(const CpGrid& grid,
+                               const std::vector<OpmWellType> * wells,
+                               const double* transmissibilities,
+                               const CollectiveCommunication<MPI_Comm>& cc,
+                               EdgeWeightMethod edgeWeightsMethod, int root);
 }
 }
 #endif // HAVE_ZOLTAN

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -159,7 +159,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
     {
 #ifdef HAVE_ZOLTAN
         auto part_and_wells =
-            cpgrid::zoltanGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0);
+            cpgrid::zoltanSerialGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0);
         using std::get;
         auto cell_part = std::get<0>(part_and_wells);
         auto wells_on_proc = std::get<1>(part_and_wells);

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -137,8 +137,10 @@ std::pair<bool, std::vector<std::pair<std::string,bool> > >
 CpGrid::scatterGrid(EdgeWeightMethod method,
                     [[maybe_unused]] bool ownersFirst,
                     const std::vector<cpgrid::OpmWellType> * wells,
+                    [[maybe_unused]] bool serialPartitioning,
                     const double* transmissibilities,
-                    [[maybe_unused]] bool addCornerCells, int overlapLayers)
+                    [[maybe_unused]] bool addCornerCells,
+                    int overlapLayers)
 {
     // Silence any unused argument warnings that could occur with various configurations.
     static_cast<void>(wells);
@@ -158,8 +160,9 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
     if (cc.size() > 1)
     {
 #ifdef HAVE_ZOLTAN
-        auto part_and_wells =
-            cpgrid::zoltanSerialGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0);
+        auto part_and_wells = serialPartitioning
+            ? cpgrid::zoltanSerialGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0)
+            : cpgrid::zoltanGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0);
         using std::get;
         auto cell_part = std::get<0>(part_and_wells);
         auto wells_on_proc = std::get<1>(part_and_wells);


### PR DESCRIPTION
This replaces #488.

This has been rebased on master, and squashed into the first commit. The second commits adds the option to choose partitioning at runtime.

A note on argument order: I put the new bool argument between the wells and trans arguments to avoid possible argument mistakes, especially since the myriad loadBalance() variants have lots of default arguments. (Why are there so many? Six main variants, or 20(!) if you count various defaulting possibilities. Happily they all call the same scatterGrid() method.)

Since this changes the API for one of the loadBalance() methods (the one used from Flow) a downstream PR is required.