### PR TITLE
Fixes deprecation warnings about fixedsize for DUNE>=2.8

### DIFF
--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -962,7 +962,12 @@ struct AttributeDataHandle
         : rank_(rank), indicator_(indicator), vals_(vals),
         c2e_(cell_to_entity), grid_(grid)
     {}
+
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize()
+#else
     bool fixedsize()
+#endif
     {
         return true;
     }

--- a/opm/grid/cpgrid/Entity2IndexDataHandle.hpp
+++ b/opm/grid/cpgrid/Entity2IndexDataHandle.hpp
@@ -61,14 +61,18 @@ public:
     Entity2IndexDataHandle(const CpGridData& fromGrid, const CpGridData& toGrid, DataHandle& data)
         : fromGrid_(fromGrid), toGrid_(toGrid), data_(data)
     {}
+
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize()
+    {
+        return data_.fixedSize(3, codim);
+    }
+#else
     bool fixedsize()
     {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
-        return data_.fixedSize(3, codim);
-#else
         return data_.fixedsize(3, codim);
-#endif
     }
+#endif
     std::size_t size(std::size_t i)
     {
         return data_.size(Entity<codim>(fromGrid_, i, true));

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -119,7 +119,12 @@ public:
     {}
 
     typedef int DataType;
+
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize()
+#else
     bool fixedsize()
+#endif
     {
         return true;
     }
@@ -216,7 +221,11 @@ public:
     {}
 
     typedef int DataType;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize()
+#else
     bool fixedsize()
+#endif
     {
         // We used fixedsize for the message as there is a bug in DUNE
         // up to 2.6.0


### PR DESCRIPTION
VariableSizeCommunicator::fixedsize was deprecated lately.

I think this should be backported to the release.