### PR TITLE
Save/export information about Numerical Aquifer cells in CpGrid.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,23 @@ if(MPI_FOUND)
 endif()
 
 if(MPI_FOUND AND HAVE_OPM_TESTS)
+  # opm_add_test would need a driver script to run the
+  # parallel test (tests/run-parallel-unitTest.sh which
+  # is in opm-simulators and needs to be moved) until
+  # then we use opm_add_test and an additional call to add_test
+  # to run the test in parall. ONLY_COMPILE does not work because
+  # somehow -DBOOST_TEST_DYN_LINK is skipped and there is no main.
+  opm_add_test(cpgrid_aquifer_test
+    SOURCES tests/cpgrid/cpgrid_aquifer_test.cpp
+    DEPENDS opmgrid
+    #ONLY_COMPILE
+    PROCESSORS 4
+    CONDITION MPI_FOUND AND Boost_UNIT_TEST_FRAMEWORK_FOUND
+    DRIVER_ARGS -np 4
+    TEST_ARGS -- ${OPM_TESTS_ROOT}/aquifer-num/3D_2AQU_NUM.DATA
+    LIBRARIES opmgrid ${Boost_LIBRARIES})
   add_test(cpgrid_aquifer_parallel_test ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 bin/cpgrid_aquifer_test -- ${OPM_TESTS_ROOT}/aquifer-num/3D_2AQU_NUM.DATA)
 endif()
+
 install(DIRECTORY doc/man1 DESTINATION ${CMAKE_INSTALL_MANDIR}
   FILES_MATCHING PATTERN "*.1")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,9 @@ include (${project}-prereqs)
 # it should set various lists with the names of the files to include
 include (CMakeLists_files.cmake)
 
+# Search opm-tests to use some of the data sets for testing
+include(Findopm-tests)
+
 macro (config_hook)
 	opm_need_version_of ("dune-common")
 	opm_need_version_of ("dune-geometry")
@@ -124,5 +127,8 @@ if(MPI_FOUND)
   add_test(test_communication_utils_parallel ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 bin/test_communication_utils)
 endif()
 
+if(MPI_FOUND AND HAVE_OPM_TESTS)
+  add_test(cpgrid_aquifer_parallel_test ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 bin/cpgrid_aquifer_test -- ${OPM_TESTS_ROOT}/aquifer-num/3D_2AQU_NUM.DATA)
+endif()
 install(DIRECTORY doc/man1 DESTINATION ${CMAKE_INSTALL_MANDIR}
   FILES_MATCHING PATTERN "*.1")

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -85,6 +85,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_cpgrid.cpp
   tests/test_communication_utils.cpp
   tests/test_column_extract.cpp
+  tests/cpgrid/cpgrid_aquifer_test.cpp
   tests/cpgrid/distribution_test.cpp
   tests/cpgrid/entityrep_test.cpp
   tests/cpgrid/entity_test.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -85,7 +85,6 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_cpgrid.cpp
   tests/test_communication_utils.cpp
   tests/test_column_extract.cpp
-  tests/cpgrid/cpgrid_aquifer_test.cpp
   tests/cpgrid/distribution_test.cpp
   tests/cpgrid/entityrep_test.cpp
   tests/cpgrid/entity_test.cpp

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1528,6 +1528,12 @@ namespace Dune
 
 #endif
 
+        /// \brief Get sorted active cell indices of numerical aquifer
+       const std::vector<int>& sortedNumAquiferCells() const
+       {
+           return current_view_data_->sortedNumAquiferCells();
+       }
+
     private:
         /// \brief Scatter a global grid to all processors.
         /// \param method The edge-weighting method to be used on the Zoltan partitioner.

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -367,6 +367,12 @@ public:
     enum AttributeSet{owner, overlap, copy};
 #endif
 
+    /// \brief Get sorted active cell indices of numerical aquifer
+    const std::vector<int>& sortedNumAquiferCells() const
+    {
+        return aquifer_cells_;
+    }
+
 private:
 
     /// \brief Adds entries to the parallel index set of the cells during grid construction
@@ -444,8 +450,10 @@ private:
 
     void computeGeometry(CpGrid& grid,
                          const DefaultGeometryPolicy&  globalGeometry,
+                         const std::vector<int>& globalAquiferCells,
                          const OrientedEntityTable<0, 1>& globalCell2Faces,
                          DefaultGeometryPolicy& geometry,
+                         std::vector<int>& aquiferCells,
                          const OrientedEntityTable<0, 1>& cell2Faces,
                          const std::vector< std::array<int,8> >& cell2Points);
 
@@ -512,6 +520,9 @@ private:
     /// the zcorn values will typically be modified, and we retain a
     /// copy here to be able to create an EclipseGrid for output.
     std::vector<double> zcorn;
+
+    /// \brief Sorted vector of aquifer cell indices.
+    std::vector<int> aquifer_cells_;
 
 #if HAVE_MPI
 

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -310,13 +310,16 @@ namespace cpgrid
         std::unordered_map<size_t, double> aquifer_cell_volumes_local;
         if (ecl_state && ecl_state->aquifer().hasNumericalAquifer()) {
             const auto& aquifer_cell_volumes = ecl_state->aquifer().numericalAquifers().aquiferCellVolumes();
+            aquifer_cells_.reserve(aquifer_cell_volumes.size());
             for (auto nc = this->global_cell_.size(), i = 0 * nc; i < nc; ++i) {
                 auto aquCellPos = aquifer_cell_volumes.find(this->global_cell_[i]);
                 if (aquCellPos != aquifer_cell_volumes.end()) {
                     aquifer_cell_volumes_local.emplace(i, aquCellPos->second);
+                    aquifer_cells_.push_back(i);
                 }
             }
         }
