### PR TITLE
Changed encoding of header files to UTF-8

### DIFF
--- a/opm/grid/common/GridPartitioning.hpp
+++ b/opm/grid/common/GridPartitioning.hpp
@@ -5,7 +5,7 @@
 // Created: Mon Sep  7 10:09:13 2009
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
-//            Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            BÃ¥rd Skaflestad     <bard.skaflestad@sintef.no>
 //
 // $Date$
 //

--- a/opm/grid/cpgrid/DefaultGeometryPolicy.hpp
+++ b/opm/grid/cpgrid/DefaultGeometryPolicy.hpp
@@ -5,7 +5,7 @@
 // Created: Tue Jun  2 16:23:01 2009
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
-//            Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            BÃ¥rd Skaflestad     <bard.skaflestad@sintef.no>
 //
 // $Date$
 //

--- a/opm/grid/cpgrid/Indexsets.hpp
+++ b/opm/grid/cpgrid/Indexsets.hpp
@@ -5,7 +5,7 @@
 // Created: Fri May 29 23:30:01 2009
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
-//            Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            BÃ¥rd Skaflestad     <bard.skaflestad@sintef.no>
 //
 // $Date$
 //

--- a/opm/grid/cpgrid/Intersection.hpp
+++ b/opm/grid/cpgrid/Intersection.hpp
@@ -5,7 +5,7 @@
 // Created: Tue Jun  9 11:17:13 2009
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
-//            Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            BÃ¥rd Skaflestad     <bard.skaflestad@sintef.no>
 //
 // $Date$
 //

--- a/opm/grid/cpgrid/Iterators.hpp
+++ b/opm/grid/cpgrid/Iterators.hpp
@@ -5,7 +5,7 @@
 // Created: Fri May 29 23:29:09 2009
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
-//            Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            BÃ¥rd Skaflestad     <bard.skaflestad@sintef.no>
 //
 // $Date$
 //

--- a/opm/grid/cpgrid/OrientedEntityTable.hpp
+++ b/opm/grid/cpgrid/OrientedEntityTable.hpp
@@ -5,7 +5,7 @@
 // Created: Wed Aug 26 11:13:20 2009
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
-//            Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            BÃ¥rd Skaflestad     <bard.skaflestad@sintef.no>
 //
 // $Date$
 //


### PR DESCRIPTION
Should fix lintian warning about national-encoding.

Note that Debian is in the process of phasing out support for national
encodings.