### PR TITLE
Adding an Opm version of Dune::MPIHelper

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -58,6 +58,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/grid/utility/cartesianToCompressed.cpp
   opm/grid/utility/StopWatch.cpp
   opm/grid/utility/WachspressCoord.cpp
+  opm/grid/parallel/mpihelper_set_and_get.cpp
   )
 
 if (opm-common_FOUND)
@@ -223,4 +224,5 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/grid/utility/OpmParserIncludes.hpp
   opm/grid/utility/platform_dependent/disable_warnings.h
   opm/grid/utility/platform_dependent/reenable_warnings.h
+  opm/grid/parallel/mpihelper_set_and_get.hpp
   )

--- a/opm/grid/parallel/LICENSE.md
+++ b/opm/grid/parallel/LICENSE.md
@@ -1,0 +1,421 @@
+Copyright holders:
+==================
+
+2015--2017    Marco Agnese
+2015          Martin Alkämper
+2003--2010    Peter Bastian
+2004--2017    Markus Blatt
+2013          Andreas Buhr
+2011--2017    Ansgar Burchardt
+2004--2005    Adrian Burri
+2014          Benjamin Bykowski (may appear in the logs as "Convex Function")
+2014          Marco Cecchetti
+2006--2018    Andreas Dedner
+2003          Marc Droske
+2003--2018    Christian Engwer
+2004--2018    Jorrit Fahlke
+2016          Thomas Fetzer
+2008--2013    Bernd Flemisch
+2013--2014    Christoph Gersbacher
+2015          Stefan Girke
+2015--2017    Felix Gruber
+2005--2017    Carsten Gräser
+2010--2018    Christoph Grüninger
+2006          Bernard Haasdonk
+2015--2016    René Heß
+2015          Claus-Justus Heine
+2012--2013    Olaf Ippisch
+2013--2017    Dominic Kempf
+2009          Leonard Kern
+2013          Torbjörn Klatt
+2003--2017    Robert Klöfkorn
+2005--2007    Sreejith Pulloor Kuttanikkad
+2012--2016    Arne Morten Kvarving
+2010--2014    Andreas Lauser
+2016--2017    Tobias Leibner
+2015          Lars Lubkoll
+2012--2017    Tobias Malkmus
+2007--2011    Sven Marnach
+2010--2017    René Milk
+2011--2018    Steffen Müthing
+2003--2006    Thimo Neubauer
+2011          Rebecca Neumann
+2008--2018    Martin Nolte
+2014          Andreas Nüßing
+2004--2005    Mario Ohlberger
+2014          Steffen Persvold
+2008--2017    Elias Pipping
+2011          Dan Popovic
+2017          Simon Praetorius
+2009          Atgeirr Rasmussen
+2006--2014    Uli Sack
+2003--2017    Oliver Sander
+2006          Klaus Schneider
+2004          Roland Schulz
+2015          Nicolas Schwenck
+2016          Linus Seelinger
+2009--2014    Bård Skaflestad
+2012          Matthias Wohlmuth
+2011--2016    Jonathan Youett
+
+
+The DUNE library and headers are licensed under version 2 of the GNU
+General Public License (see below), with a special exception for
+linking and compiling against DUNE, the so-called "runtime exception."
+The license is intended to be similar to the GNU Lesser General
+Public License, which by itself isn't suitable for a template library.
+
+The exact wording of the exception reads as follows:
+
+   As a special exception, you may use the DUNE source files as part
+   of a software library or application without restriction.
+   Specifically, if other files instantiate templates or use macros or
+   inline functions from one or more of the DUNE source files, or you
+   compile one or more of the DUNE source files and link them with
+   other files to produce an executable, this does not by itself cause
+   the resulting executable to be covered by the GNU General Public
+   License.  This exception does not however invalidate any other
+   reasons why the executable file might be covered by the GNU General
+   Public License.
+
+
+        GNU GENERAL PUBLIC LICENSE
+           Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+          Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+        GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+          NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+         END OF TERMS AND CONDITIONS
+
+      How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/opm/grid/parallel/mpihelper_set_and_get.cpp
+++ b/opm/grid/parallel/mpihelper_set_and_get.cpp
@@ -1,0 +1,20 @@
+// -*- tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+// vi: set et ts=4 sw=2 sts=2:
+
+
+#include <dune/common/parallel/collectivecommunication.hh>
+
+#include <dune/common/parallel/mpicollectivecommunication.hh>
+#include "mpihelper_set_and_get.hpp"
+
+namespace Opm
+{
+ 
+  // define our static member variables of class MPISetAndGetHelper
+  MPISetAndGetHelper::MPICommunicator MPISetAndGetHelper::DUNE_MPI_COMM_ {MPI_COMM_WORLD};
+  int MPISetAndGetHelper::rank_ = 0;
+  int MPISetAndGetHelper::size_ = 0 ;
+
+
+
+}

