### PR TITLE
Fixed DUNE 2.7 problems for distribution_test.

### DIFF
--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -120,7 +120,7 @@ public:
 
     typedef int DataType;
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 8)
     bool fixedSize()
 #else
     bool fixedsize()
@@ -221,7 +221,7 @@ public:
     {}
 
     typedef int DataType;
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 8)
     bool fixedSize()
 #else
     bool fixedsize()


### PR DESCRIPTION
Completes #556. The test assumed that VariableSizeCommunicator::fixedSize appeared in version 2.7 but it was 2.8.

Closes #557 