### PR TITLE
Added partition method without grid distribution.

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -828,7 +828,7 @@ namespace Dune
         template<class DataHandle>
         bool loadBalance(DataHandle& data,
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
-			 decltype(data.fixedSize(0,0)) overlapLayers=1, bool useZoltan = true)
+                         decltype(data.fixedSize(0,0)) overlapLayers=1, bool useZoltan = true)
 #else
                          decltype(data.fixedsize(0,0)) overlapLayers=1, bool useZoltan = true)
 #endif
@@ -889,6 +889,15 @@ namespace Dune
             }
             return ret;
         }
+
+         /// \brief Partitions the grid using Zoltan without decomposing and distributing it among processes.
+         /// \param wells The wells of the eclipse.
+         /// \param transmissibilities The transmissibilities used to calculate the edge weights.
+         /// \param numParts Number of parts in the partition.
+         /// \return 
+         std::vector<int> zoltanPartitionWithoutScatter(const std::vector<cpgrid::OpmWellType> * wells,
+                                                        const double* transmissibilities, int numParts,
+                                                        const double zoltanImbalanceTol);
 
         /// The new communication interface.
         /// \brief communicate objects for all codims on a given level

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -894,7 +894,7 @@ namespace Dune
          /// \param wells The wells of the eclipse.
          /// \param transmissibilities The transmissibilities used to calculate the edge weights.
          /// \param numParts Number of parts in the partition.
-         /// \return 
+         /// \return An array with the domain index for each cell.
          std::vector<int> zoltanPartitionWithoutScatter(const std::vector<cpgrid::OpmWellType> * wells,
                                                         const double* transmissibilities, int numParts,
                                                         const double zoltanImbalanceTol);

--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -501,7 +501,7 @@ private:
                                  &exportLocalGids, /* Local IDs of the vertices I must send */
                                  &exportProcs, /* Process to which I send each of the vertices */
                                  &exportToPart); /* Partition to which each vertex will belong */
-        std::cout << numExport<<" "<< cpgrid.numCells() << std::endl;
+
         // This is very important: by default, zoltan sets numImport to -1,
         // as we are only running Zoltan in serial.
         // In order to make sense of the rest of  the code, this must be set

--- a/opm/grid/common/ZoltanPartition.hpp
+++ b/opm/grid/common/ZoltanPartition.hpp
@@ -175,7 +175,37 @@ zoltanSerialGraphPartitionGridOnRoot(const CpGrid& grid,
                                EdgeWeightMethod edgeWeightsMethod, int root,
                                const double zoltanImbalanceTol,
                                bool allowDistributedWells);
+
+/// \brief Partition a CpGrid using Zoltan
+///
+/// This function will extract Zoltan's graph information
+/// from the grid, and the wells and use it to partition the grid.
+/// The difference between this function and zoltanGraphPartitionGridOnRoot
+/// is that the number of parts is an argument of the method and not inferred
+/// by the MPI communicator.
+/// 
+/// @param grid The grid to partition
+/// @param wells The wells of the eclipse If null wells will be neglected.
+/// @param transmissibilities The transmissibilities associated with the
+///             faces
+/// @paramm cc  The MPI communicator to use for the partitioning.
+///             The will be partitioned among the partiticipating processes.
+/// @param edgeWeightMethod The method used to calculate the weights associated
+///             with the edges of the graph (uniform, transmissibilities, log thereof)
+/// @param root The process number that holds the global grid.
+/// @param numParts How many parts to divide the grid into.
+/// @return A list containing the part of cell i for all cells.
+std::vector<int>
+zoltanGraphPartitionGridForJac(const CpGrid& cpgrid,
+                               const std::vector<OpmWellType> * wells,
+			       const double* transmissibilities,
+			       const CollectiveCommunication<MPI_Comm>& cc,
+			       EdgeWeightMethod edgeWeightsMethod, int root,
+			       int numParts, const double zoltanImbalanceTol);
+
 }
 }
+
+
 #endif // HAVE_ZOLTAN
 #endif // header guard

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -135,6 +135,24 @@ namespace Dune
           global_id_set_(*current_view_data_)
     {}
 
+std::vector<int> CpGrid::zoltanPartitionWithoutScatter(const std::vector<cpgrid::OpmWellType> * wells,
+                                                       const double* transmissibilities, int numParts,
+                                                       const double zoltanImbalanceTol)
+{
+    std::vector<int> cell_part(this->numCells());
+#if HAVE_MPI
+    auto& cc = data_->ccobj_;
+#ifdef HAVE_ZOLTAN
+    EdgeWeightMethod met = EdgeWeightMethod(1);
+
+    return cpgrid::zoltanGraphPartitionGridForJac(*this, wells, transmissibilities, cc, met, 0,
+                                                  numParts, zoltanImbalanceTol);
+
+#endif
+#endif
+    return cell_part;
+}
+
 
 std::pair<bool, std::vector<std::pair<std::string,bool> > >
 CpGrid::scatterGrid(EdgeWeightMethod method,


### PR DESCRIPTION
This function is intended to create a domain decomposition into N domains that will be used to set up a block-Jacobi type smoother to be used on one process.

Cleaned up version of status in https://github.com/andrthu/opm-grid/tree/partition-without-scatter for better overview.
There seemed to only one relevant commit. Is that right, @andrthu?