### PR TITLE
Allow partitioning without zoltan by cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ cmake_minimum_required (VERSION 2.8)
 
 option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)
 option(ENABLE_3DPROPS_TESTING "Build and use the new experimental 3D properties" OFF)
+option(REQUIRE_ZOLTAN "Require Zoltan to be found (needed for productive run" ON)
 if (ENABLE_3DPROPS_TESTING)
   add_definitions(-DENABLE_3DPROPS_TESTING)
 endif()
@@ -90,10 +91,10 @@ macro (config_hook)
 	list (APPEND ${project}_CONFIG_IMPL_VARS
 		HAVE_DUNE_GRID_CHECKS
 		)
-	if(NOT ZOLTAN_FOUND AND MPI_C_FOUND)
+	if(NOT ZOLTAN_FOUND AND MPI_C_FOUND AND REQUIRE_ZOLTAN)
 		message(SEND_ERROR "opm-grid with MPI support requires the package ZOLTAN."
 			"Please install it (e.g. from http://www.cs.sandia.gov/zoltan/.)")
-	endif(NOT ZOLTAN_FOUND AND MPI_C_FOUND)
+	endif(NOT ZOLTAN_FOUND AND MPI_C_FOUND AND REQUIRE_ZOLTAN)
 endmacro (config_hook)
 
 macro (prereqs_hook)

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -704,7 +704,11 @@ namespace Dune
                     int overlapLayers=1, bool useZoltan = true)
         {
             auto ret = loadBalance(wells, transmissibilities, overlapLayers, useZoltan);
-            scatterData(data);
+            using std::get;
+            if (get<0>(ret))
+            {
+                scatterData(data);
+            }
             return ret;
         }
 
@@ -742,7 +746,11 @@ namespace Dune
                     bool addCornerCells=false, int overlapLayers=1, bool useZoltan = true)
         {
             auto ret = scatterGrid(method, ownersFirst, wells, serialPartitioning, transmissibilities, addCornerCells, overlapLayers, useZoltan);
-            scatterData(data);
+            using std::get;
+            if (get<0>(ret))
+            {
+                scatterData(data);
+            }
             return ret;
         }
 
@@ -759,7 +767,10 @@ namespace Dune
                          int overlapLayers=1, bool useZoltan = true)
         {
             bool ret = loadBalance(overlapLayers, useZoltan);
-            scatterData(data);
+            if (ret)
+            {
+                scatterData(data);
+            }
             return ret;
         }
 

--- a/opm/grid/common/WellConnections.hpp
+++ b/opm/grid/common/WellConnections.hpp
@@ -40,6 +40,7 @@
 
 
 #include <opm/grid/utility/OpmParserIncludes.hpp>
