### PR TITLE
[cmake] Cleanup prerequisites.

### DIFF
--- a/opm-grid-prereqs.cmake
+++ b/opm-grid-prereqs.cmake
@@ -21,8 +21,6 @@ set (opm-grid_DEPS
   # compile with C99 support if available
   "C99"
   # various runtime library enhancements
-  "Boost 1.44.0
-    COMPONENTS date_time system unit_test_framework REQUIRED"
   "MPI"
   "dune-common REQUIRED"
   "dune-grid REQUIRED"


### PR DESCRIPTION
Actually there is no direct boost dependency. Hence the one on date_time is not needed at all and the rest is already a dependency of opm-common. No need to list it here again.