### PR TITLE
Make internal partitioning methods return WellConnections, too.

### DIFF
--- a/opm/grid/common/GridPartitioning.cpp
+++ b/opm/grid/common/GridPartitioning.cpp
@@ -588,8 +588,9 @@ namespace cpgrid
 #if HAVE_MPI
 
    std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
-               std::vector<std::tuple<int,int,char> >,
-               std::vector<std::tuple<int,int,char,int> > >
+              std::vector<std::tuple<int,int,char> >,
+              std::vector<std::tuple<int,int,char,int> >,
+              WellConnections>
     createZoltanListsFromParts(const CpGrid& grid, const std::vector<cpgrid::OpmWellType> * wells,
                                const double* transmissibilities, const std::vector<int>& parts,
                                bool allowDistributedWells)
@@ -656,7 +657,8 @@ namespace cpgrid
 
     std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
                std::vector<std::tuple<int,int,char> >,
-               std::vector<std::tuple<int,int,char,int> > >
+               std::vector<std::tuple<int,int,char,int> >,
+               WellConnections>
     vanillaPartitionGridOnRoot(const CpGrid& grid, const std::vector<cpgrid::OpmWellType> * wells,
                                const double* transmissibilities, bool allowDistributedWells = false)
     {

--- a/opm/grid/common/GridPartitioning.cpp
+++ b/opm/grid/common/GridPartitioning.cpp
@@ -632,7 +632,7 @@ namespace cpgrid
                                      exportToPart.data(), 0,
                                      grid.comm());
         std::unique_ptr<cpgrid::CombinedGridWellGraph> gridAndWells;
