### PR TITLE
Do not use thickness specified via PINCH to find uniquepoints.

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -291,10 +291,8 @@ namespace Dune
 
         /// Read the Eclipse grid format ('grdecl').
         /// \param input_data the data in grdecl format, declared in preprocess.h.
-        /// \param z_tolerance points along a pillar that are closer together in z
-        ///        coordinate than this parameter, will be replaced by a single point.
         /// \param remove_ij_boundary if true, will remove (i, j) boundaries. Used internally.
-        void processEclipseFormat(const grdecl& input_data, double z_tolerance, bool remove_ij_boundary, bool turn_normals = false);
+        void processEclipseFormat(const grdecl& input_data, bool remove_ij_boundary, bool turn_normals = false);
 
         //@}
 

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -496,7 +496,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
         using NNCMap = std::set<std::pair<int, int>>;
         using NNCMaps = std::array<NNCMap, 2>;
         NNCMaps nnc;
-        current_view_data_->processEclipseFormat(g, nullptr, nnc, 0.0, false, false, false);
+        current_view_data_->processEclipseFormat(g, nullptr, nnc, false, false, false);
         // global grid only on rank 0
         current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
                                              current_view_data_->logical_cartesian_size_.size(),
@@ -548,13 +548,14 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
 
 #endif
 
-    void CpGrid::processEclipseFormat(const grdecl& input_data, double z_tolerance,
+    void CpGrid::processEclipseFormat(const grdecl& input_data,
                                       bool remove_ij_boundary, bool turn_normals)
     {
         using NNCMap = std::set<std::pair<int, int>>;
         using NNCMaps = std::array<NNCMap, 2>;
         NNCMaps nnc;
-        current_view_data_->processEclipseFormat(input_data, nullptr, nnc, z_tolerance, remove_ij_boundary, turn_normals, false);
+        current_view_data_->processEclipseFormat(input_data, nullptr, nnc,
+                                                 remove_ij_boundary, turn_normals, false);
         current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
                                              current_view_data_->logical_cartesian_size_.size(),
                                              0);

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -221,15 +221,12 @@ public:
     ///        aquifer information when ecl_state is available. NNC and aquifer connection
     ///        information will also be updated during the function call when available and necessary.
     /// \param nnc is the non-neighboring connections
-    /// \param z_tolerance points along a pillar that are closer together in z
-    ///        coordinate than this parameter, will be replaced by a single point.
     /// \param remove_ij_boundary if true, will remove (i, j) boundaries. Used internally.
     /// \param pinchActive If true, we will add faces between vertical cells that have only inactive cells or cells
     ///            with zero volume between them. If false these cells will not be connected.
     void processEclipseFormat(const grdecl& input_data, Opm::EclipseState* ecl_state,
-                              std::array<std::set<std::pair<int, int>>, 2>& nnc, double z_tolerance, bool remove_ij_boundary,
-                              bool turn_normals, bool pinchActive);
-
+                              std::array<std::set<std::pair<int, int>>, 2>& nnc,
+                              bool remove_ij_boundary, bool turn_normals, bool pinchActive);
 
     /// @brief
     ///    Extract Cartesian index triplet (i,j,k) of an active cell.

--- a/opm/grid/cpgrid/dgfparser.hh
+++ b/opm/grid/cpgrid/dgfparser.hh
@@ -181,7 +181,7 @@ namespace Dune
 
     // create grid
     grid_ = new Grid;
-    grid_->processEclipseFormat( g, 0.0, false, false );
+    grid_->processEclipseFormat( g, false, false );
   }
 
 

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -223,10 +223,6 @@ namespace cpgrid
             this->zcorn = clipped_zcorn;
         }
 
-        // Get z_tolerance.
-        const double z_tolerance = ecl_grid.isPinchActive() ?
-            ecl_grid.getPinchThresholdThickness() : 0.0;
-
         if (periodic_extension) {
             // Extend grid periodically with one layer of cells in the (i, j) directions.
             std::vector<double> new_coord;
@@ -235,10 +231,10 @@ namespace cpgrid
             grdecl new_g;
             addOuterCellLayer(g, new_coord, new_zcorn, new_actnum, new_g);
             // Make the grid.
-            processEclipseFormat(new_g, ecl_state, nnc_cells, z_tolerance, true, turn_normals, pinchActive);
+            processEclipseFormat(new_g, ecl_state, nnc_cells, true, turn_normals, pinchActive);
         } else {
             // Make the grid.
-            processEclipseFormat(g, ecl_state, nnc_cells, z_tolerance, false, turn_normals, pinchActive);
+            processEclipseFormat(g, ecl_state, nnc_cells, false, turn_normals, pinchActive);
         }
 
         return minpv_result.removed_cells;
@@ -251,7 +247,7 @@ namespace cpgrid
 
     /// Read the Eclipse grid format ('.grdecl').
     void CpGridData::processEclipseFormat(const grdecl& input_data, Opm::EclipseState* ecl_state,
-                                          NNCMaps& nnc, double z_tolerance, bool remove_ij_boundary, bool turn_normals,
+                                          NNCMaps& nnc, bool remove_ij_boundary, bool turn_normals,
                                           bool pinchActive)
     {
         if( ccobj_.rank() != 0 )
@@ -270,9 +266,9 @@ namespace cpgrid
             for ([[maybe_unused]]const auto&[global_index, volume] : aquifer_cell_volumes) {
                 is_aquifer_cell[global_index] = 1;
             }
-            process_grdecl(&input_data, z_tolerance, is_aquifer_cell.data(), &output, pinchActive);
+            process_grdecl(&input_data, 0, is_aquifer_cell.data(), &output, pinchActive);
         } else {
-            process_grdecl(&input_data, z_tolerance, nullptr, &output, pinchActive);
+            process_grdecl(&input_data, 0, nullptr, &output, pinchActive);
         }
         if (remove_ij_boundary) {
             removeOuterCellLayer(output);


### PR DESCRIPTION
When preprocessing the grid in uniquepoints.c and preprocess.c we used to use the thickness specified via the PINCH keyword when calling preprocess in processEclipseFormat. That seems wrong as it will neglect whether there is MINPV specified at all and whether the cell we remove has a small enough value.

One example is a deck without MINPV, PINCH with thickness t, and with a grid that is a stack cells with a thickness t1 with t1 < t and 2*t1 > t. In that case every second cell would have vanished.

Wondering what would have happend with t bigger than the hight of the grid...

Not sure whether this will break other stuff though.