### PR TITLE
dune 2.7+ warnings

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -827,7 +827,11 @@ namespace Dune
         /// \warning May only be called once.
         template<class DataHandle>
         bool loadBalance(DataHandle& data,
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+			 decltype(data.fixedSize(0,0)) overlapLayers=1, bool useZoltan = true)
+#else
                          decltype(data.fixedsize(0,0)) overlapLayers=1, bool useZoltan = true)
+#endif
         {
             // decltype usage needed to tell the compiler not to use this function if first
             // argument is std::vector but rather loadbalance by parts

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -245,7 +245,11 @@ struct DefaultContainerHandle
     DefaultContainerHandle(const C& gatherCont, C& scatterCont)
         : gatherCont_(gatherCont), scatterCont_(scatterCont)
     {}
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize(std::size_t, std::size_t)
+#else
     bool fixedsize(std::size_t, std::size_t)
+#endif
     {
         return true;
     }
@@ -286,7 +290,11 @@ struct FaceTagNormalBIdHandle
         : gatherTags_(gatherTags), gatherNormals_(gatherNormals), gatherBIds_(gatherBIds),
           scatterTags_(scatterTags), scatterNormals_(scatterNormals), scatterBIds_(scatterBIds)
     {}
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize(int, int)
+#else
     bool fixedsize(int, int)
+#endif
     {
         return true;
     }
@@ -343,7 +351,11 @@ struct FaceTagNormalHandle
         : gatherTags_(gatherTags), gatherNormals_(gatherNormals),
           scatterTags_(scatterTags), scatterNormals_(scatterNormals)
     {}
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize(int, int)
+#else
     bool fixedsize(int, int)
+#endif
     {
         return true;
     }
@@ -391,7 +403,11 @@ struct PointGeometryHandle
     PointGeometryHandle(const Container& gatherCont, Container& scatterCont)
         : gatherPoints_(gatherCont), scatterPoints_(scatterCont)
     {}
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize(int, int)
+#else
     bool fixedsize(int, int)
+#endif
     {
         return true;
     }
@@ -447,7 +463,11 @@ struct FaceGeometryHandle
     FaceGeometryHandle(const Container& gatherCont, Container& scatterCont)
         : gatherPoints_(gatherCont), scatterPoints_(scatterCont)
     {}
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize(int, int)
+#else
     bool fixedsize(int, int)
+#endif
     {
         return true;
     }
@@ -499,7 +519,11 @@ struct CellGeometryHandle
         : gatherCont_(gatherCont), scatterCont_(scatterCont), pointGeom_(pointGeom),
           cell2Points_(cell2Points)
     {}
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize(int, int)
+#else
     bool fixedsize(int, int)
+#endif
     {
         return true;
     }
@@ -565,7 +589,11 @@ struct Cell2PointsDataHandle
         : globalCell2Points_(globalCell2Points), globalIds_(globalIds), globalAdditionalPointIds_(globalAdditionalPointIds),
           localCell2Points_(localCell2Points), flatGlobalPoints_(flatGlobalPoints), additionalPointIds_(additionalPointIds)
     {}
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize(int, int)
+#else
     bool fixedsize(int, int)
+#endif
     {
         return false;
     }
@@ -627,7 +655,11 @@ struct RowSizeDataHandle
                       std::vector<int>& noEntries)
         : global_(global), noEntries_(noEntries)
     {}
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize(int, int)
+#else
     bool fixedsize(int, int)
+#endif
     {
         return true;
     }
@@ -686,7 +718,11 @@ struct SparseTableDataHandle
                           const std::map<int,int>& global2Local)
         : global_(global), globalIds_(globalIds), local_(local), global2Local_(global2Local)
     {}
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize(int, int)
+#else
     bool fixedsize(int, int)
+#endif
     {
         return false;
     }
@@ -741,7 +777,11 @@ struct OrientedEntityTableDataHandle
                                   const IdSet* globalIds = nullptr)
         : global_(global), local_(local), globalIds_(globalIds)
     {}
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize(int, int)
+#else
     bool fixedsize(int, int)
+#endif
     {
         return false;
     }

--- a/opm/grid/cpgrid/DataHandleWrappers.hpp
+++ b/opm/grid/cpgrid/DataHandleWrappers.hpp
@@ -39,6 +39,8 @@
 #include "OrientedEntityTable.hpp"
 #include "EntityRep.hpp"
 
+#include <dune/common/version.hh>
+
 namespace Dune
 {
 namespace cpgrid
@@ -71,7 +73,12 @@ struct FaceViaCellHandleWrapper
                              const C2FTable& c2f)
         : handle_(handle), c2fGather_(c2fGather), c2f_(c2f)
     {}
+
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize(int, int)
+#else
     bool fixedsize(int, int)
+#endif
     {
         return false; // as the faces per cell differ
     }
@@ -176,6 +183,16 @@ struct PointViaCellHandleWrapper : public PointViaCellWarner
                              const C2PTable& c2p)
         : handle_(handle), c2pGather_(c2pGather), c2p_(c2p)
     {}
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize(int i, int j)
+    {
+        if( ! handle_.fixedSize(i, j))
+        {
+            this->warn();
+        }
+        return handle_.fixedSize(i, j);
+    }
+#else
     bool fixedsize(int i, int j)
     {
         if( ! handle_.fixedsize(i, j))
@@ -184,6 +201,7 @@ struct PointViaCellHandleWrapper : public PointViaCellWarner
         }
         return handle_.fixedsize(i, j);
     }
+#endif
     template<class T>
     typename std::enable_if<T::codimension != 0, std::size_t>::type
     size(const T&)

--- a/opm/grid/cpgrid/Entity2IndexDataHandle.hpp
+++ b/opm/grid/cpgrid/Entity2IndexDataHandle.hpp
@@ -34,6 +34,8 @@
 #ifndef OPM_ENTITY2INDEXDATAHANDLE_HEADER
 #define OPM_ENTITY2INDEXDATAHANDLE_HEADER
 
+#include <dune/common/version.hh>
+
 namespace Dune
 {
 namespace cpgrid
@@ -61,7 +63,11 @@ public:
     {}
     bool fixedsize()
     {
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+        return data_.fixedSize(3, codim);
+#else
         return data_.fixedsize(3, codim);
+#endif
     }
     std::size_t size(std::size_t i)
     {

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -66,7 +66,11 @@ public:
           dist_cell_ids_(dist_cell_ids)
     {}
     typedef int DataType;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize(int /*dim*/, int /*codim*/)
+#else
     bool fixedsize(int /*dim*/, int /*codim*/)
+#endif
     {
         return true;
     }
@@ -155,7 +159,12 @@ public:
     {}
 
     typedef int DataType;
+
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize(int /*dim*/, int /*codim*/)
+#else
     bool fixedsize(int /*dim*/, int /*codim*/)
+#endif
     {
         return true;
     }
@@ -260,7 +269,11 @@ class DummyDataHandle
 {
 public:
     typedef double DataType;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize(int /*dim*/, int /*codim*/)
+#else
     bool fixedsize(int /*dim*/, int /*codim*/)
+#endif
     {
         return true;
     }
@@ -301,7 +314,11 @@ public:
     {}
 
     typedef int DataType;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize(int /*dim*/, int /*codim*/)
+#else
     bool fixedsize(int /*dim*/, int /*codim*/)
+#endif
     {
         return true;
     }


### PR DESCRIPTION
Quell warnings with dune 2.7. Debian 11 is near and then ci will move to 2.7..