### PR TITLE
getting aquifer cells with zero volume work

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -264,7 +264,8 @@ namespace Dune
         /// \param poreVolume pore volumes for use in MINPV processing, if asked for in deck
         void processEclipseFormat(const Opm::EclipseGrid* ecl_grid, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
                                   const std::vector<double>& poreVolume = std::vector<double>(),
-                                  const Opm::NNC& = Opm::NNC());
+                                  const Opm::NNC& = Opm::NNC(),
+                                  const std::unordered_map<size_t, double>& aquifer_cell_volumes = std::unordered_map<size_t, double>());
 #endif
 
         /// Read the Eclipse grid format ('grdecl').

--- a/opm/grid/common/GeometryHelpers.hpp
+++ b/opm/grid/common/GeometryHelpers.hpp
@@ -6,7 +6,7 @@
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
 //            Halvor M Nilsen     <hnil@sintef.no>
-//            Bjørn Spjelkavik    <bsp@sintef.no>
+//            BjÃ¸rn Spjelkavik    <bsp@sintef.no>
 //
 // $Date$
 //
@@ -148,10 +148,10 @@ namespace Dune
             for (int i = 0; i < num_points; ++i) {
                 Point tet[4] = { cell_centroid, face_centroid, points[i], points[(i+1)%num_points] };
                 double small_volume = std::fabs(simplex_volume(tet));
-                assert(small_volume > 0);
+                assert(small_volume >= 0);
                 tot_volume += small_volume;
             }
-            assert(tot_volume>0);
+            assert(tot_volume>=0);
             return tot_volume;
         }
 
@@ -172,7 +172,7 @@ namespace Dune
             for (int i = 0; i < num_points; ++i) {
                 Point tet[4] = { cell_centroid, face_centroid, points[i], points[(i+1)%num_points] };
                 double small_volume = std::fabs(simplex_volume(tet));
-                assert(small_volume > 0);
+                assert(small_volume >= 0);
                 Point small_centroid = tet[0];
                 for(int j = 1; j < 4; ++j){
                     small_centroid += tet[j];
@@ -182,7 +182,7 @@ namespace Dune
                 tot_volume += small_volume;
             }
             centroid /= tot_volume;
-            assert(tot_volume>0);
+            assert(tot_volume>=0);
             return centroid;
         
         }

--- a/opm/grid/cornerpoint_grid.c
+++ b/opm/grid/cornerpoint_grid.c
@@ -173,7 +173,7 @@ create_grid_cornerpoint(const struct grdecl *in, double tol)
        return NULL;
    }
 
-   process_grdecl(in, tol, &pg);
+   process_grdecl(in, tol, NULL, &pg);
 
    /*
     *  Convert "struct processed_grid" to "struct UnstructuredGrid".

--- a/opm/grid/cpgpreprocess/preprocess.c
+++ b/opm/grid/cpgpreprocess/preprocess.c
@@ -63,6 +63,7 @@ process_vertical_faces(int direction,
 static void
 process_horizontal_faces(int **intersections,
                          int *plist,
+                         const int* is_aquifer_cell,
                          struct processed_grid *out);
 
 static int
@@ -300,6 +301,7 @@ process_vertical_faces(int direction,
 static void
 process_horizontal_faces(int **intersections,
                          int *plist,
+                         const int* is_aquifer_cell,
                          struct processed_grid *out)
 {
     int i,j,k;
@@ -344,16 +346,16 @@ process_horizontal_faces(int **intersections,
 
 
             for (k = 1; k<nz*2+1; ++k){
+                idx = linearindex(out->dimensions, i,j,(k-1)/2);
 
                 /* Skip if space between face k and face k+1 is collapsed. */
                 /* Note that inactive cells (with ACTNUM==0) have all been  */
                 /* collapsed in finduniquepoints.                           */