+#include <opm/grid/CpGrid.hpp>
 
 namespace Dune
 {
@@ -65,7 +66,7 @@ public:
     WellConnections() = default;
 
     /// \brief Constructor
-    /// \param schedule The eclipse information
+    /// \param wells The eclipse information about the wells
     /// \param cartesianSize The logical cartesian size of the grid.
     /// \param cartesian_to_compressed Mapping of cartesian index
     ///        compressed cell index. The compressed index is used
@@ -73,6 +74,15 @@ public:
     WellConnections(const std::vector<OpmWellType>& wells,
                     const std::array<int, 3>& cartesianSize,
                     const std::vector<int>& cartesian_to_compressed);
+
+    /// \brief Constructor
+    /// \param wells The eclipse information about the wells
+    /// \param cpGrid The corner point grid
+    /// \param cartesian_to_compressed Mapping of cartesian index
+    ///        compressed cell index. The compressed index is used
+    ///        to represent the well conditions.
+    WellConnections(const std::vector<OpmWellType>& wells,
+                    const Dune::CpGrid& cpGrid);
 
     /// \brief Initialze the data of the container
     /// \param schedule The eclipse information
@@ -118,6 +128,22 @@ private:
 
 
 #ifdef HAVE_MPI
+/// \brief Determines the wells that have peforate cells for each process.
+///
+/// On the root process omputes for all processes all indices of wells that
+/// will perforate local cells.
+/// Note that a well might perforate local cells of multiple processes
+///
+/// \param parts The partition number for each cell
+/// \param well The eclipse information about the wells.
+/// \param cpGrid The unbalanced grid we compute on.
+/// \return On the rank that has the global grid a vector with the well
+///         indices for process i at index i.
+std::vector<std::vector<int> >
+perforatingWellIndicesOnProc(const std::vector<int>& parts,
+                  const std::vector<Dune::cpgrid::OpmWellType>& wells,
+                  const CpGrid& cpgrid);
+
 /// \brief Computes wells assigned to processes.
 ///
 /// Computes for all processes all indices of wells that
@@ -133,6 +159,8 @@ private:
 ///                   global cell index, the process rank that exports it, and the
 ///                   attribute on this rank (assumed to be owner)
 /// \param cc Information about the parallelism together with the decomposition.
+/// \return On rank 0 a vector with the well indices for process i
+///         at index i.
 std::vector<std::vector<int> >
 postProcessPartitioningForWells(std::vector<int>& parts,
                                 std::function<int(int)> gid,

--- a/opm/grid/common/WellConnections.hpp
+++ b/opm/grid/common/WellConnections.hpp
@@ -78,9 +78,6 @@ public:
     /// \brief Constructor
     /// \param wells The eclipse information about the wells
     /// \param cpGrid The corner point grid
-    /// \param cartesian_to_compressed Mapping of cartesian index
-    ///        compressed cell index. The compressed index is used
-    ///        to represent the well conditions.
     WellConnections(const std::vector<OpmWellType>& wells,
                     const Dune::CpGrid& cpGrid);
 

--- a/opm/grid/common/ZoltanGraphFunctions.hpp
+++ b/opm/grid/common/ZoltanGraphFunctions.hpp
@@ -112,7 +112,14 @@ void getCpGridWellsEdgeList(void *cpGridWellsPointer, int sizeGID, int sizeLID,
                        int *num_edges,
                        ZOLTAN_ID_PTR nborGID, int *nborProc,
                        int wgt_dim, float *ewgts, int *err);
+} // end namespace cpgrid
+} // end namespace Dune
 
+#endif // HAVE_ZOLTAN
+namespace Dune
+{
+namespace cpgrid
+{
 /// \brief A graph repesenting a grid together with the well completions.
 ///
 /// The edges of the graph are formed by the superset of the edges representing
@@ -224,7 +231,7 @@ private:
     double log_min_;
 };
 
-
+#ifdef HAVE_ZOLTAN
 /// \brief Sets up the call-back functions for ZOLTAN's graph partitioning.
 /// \param zz The struct with the information for ZOLTAN.
 /// \param grid The grid to partition.
@@ -235,8 +242,8 @@ void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz, const Dune::CpGrid& grid,
 void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz,
                                    const CombinedGridWellGraph& graph,
                                    bool pretendNull);
+#endif // HAVE_ZOLTAN
 } // end namespace cpgrid
 } // end namespace Dune
 
-#endif // HAVE_ZOLTAN
 #endif // header guard

