### PR TITLE
Drop boost::iterator_range usage

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -214,6 +214,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/grid/transmissibility/TransTpfa_impl.hpp
   opm/grid/utility/compressedToCartesian.hpp
   opm/grid/utility/cartesianToCompressed.hpp
+  opm/grid/utility/IteratorRange.hpp
   opm/grid/utility/RegionMapping.hpp
   opm/grid/utility/SparseTable.hpp
   opm/grid/utility/StopWatch.hpp

--- a/opm/grid/GridHelpers.cpp
+++ b/opm/grid/GridHelpers.cpp
@@ -296,12 +296,6 @@ double faceArea(const UnstructuredGrid& grid, int face_index)
     return grid.face_areas[face_index];
 }
 
-int faceTag(const UnstructuredGrid& grid,
-            boost::iterator_range<const int*>::const_iterator face)
-{
-    return grid.cell_facetag[face-cell2Faces(grid)[0].begin()];
-}
-
 SparseTableView cell2Faces(const UnstructuredGrid& grid)
 {
     return SparseTableView(grid.cell_faces, grid.cell_facepos, numCells(grid));

--- a/opm/grid/GridHelpers.hpp
+++ b/opm/grid/GridHelpers.hpp
@@ -45,17 +45,6 @@ namespace UgGridHelpers
 class SparseTableView
 {
 public:
-    class IntRange : public boost::iterator_range<const int*>
-    {
-    public:
-        typedef boost::iterator_range<const int*> BaseRowType;
-        typedef BaseRowType::size_type size_type;
-        typedef int value_type;
-
-        IntRange(const int* start_arg, const int* end_arg)
-            : BaseRowType(start_arg, end_arg)
-        {}
-    };
     /// \brief The type of the roww.
     typedef boost::iterator_range<const int*> row_type;
 

--- a/opm/grid/GridHelpers.hpp
+++ b/opm/grid/GridHelpers.hpp
@@ -281,12 +281,6 @@ const double* faceNormal(const UnstructuredGrid& grid, int face_index);
 /// \param face_index The index of the face in the grid.
 double faceArea(const UnstructuredGrid& grid, int face_index);
 
-/// \brief Get Eclipse Cartesian tag of a face
-/// \param grid The grid that the face is part of.
-/// \param cell_face The face attached to a cell as obtained from cell2Faces()
-/// \return 0, 1, 2, 3, 4, 5 for I-, I+, J-, J+, K-, K+
-int faceTag(const UnstructuredGrid& grid, boost::iterator_range<const int*>::const_iterator cell_face);
-
 /// \brief Maps the grid type to the associated type of the cell to faces mapping.
 ///
 /// Provides a type named Type.

--- a/opm/grid/GridHelpers.hpp
+++ b/opm/grid/GridHelpers.hpp
@@ -25,11 +25,8 @@
 
 #include <opm/grid/UnstructuredGrid.h>
 
+#include <opm/grid/utility/IteratorRange.hpp>
 #include <opm/grid/utility/OpmParserIncludes.hpp>
-
-#include <opm/grid/utility/platform_dependent/disable_warnings.h>
-#include <boost/range/iterator_range.hpp>
-#include <opm/grid/utility/platform_dependent/reenable_warnings.h>
 
 
 namespace Opm
@@ -46,7 +43,7 @@ class SparseTableView
 {
 public:
     /// \brief The type of the roww.
-    typedef boost::iterator_range<const int*> row_type;
+    using row_type = iterator_range_pod<int>;
 
     /// \brief Creates a sparse table view
     /// \param data The array with data of the table.
@@ -63,7 +60,8 @@ public:
     row_type operator[](std::size_t row) const
     {
         assert(row<=size());
-        return row_type(data_ + offset_[row], data_ + offset_[row+1]);
+        return row_type{data_ + offset_[row],
+                        data_ + offset_[row+1]};
     }
 
     /// \brief Get the size of the table.

--- a/opm/grid/cpgrid/GridHelpers.hpp
+++ b/opm/grid/cpgrid/GridHelpers.hpp
@@ -254,7 +254,7 @@ public:
         }
 
     private:
-        // Note that row_ is a boost::iterator_range returned by Opm::SparseTable.
+        // Note that row_ is a Opm::iterator_range returned by Opm::SparseTable.
         // and stored in CellFacesRow. It is a temporary object that only lives
         // as long as there is a reference to it e.g. by storing the Cell2FacesRow.
         // Therefore it needs to be copied. As it is rather light weight this
@@ -282,7 +282,7 @@ public:
     }
 
 private:
-    // Note that row_ is a boost::iterator_range returned by Opm::SparseTable.
+    // Note that row_ is a Opm::iterator_range returned by Opm::SparseTable.
     // and stored in CellFacesRow. It is a temporary object that only lives
     // as long as there is a reference to it e.g. by storing the Cell2FacesRow.
     // Therefore it needs to be copied. As it is rather light weight this

--- a/opm/grid/cpgrid/OrientedEntityTable.hpp
+++ b/opm/grid/cpgrid/OrientedEntityTable.hpp
@@ -60,7 +60,7 @@ namespace Dune
 
             /// @brief Default constructor yielding an empty range.
             OrientedEntityRange()
-                : R(ToTypePtr(0), ToTypePtr(0)), orientation_(true)
+                : orientation_(true)
             {
             }
             /// @brief Constructor taking a row type and an orientation.
@@ -79,7 +79,7 @@ namespace Dune
             /// @return Entity representation.
             ToType operator[](int subindex) const
             {
-                ToType erep = R::operator[](subindex);
+                ToType erep = *(this->begin() + subindex);
                 return orientation_ ? erep : erep.opposite();
             }
         private:

--- a/opm/grid/utility/IteratorRange.hpp
+++ b/opm/grid/utility/IteratorRange.hpp
@@ -1,0 +1,91 @@
+/*
+  Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
+  Copyright 2009, 2010 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_ITERATOR_RANGE_HEADER
+#define OPM_ITERATOR_RANGE_HEADER
+
+#include <iterator>
+#include <type_traits>
+
+namespace Opm {
+
+template <class DataType>
+struct iterator_range_pod {
+    iterator_range_pod(const DataType* begin, const DataType* end) : begin_(begin), end_(end) {}
+    iterator_range_pod() = default;
+
+    size_t size() const { return std::distance(begin_,end_); }
+    bool empty() const { return begin_ == end_; }
+    bool operator==(const iterator_range_pod<DataType>& rhs) const
+    { return (begin_ == rhs.begin_) && (end_ == rhs.end_); }
+
+    const DataType& operator[](int idx) const { return begin_[idx]; }
+
+    const DataType* begin() const { return begin_; }
+    const DataType* end() const { return end_; }
+
+protected:
+    const DataType* begin_;
+    const DataType* end_;
+
+};
+
+template <class Iter>
+struct iterator_range {
+    iterator_range(Iter begin, Iter end) : begin_(begin), end_(end) {}
+    iterator_range() = default;
+
+    size_t size() const { return std::distance(begin_,end_); }
+    bool empty() const { return begin_ == end_; }
+    bool operator==(const iterator_range<Iter>& rhs) const
+    { return (begin_ == rhs.begin_) && (end_ == rhs.end_); }
+
+    const typename Iter::value_type& operator[](int idx) const
+    { return *(begin_+ idx); }
+
+    Iter begin() const { return begin_; }
+    Iter end() const { return end_; }
+
+protected:
+    Iter begin_, end_;
+};
+
+template<typename Iter>
+struct mutable_iterator_range {
+    mutable_iterator_range(Iter begin, Iter end) : begin_(begin), end_(end) {}
+    mutable_iterator_range() = default;
+
+    size_t size() const { return std::distance(begin_,end_); }
+    bool empty() const { return begin_ == end_; }
+    bool operator==(const Iter& rhs) const
+    { return (begin_ == rhs.begin_) && (end_ == rhs.end_); }
+
+    typename Iter::value_type& operator[](int idx)
+    { return begin_[idx]; }
+
+    Iter begin() const { return begin_; }
+    Iter end() const { return end_; }
+
+protected:
+    Iter begin_, end_;
+};
+
+}
+
+#endif // OPM_ITERATOR_RANGE_HEADER

--- a/opm/grid/utility/RegionMapping.hpp
+++ b/opm/grid/utility/RegionMapping.hpp
@@ -20,7 +20,7 @@
 #ifndef OPM_REGIONMAPPING_HEADER_INCLUDED
 #define OPM_REGIONMAPPING_HEADER_INCLUDED
 
-#include <boost/range.hpp>
+#include <opm/grid/utility/IteratorRange.hpp>
 
 #include <unordered_map>
 #include <vector>
@@ -73,7 +73,7 @@ namespace Opm
          */
         typedef typename std::vector<CellId>::const_iterator CellIter;
 
-        typedef boost::iterator_range<CellIter> Range;
+        using Range = iterator_range<CellIter>;
 
         /**
          * Compute region number of given active cell.

--- a/opm/grid/utility/SparseTable.hpp
+++ b/opm/grid/utility/SparseTable.hpp
@@ -38,8 +38,8 @@
 #include <vector>
 #include <numeric>
 #include <algorithm>
-#include <boost/range/iterator_range.hpp>
 #include <opm/grid/utility/ErrorMacros.hpp>
+#include <opm/grid/utility/IteratorRange.hpp>
 
 #include <ostream>
 
@@ -160,23 +160,23 @@ namespace Opm
         }
 
         /// Defining the row type, returned by operator[].
-        typedef boost::iterator_range<const T*> row_type;
-        typedef boost::iterator_range<T*>       mutable_row_type;
+        using row_type = iterator_range<typename std::vector<T>::const_iterator>;
+        using mutable_row_type = mutable_iterator_range<typename std::vector<T>::iterator>;
 
         /// Returns a row of the table.
         row_type operator[](int row) const
         {
             assert(row >= 0 && row < size());
-            const T* start_ptr = data_.data();
-            return row_type(start_ptr + row_start_[row], start_ptr + row_start_[row + 1]);
+            return row_type{data_.begin()+ row_start_[row],
+                            data_.begin() + row_start_[row + 1]};
         }
 
         /// Returns a mutable row of the table.
         mutable_row_type operator[](int row)
         {
             assert(row >= 0 && row < size());
-            T* start_ptr = data_.data();
-            return mutable_row_type(start_ptr + row_start_[row], start_ptr + row_start_[row + 1]);
+            return mutable_row_type{data_.begin() + row_start_[row],
+                                    data_.begin() + row_start_[row + 1]};
         }
 
         /// Iterator for iterating over the container as a whole,


### PR DESCRIPTION
Motivation is to avoid parsing boost headers in downstream code.