### PR TITLE
Do not connect cells from distant layers vertically without PINCH.

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -242,6 +242,34 @@ namespace Dune
 
 #if HAVE_ECL_INPUT
         /// Read the Eclipse grid format ('grdecl').
+        ///
+        /// \return Vector of global indices to the cells which have
+        ///         been removed in the grid processing due to small pore volume. Function only returns
+        ///         indices on rank 0, the vector is empty of other ranks.
+        /// \param ecl_grid the high-level object from opm-parser which represents the simulation's grid
+        ///        In a parallel run this may be a nullptr on all ranks but rank zero.
+        /// \param ecl_state the object from opm-parser provide information regarding to pore volume, NNC,
+        ///        aquifer information when ecl_state is available. NNC and aquifer connection
+        ///        information will also be updated during the function call when available and necessary.
+        /// \param periodic_extension if true, the grid will be (possibly) refined, so that
+        ///        intersections/faces along i and j boundaries will match those on the other
+        ///        side. That is, i- faces will match i+ faces etc.
+        /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
+        /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
+        /// \param pinchActive Force specific pinch behaviour. If true a face will connect two vertical cells, that are
+        ///           topological connected, even if there are cells with zero volume between them. If false these
+        ///           cells will not be connected despite their faces coinciding.
+        std::vector<std::size_t> processEclipseFormat(const Opm::EclipseGrid* ecl_grid,
+                                                      Opm::EclipseState* ecl_state,
+                                                      bool periodic_extension, bool turn_normals, bool clip_z,
+                                                      bool pinchActive);
+
+        /// Read the Eclipse grid format ('grdecl').
+        ///
+        /// Pinch behaviour is determind from the parameter ecl_grid. If ecl_grid is a nullptr or PINCH was specified for
+        /// the grid, then a face will connect two vertical cells, that are topological connected, even if there are
+        /// cells with zero volume between them, Otherwise these cells will not be connected despite their faces coinciding.
+        ///
         /// \return Vector of global indices to the cells which have
         ///         been removed in the grid processing due to small pore volume. Function only returns
         ///         indices on rank 0, the vector is empty of other ranks.
@@ -258,6 +286,7 @@ namespace Dune
         std::vector<std::size_t> processEclipseFormat(const Opm::EclipseGrid* ecl_grid,
                                                       Opm::EclipseState* ecl_state,
                                                       bool periodic_extension, bool turn_normals = false, bool clip_z = false);
+
 #endif
 
         /// Read the Eclipse grid format ('grdecl').

--- a/opm/grid/cornerpoint_grid.c
+++ b/opm/grid/cornerpoint_grid.c
@@ -173,7 +173,7 @@ create_grid_cornerpoint(const struct grdecl *in, double tol)
        return NULL;
    }
 
