### PR TITLE
Avoid include of Parser.hpp and Deck.hpp

### DIFF
--- a/examples/grdecl2vtu.cpp
+++ b/examples/grdecl2vtu.cpp
@@ -32,6 +32,7 @@
 #include <opm/grid/CpGrid.hpp>
 
 #include <opm/grid/utility/OpmParserIncludes.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
 
 using namespace Dune;
 

--- a/opm/grid/utility/OpmParserIncludes.hpp
+++ b/opm/grid/utility/OpmParserIncludes.hpp
@@ -20,11 +20,7 @@
 #define OPM_GRID_OPMPARSERINCLUDES_HEADER_INCLUDED
 
 #if HAVE_ECL_INPUT
-#include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Deck/DeckItem.hpp>
-#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
-#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
 #include <opm/common/utility/ActiveGridCells.hpp>
@@ -33,7 +29,6 @@
 namespace Dune {
     namespace cpgrid {
         typedef Opm::Well OpmWellType;
-        typedef Opm::EclipseState OpmEclipseStateType;
     }
 }
 #else // #if HAVE_ECL_INPUT
@@ -41,7 +36,6 @@ namespace Dune {
 namespace Dune {
     namespace cpgrid {
         typedef int OpmWellType;
-        typedef int OpmEclipseStateType;
     }
 }
 

--- a/tests/test_column_extract.cpp
+++ b/tests/test_column_extract.cpp
@@ -9,6 +9,7 @@
 #include <opm/grid/GridManager.hpp>
 
 #include <opm/grid/utility/OpmParserIncludes.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
 
 #include <cstddef>
 #include <iostream>

--- a/tests/test_cpgrid.cpp
+++ b/tests/test_cpgrid.cpp
@@ -21,7 +21,7 @@ using Dune::referenceElement; //grid check assume usage of Dune::Geometry
 #include <opm/grid/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/grid/utility/OpmParserIncludes.hpp>
-
+#include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <iostream>
 
 template <class GridView>

--- a/tests/test_ug.cpp
+++ b/tests/test_ug.cpp
@@ -25,6 +25,8 @@
 #include <opm/grid/cpgpreprocess/preprocess.h>
 
 #include <opm/grid/utility/OpmParserIncludes.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
 
 using namespace std;
 


### PR DESCRIPTION
The file `OpmParserIncludes.hpp` includes the header `parser/Parser.hpp` which transitively brings in half of opm-common. In particular it allowed for silent usage of `Deck` in: #517. 

With this PR only the "really needed" headers are included with the `OpmParserIncludes.hpp`. If this is merged #517 will need to explicitly include the dependencies from opm-common; which is in my opinion a good thing.


As an aside I would really like to reignite this: https://github.com/OPM/opm-grid/pull/401