--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -47,7 +47,8 @@ makeImportAndExportLists(const Dune::CpGrid& cpgrid,
                          const Id* exportLocalGids,
                          const Id* exportGlobalGids,
                          const int* exportToPart,
-                         const Id* importGlobalGids) {
+                         const Id* importGlobalGids,
+                         bool allowDistributedWells) {
 
     int                         size = cpgrid.numCells();
     int                         rank  = cc.rank();
@@ -90,7 +91,7 @@ makeImportAndExportLists(const Dune::CpGrid& cpgrid,
 
 
 
-    if( wells )
+    if( wells && ! allowDistributedWells)
     {
         auto gidGetter = [&cpgrid](int i) { return cpgrid.globalIdSet().id(Dune::createEntity<0>(cpgrid, i, true));};
         wellsOnProc =

--- a/opm/grid/common/ZoltanPartition.hpp
+++ b/opm/grid/common/ZoltanPartition.hpp
@@ -24,7 +24,35 @@
 
 #include <opm/grid/CpGrid.hpp>
 #include <opm/grid/common/ZoltanGraphFunctions.hpp>
+#if HAVE_MPI
+namespace Dune
+{
+namespace cpgrid
+{
+template<class Id>
+std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
+           std::vector<std::tuple<int,int,char> >,
+           std::vector<std::tuple<int,int,char,int> > >
+makeImportAndExportLists(const Dune::CpGrid& cpgrid,
+                         const Dune::CollectiveCommunication<MPI_Comm>& cc,
+                         const std::vector<Dune::cpgrid::OpmWellType> * wells,
+                         const Dune::cpgrid::CombinedGridWellGraph* gridAndWells,
+                         int root,
+                         int numExport,
+                         int numImport,
+                         const Id* exportLocalGids,
+                         const Id* exportGlobalGids,
+                         const int* exportToPart,
+                         const Id* importGlobalGids);
 
+template<class Id>
+std::tuple<int, std::vector<Id> >
+scatterExportInformation(int numExport, const Id* exportGlobalGids,
+                         const int* exportToPart, int root,
+                         const Dune::CollectiveCommunication<MPI_Comm>& cc);
+} // end namespace cpgrid
+} // end namespace Dune
+#endif //HAVE_MPI
 #if defined(HAVE_ZOLTAN) && defined(HAVE_MPI)
 namespace Dune
 {

--- a/opm/grid/common/ZoltanPartition.hpp
+++ b/opm/grid/common/ZoltanPartition.hpp
@@ -43,7 +43,8 @@ makeImportAndExportLists(const Dune::CpGrid& cpgrid,
                          const Id* exportLocalGids,
                          const Id* exportGlobalGids,
                          const int* exportToPart,
-                         const Id* importGlobalGids);
+                         const Id* importGlobalGids,
+                         bool allowDistributedWells = false);
 
 template<class Id>
 std::tuple<int, std::vector<Id> >

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -229,7 +229,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
                                              exportGlobalIds.data(),
                                              exportToPart.data(),
                                              importGlobalIds.data(),
-                                             true);
+                                             /* allowDistributedWells = */ false);
         }
 
         // first create the overlap

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -52,6 +52,7 @@
 #include <fstream>
 #include <iostream>
 #include <iomanip>
+#include <tuple>
 
 namespace
 {
@@ -140,7 +141,8 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
                     [[maybe_unused]] bool serialPartitioning,
                     const double* transmissibilities,
                     [[maybe_unused]] bool addCornerCells,
-                    int overlapLayers)
+                    int overlapLayers,
+                    bool useZoltan)
 {
     // Silence any unused argument warnings that could occur with various configurations.
     static_cast<void>(wells);
@@ -159,49 +161,76 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
 
     if (cc.size() > 1)
     {
+        std::vector<int> cell_part;
+        std::vector<std::pair<std::string,bool>> wells_on_proc;
+        std::vector<std::tuple<int,int,char>> exportList;
+        std::vector<std::tuple<int,int,char,int>> importList;
+
+        if (useZoltan)
+        {
 #ifdef HAVE_ZOLTAN
-        auto part_and_wells = serialPartitioning
-            ? cpgrid::zoltanSerialGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0)
-            : cpgrid::zoltanGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0);
-        using std::get;
-        auto cell_part = std::get<0>(part_and_wells);
-        auto wells_on_proc = std::get<1>(part_and_wells);
-        auto exportList = std::get<2>(part_and_wells);
-        auto importList = std::get<3>(part_and_wells);
+            std::tie(cell_part, wells_on_proc, exportList, importList)
+                = serialPartitioning
+                ? cpgrid::zoltanSerialGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0)
+                : cpgrid::zoltanGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0);
 #else