+        std::sort(aquifer_cells_.begin(), aquifer_cells_.end());
         buildGeom(output, cell_to_face_, cell_to_point_, face_to_output_face, aquifer_cell_volumes_local, geometry_.geomVector(std::integral_constant<int,0>()),
                   geometry_.geomVector(std::integral_constant<int,1>()), geometry_.geomVector(std::integral_constant<int,3>()),
                   face_normals_, turn_normals);

--- a/tests/cpgrid/cpgrid_aquifer_test.cpp
+++ b/tests/cpgrid/cpgrid_aquifer_test.cpp
@@ -58,13 +58,7 @@ BOOST_TEST_GLOBAL_FIXTURE( CommandLineDataFileMpiInit);
 
 
 BOOST_AUTO_TEST_CASE(CpGridAquiferTest)
-{    
-    if(CommandLineDataFileMpiInit::helper().size()==1)
-    {
-         std::cerr<<"Test should be run parallel"<<std::endl;
-        return;
-    }
-
+{
     Opm::Parser parser;
     Opm::ParseContext context;
     Opm::ErrorGuard guard;

--- a/tests/cpgrid/cpgrid_aquifer_test.cpp
+++ b/tests/cpgrid/cpgrid_aquifer_test.cpp
@@ -1,0 +1,98 @@
+#include <config.h>
+
+#include <dune/common/version.hh>
+
+#define BOOST_TEST_MODULE CPGridAquiferTests
+#include <boost/test/unit_test.hpp>
+
+#include <opm/grid/CpGrid.hpp>
+#include <opm/grid/common/CommunicationUtils.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#if HAVE_MPI
+class MPIError {
+public:
+  /** @brief Constructor. */
+  MPIError(std::string s, int e) : errorstring(s), errorcode(e){}
+  /** @brief The error string. */
+  std::string errorstring;
+  /** @brief The mpi error code. */
+  int errorcode;
+};
+
+void MPI_err_handler(MPI_Comm *, int *err_code, ...){
+  char *err_string=new char[MPI_MAX_ERROR_STRING];
+  int err_length;
+  MPI_Error_string(*err_code, err_string, &err_length);
+  std::string s(err_string, err_length);
+  std::cerr << "An MPI Error ocurred:"<<std::endl<<s<<std::endl;
+  delete[] err_string;
+  throw MPIError(s, *err_code);
+}
+#endif
+
+struct CommandLineDataFileMpiInit
+{
+    void setup()
+    {
+        auto& argv = boost::unit_test::framework::master_test_suite().argv;
+        auto& argc = boost::unit_test::framework::master_test_suite().argc;
+        Dune::MPIHelper::instance(argc, argv);
+        if(argc>1)
+            caseFileName = std::string(argv[argc-1]);
+    }
+    void teardown()
+    {
+    }
+    static const Dune::MPIHelper& helper(){
+        auto& argv = boost::unit_test::framework::master_test_suite().argv;
+        auto& argc = boost::unit_test::framework::master_test_suite().argc;
+        return Dune::MPIHelper::instance(argc, argv);
+    }
+    static std::string caseFileName;
+};
+
+std::string CommandLineDataFileMpiInit::caseFileName;
+
+BOOST_TEST_GLOBAL_FIXTURE( CommandLineDataFileMpiInit);
+
+
+BOOST_AUTO_TEST_CASE(CpGridAquiferTest)
+{    
+    if(CommandLineDataFileMpiInit::helper().size()==1)
+    {
+         std::cerr<<"Test should be run parallel"<<std::endl;
+        return;
+    }
+
+    Opm::Parser parser;
+    Opm::ParseContext context;
+    Opm::ErrorGuard guard;
+    BOOST_REQUIRE(CommandLineDataFileMpiInit::caseFileName.size());
+    const auto deck = parser.parseFile(CommandLineDataFileMpiInit::caseFileName, context,
+                                       guard);
+    Dune::CpGrid grid;
+    Opm::EclipseGrid ecl_grid(deck);
+    grid.processEclipseFormat(&ecl_grid, nullptr, false, false, false);
+
+    auto aquifer_cells = grid.sortedNumAquiferCells();
+    for( auto& cell: aquifer_cells)
+    {
+        cell = grid.globalCell()[cell];
+    }
+    grid.loadBalance();
+    auto load_balanced_aquifer_cells = grid.sortedNumAquiferCells();
+
+    for( auto&& cell: load_balanced_aquifer_cells)
+    {
+        cell = grid.globalCell()[cell];
+    }
+
+    auto [gathered_aquifer_cells, offset] = Opm::allGatherv(load_balanced_aquifer_cells, CommandLineDataFileMpiInit::helper().getCollectiveCommunication());
+
+    offset.size();
+    std::sort(aquifer_cells.begin(), aquifer_cells.end());
+    std::sort(gathered_aquifer_cells.begin(), gathered_aquifer_cells.end());
+
+    BOOST_TEST(aquifer_cells == gathered_aquifer_cells);
+}


### PR DESCRIPTION
This is done as a sorted range of active indices of aquifer cells. The information is communicated during loadbalance.

For parallel testing we use a data file from opm-tests.

Is there a way to deactivate the serial test? It is rather useless...