### PR TITLE
Support DUNE 2.8 with minimal amount of deprecation warnings.

### DIFF
--- a/examples/finitevolume/finitevolume.cc
+++ b/examples/finitevolume/finitevolume.cc
@@ -51,11 +51,10 @@ template<class G>
 void timeloop(const G& grid, double tend)
 {
     // make a mapper for codim 0 entities in the leaf grid
-#if DUNE_VERSION_NEWER(DUNE_GEOMETRY, 2, 6)
-    Dune::LeafMultipleCodimMultipleGeomTypeMapper<G> mapper(grid, Dune::mcmgElementLayout());
+#if DUNE_VERSION_NEWER(DUNE_GEOMETRY, 2, 8)
+    Dune::MultipleCodimMultipleGeomTypeMapper<typename G::LeafGridView>  mapper(grid.leafGridView(), Dune::mcmgElementLayout());
 #else
-    Dune::LeafMultipleCodimMultipleGeomTypeMapper<G,P0Layout>
-    mapper(grid);
+    Dune::LeafMultipleCodimMultipleGeomTypeMapper<G> mapper(grid, Dune::mcmgElementLayout());
 #endif
 
     // allocate a vector for the concentration

--- a/opm/grid/polyhedralgrid/grid.hh
+++ b/opm/grid/polyhedralgrid/grid.hh
@@ -16,7 +16,7 @@
 //- dune-grid includes
 #include <dune/grid/common/grid.hh>
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+#if DUNE_VERSION_GTE(DUNE_COMMON, 2, 7)
 #include <dune/common/parallel/communication.hh>
 #else
 #include <dune/common/parallel/collectivecommunication.hh>

--- a/opm/grid/polyhedralgrid/gridfactory.hh
+++ b/opm/grid/polyhedralgrid/gridfactory.hh
@@ -37,11 +37,15 @@ namespace Dune
     typedef Dune::FieldVector<ctype,dimensionworld> CoordinateType;
     typedef CoordinateType  Coordinate;
 
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+#if DUNE_VERSION_GTE(DUNE_GRID, 2, 7)
+#if DUNE_VERSION_LT(DUNE_GRID, 2, 8)
     typedef ToUniquePtr<Grid>       UniquePtrType;
-#else // #if DUNE_VERSION_NEWER(DUNE_GRID, 2, 6)
+#else
+    using UniquePtrType = std::unique_ptr<Grid>;
+#endif
+#else // #if DUNE_VERSION_GTE(DUNE_GRID, 2, 7)
     typedef Grid*  UniquePtrType;
-#endif // #else // #if DUNE_VERSION_NEWER(DUNE_GRID, 2, 6)
+#endif // #else // #if DUNE_VERSION_GTE(DUNE_GRID, 2, 7)
 
 
     /** \brief Default constructor */
@@ -94,14 +98,6 @@ namespace Dune
 
 
       }
-    }
-
-    virtual void insertElement(const GeometryType& type,
-                               const std::vector<unsigned int>& vertices,
-                               const std::shared_ptr<VirtualFunction<FieldVector<ctype,dimension>,FieldVector<ctype,dimensionworld> > >&)
-    {
-      std::cerr << "Warning: elementParametrization is being ignored in insertElement!" << std::endl;
-      insertElement( type, vertices );
     }
 
     void insertBoundarySegment(const std::vector<unsigned int>&)
@@ -254,7 +250,7 @@ namespace Dune
         }
       }
 
-      return new Grid( std::move( ug ) );
+      return UniquePtrType( new Grid( std::move( ug ) ));
     }
 
   protected:


### PR DESCRIPTION
- deprecated ToUniquePtr was dropped and we select the right type now manually in the GridFactory
- Use `MultipleCodimMultipleGeomTypeMapper<Grid>` instead of `LeafMultipleCodimMultipleGeomTypeMapper<Grid,Layout>`