-        if (wells && !allowDistributedWells)
+        if (wells)
         {
             bool partitionIsEmpty = (grid.size(0) == 0);
             EdgeWeightMethod method{}; // We don't care which method is used, we only need the graph.

--- a/opm/grid/common/GridPartitioning.hpp
+++ b/opm/grid/common/GridPartitioning.hpp
@@ -46,6 +46,8 @@
 #include <dune/common/parallel/mpihelper.hh>
 
 #include <opm/grid/utility/OpmParserIncludes.hpp>
+#include <opm/grid/common/WellConnections.hpp>
+
 namespace Dune
 {
 
@@ -121,17 +123,20 @@ namespace cpgrid
     ///         a vector containing a pair of name  and a boolean indicating whether this well has
     ///         perforated cells local to the process of all wells,
     ///         vector containing information for each exported cell (global id
-    ///         of cell, process id to send to, attribute there), and a vector containing
+    ///         of cell, process id to send to, attribute there), a vector containing
     ///         information for each imported cell (global index, process id that sends, attribute here, local index
-    ///         here)
+    ///         here), and a WellConnections object containing information about the well connections
+    ///         (if argument wells was not null and this is the root rank this will contain connections in
+    ///          form of global indices)
     std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
                std::vector<std::tuple<int,int,char> >,
-               std::vector<std::tuple<int,int,char,int> > >
+               std::vector<std::tuple<int,int,char,int> >,
+               WellConnections>
     createZoltanListsFromParts(const CpGrid& grid, const std::vector<cpgrid::OpmWellType> * wells,
                                const double* transmissibilities, const std::vector<int>& parts,
                                bool allowDistributedWells);
 
-    /// \brief Creats a vanilla partitioning without a real loadbalancer
+    /// \brief Creates a vanilla partitioning without a real loadbalancer
     ///
     /// The loadbalancing will take place on the cartesian grid.
     /// \param grid The grid
@@ -143,12 +148,15 @@ namespace cpgrid
     ///         a vector containing a pair of name  and a boolean indicating whether this well has
     ///         perforated cells local to the process of all wells,
     ///         vector containing information for each exported cell (global id
-    ///         of cell, process id to send to, attribute there), and a vector containing
+    ///         of cell, process id to send to, attribute there), a vector containing
     ///         information for each imported cell (global index, process id that sends, attribute here, local index
-    ///         here)
+    ///         here), and a WellConnections object containing information about the well connections
+    ///         (if argument wells was not null and this is the root rank this will contain connections in
+    ///          form of global indices)
     std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
                std::vector<std::tuple<int,int,char> >,
-               std::vector<std::tuple<int,int,char,int> > >
+               std::vector<std::tuple<int,int,char,int> >,
+               WellConnections>
     vanillaPartitionGridOnRoot(const CpGrid& grid,
                                const std::vector<cpgrid::OpmWellType> * wells,
                                const double* transmissibilities,

--- a/opm/grid/common/WellConnections.hpp
+++ b/opm/grid/common/WellConnections.hpp
@@ -125,7 +125,7 @@ private:
 
 
 #ifdef HAVE_MPI
-/// \brief Determines the wells that have peforate cells for each process.
+/// \brief Determines the wells that have perforate cells for each process.
 ///
 /// On the root process omputes for all processes all indices of wells that
 /// will perforate local cells.

--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -36,7 +36,8 @@ namespace cpgrid
 template<class Id>
 std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
            std::vector<std::tuple<int,int,char> >,
-           std::vector<std::tuple<int,int,char,int> > >
+           std::vector<std::tuple<int,int,char,int> >,
+           WellConnections>
 makeImportAndExportLists(const Dune::CpGrid& cpgrid,
                          const Dune::CollectiveCommunication<MPI_Comm>& cc,
                          const std::vector<Dune::cpgrid::OpmWellType> * wells,
@@ -96,6 +97,7 @@ makeImportAndExportLists(const Dune::CpGrid& cpgrid,
         if (allowDistributedWells)
         {
             wellsOnProc = perforatingWellIndicesOnProc(parts, *wells, cpgrid);
+            // In case we want to
         }
         else
         {
@@ -140,7 +142,8 @@ makeImportAndExportLists(const Dune::CpGrid& cpgrid,
                                                             cc,
                                                             root);
     }
-    return std::make_tuple(parts, parallel_wells, myExportList, myImportList);
+    return std::make_tuple(parts, parallel_wells, myExportList, myImportList,
+                           wells ? gridAndWells->getWellConnections(): WellConnections());
 }
 
 template<class Id>
@@ -220,7 +223,8 @@ scatterExportInformation(int numExport, const Id* exportGlobalGids,
 template
 std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
            std::vector<std::tuple<int,int,char> >,
-           std::vector<std::tuple<int,int,char,int> > >
+           std::vector<std::tuple<int,int,char,int> >,
+           WellConnections>
 makeImportAndExportLists(const Dune::CpGrid&,
                          const Dune::CollectiveCommunication<MPI_Comm>&,
                          const std::vector<Dune::cpgrid::OpmWellType>*,
@@ -268,7 +272,8 @@ void setDefaultZoltanParameters(Zoltan_Struct* zz) {
 
 std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
            std::vector<std::tuple<int,int,char> >,
-           std::vector<std::tuple<int,int,char,int> > >
+           std::vector<std::tuple<int,int,char,int> >,
+           WellConnections>
 zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
                                const std::vector<OpmWellType> * wells,
                                const double* transmissibilities,
@@ -383,7 +388,8 @@ public:
     std::tuple<std::vector<int>,
                std::vector<std::pair<std::string, bool>>,
                std::vector<std::tuple<int, int, char>>,
-               std::vector<std::tuple<int, int, char, int>>>
+               std::vector<std::tuple<int, int, char, int>>,
+               WellConnections>
     partition()
     {
         MPI_Barrier(cc);
@@ -512,7 +518,8 @@ private:
 std::tuple<std::vector<int>,
            std::vector<std::pair<std::string, bool>>,
            std::vector<std::tuple<int, int, char>>,
-           std::vector<std::tuple<int, int, char, int>>>
+           std::vector<std::tuple<int, int, char, int>>,
+           WellConnections>
 zoltanSerialGraphPartitionGridOnRoot(const CpGrid& cpgrid,
                                      const std::vector<OpmWellType>* wells,
                                      const double* transmissibilities,

--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -97,7 +97,6 @@ makeImportAndExportLists(const Dune::CpGrid& cpgrid,
         if (allowDistributedWells)
         {
             wellsOnProc = perforatingWellIndicesOnProc(parts, *wells, cpgrid);
-            // In case we want to
         }
         else
         {

--- a/opm/grid/common/ZoltanPartition.hpp
+++ b/opm/grid/common/ZoltanPartition.hpp
@@ -24,6 +24,8 @@
 
 #include <opm/grid/CpGrid.hpp>
 #include <opm/grid/common/ZoltanGraphFunctions.hpp>
+#include <opm/grid/common/WellConnections.hpp>
+
 #if HAVE_MPI
 namespace Dune
 {
@@ -56,11 +58,14 @@ namespace cpgrid
 ///         vector containing information for each exported cell (global id
 ///         of cell, process id to send to, attribute there), and a vector containing
 ///         information for each imported cell (global index, process id that sends, attribute here, local index
-///         here)
+///         here), and a WellConnections object containing information about the well connections
+///         (if argument wells was not null and this is the root rank this will contain connections in
+///          form of global indices)
 template<class Id>
 std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
            std::vector<std::tuple<int,int,char> >,
-           std::vector<std::tuple<int,int,char,int> > >
+           std::vector<std::tuple<int,int,char,int> >,
+           WellConnections>
 makeImportAndExportLists(const Dune::CpGrid& cpgrid,
                          const Dune::CollectiveCommunication<MPI_Comm>& cc,
                          const std::vector<Dune::cpgrid::OpmWellType> * wells,
@@ -111,12 +116,16 @@ namespace cpgrid
 ///         a vector containing a pair of name  and a boolean indicating whether this well has
 ///         perforated cells local to the process of all wells,
 ///         vector containing information for each exported cell (global id
-///         of cell, process id to send to, attribute there), and a vector containing
+///         of cell, process id to send to, attribute there), a vector containing
 ///         information for each imported cell (global index, process id that sends, attribute here, local index
-///         here)
+///         here), and a WellConnections object containing information about the well connections
+///         (if argument wells was not null and this is the root rank this will contain connections in
+///          form of global indices)
+
 std::tuple<std::vector<int>,std::vector<std::pair<std::string,bool>>,
            std::vector<std::tuple<int,int,char> >,
-           std::vector<std::tuple<int,int,char,int> >  >
+           std::vector<std::tuple<int,int,char,int> >,
+           WellConnections>
 zoltanGraphPartitionGridOnRoot(const CpGrid& grid,
                                const std::vector<OpmWellType> * wells,
                                const double* transmissibilities,
@@ -148,14 +157,17 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& grid,
 ///         the number of the process that owns it after repartitioning,
 ///         a set of names of wells that should be defunct in a parallel
 ///         simulation, vector containing information for each exported cell (global id
-///         of cell, process id to send to, attribute there), and a vector containing
+///         of cell, process id to send to, attribute there), a vector containing
 ///         information for each imported cell (global index, process id that sends, attribute here, local index
-///         here)
+///         here), and a WellConnections object containing information about the well connections
+///         (if argument wells was not null and this is the root rank this will contain connections in
+///          form of global indices)
 ///
 /// @note This function will only do *serial* partioning.
 std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
            std::vector<std::tuple<int,int,char> >,
-           std::vector<std::tuple<int,int,char,int> >  >
+           std::vector<std::tuple<int,int,char,int> >,
+           WellConnections>
 zoltanSerialGraphPartitionGridOnRoot(const CpGrid& grid,
                                const std::vector<OpmWellType> * wells,
                                const double* transmissibilities,

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -172,6 +172,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
         std::vector<std::pair<std::string,bool>> wells_on_proc;
         std::vector<std::tuple<int,int,char>> exportList;
         std::vector<std::tuple<int,int,char,int>> importList;
+        cpgrid::WellConnections wellConnections;
 
         auto inputNumParts = input_cell_part.size();
         inputNumParts = this->comm().max(inputNumParts);
@@ -240,7 +241,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
 
 
             // Partitioning given externally
-            std::tie(computedCellPart, wells_on_proc, exportList, importList) =
+            std::tie(computedCellPart, wells_on_proc, exportList, importList, wellConnections) =
                 cpgrid::createZoltanListsFromParts(*this, wells, nullptr, input_cell_part,
                                                    true);
         }
@@ -249,7 +250,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
             if (useZoltan)
             {
 #ifdef HAVE_ZOLTAN
-                std::tie(computedCellPart, wells_on_proc, exportList, importList)
+                std::tie(computedCellPart, wells_on_proc, exportList, importList, wellConnections)
                     = serialPartitioning
                     ? cpgrid::zoltanSerialGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0, zoltanImbalanceTol, allowDistributedWells)
                     : cpgrid::zoltanGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0, zoltanImbalanceTol, allowDistributedWells);
@@ -259,7 +260,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
             }
             else
             {
-                std::tie(computedCellPart, wells_on_proc, exportList, importList) =
+                std::tie(computedCellPart, wells_on_proc, exportList, importList, wellConnections) =
                     cpgrid::vanillaPartitionGridOnRoot(*this, wells, transmissibilities, allowDistributedWells);
             }
         }


### PR DESCRIPTION
This is preparatory step to support `--matrix-add-well-contributions=true` for distributed wells. In that case will need to add perforated cells of well as copy/overlap cells. For this we will need information about the wells as is available in WellConnections.

Next step is to add a function addOverlapWells that adds the well overlap cells. That one might be more tricky, though.