### PR TITLE
Fix compilation of mirror_grid.

### DIFF
--- a/opm/grid/utility/OpmParserIncludes.hpp
+++ b/opm/grid/utility/OpmParserIncludes.hpp
@@ -20,6 +20,8 @@
 #define OPM_GRID_OPMPARSERINCLUDES_HEADER_INCLUDED
 
 #if HAVE_ECL_INPUT
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>


### PR DESCRIPTION
Somehow it failed due incomplete types Opm::Deck and Opm::ParseContext. Change the header inclusion to fix this.

#525 broke the build. :flushed: 