### PR TITLE
Fix PR #553 for DUNE 2.7 (VariableSizeComunicator needs fixedsize method).

### DIFF
--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -963,7 +963,7 @@ struct AttributeDataHandle
         c2e_(cell_to_entity), grid_(grid)
     {}
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 8)
     bool fixedSize()
 #else
     bool fixedsize()

--- a/opm/grid/cpgrid/Entity2IndexDataHandle.hpp
+++ b/opm/grid/cpgrid/Entity2IndexDataHandle.hpp
@@ -62,7 +62,7 @@ public:
         : fromGrid_(fromGrid), toGrid_(toGrid), data_(data)
     {}
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 8)
     bool fixedSize()
     {
         return data_.fixedSize(3, codim);
@@ -70,7 +70,11 @@ public:
 #else
     bool fixedsize()
     {
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+        return data_.fixedSize(3, codim);
+#else
         return data_.fixedsize(3, codim);
+#endif
     }
 #endif
     std::size_t size(std::size_t i)


### PR DESCRIPTION
In contrast to the Grid data handles, which have fixedSize since 2.7, the handle used by VariableSizeCommunicator got the fixedSize method only later for DUNE 2.8.

This commit fixes this inconsistency in OPM and hence compilation with DUNE 2.7.