### PR TITLE
Fix NNC creation for horizontal faces with no connected cells.

### DIFF
--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -865,17 +865,20 @@ namespace cpgrid
                     if (fnc[1] == -1 ) {
                         // Add the NNC created from the minpv processs
                         // at the bottom of the cell.
-                        auto it = nnc[PinchNNC].lower_bound({global_cell[fnc[0]], 0});
-                        if (it != nnc[PinchNNC].end() && it->first == global_cell[fnc[0]]) {
-                            const int other_cell = global_to_local[it->second];
-                            cells[cellcount].setValue(other_cell, false);
-                            ++cellcount;
-                            // Now we must ensure that the face connecting
-                            // the second cell to the boundary is skipped,
-                            // it is considered replaced by the connection
-                            // added here.
-                            // Note: not done anymore, see comment below.
-                            // next_skip_zmin_face = other_cell;
+                        if(fnc[0] != -1)
+                        {
+                            auto it = nnc[PinchNNC].lower_bound({global_cell[fnc[0]], 0});
+                            if (it != nnc[PinchNNC].end() && it->first == global_cell[fnc[0]]) {
+                                const int other_cell = global_to_local[it->second];
+                                cells[cellcount].setValue(other_cell, false);
+                                ++cellcount;
+                                // Now we must ensure that the face connecting
+                                // the second cell to the boundary is skipped,
+                                // it is considered replaced by the connection
+                                // added here.
+                                // Note: not done anymore, see comment below.
+                                // next_skip_zmin_face = other_cell;
+                            }
                         }
                     } else if (fnc[0] == -1) {
                         // This block has been disabled, as removing the original top face


### PR DESCRIPTION
At least for the grid Hummocky in opm-upscaling there (lots) of faces with -1 for both connected cells. This resulted in valgrind
complaining about reading uninitialized values global_cell[fnc[0]] as fnc[0] was -1.

Hence we need to cater for this.