### PR TITLE
Support partition with external loadbalancing information

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -767,9 +767,57 @@ namespace Dune
         /// \warning May only be called once.
         template<class DataHandle>
         bool loadBalance(DataHandle& data,
-                         int overlapLayers=1, bool useZoltan = true)
+                         decltype(data.fixedsize(0,0)) overlapLayers=1, bool useZoltan = true)
         {
+            // decltype usage needed to tell the compiler not to use this function if first
+            // argument is std::vector but rather loadbalance by parts
             bool ret = loadBalance(overlapLayers, useZoltan);
+            if (ret)
+            {
+                scatterData(data);
+            }
+            return ret;
+        }
+
+        /// \brief Distributes this grid over the available nodes in a distributed machine
+        /// \param parts The partitioning information. For a cell with local index i the entry
+        ///              parts[i] is the partion number. Partition numbers need to start with zero
+        ///              and need to be consectutive also parts.size()==grid.leafGridView().size()
+        ///              and the ranks communicator need to be able to map all parts. Needs to valid
+        ///              at rank 0. Number of parts cannot exceed the number of ranks. Parts need to
+        ///              numbered consecutively starting from zero.
+        /// \param ownersFirst Order owner cells before copy/overlap cells.
+        /// \param addCornerCells Add corner cells to the overlap layer.
+        /// \param overlapLayers The number of layers of cells of the overlap region (default: 1).
+        /// \warning May only be called once.
+        bool loadBalance(const std::vector<int>& parts, bool ownersFirst=false,
+                         bool addCornerCells=false, int overlapLayers=1)
+        {
+            using std::get;
+            return get<0>(scatterGrid(defaultTransEdgeWgt,  ownersFirst, /* wells = */ {},
+                                      /* serialPartitioning = */ false,
+                                      /* trabsmissibilities = */ {},
+                                      addCornerCells, overlapLayers, /* useZoltan =*/ false,
+                                      /* zoltanImbalanceTol (ignored) = */ 0.0, parts));
+        }
+
+        /// \brief Distributes this grid and data over the available nodes in a distributed machine
+        /// \param data A data handle describing how to distribute attached data.
+        /// \param parts The partitioning information. For a cell with local index i the entry
+        ///              parts[i] is the partion number. Partition numbers need to start with zero
+        ///              and need to be consectutive also parts.size()==grid.leafGridView().size()
+        ///              and the ranks communicator need to be able to map all parts. Needs to valid
+        ///              at rank 0. Number of parts cannot exceed the number of ranks. Parts need to
+        ///              numbered consecutively starting from zero.
+        /// \param ownersFirst Order owner cells before copy/overlap cells.
+        /// \param addCornerCells Add corner cells to the overlap layer.
+        /// \param overlapLayers The number of layers of cells of the overlap region (default: 1).
+        /// \warning May only be called once.
+        template<class DataHandle>
+        bool loadBalance(DataHandle& data, const std::vector<int>& parts, bool ownersFirst=false,
+                         bool addCornerCells=false, int overlapLayers=1)
+        {
+            bool ret = loadBalance(parts, ownersFirst, addCornerCells, overlapLayers);
             if (ret)
             {
                 scatterData(data);
@@ -1419,10 +1467,12 @@ namespace Dune
         ///                           the Zoltan partitioner. This is done to improve the numerical
         ///                           performance of the parallel preconditioner.
         /// \param addCornerCells Add corner cells to the overlap layer.
-        /// \param The number of layers of cells of the overlap region.
+        /// \param overlapLayers The number of layers of cells of the overlap region.
         /// \param useZoltan Whether to use Zoltan for partitioning or our simple approach based on
         ///        rectangular partitioning the underlying cartesian grid.
         /// \param zoltanImbalanceTol Set the imbalance tolerance used by Zoltan
+        /// \param cell_part When using an external loadbalancer the partition number for each cell.
+        ///                  If empty or not specified we use internal load balancing.
         /// \return A pair consisting of a boolean indicating whether loadbalancing actually happened and
         ///         a vector containing a pair of name and a boolean, indicating whether this well has
         ///         perforated cells local to the process, for all wells (sorted by name)
@@ -1435,7 +1485,8 @@ namespace Dune
                     bool addCornerCells,
                     int overlapLayers,
                     bool useZoltan = true,
-                    double zoltanImbalanceTol = 1.1);
+                    double zoltanImbalanceTol = 1.1,
+                    const std::vector<int>& input_cell_part = {});
 
         /** @brief The data stored in the grid.
          *

--- a/opm/grid/common/GridPartitioning.cpp
+++ b/opm/grid/common/GridPartitioning.cpp
@@ -18,6 +18,7 @@
   Copyright 2009, 2010, 2013 Statoil ASA.
   Copyright 2013, 2015 Dr. Markus Blatt - HPC-Simulation-Software & Services
   Copyright 2015       NTNU
+  Copyright 2020, 2021 OPM-OP AS
   This file is part of The Open Porous Media project  (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -41,6 +42,7 @@
 #include "GridPartitioning.hpp"
 #include <opm/grid/CpGrid.hpp>
 #include <opm/grid/cpgrid/CpGridData.hpp>
+#include <opm/grid/common/ZoltanPartition.hpp>
 #include <stack>
 
 #ifdef HAVE_MPI
@@ -580,5 +582,99 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
         return 0;
 #endif
     }
+
+namespace cpgrid
+{
+    std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
+               std::vector<std::tuple<int,int,char> >,
+               std::vector<std::tuple<int,int,char,int> > >
+    createZoltanListsFromParts(const CpGrid& grid, const std::vector<cpgrid::OpmWellType> * wells,
+                               const double* transmissibilities, const std::vector<int>& parts,
+                               bool allowDistributedWells)
+    {
+        std::vector<int> exportGlobalIds;
+        std::vector<int> exportLocalIds;
+        std::vector<int> exportToPart;
+        std::vector<int> importGlobalIds;
+        std::size_t numExport = 0;
+        int root = 0;
+
+        if (grid.comm().rank() == 0)
+        {
+            // Create export lists as from Zoltan output, do not include part 0!
+            auto numCells = grid.size(0);
+            exportGlobalIds.reserve(numCells);
+            exportLocalIds.reserve(numCells);
+            exportToPart.reserve(numCells);
+            for (auto cell = grid.leafbegin<0>(), cellEnd = grid.leafend<0>();
+                 cell != cellEnd; ++cell)
+            {
+                const auto& gid = grid.globalIdSet().id(*cell);
+                const auto& lid = grid.localIdSet().id(*cell);
+                const auto& index = grid.leafIndexSet().index(cell);
+                const auto& part = parts[index];
+                if (part != 0 )
+                {
+                    exportGlobalIds.push_back(gid);
+                    exportLocalIds.push_back(lid);
+                    exportToPart.push_back(part);
+                    ++numExport;
+                }
+            }
+        }
+
+        int numImport = 0;
+        std::tie(numImport, importGlobalIds) =
+            scatterExportInformation(numExport, exportGlobalIds.data(),
+                                     exportToPart.data(), 0,
+                                     grid.comm());
+        std::unique_ptr<cpgrid::CombinedGridWellGraph> gridAndWells;
+        if (wells && !allowDistributedWells)
+        {
+            bool partitionIsEmpty = (grid.size(0) == 0);
+            EdgeWeightMethod method{}; // We don't care which method is used, we only need the graph.
+            gridAndWells.reset(new cpgrid::CombinedGridWellGraph(grid,
+                                                                 wells,
+                                                                 transmissibilities,
+                                                                 partitionIsEmpty,
+                                                                 method));
+        }
+        return makeImportAndExportLists(grid, grid.comm(),
+                                        wells,
+                                        gridAndWells.get(),
+                                        root,
+                                        numExport,
+                                        numImport,
+                                        exportLocalIds.data(),
+                                        exportGlobalIds.data(),
+                                        exportToPart.data(),
+                                        importGlobalIds.data(),
+                                        allowDistributedWells);
+    }
+
+    std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
+               std::vector<std::tuple<int,int,char> >,
+               std::vector<std::tuple<int,int,char,int> > >
+    vanillaPartitionGridOnRoot(const CpGrid& grid, const std::vector<cpgrid::OpmWellType> * wells,
+                               const double* transmissibilities, bool allowDistributedWells = false)
+    {
+        int root = 0;
+        const auto& cc = grid.comm();
+        std::vector<int> parts;
+
+        if (cc.rank() == root)
+        {
+            std::cout<<"WARNING: Using poor man's load balancer"<<std::endl;
+            parts.resize(grid.size(0));
+            int  numParts=-1;
+            std::array<int, 3> initialSplit;
+            initialSplit[1]=initialSplit[2]=std::pow(cc.size(), 1.0/3.0);
+            initialSplit[0]=cc.size()/(initialSplit[1]*initialSplit[2]);
+            partition(grid, initialSplit, numParts, parts, false, false);
+        }
+        return createZoltanListsFromParts(grid, wells, transmissibilities, parts,
+                                          allowDistributedWells);
+    }
+} // namespace cpgrid
 } // namespace Dune
 

--- a/opm/grid/common/ZoltanGraphFunctions.hpp
+++ b/opm/grid/common/ZoltanGraphFunctions.hpp
@@ -135,7 +135,7 @@ public:
     /// \brief Create a graph representing a grid together with the wells.
     /// \param grid The grid.
     /// \param wells The wells used or null.
-    /// \param transmissibilities The transmissibilities associated with the faces
+    /// \param transmissibilities The transmissibilities associated with the faces. May be null
     /// \param pretendEmptyGrid True if we should pretend the grid and wells are empty.
     /// \param edgeWeightsMethod The method used to calculated the edge weights.
     CombinedGridWellGraph(const Dune::CpGrid& grid,

--- a/opm/grid/common/ZoltanPartition.hpp
+++ b/opm/grid/common/ZoltanPartition.hpp
@@ -29,6 +29,34 @@ namespace Dune
 {
 namespace cpgrid
 {
+/// \brief Creates all the information needed from the partitioning
+///
+/// Note that if wells is not null and allowDitributedWells is false,
+/// then the partitioning is postprocessed such that all cells that a
+/// perforated by a well are part of the interior of exactly one process.
+/// Otherwise they might spreaded between multiple processes.
+///
+/// \param grid The grid
+/// \param cc  The MPI communicator used for the partitioning.
+/// \param wells Pointer to vector with all possible wells (all perforations) of the problem.
+///              nullptr is possible
+/// \param gridAndWells Graph representing grid and wells (must match the other parameters!)
+/// \param root The rank that has the whole grid before loadbalancing.
+/// \param numExport The number of exported cells (created e.g. by Zoltan)
+/// \param numImport The number of imported cells (created e.g. by Zoltan)
+/// \param exportGlobalIds C-array of the global ids of exported cells (created e.g. by Zoltan)
+/// \param exportLocalIds C-array of the local ids of exported cells (created e.g. by Zoltan)
+/// \param exportToPart C-array with target partition of exported cells (created e.g. by Zoltan)
+/// \param importGlobalIds C-array of the global ids of exported cells (created e.g. by Zoltan)
+/// \param allowDistributedWells Whether wells might be distibuted to the interior of multiple processes.
+/// \return  A tuple consisting of a vector that contains for each local cell of the original grid the
+///         the number of the process that owns it after repartitioning,
+///         a vector containing a pair of name  and a boolean indicating whether this well has
+///         perforated cells local to the process of all wells,
+///         vector containing information for each exported cell (global id
+///         of cell, process id to send to, attribute there), and a vector containing
+///         information for each imported cell (global index, process id that sends, attribute here, local index
+///         here)
 template<class Id>
 std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
            std::vector<std::tuple<int,int,char> >,


### PR DESCRIPTION
Instead of using Zoltan or our Vanilla loadbalancing the information about the loadbalancing (partition index per cell) is provided from outside. That allows to use any loadbalancer or even guess a load balancing.