--- a/opm/grid/parallel/mpihelper_set_and_get.hpp
+++ b/opm/grid/parallel/mpihelper_set_and_get.hpp
@@ -1,0 +1,180 @@
+// -*- tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+// vi: set et ts=4 sw=2 sts=2:
+/*
+ * File: opm/grid/parallel/mpihelper_set_and_get.hpp
+ * 
+ * This MPI helper class has been derived from the Dune library MPIHelper classes
+ * defined in the file dune-common/opm/grid/parallel/mpihelper_set_and_get.hpp
+ * 
+ * See LICENCE.md in this directory for licence terms
+ * 
+ * 
+ */
+
+
+#ifndef DUNE_MPIHELPER
+#define DUNE_MPIHELPER
+
+#if HAVE_MPI
+#include <cassert>
+#endif
+
+#if HAVE_MPI
+#include <mpi.h>
+#endif
+
+#include <dune/common/parallel/collectivecommunication.hh>
+#if HAVE_MPI
+#include <dune/common/parallel/mpicollectivecommunication.hh>
+#include <dune/common/stdstreams.hh>
+#endif
+#include <dune/common/visibility.hh>
+
+// typedef MPI_Comm MPICommunicator;
+
+namespace Opm
+{
+  
+  
+  /**
+   * @brief A real mpi helper that can set as well as get the MPI communicator.
+   *
+   * This helper should be used for parallel programs.
+   */
+  class MPISetAndGetHelper
+  {
+  public:
+    
+    /**
+     * @brief The type of the mpi communicator.
+     */
+     typedef MPI_Comm MPICommunicator;
+
+    /** \brief get the default communicator
+     *
+     *  Return a communicator to exchange data with all processes
+     *
+     *  \returns MPI_COMM_WORLD
+     */
+    static MPICommunicator getCommunicator ()
+    {
+      return DUNE_MPI_COMM_;
+    }
+    
+    /** \brief set the default communicator
+     * 
+     *  Return a communicator to exchange data with all processes.
+     *  This function also sets @rank_ and size_ to values from the input
+     *  communicator
+     *
+     *  \returns MPI_COMM_WORLD
+     */
+    static void setCommunicator (MPICommunicator DUNE_MPI_COMM)
+    {
+            
+       DUNE_MPI_COMM_ = DUNE_MPI_COMM;
+       MPI_Comm_rank(DUNE_MPI_COMM_,&rank_);
+       MPI_Comm_size(DUNE_MPI_COMM_,&size_);
+      
+    }
+
+    /** \brief get a local communicator
+     *
+     *  Returns a communicator to exchange data with the local process only
+     *
+     *  \returns MPI_COMM_SELF
+     */
+    static MPICommunicator getLocalCommunicator ()
+    {
+      return MPI_COMM_SELF;
+    }
+
+    static Dune::CollectiveCommunication<MPICommunicator>
+    getCollectiveCommunication()
+    {
+      return Dune::CollectiveCommunication<MPICommunicator>(getCommunicator());
+    }
+    /**
+     * @brief Get the singleton instance of the helper.
+     *
+     * This method has to be called with the same arguments
+     * that the main method of the program was called:
+     * \code
+     * int main(int argc, char** argv){
+     *   MPISetAndGetHelper::instance(argc, argv);
+     *   // program code comes here
+     *   ...
+     * }
+     * \endcode
+     * @param argc The number of arguments provided to main.
+     * @param argv The arguments provided to main.
+     */
+    DUNE_EXPORT static MPISetAndGetHelper& instance(int& argc, char**& argv)
+    {
+      // create singleton instance
+      static MPISetAndGetHelper singleton (argc, argv);
+      return singleton;
+    }
+
+    /**
+     * @brief return rank of process
+     */
+    static int rank ()  { return rank_; }
+    /**
+     * @brief return number of processes
+     */
+    static int size ()  { return size_; }
+
+  private:
+    static int rank_;
+    static int size_;
+    static MPICommunicator DUNE_MPI_COMM_;
+    bool initializedHere_;
+    void prevent_warning(int){}
+
+    //! \brief calls MPI_Init with argc and argv as parameters
+    MPISetAndGetHelper(int& argc, char**& argv)
+    : initializedHere_(false)
+    {
+      int wasInitialized = -1;
+      MPI_Initialized( &wasInitialized );
+      if(!wasInitialized)
+      {
+        rank_ = -1;
+        size_ = -1;
+        static int is_initialized = MPI_Init(&argc, &argv);
+        prevent_warning(is_initialized);
+        initializedHere_ = true;
+        
+        MPISetAndGetHelper::setCommunicator (MPI_COMM_WORLD) ; 
+      }
+
+      // MPISetAndGetHelper::setCommunicator (MPI_COMM_WORLD) ; 
+      // MPI_Comm_rank(MPI_COMM_WORLD,&rank_);
+      // MPI_Comm_size(MPI_COMM_WORLD,&size_);
+
+      //assert( rank_ >= 0 );
+      //assert( size_ >= 1 );
+
+      std::cout << "Called  MPI_Init on p=" << rank_ << "!" << std::endl;
+    }
+    //! \brief calls MPI_Finalize
+    ~MPISetAndGetHelper()
+    {
+      int wasFinalized = -1;
+      MPI_Finalized( &wasFinalized );
+      if(!wasFinalized && initializedHere_)
+      {
+        MPI_Finalize();
+        std::cout << "Called MPI_Finalize on p=" << rank_ << "!" <<std::endl;
+      }
+
+    }
+    MPISetAndGetHelper(const MPISetAndGetHelper&);
+    MPISetAndGetHelper& operator=(const MPISetAndGetHelper);
+  };
+  
+
+
+} // end namespace Dune
+#endif