+                /* we keep aquifer cells active always even the cells have zero thickness or volume */
                 if (c[0][k] == c[0][k+1] && c[1][k] == c[1][k+1] &&
-                    c[2][k] == c[2][k+1] && c[3][k] == c[3][k+1]){
+                    c[2][k] == c[2][k+1] && c[3][k] == c[3][k+1] && !(is_aquifer_cell && is_aquifer_cell[idx])){
 
-                    /* If the pinch is a cell: */
-                    if (k%2){
-                        idx = linearindex(out->dimensions, i,j,(k-1)/2);
+                     if (k%2) {
                         cell[idx] = -1;
                     }
                 }
@@ -760,6 +762,7 @@ reverse_face_nodes(struct processed_grid *out)
 */
 void process_grdecl(const struct grdecl   *in,
                     double                tolerance,
+                    const int*     is_aquifer_cell,
                     struct processed_grid *out)
 {
     struct grdecl g;
@@ -872,7 +875,7 @@ void process_grdecl(const struct grdecl   *in,
 
     process_vertical_faces   (0, &intersections, plist, work, out);
     process_vertical_faces   (1, &intersections, plist, work, out);
-    process_horizontal_faces (   &intersections, plist,       out);
+    process_horizontal_faces (   &intersections, plist, is_aquifer_cell, out);
 
     free (plist);
     free (work);

--- a/opm/grid/cpgpreprocess/preprocess.h
+++ b/opm/grid/cpgpreprocess/preprocess.h
@@ -129,6 +129,7 @@ extern "C" {
      */
     void process_grdecl(const struct grdecl   *g  ,
                         double                 tol,
+                        const int*   is_aquifer_cell,
                         struct processed_grid *out);
 
     /**

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -525,11 +525,12 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
                                       bool periodic_extension,
                                       bool turn_normals, bool clip_z,
                                       const std::vector<double>& poreVolume,
-                                      const Opm::NNC& nncs)
+                                      const Opm::NNC& nncs,
+                                      const std::unordered_map<size_t, double>& aquifer_cell_volumes)
     {
         current_view_data_->processEclipseFormat(ecl_grid, periodic_extension,
                                                  turn_normals, clip_z,
-                                                 poreVolume, nncs);
+                                                 poreVolume, nncs, aquifer_cell_volumes);
         current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
                                              current_view_data_->logical_cartesian_size_.size(),
                                              0);

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -204,7 +204,8 @@ public:
     /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
     /// \param poreVolume pore volumes for use in MINPV processing, if asked for in deck
     void processEclipseFormat(const Opm::EclipseGrid* ecl_grid, bool periodic_extension, bool turn_normals = false, bool clip_z = false,
-                              const std::vector<double>& poreVolume = std::vector<double>(), const Opm::NNC& nncs = Opm::NNC());
+                              const std::vector<double>& poreVolume = std::vector<double>(), const Opm::NNC& nncs = Opm::NNC(),
+                              const std::unordered_map<size_t, double>& aquifer_cell_volumes = std::unordered_map<size_t, double>());
 #endif
 
     /// Read the Eclipse grid format ('grdecl').
@@ -212,7 +213,8 @@ public:
     /// \param z_tolerance points along a pillar that are closer together in z
     ///        coordinate than this parameter, will be replaced by a single point.
     /// \param remove_ij_boundary if true, will remove (i, j) boundaries. Used internally.
-    void processEclipseFormat(const grdecl& input_data, const std::array<std::set<std::pair<int, int>>, 2>& nnc, double z_tolerance, bool remove_ij_boundary, bool turn_normals = false);
+    void processEclipseFormat(const grdecl& input_data, const std::array<std::set<std::pair<int, int>>, 2>& nnc, double z_tolerance, bool remove_ij_boundary, bool turn_normals = false,
+                              const std::unordered_map<size_t, double>& aquifer_cell_volumes = std::unordered_map<size_t, double>());
 
 
     /// @brief


### PR DESCRIPTION
even these cells have zero cell volume from the grid geometry, we can still specify pore volume (not handled yet, because opm-common does not support it yet) or numercial aquifer cells with them. We have to keep them in the grid. 