-        OPM_THROW(std::runtime_error, "Parallel runs depend on ZOLTAN. Please install!");
-        // std::vector<int> cell_part(current_view_data_->global_cell_.size());
-        // int  num_parts=-1;
-        // std::array<int, 3> initial_split;
-        // initial_split[1]=initial_split[2]=std::pow(cc.size(), 1.0/3.0);
-        // initial_split[0]=cc.size()/(initial_split[1]*initial_split[2]);
-        // partition(*this, initial_split, num_parts, cell_part, false, false);
-        // const auto& cpgdim =  logicalCartesianSize();
-        // std::vector<int> cartesian_to_compressed(cpgdim[0]*cpgdim[1]*cpgdim[2], -1);
-        // for( int i=0; i < numCells(); ++i )
-        // {
-        //     cartesian_to_compressed[globalCell()[i]] = i;
-        // }
+            OPM_THROW(std::runtime_error, "Parallel runs depend on ZOLTAN if useZoltan is true. Please install!");
+#endif // HAVE_ZOLTAN
+        }
+        else
+        {
+        std::vector<int> exportGlobalIds;
+        std::vector<int> exportLocalIds;
+        std::vector<int> exportToPart;
+        std::vector<int> importGlobalIds;
+        std::size_t numExport = 0;
+        int root = 0;
 
-        // std::unordered_set<std::string> defunct_wells;
-
-        // if ( wells )
-        // {
-        //     cpgrid::WellConnections well_connections(*wells,
-        //                                              cpgdim,
-        //                                              cartesian_to_compressed);
-
-        //     auto wells_on_proc =
-        //         cpgrid::postProcessPartitioningForWells(cell_part,
-        //                                                 *wells,
-        //                                                 well_connections,
-        //                                                 cc.size());
-        //     defunct_wells = cpgrid::computeDefunctWellNames(wells_on_proc,
-        //                                                     *wells,
-        //                                                     cc,
-        //                                                     0);
-        // }
-#endif
+        if (cc.rank() == root)
+        {
+            std::vector<int> parts(current_view_data_->global_cell_.size());
+            int  numParts=-1;
+            std::array<int, 3> initialSplit;
+            initialSplit[1]=initialSplit[2]=std::pow(cc.size(), 1.0/3.0);
+            initialSplit[0]=cc.size()/(initialSplit[1]*initialSplit[2]);
+            partition(*this, initialSplit, numParts, parts, false, false);
+            // Create export lists as from Zoltan output, do not include part 0!
+            exportGlobalIds.reserve(numCells());
+            exportLocalIds.reserve(numCells());
+            exportToPart.reserve(numCells());
+            for (auto cell = leafbegin<0>(), cellEnd = leafend<0>();
+                 cell != cellEnd; ++cell)
+            {
+                const auto& gid = globalIdSet().id(*cell);
+                const auto& lid = localIdSet().id(*cell);
+                const auto& index = leafIndexSet().index(cell);
+                const auto& part = parts[index];
+                if (part != 0 )
+                {
+                    exportGlobalIds.push_back(gid);
+                    exportLocalIds.push_back(lid);
+                    exportToPart.push_back(part);
+                    ++numExport;
+                }
+            }
+        }
+        int numImport = 0;
+        std::tie(numImport, importGlobalIds) =
+            cpgrid::scatterExportInformation(numExport, exportGlobalIds.data(),
+                                             exportToPart.data(), 0, cc);
+        std::tie(cell_part, wells_on_proc, exportList, importList) =
+            cpgrid::makeImportAndExportLists(*this, comm(),
+                                             wells,
+                                             nullptr,
+                                             root,
+                                             numExport,
+                                             numImport,
+                                             exportLocalIds.data(),
+                                             exportGlobalIds.data(),
+                                             exportToPart.data(),
+                                             importGlobalIds.data(),
+                                             true);
+        }
 
         // first create the overlap
         // map from process to global cell indices in overlap

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -538,7 +538,7 @@ BOOST_AUTO_TEST_CASE(distribute)
 
         const Dune::CpGrid::LeafIndexSet& ix1 = grid.leafIndexSet();
 #if HAVE_MPI
