### PR TITLE
Fix: unconnected wells give undefined behaviour in parallel.

### DIFF
--- a/opm/grid/common/WellConnections.cpp
+++ b/opm/grid/common/WellConnections.cpp
@@ -183,11 +183,16 @@ postProcessPartitioningForWells(std::vector<int>& parts,
 
         for (const auto &well : wells) {
             const auto &connections = well_connections[well_index];
+            if (connections.empty()) {
+                // No connections, nothing to move or worry about.
+                ++well_index;
+                continue;
+            }
             std::map<int, std::size_t> no_connections_on_proc;
             for (auto connection_index : connections) {
                 ++no_connections_on_proc[parts[connection_index]];
             }
-
+            assert(!no_connections_on_proc.empty());
             int owner = no_connections_on_proc.begin()->first;
 
             // \todo remove trigger code for #476 that moves all wells to the last rank


### PR DESCRIPTION
This situation would segfault (clang, macos) or fail silently (linux) with the current master. The line
```C++
int owner = no_connections_on_proc.begin()->first;
```
would bomb (or not) because the no_connections_on_proc map was empty.