### PR TITLE
Refine a geometry object into a regular grid

### DIFF
--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -240,36 +240,102 @@ BOOST_AUTO_TEST_CASE(cellgeom)
 }
 
 
+template <typename T>
+inline void
+check_coordinates(T c1, T c2)
+{
+    for (int c = 0; c < 3; c++) {
+        BOOST_CHECK_CLOSE(c1[c], c2[c], 1e-6);
+    }
+}
+
 void
 check_refined_grid(const cpgrid::Geometry<3, 3>& parent,
                    const std::vector<cpgrid::Geometry<3, 3>>& refined,
-                   const std::array<int, 3>& cells)
+                   const std::array<int, 3>& cells_per_dim)
 {
     using Geometry = cpgrid::Geometry<3, 3>;
     using GlobalCoordinate = Geometry::GlobalCoordinate;
 
-    int count = cells[0] * cells[1] * cells[2];
+    int count = cells_per_dim[0] * cells_per_dim[1] * cells_per_dim[2];
     BOOST_CHECK_EQUAL(refined.size(), count);
 
-    // Check the position of the first refined cell.
-    for (int c = 0; c < 3; c++) {
-        BOOST_CHECK_CLOSE(refined[0].corner(0)[c], parent.corner(0)[c], 1e-6);
-    }
-    // Check the last corner of the last cell.
-    for (int c = 0; c < 3; c++) {
-        BOOST_CHECK_CLOSE(refined[count - 1].corner(7)[c], parent.corner(7)[c], 1e-6);
-    }
-    // Check the center of the first cell.
-    GlobalCoordinate center = {0.0, 0.0, 0.0};
-    for (int h = 0; h < 8; h++) {
-        for (int c = 0; c < 3; c++) {
-            center[c] += refined[0].corner(h)[c] / 8.0;
+    // Check the corners of the refined grid with the parent corners.
+    int idx = 0;
+    for (int k = 0; k < 1; k++) {
+        int slice = cells_per_dim[0] * cells_per_dim[1];
+        for (int j = 0; j < 1; j++) {
+            for (int i = 0; i < 1; i++) {
+                auto& r = refined[k * slice + j * cells_per_dim[0] + i];
+                check_coordinates(r.corner(idx), parent.corner(idx));
+                idx++;
+            }
         }
     }
-    for (int c = 0; c < 3; c++) {
-        BOOST_CHECK_CLOSE(refined[0].center()[c], center[c], 1e-6);
+
+    // Make sure the corners of neighboring cells overlap.
+    for (int k = 0; k < cells_per_dim[2]; k++) {
+        int slice = cells_per_dim[1] * cells_per_dim[0];
+        for (int j = 0; j < cells_per_dim[1]; j++) {
+            for (int i = 0; i < cells_per_dim[0]; i++) {
+                auto& r0 = refined[k * slice + cells_per_dim[0] * j + i];
+                if (i < cells_per_dim[0] - 1) {
+                    auto& r1 = refined[k * slice + cells_per_dim[0] * j + i + 1];
+                    check_coordinates(r0.corner(1), r1.corner(0));
+                    check_coordinates(r0.corner(3), r1.corner(2));
+                    check_coordinates(r0.corner(5), r1.corner(4));
+                    check_coordinates(r0.corner(7), r1.corner(6));
+                }
+                if (j < cells_per_dim[1] - 1) {
+                    auto& r1 = refined[k * slice + cells_per_dim[0] * (j + 1) + i];
+                    check_coordinates(r0.corner(2), r1.corner(0));
+                    check_coordinates(r0.corner(3), r1.corner(1));
+                    check_coordinates(r0.corner(6), r1.corner(4));
+                    check_coordinates(r0.corner(7), r1.corner(5));
+                }
+                if (k < cells_per_dim[2] - 1) {
+                    auto& r1 = refined[(k + 1) * slice + cells_per_dim[0] * j + i];
+                    check_coordinates(r0.corner(4), r1.corner(0));
+                    check_coordinates(r0.corner(5), r1.corner(1));
+                    check_coordinates(r0.corner(6), r1.corner(2));
+                    check_coordinates(r0.corner(7), r1.corner(3));
+                }
+            }
+        }
     }
 
+    // Check the centers of the cells.
+    for (auto r : refined) {
+        GlobalCoordinate center = {0.0, 0.0, 0.0};
+        for (int h = 0; h < 8; h++) {
+            for (int c = 0; c < 3; c++) {
+                center[c] += r.corner(h)[c] / 8.0;
+            }
+        }
+        check_coordinates(r.center(), center);
+    }
+
+    // Check that the weighted mean of all centers equals the parent center
+    GlobalCoordinate center = {0.0, 0.0, 0.0};
+    for (auto r : refined) {
+        for (int c = 0; c < 3; c++) {
+            center[c] += r.center()[c] * r.volume() / parent.volume();
+        }
+    }
+    check_coordinates(parent.center(), center);
+
+    // Check that mean of all corners equals the center of the parent.
+    center = {0.0, 0.0, 0.0};
+    for (auto r : refined) {
+        for (int h = 0; h < 8; h++) {
+            for (int c = 0; c < 3; c++) {
+                center[c] += r.corner(h)[c] / count / 8;
+            }
+        }
+    }
+    check_coordinates(parent.center(), center);
+
+    // Check the total volume against the parent volume.
     Geometry::ctype volume = 0.0;
     for (auto r : refined) {
         volume += r.volume();


### PR DESCRIPTION
This PR is initially for discussing on how proceed with local grid refinement, in particular with @blattms 

This PR adds a method to refine a geometry object in regular grid, returning a vector of the new geometry objects.

Some remarks:
- Currently implemented using local coordinates, which seems natural, but could also be done more directly. In fact, the test uses a direct calculation to check the method.
- The geometry objects does not manage some of its storage, so that is currently passed as a vector of arrays for each newly created geometry object. Maybe that needs to be passed as contiguous memory for efficiency, but that does not seem to be necessary yet for the purpose of the current discussion.
