### PR TITLE
Improve warning message for invalid NNC

### DIFF
--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -167,16 +167,12 @@ namespace cpgrid
             nnc_cells[PinchNNC].insert({low, high});
         }
         // Add explicit NNCs.
-        for (const auto single_nnc : nncs.data()) {
-            // Repeated NNCs will only exist in the map once
-            // (repeated insertions have no effect), and we make
-            // sure NNCs specified using either order of cells
-            // end up with the same {low, high} pair.
-            // The code that computes the transmissibilities is responsible
-            // for ensuring repeated NNC transmissibilities are added.
-            auto low = std::min(single_nnc.cell1, single_nnc.cell2);
-            auto high = std::max(single_nnc.cell1, single_nnc.cell2);
-            nnc_cells[ExplicitNNC].insert({low, high});
+        for (const auto single_nnc : nncs.input()) {
+            // Repeated NNCs will only exist in the map once (repeated
+            // insertions have no effect). The code that computes the
+            // transmissibilities is responsible for ensuring repeated NNC
+            // transmissibilities are added.
+            nnc_cells[ExplicitNNC].insert({single_nnc.cell1, single_nnc.cell2});
         }
 
         // this variable is only required because getCellZvals() needs


### PR DESCRIPTION
Downstream of: https://github.com/OPM/opm-common/pull/2095

OK: It started out as work to reduce/improve warnings about invalid NNCs, but in the process the following things happened:

1. The initial processing of NNCs in opm-common was refactored, thereby filtering out a large fraction of the warnings due to coupling to inactive cells.

2. It turned out that the remaining warnings about NNC problems came from handling the `EDITNNC` keyword in the transmissibility calculations in opm-simulators.

So - all in all this PR is now only a tiny adaption to upstream changes in opm-common