-   process_grdecl(in, tol, NULL, &pg);
+   process_grdecl(in, tol, NULL, &pg, false);
 
    /*
     *  Convert "struct processed_grid" to "struct UnstructuredGrid".

--- a/opm/grid/cpgpreprocess/preprocess.h
+++ b/opm/grid/cpgpreprocess/preprocess.h
@@ -125,11 +125,14 @@ extern "C" {
      *                    neighbourship definition, vertex geometry, face's
      *                    constituent vertices, and local-to-global cell
      *                    mapping.
+     * @param[in] pinchActive Whether cells with zero volume should be pinched out
+     *                    and neighboring cells should be connected.
      */
     void process_grdecl(const struct grdecl   *g  ,
                         double                 tol,
                         const int*   is_aquifer_cell,
-                        struct processed_grid *out);
+                        struct processed_grid *out,
+                        int pinchActive);
 
     /**
      * Release memory resources acquired in previous grid processing using

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -527,15 +527,25 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
     std::vector<std::size_t> CpGrid::processEclipseFormat(const Opm::EclipseGrid* ecl_grid,
                                                           Opm::EclipseState* ecl_state,
                                                           bool periodic_extension,
-                                                          bool turn_normals, bool clip_z)
+                                                          bool turn_normals, bool clip_z,
+                                                          bool pinchActive)
     {
         auto removed_cells = current_view_data_->processEclipseFormat(ecl_grid, ecl_state, periodic_extension,
-                                                                      turn_normals, clip_z);
+                                                                      turn_normals, clip_z, pinchActive);
         current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
                                              current_view_data_->logical_cartesian_size_.size(),
                                              0);
         return removed_cells;
     }
+
+    std::vector<std::size_t> CpGrid::processEclipseFormat(const Opm::EclipseGrid* ecl_grid_ptr,
+                                                              Opm::EclipseState* ecl_state,
+                                                              bool periodic_extension, bool turn_normals, bool clip_z)
+    {
+        return processEclipseFormat(ecl_grid_ptr, ecl_state, periodic_extension, turn_normals, clip_z,
+                             !ecl_grid_ptr || ecl_grid_ptr->isPinchActive());
+    }
+
 #endif
 
     void CpGrid::processEclipseFormat(const grdecl& input_data, double z_tolerance,

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -496,7 +496,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
         using NNCMap = std::set<std::pair<int, int>>;
         using NNCMaps = std::array<NNCMap, 2>;
         NNCMaps nnc;
-        current_view_data_->processEclipseFormat(g, nullptr, nnc, 0.0, false, false);
+        current_view_data_->processEclipseFormat(g, nullptr, nnc, 0.0, false, false, false);
         // global grid only on rank 0
         current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
                                              current_view_data_->logical_cartesian_size_.size(),
@@ -544,7 +544,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
         using NNCMap = std::set<std::pair<int, int>>;
         using NNCMaps = std::array<NNCMap, 2>;
         NNCMaps nnc;
-        current_view_data_->processEclipseFormat(input_data, nullptr, nnc, z_tolerance, remove_ij_boundary, turn_normals);
+        current_view_data_->processEclipseFormat(input_data, nullptr, nnc, z_tolerance, remove_ij_boundary, turn_normals, false);
         current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
                                              current_view_data_->logical_cartesian_size_.size(),
                                              0);

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -224,8 +224,11 @@ public:
     /// \param z_tolerance points along a pillar that are closer together in z
     ///        coordinate than this parameter, will be replaced by a single point.
     /// \param remove_ij_boundary if true, will remove (i, j) boundaries. Used internally.
+    /// \param pinchActive If true, we will add faces between vertical cells that have only inactive cells or cells
+    ///            with zero volume between them. If false these cells will not be connected.
     void processEclipseFormat(const grdecl& input_data, Opm::EclipseState* ecl_state,
-                              std::array<std::set<std::pair<int, int>>, 2>& nnc, double z_tolerance, bool remove_ij_boundary, bool turn_normals = false);
+                              std::array<std::set<std::pair<int, int>>, 2>& nnc, double z_tolerance, bool remove_ij_boundary,
+                              bool turn_normals, bool pinchActive);
 
 
     /// @brief

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -212,7 +212,7 @@ public:
     /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
     /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
     std::vector<std::size_t> processEclipseFormat(const Opm::EclipseGrid* ecl_grid, Opm::EclipseState* ecl_state,
-                                                  bool periodic_extension, bool turn_normals = false, bool clip_z = false);
+                                                  bool periodic_extension, bool turn_normals = false, bool clip_z = false, bool pinchActive = true);
 #endif
 
     /// Read the Eclipse grid format ('grdecl').

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -118,7 +118,8 @@ namespace cpgrid
 #if HAVE_ECL_INPUT
     std::vector<std::size_t> CpGridData::processEclipseFormat(const Opm::EclipseGrid* ecl_grid_ptr,
                                                               Opm::EclipseState* ecl_state,
-                                                              bool periodic_extension, bool turn_normals, bool clip_z)
+                                                              bool periodic_extension, bool turn_normals, bool clip_z,
+                                                              bool pinchActive)
     {
         std::vector<std::size_t> removed_cells;
         if (ccobj_.rank() != 0 ) {
@@ -234,10 +235,10 @@ namespace cpgrid
             grdecl new_g;
             addOuterCellLayer(g, new_coord, new_zcorn, new_actnum, new_g);
             // Make the grid.
-            processEclipseFormat(new_g, ecl_state, nnc_cells, z_tolerance, true, turn_normals, ecl_grid.isPinchActive());
+            processEclipseFormat(new_g, ecl_state, nnc_cells, z_tolerance, true, turn_normals, pinchActive);
         } else {
             // Make the grid.
-            processEclipseFormat(g, ecl_state, nnc_cells, z_tolerance, false, turn_normals, ecl_grid.isPinchActive());
+            processEclipseFormat(g, ecl_state, nnc_cells, z_tolerance, false, turn_normals, pinchActive);
         }
 
         return minpv_result.removed_cells;

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -234,10 +234,10 @@ namespace cpgrid
             grdecl new_g;
             addOuterCellLayer(g, new_coord, new_zcorn, new_actnum, new_g);
             // Make the grid.
-            processEclipseFormat(new_g, ecl_state, nnc_cells, z_tolerance, true, turn_normals);
+            processEclipseFormat(new_g, ecl_state, nnc_cells, z_tolerance, true, turn_normals, ecl_grid.isPinchActive());
         } else {
             // Make the grid.
-            processEclipseFormat(g, ecl_state, nnc_cells, z_tolerance, false, turn_normals);
+            processEclipseFormat(g, ecl_state, nnc_cells, z_tolerance, false, turn_normals, ecl_grid.isPinchActive());
         }
 
         return minpv_result.removed_cells;
@@ -250,7 +250,8 @@ namespace cpgrid
 
     /// Read the Eclipse grid format ('.grdecl').
     void CpGridData::processEclipseFormat(const grdecl& input_data, Opm::EclipseState* ecl_state,
-                                          NNCMaps& nnc, double z_tolerance, bool remove_ij_boundary, bool turn_normals)
+                                          NNCMaps& nnc, double z_tolerance, bool remove_ij_boundary, bool turn_normals,
+                                          bool pinchActive)
     {
         if( ccobj_.rank() != 0 )
         {
@@ -268,9 +269,9 @@ namespace cpgrid
             for ([[maybe_unused]]const auto&[global_index, volume] : aquifer_cell_volumes) {
                 is_aquifer_cell[global_index] = 1;
             }
-            process_grdecl(&input_data, z_tolerance, is_aquifer_cell.data(), &output);
+            process_grdecl(&input_data, z_tolerance, is_aquifer_cell.data(), &output, pinchActive);
         } else {
-            process_grdecl(&input_data, z_tolerance, nullptr, &output);
+            process_grdecl(&input_data, z_tolerance, nullptr, &output, pinchActive);
         }
         if (remove_ij_boundary) {
             removeOuterCellLayer(output);


### PR DESCRIPTION
Previously, we always connected cells in a column of a corner point grid if there were only collapsed cells (with zero volume) between them. This is correct if PINCH was specified in the deck. But for decks without PINCH this behaviour differed from the reference simulator (which would not connect such cells with a face).

Now we check whether PINCH was specified in the deck and only in this case we will construct a face connecting such cells. Main algorithmic treatment is in preprocess.c (function process_vertical_faces).