### PR TITLE
Remove explicit copy-constructor from class

### DIFF
--- a/opm/grid/polyhedralgrid/iterator.hh
+++ b/opm/grid/polyhedralgrid/iterator.hh
@@ -37,10 +37,6 @@ namespace Dune
         entityImpl() = EntityImpl( data, EntitySeed( 0 ) );
     }
 
-    PolyhedralGridIterator ( const This& other )
-    : Base( other )
-    {}
-
     /** \brief increment */
     void increment ()
     {


### PR DESCRIPTION
since it already has a explicitly cc, the implicit
assignment operator is deprecated. clang likes to
point this out.