### PR DESCRIPTION
Hi, this is first pass of adding a new MPIHelper to Opm, named MPISetAndGetHelper . It is derived from Dune::MPIHelper ([mpihelper.hh](https://github.com/dune-project/dune-common/blob/master/dune/common/parallel/mpihelper.hh)) and rewritten so that the MPI communicator used can be set and updated with another MPI_Comm that may be a subset of MPI_COMM_WORLD. This is required so that the Damaris library can partition the ranks into compute and server ranks and will return a sub-communicator that the compute ranks can use. This sub-communicator is proposed to be stored in the MPISetAndGetHelper object (a singleton) that can be used within Opm code whenever required for MPI based communication.

The next changes i'd make are the following within the directory containing OPM repositories:
```
ls
opm-common  opm-grid  opm-material  opm-models  opm-simulators  opm-upscaling
```
A general sed find and replace:
```
# Replacing all the dune mpihelper.hh references 
find . -type f -name *.cpp -exec sed -i 's|dune/common/parallel/mpihelper.hh|opm/grid/parallel/mpihelper_set_and_get.hpp|' {} \;
find . -type f -name *.hpp -exec sed -i 's|dune/common/parallel/mpihelper.hh|opm/grid/parallel/mpihelper_set_and_get.hpp|' {} \;
find . -type f -name *.cc  -exec sed -i 's|dune/common/parallel/mpihelper.hh|opm/grid/parallel/mpihelper_set_and_get.hpp|' {} \;
find . -type f -name *.hh  -exec sed -i 's|dune/common/parallel/mpihelper.hh|opm/grid/parallel/mpihelper_set_and_get.hpp|' {} \;

# Dune::MPIHelper  Opm::MPISetAndGetHelper
find . -type f -name *.cpp -exec sed -i 's|Dune::MPIHelper|Opm::MPISetAndGetHelper|' {} \;
find . -type f -name *.hpp -exec sed -i 's|Dune::MPIHelper|Opm::MPISetAndGetHelper|' {} \;
find . -type f -name *.hh -exec sed -i 's|Dune::MPIHelper|Opm::MPISetAndGetHelper|' {} \;
find . -type f -name *.cc -exec sed -i 's|Dune::MPIHelper|Opm::MPISetAndGetHelper|' {} \;

find . -type f -name *.hh -exec sed -i 's|MPIHelper::MPICommunicator|MPISetAndGetHelper::MPICommunicator|' {} \;
find . -type f -name *.cpp -exec sed -i 's|MPIHelper::MPICommunicator|MPISetAndGetHelper::MPICommunicator|' {} \;
find . -type f -name *.hpp -exec sed -i 's|MPIHelper::MPICommunicator|MPISetAndGetHelper::MPICommunicator|' {} \;

find . -type f -name *.hh -exec sed -i 's|MPIHelper|MPISetAndGetHelper|' {} \;
find . -type f -name *.cpp -exec sed -i 's|MPIHelper|MPISetAndGetHelper|' {} \;
find . -type f -name *.hpp -exec sed -i 's|MPIHelper|MPISetAndGetHelper|' {} \;

# Set PATH_TO_GITSRC to appropriate directory
PATH_TO_GITSRC=/home/jbowden/ACROSS/WP7/srcbuild/downloaddeps/opm-inria-gitrepos
sed -i 's|CpGridData(MPISetAndGetHelper::MPICommunicator comm)|CpGridData(Opm::MPISetAndGetHelper::MPICommunicator comm)|'  ${PATH_TO_GITSRC}/opm-grid/opm/grid/cpgrid/CpGridData.hpp

sed -i 's|typedef MPISetAndGetHelper::MPICommunicator MPICommunicator|typedef Opm::MPISetAndGetHelper::MPICommunicator MPICommunicator|'  ${PATH_TO_GITSRC}/opm-grid/opm/grid/cpgrid/CpGridData.hpp

sed -i 's|CpGrid(MPISetAndGetHelper::MPICommunicator|CpGrid(Opm::MPISetAndGetHelper::MPICommunicator|' ${PATH_TO_GITSRC}/opm-grid/opm/grid/CpGrid.hpp

# CpGridData(MPISetAndGetHelper::MPICommunicator
sed -i 's|CpGridData(MPISetAndGetHelper::MPICommunicator|CpGridData(Opm::MPISetAndGetHelper::MPICommunicator|' ${PATH_TO_GITSRC}/opm-grid/opm/grid/cpgrid/CpGridData.cpp

sed -i 's|CpGrid(MPISetAndGetHelper::MPICommunicator|CpGrid(Opm::MPISetAndGetHelper::MPICommunicator|'  ${PATH_TO_GITSRC}/opm-grid/opm/grid/cpgrid/CpGrid.cpp
```

Doing those substitutions I find that ```opm-grid``` compiles and links, however ```opm-simulation``` fails in multiple places.
This is possibly due to the extra opm:: namespace tags on the object references, however your guess is probably better than mine.

Anyway, it is a start.