-        BOOST_REQUIRE(&ix!=&ix1);
+        BOOST_REQUIRE(&ix==&ix1);
 #endif
 
         for (Dune::CpGrid::Codim<0>::LeafIterator it = grid.leafbegin<0>();

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -26,6 +26,11 @@
 
 #include <opm/grid/utility/platform_dependent/reenable_warnings.h>
 
+#ifdef HAVE_ZOLTAN
+bool USE_ZOLTAN = true;
+#else
+bool USE_ZOLTAN = false;
+#endif
 
 #if HAVE_MPI
 class MPIError {
@@ -334,7 +339,7 @@ BOOST_AUTO_TEST_CASE(testDistributedComm)
     std::array<double, 3> size={{ 8.0, 4.0, 2.0}};
     //grid.setUniqueBoundaryIds(true); // set and compute unique boundary ids.
     grid.createCartesian(dims, size);
-    grid.loadBalance();
+    grid.loadBalance(1, USE_ZOLTAN);
 #ifdef HAVE_DUNE_ISTL
     using AttributeSet = Dune::OwnerOverlapCopyAttributeSet::AttributeSet;
 #else
@@ -366,7 +371,7 @@ BOOST_AUTO_TEST_CASE(compareWithSequential)
     grid.setUniqueBoundaryIds(true); // set and compute unique boundary ids.
     seqGrid.setUniqueBoundaryIds(true);
     grid.createCartesian(dims, size);
-    grid.loadBalance();
+    grid.loadBalance(1, USE_ZOLTAN);
     seqGrid.createCartesian(dims, size);
 
     auto idSet = grid.globalIdSet(), seqIdSet = seqGrid.globalIdSet();
@@ -508,7 +513,7 @@ BOOST_AUTO_TEST_CASE(distribute)
     const Dune::CpGrid::GlobalIdSet& unbalanced_gid_set=grid.globalIdSet();
 
     grid.communicate(data, Dune::All_All_Interface, Dune::ForwardCommunication);
-    grid.loadBalance(data);
+    grid.loadBalance(data, 1, USE_ZOLTAN);
 
     if ( grid.numCells())
     {
@@ -587,7 +592,41 @@ BOOST_AUTO_TEST_CASE(cellGatherScatterWithMPI)
     typedef Dune::CpGrid::LeafGridView GridView;
     enum{dimWorld = GridView::dimensionworld};
 
-    grid.loadBalance();
+    grid.loadBalance(1, USE_ZOLTAN);
+    auto global_grid = grid;
+    global_grid.switchToGlobalView();
+
+    auto scatter_handle = CheckGlobalCellHandle(global_grid.globalCell(),
+                                                grid.globalCell());
+    auto gather_handle  = CheckGlobalCellHandle(grid.globalCell(),
+                                                global_grid.globalCell());
+    auto bid_handle     = CheckBoundaryIdHandle(global_grid, grid);
+
+#if HAVE_MPI
+    Dune::VariableSizeCommunicator<> scatter_gather_comm(grid.comm(), grid.cellScatterGatherInterface(), 8*4*2*8);
+    scatter_gather_comm.forward(scatter_handle);
+    scatter_gather_comm.backward(gather_handle);
+    scatter_gather_comm.forward(bid_handle);
+#else
+    (void) scatter_handle;
+    (void) gather_handle;
+    (void) bid_handle;
+#endif
+}
+// A small test that gathers/scatter the global cell indices.
+// On the sending side these are sent and on the receiving side
+// these are check with the globalCell values.
+BOOST_AUTO_TEST_CASE(cellGatherScatterWithMPIWithoutZoltan)
+{
+
+    Dune::CpGrid grid;
+    std::array<int, 3> dims={{8, 4, 2}};
+    std::array<double, 3> size={{ 8.0, 4.0, 2.0}};
+    grid.createCartesian(dims, size);
+    typedef Dune::CpGrid::LeafGridView GridView;
+    enum{dimWorld = GridView::dimensionworld};
+
+    grid.loadBalance(1, false);
     auto global_grid = grid;
     global_grid.switchToGlobalView();
 
@@ -624,7 +663,7 @@ BOOST_AUTO_TEST_CASE(intersectionOverlap)
     typedef GridView::Codim<0>::Iterator ElementIterator;
     typedef typename GridView::IntersectionIterator IntersectionIterator;
 
-    grid.loadBalance();
+    grid.loadBalance(1, USE_ZOLTAN);
     ElementIterator endEIt = gridView.end<0>();
     for (ElementIterator eIt = gridView.begin<0>(); eIt != endEIt; ++eIt) {
         IntersectionIterator isEndIt = gridView.iend(eIt);


### PR DESCRIPTION
Default is still to require Zoltan. But this will give me the option to test without it (to force wells to be distributed). Even if that is not possible, most of the code will be needed to allow a force loadbalance (by providing the partition number for each cell from outside.

This should not change anything for flow.