### PR TITLE
Make CpGrid more DUNE 2.9 compatible

### DIFF
--- a/examples/finitevolume/evolve.hh
+++ b/examples/finitevolume/evolve.hh
@@ -105,14 +105,14 @@ void evolve(const G& grid, const M& mapper, V& c, double t, double& dt)
 
                 // compute flux from one side only
                 // this should become easier with the new IntersectionIterator functionality!
-                if (it->level()>outside->level() ||
-                        (it->level()==outside->level() && indexi<indexj))
+                if (it->level()>outside.level() ||
+                        (it->level()==outside.level() && indexi<indexj))
                 {
                     // compute factor in neighbor
-                    Dune::GeometryType nbgt = outside->type();
+                    Dune::GeometryType nbgt = outside.type();
                     const Dune::FieldVector<ct,dim>&
                     nblocal = Dune::ReferenceElements<ct,dim>::general(nbgt).position(0,0);
-                    double nbvolume = outside->geometry().integrationElement(nblocal)
+                    double nbvolume = outside.geometry().integrationElement(nblocal)
                                       *Dune::ReferenceElements<ct,dim>::general(nbgt).volume();
 
                     double nbfactor = velocity*integrationOuterNormal/nbvolume;

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -180,6 +180,7 @@ namespace Dune
     typedef Dune::MPIHelper::MPICommunicator MPICommunicator;
 #if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
     using Communication = Dune::Communication<MPICommunicator>;
+    using CollectiveCommunication = Communication;
 #else
     using CollectiveCommunication = Dune::CollectiveCommunication<MPICommunicator>;
     using Communication = Dune::CollectiveCommunication<MPICommunicator>;

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -182,6 +182,7 @@ namespace Dune
 
     typedef Dune::MPIHelper::MPICommunicator MPICommunicator;
     typedef Dune::CollectiveCommunication<MPICommunicator> CollectiveCommunication;
+    using Communication = Dune::CollectiveCommunication<MPICommunicator>;
     };
 
     ////////////////////////////////////////////////////////////////////////

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -15,7 +15,7 @@
 
 /*
   Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
-  Copyright 2009, 2010, 2014, 2022 Euinor ASA.
+  Copyright 2009, 2010, 2014, 2022 Equinor ASA.
   Copyright 2014, 2015 Dr. Blatt - HPC-Simulartion-Software & Services
   Copyright 2015       NTNU
 
@@ -180,7 +180,6 @@ namespace Dune
     typedef Dune::MPIHelper::MPICommunicator MPICommunicator;
 #if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
     using Communication = Dune::Communication<MPICommunicator>;
-    using CollectiveCommunication = Dune::Communication<MPICommunicator>;
 #else
     using CollectiveCommunication = Dune::CollectiveCommunication<MPICommunicator>;
     using Communication = Dune::CollectiveCommunication<MPICommunicator>;
@@ -535,7 +534,7 @@ namespace Dune
         }
 
         /*  No refinement implemented. GridDefaultImplementation's methods will be used.
-x
+
         /// \brief Mark entity for refinement
         ///
         /// This only works for entities of codim 0.

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -181,8 +181,13 @@ namespace Dune
         /// \brief The type of the collective communication.
 
     typedef Dune::MPIHelper::MPICommunicator MPICommunicator;
-    typedef Dune::CollectiveCommunication<MPICommunicator> CollectiveCommunication;
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+    using Communication = Dune::Communication<MPICommunicator>;
+    using CollectiveCommunication = Dune::Communication<MPICommunicator>;
+#else
+    using CollectiveCommunication = Dune::CollectiveCommunication<MPICommunicator>;
     using Communication = Dune::CollectiveCommunication<MPICommunicator>;
+#endif
     };
 
     ////////////////////////////////////////////////////////////////////////
@@ -931,7 +936,7 @@ namespace Dune
         }
 
         /// \brief Get the collective communication object.
-        const CollectiveCommunication& comm () const
+        const typename CpGridTraits::Communication& comm () const
         {
             return current_view_data_->ccobj_;
         }

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -15,7 +15,7 @@
 
 /*
   Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
-  Copyright 2009, 2010, 2014 Statoil ASA.
+  Copyright 2009, 2010, 2014, 2022 Euinor ASA.
   Copyright 2014, 2015 Dr. Blatt - HPC-Simulartion-Software & Services
   Copyright 2015       NTNU
 
@@ -135,10 +135,7 @@ namespace Dune
             typedef cpgrid::Iterator<cd, All_Partition> LeafIterator;
 
             /// \brief The type of the entity pointer for entities of this codim.
-            typedef cpgrid::EntityPointer<cd> EntityPointer;
-
-            /// \brief The type of the entity pointer for entities of this codim.
-            typedef cpgrid::EntityPointer<cd> EntitySeed;
+            typedef cpgrid::Entity<cd> EntitySeed;
 
             /// \brief Traits associated with a specific grid partition type.
             /// \tparam pitype The type of the grid partition.
@@ -532,13 +529,13 @@ namespace Dune
 
         /// given an EntitySeed (or EntityPointer) return an entity object
         template <int codim>
-        cpgrid::Entity<codim> entity( const cpgrid::EntityPointer< codim >& seed ) const
+        cpgrid::Entity<codim> entity( const cpgrid::Entity< codim >& seed ) const
         {
-            return cpgrid::Entity<codim>( *seed );
+            return seed;
         }
 
         /*  No refinement implemented. GridDefaultImplementation's methods will be used.
-
+x
         /// \brief Mark entity for refinement
         ///
         /// This only works for entities of codim 0.

--- a/opm/grid/common/GridPartitioning.cpp
+++ b/opm/grid/common/GridPartitioning.cpp
@@ -15,7 +15,7 @@
 
 /*
   Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
-  Copyright 2009, 2010, 2013 Statoil ASA.
+  Copyright 2009, 2010, 2013, 2022 Equinor ASA.
   Copyright 2013, 2015 Dr. Markus Blatt - HPC-Simulation-Software & Services
   Copyright 2015       NTNU
   Copyright 2020, 2021 OPM-OP AS
@@ -100,12 +100,12 @@ namespace Dune
                                         std::vector<int>& cell_colour)
         {
             const CpGrid::LeafIndexSet& ix = grid.leafIndexSet();
-            int my_index = ix.index(*c);
+            int my_index = ix.index(c);
             cell_colour[my_index] = colour;
             // For each neighbour...
-            for (CpGrid::LeafIntersectionIterator it = c->ileafbegin(); it != c->ileafend(); ++it) {
+            for (CpGrid::LeafIntersectionIterator it = c.ileafbegin(); it != c.ileafend(); ++it) {
                 if (it->neighbor()) {
-                    int nb_index = ix.index(*(it->outside()));
+                    int nb_index = ix.index(it->outside());
                     if (cell_part[my_index] == cell_part[nb_index] && cell_colour[nb_index] == -1) {
                         colourMyComponentRecursive(grid, it->outside(), colour, cell_part, cell_colour);
                     }
@@ -137,7 +137,7 @@ namespace Dune
                 while (cur != end) {
                     bool visit_nb = false;
                     if (cur->neighbor()) {
-                        int nb_index = ix.index(*(cur->outside()));
+                        int nb_index = ix.index(cur->outside());
                         if (cell_part[index] == cell_part[nb_index] && cell_colour[nb_index] == -1) {
                             visit_nb = true;
                         }
@@ -145,9 +145,9 @@ namespace Dune
                     if (visit_nb) {
                         NbIter cur_cp = cur;
                         v_stack.push(std::make_pair(index, std::make_pair(++cur, end)));
-                        index = ix.index(*(cur_cp->outside()));
-                        cur = cur_cp->outside()->ileafbegin();
-                        end = cur_cp->outside()->ileafend();
+                        index = ix.index(cur_cp->outside());
+                        cur = cur_cp->outside().ileafbegin();
+                        end = cur_cp->outside().ileafend();
                         cell_colour[index] = colour;
                     } else {
                         ++cur;
@@ -258,11 +258,11 @@ void addOverlapCornerCell(const CpGrid& grid, int owner,
     const int num_from_subs = from.subEntities(CpGrid::dimension);
     for ( int i = 0; i < num_from_subs ; i++ )
     {
-        int mypoint = ix.index(*from.subEntity<CpGrid::dimension>(i));
+        int mypoint = ix.index(from.subEntity<CpGrid::dimension>(i));
         const int num_nb_subs = neighbor.subEntities(CpGrid::dimension);
         for ( int j = 0; j < num_nb_subs; j++)
         {
-            int otherpoint = ix.index(*neighbor.subEntity<CpGrid::dimension>(j));
+            int otherpoint = ix.index(neighbor.subEntity<CpGrid::dimension>(j));
             if ( mypoint == otherpoint )
             {
                 cell_overlap[nb_index].insert(owner);
@@ -297,11 +297,11 @@ void addOverlapCornerCell(const CpGrid& grid, int owner,
     const int num_from_subs = from.subEntities(CpGrid::dimension);
     for ( int i = 0; i < num_from_subs ; i++ )
     {
-        int mypoint = ix.index(*from.subEntity<CpGrid::dimension>(i));
+        int mypoint = ix.index(from.subEntity<CpGrid::dimension>(i));
         const int num_nb_subs = neighbor.subEntities(CpGrid::dimension);
         for ( int j = 0; j < num_nb_subs; j++)
         {
-            int otherpoint = ix.index(*neighbor.subEntity<CpGrid::dimension>(j));
+            int otherpoint = ix.index(neighbor.subEntity<CpGrid::dimension>(j));
             if ( mypoint == otherpoint )
             {
                 // Note: multiple adds for same process are possible
@@ -320,7 +320,7 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
         const CpGrid::LeafIndexSet& ix = grid.leafIndexSet();
         for (CpGrid::LeafIntersectionIterator iit = e.ileafbegin(); iit != e.ileafend(); ++iit) {
             if ( iit->neighbor() ) {
-                int nb_index = ix.index(*(iit->outside()));
+                int nb_index = ix.index(iit->outside());
                 if ( cell_part[nb_index]!=owner )
                 {
                     cell_overlap[nb_index].insert(owner);
@@ -328,20 +328,20 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
                     if ( recursion_deps>0 )
                     {
                         // Add another layer
-                        addOverlapLayer(grid, nb_index, *(iit->outside()), owner,
+                        addOverlapLayer(grid, nb_index, iit->outside(), owner,
                                         cell_part, cell_overlap, recursion_deps-1);
                     }
                     else
                     {
                         // Add cells to the overlap that just share a corner with e.
-                        for (CpGrid::LeafIntersectionIterator iit2 = iit->outside()->ileafbegin();
-                             iit2 != iit->outside()->ileafend(); ++iit2)
+                        for (CpGrid::LeafIntersectionIterator iit2 = iit->outside().ileafbegin();
+                             iit2 != iit->outside().ileafend(); ++iit2)
                         {
                            if ( iit2->neighbor() )
                            {
-                               int nb_index2 = ix.index(*(iit2->outside()));
+                               int nb_index2 = ix.index(iit2->outside( ));
                                if( cell_part[nb_index2]==owner ) continue;
-                               addOverlapCornerCell(grid, owner, e, *(iit2->outside()),
+                               addOverlapCornerCell(grid, owner, e, iit2->outside(),
                                                     cell_part, cell_overlap);
                            }
                        }
@@ -383,7 +383,7 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
         const CpGrid::LeafIndexSet& ix = grid.leafIndexSet();
         for (CpGrid::LeafIntersectionIterator iit = e.ileafbegin(); iit != e.ileafend(); ++iit) {
             if ( iit->neighbor() ) {
-                int nb_index = ix.index(*(iit->outside()));
+                int nb_index = ix.index(iit->outside());
                 if ( cell_part[nb_index]!=owner )
                 {
                     // Note: multiple adds for same process are possible
@@ -392,20 +392,20 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
                     if ( recursion_deps>0 )
                     {
                         // Add another layer
-                        addOverlapLayer(grid, nb_index, *(iit->outside()), owner,
+                        addOverlapLayer(grid, nb_index, iit->outside(), owner,
                                         cell_part, exportList, addCornerCells, recursion_deps-1);
                     }
                     else if (addCornerCells)
                     {
                         // Add cells to the overlap that just share a corner with e.
-                        for (CpGrid::LeafIntersectionIterator iit2 = iit->outside()->ileafbegin();
-                             iit2 != iit->outside()->ileafend(); ++iit2)
+                        for (CpGrid::LeafIntersectionIterator iit2 = iit->outside().ileafbegin();
+                             iit2 != iit->outside().ileafend(); ++iit2)
                         {
                             if ( iit2->neighbor() )
                             {
-                                int nb_index2 = ix.index(*(iit2->outside()));
+                                int nb_index2 = ix.index(iit2->outside());
                                 if( cell_part[nb_index2]!=owner ) {
-                                    addOverlapCornerCell(grid, owner, e, *(iit2->outside()),
+                                    addOverlapCornerCell(grid, owner, e, iit2->outside(),
                                                          cell_part, exportList);
                                 }
                             }
@@ -432,7 +432,7 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
                 // zero transmissibility -> no flux over the face -> zero offdiagonal.
                 // This is a reservoir simulation spesific thing that reduce parallel overhead.
                 if ( trans[faceId] != 0.0 ) {
-                    int nb_index = ix.index(*(iit->outside()));
+                    int nb_index = ix.index(iit->outside());
                     if ( cell_part[nb_index]!=owner )
                     {
                         // Note: multiple adds for same process are possible
@@ -447,14 +447,14 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
                         else if (addCornerCells)
                         {
                             // Add cells to the overlap that just share a corner with e.
-                            for (CpGrid::LeafIntersectionIterator iit2 = iit->outside()->ileafbegin();
-                                 iit2 != iit->outside()->ileafend(); ++iit2)
+                            for (CpGrid::LeafIntersectionIterator iit2 = iit->outside().ileafbegin();
+                                 iit2 != iit->outside().ileafend(); ++iit2)
                             {
                                 if ( iit2->neighbor() )
                                 {
-                                    int nb_index2 = ix.index(*(iit2->outside()));
+                                    int nb_index2 = ix.index(iit2->outside());
                                     if( cell_part[nb_index2]!=owner ) {
-                                        addOverlapCornerCell(grid, owner, e, *(iit2->outside()),
+                                        addOverlapCornerCell(grid, owner, e, iit2->outside(),
                                                              cell_part, exportList);
                                     }
                                 }

--- a/opm/grid/common/GridPartitioning.cpp
+++ b/opm/grid/common/GridPartitioning.cpp
@@ -469,7 +469,11 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
     int addOverlapLayer(const CpGrid& grid, const std::vector<int>& cell_part,
                         std::vector<std::tuple<int,int,char>>& exportList,
                         std::vector<std::tuple<int,int,char,int>>& importList,
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+                        const Communication<Dune::MPIHelper::MPICommunicator>& cc,
+#else
                         const CollectiveCommunication<Dune::MPIHelper::MPICommunicator>& cc,
+#endif
                         [[maybe_unused]] bool addCornerCells,
                         [[maybe_unused]] const double* trans, int layers)
     {

--- a/opm/grid/common/GridPartitioning.hpp
+++ b/opm/grid/common/GridPartitioning.hpp
@@ -104,7 +104,11 @@ namespace Dune
     int addOverlapLayer(const CpGrid& grid, const std::vector<int>& cell_part,
                         std::vector<std::tuple<int,int,char>>& exportList,
                         std::vector<std::tuple<int,int,char,int>>& importList,
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+                        const Communication<Dune::MPIHelper::MPICommunicator>& cc,
+#else
                         const CollectiveCommunication<Dune::MPIHelper::MPICommunicator>& cc,
+#endif
                         bool addCornerCells, const double* trans, int layers = 1);
 
 namespace cpgrid

--- a/opm/grid/common/WellConnections.cpp
+++ b/opm/grid/common/WellConnections.cpp
@@ -154,7 +154,11 @@ postProcessPartitioningForWells(std::vector<int>& parts,
                                 const WellConnections& well_connections,
                                 std::vector<std::tuple<int,int,char>>& exportList,
                                 std::vector<std::tuple<int,int,char,int>>& importList,
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+                                const Communication<MPI_Comm>& cc)
+#else
                                 const CollectiveCommunication<MPI_Comm>& cc)
+#endif
 {
     auto no_procs = cc.size();
     auto noCells = parts.size();
@@ -371,7 +375,11 @@ postProcessPartitioningForWells(std::vector<int>& parts,
 std::vector<std::pair<std::string,bool>>
 computeParallelWells(const std::vector<std::vector<int> >& wells_on_proc,
                      const std::vector<OpmWellType>& wells,
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+                     const Communication<MPI_Comm>& cc,
+#else
                      const CollectiveCommunication<MPI_Comm>& cc,
+#endif
                      int root)
 {
     // We need to use well names as only they are consistent.

--- a/opm/grid/common/WellConnections.hpp
+++ b/opm/grid/common/WellConnections.hpp
@@ -165,7 +165,11 @@ postProcessPartitioningForWells(std::vector<int>& parts,
                                 const WellConnections& well_connections,
                                 std::vector<std::tuple<int,int,char>>& exportList,
                                 std::vector<std::tuple<int,int,char,int>>& importList,
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+                                const Communication<MPI_Comm>& cc);
+#else
                                 const CollectiveCommunication<MPI_Comm>& cc);
+#endif
 
 /// \brief Computes whether wells are perforating cells on this process.
 /// \param wells_on_proc well indices assigned to each process
@@ -178,7 +182,11 @@ postProcessPartitioningForWells(std::vector<int>& parts,
 std::vector<std::pair<std::string,bool>>
 computeParallelWells(const std::vector<std::vector<int> >& wells_on_proc,
                      const std::vector<OpmWellType>&  wells,
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+                     const Communication<MPI_Comm>& cc,
+#else
                      const CollectiveCommunication<MPI_Comm>& cc,
+#endif
                      int root);
 #endif
 } // end namespace cpgrid

--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -39,7 +39,11 @@ std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
            std::vector<std::tuple<int,int,char,int> >,
            WellConnections>
 makeImportAndExportLists(const Dune::CpGrid& cpgrid,
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+                         const Dune::Communication<MPI_Comm>& cc,
+#else
                          const Dune::CollectiveCommunication<MPI_Comm>& cc,
+#endif
                          const std::vector<Dune::cpgrid::OpmWellType> * wells,
                          const Dune::cpgrid::CombinedGridWellGraph* gridAndWells,
                          int root,
@@ -149,7 +153,11 @@ template<class Id>
 std::tuple<int, std::vector<Id> >
 scatterExportInformation(int numExport, const Id* exportGlobalGids,
                          const int* exportToPart, int root,
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+                         const Communication<MPI_Comm>& cc)
+#else
                          const Dune::CollectiveCommunication<MPI_Comm>& cc)
+#endif
 {
     int numImport;
     std::vector<int> numberOfExportedVerticesPerProcess;
@@ -225,7 +233,11 @@ std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
            std::vector<std::tuple<int,int,char,int> >,
            WellConnections>
 makeImportAndExportLists(const Dune::CpGrid&,
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+                         const Communication<MPI_Comm>&,
+#else
                          const Dune::CollectiveCommunication<MPI_Comm>&,
+#endif
                          const std::vector<Dune::cpgrid::OpmWellType>*,
                          const Dune::cpgrid::CombinedGridWellGraph*,
                          int,
@@ -241,7 +253,11 @@ template
 std::tuple<int, std::vector<int> >
 scatterExportInformation(int numExport, const int*,
                          const int*, int,
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+                         const Communication<MPI_Comm>&);
+#else
                          const Dune::CollectiveCommunication<MPI_Comm>&);
+#endif
 #endif // HAVE_MPI
 } // end namespace Dune
 } // end namespace cpgrid
@@ -276,7 +292,11 @@ std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
 zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
                                const std::vector<OpmWellType> * wells,
                                const double* transmissibilities,
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+                               const Communication<MPI_Comm>& cc,
+#else
                                const CollectiveCommunication<MPI_Comm>& cc,
+#endif
                                EdgeWeightMethod edgeWeightsMethod,
                                int root,
                                const double zoltanImbalanceTol,
@@ -363,10 +383,16 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
 class ZoltanSerialPartitioner
 {
 public:
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+    using CommunicationType = Communication<MPI_Comm>;
+#else
+    using CommunicationType = CollectiveCommunication<MPI_Comm>& cc;
+#endif
+
     ZoltanSerialPartitioner(const CpGrid& _cpgrid,
                             const std::vector<OpmWellType>* _wells,
                             const double* _transmissibilities,
-                            const CollectiveCommunication<MPI_Comm>& _cc,
+                            const CommunicationType& _cc,
                             EdgeWeightMethod _edgeWeightsMethod,
                             int _root,
                             const double _zoltanImbalanceTol,
@@ -522,7 +548,7 @@ private:
     const CpGrid& cpgrid;
     const std::vector<OpmWellType>* wells;
     const double* transmissibilities;
-    const CollectiveCommunication<MPI_Comm>& cc;
+    const CommunicationType& cc;
     EdgeWeightMethod edgeWeightsMethod;
     int root;
     const double zoltanImbalanceTol;
@@ -556,7 +582,11 @@ std::tuple<std::vector<int>,
 zoltanSerialGraphPartitionGridOnRoot(const CpGrid& cpgrid,
                                      const std::vector<OpmWellType>* wells,
                                      const double* transmissibilities,
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+                                     const Dune::Communication<MPI_Comm>& cc,
+#else
                                      const CollectiveCommunication<MPI_Comm>& cc,
+#endif
                                      EdgeWeightMethod edgeWeightsMethod,
                                      int root,
                                      const double zoltanImbalanceTol,
@@ -572,7 +602,11 @@ std::vector<int>
 zoltanGraphPartitionGridForJac(const CpGrid& cpgrid,
                                const std::vector<OpmWellType> * wells,
                                const double* transmissibilities,
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+                               const Dune::Communication<MPI_Comm>& cc,
+#else
                                const CollectiveCommunication<MPI_Comm>& cc,
+#endif
                                EdgeWeightMethod edgeWeightsMethod, int root,
                                int numParts, const double zoltanImbalanceTol)
 {

--- a/opm/grid/common/ZoltanPartition.hpp
+++ b/opm/grid/common/ZoltanPartition.hpp
@@ -67,7 +67,11 @@ std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
            std::vector<std::tuple<int,int,char,int> >,
            WellConnections>
 makeImportAndExportLists(const Dune::CpGrid& cpgrid,
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+                         const Dune::Communication<MPI_Comm>& cc,
+#else
                          const Dune::CollectiveCommunication<MPI_Comm>& cc,
+#endif
                          const std::vector<Dune::cpgrid::OpmWellType> * wells,
                          const Dune::cpgrid::CombinedGridWellGraph* gridAndWells,
                          int root,
@@ -83,7 +87,11 @@ template<class Id>
 std::tuple<int, std::vector<Id> >
 scatterExportInformation(int numExport, const Id* exportGlobalGids,
                          const int* exportToPart, int root,
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+                         const Dune::Communication<MPI_Comm>& cc);
+#else
                          const Dune::CollectiveCommunication<MPI_Comm>& cc);
+#endif
 } // end namespace cpgrid
 } // end namespace Dune
 #endif //HAVE_MPI
@@ -129,7 +137,11 @@ std::tuple<std::vector<int>,std::vector<std::pair<std::string,bool>>,
 zoltanGraphPartitionGridOnRoot(const CpGrid& grid,
                                const std::vector<OpmWellType> * wells,
                                const double* transmissibilities,
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+                               const Communication<MPI_Comm>& cc,
+#else
                                const CollectiveCommunication<MPI_Comm>& cc,
+#endif
                                EdgeWeightMethod edgeWeightsMethod, int root,
                                const double zoltanImbalanceTol,
                                bool allowDistributedWells,
@@ -172,7 +184,11 @@ std::tuple<std::vector<int>, std::vector<std::pair<std::string,bool>>,
 zoltanSerialGraphPartitionGridOnRoot(const CpGrid& grid,
                                const std::vector<OpmWellType> * wells,
                                const double* transmissibilities,
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+                                     const Communication<MPI_Comm>& cc,
+#else
                                const CollectiveCommunication<MPI_Comm>& cc,
+#endif
                                EdgeWeightMethod edgeWeightsMethod, int root,
                                const double zoltanImbalanceTol,
                                bool allowDistributedWells,
@@ -201,7 +217,11 @@ std::vector<int>
 zoltanGraphPartitionGridForJac(const CpGrid& cpgrid,
                                const std::vector<OpmWellType> * wells,
 			       const double* transmissibilities,
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+                               const Communication<MPI_Comm>& cc,
+#else
 			       const CollectiveCommunication<MPI_Comm>& cc,
+#endif
 			       EdgeWeightMethod edgeWeightsMethod, int root,
 			       int numParts, const double zoltanImbalanceTol);
 

--- a/opm/grid/common/p2pcommunicator.hh
+++ b/opm/grid/common/p2pcommunicator.hh
@@ -149,7 +149,11 @@ public:
     typedef MsgBuffer MessageBufferType ;
 
   protected:
-    typedef CollectiveCommunication< MPICommunicator >   BaseType;
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+    using BaseType = Dune::Communication<MPICommunicator>;
+#else
+    using BaseType = CollectiveCommunication< MPICommunicator>;
+#endif
     typedef Point2PointCommunicator< MessageBufferType > ThisType;
 
     // starting message tag

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -504,9 +504,14 @@ private:
 
     /// \brief The type of the collective communication.
     typedef MPIHelper::MPICommunicator MPICommunicator;
-    typedef Dune::CollectiveCommunication<MPICommunicator> CollectiveCommunication;
+    #if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+    using Communication = Dune::Communication<MPICommunicator>;
+#else
+    using CollectiveCommunication = Dune::CollectiveCommunication<MPICommunicator>;
+    using Communication = Dune::CollectiveCommunication<MPICommunicator>;
+#endif
     /// \brief Object for collective communication operations.
-    CollectiveCommunication ccobj_;
+    Communication ccobj_;
 
     // Boundary information (optional).
     bool use_unique_boundary_ids_;

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -19,7 +19,7 @@
 
 /*
   Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
-  Copyright 2009, 2010, 2013 Statoil ASA.
+  Copyright 2009, 2010, 2013, 2022 Equinor ASA.
   Copyright 2013 Dr. Blatt - HPC-Simulation-Software & Services
 
   This file is part of The Open Porous Media project  (OPM).
@@ -556,7 +556,6 @@ private:
     friend class Dune::CpGrid;
     template<int> friend class Entity;
     template<int> friend class EntityRep;
-    template<int> friend class EntityPointer;
     friend class Intersection;
     friend class PartitionTypeIndicator;
 };

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -15,7 +15,7 @@
 
 /*
   Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
-  Copyright 2009, 2010 Statoil ASA.
+  Copyright 2009, 2010, 2022 Equinor ASA.
 
   This file is part of The Open Porous Media project  (OPM).
 
@@ -48,18 +48,12 @@ namespace Dune
     namespace cpgrid
     {
 
-       template <int> class EntityPointer;
        template<int,int> class Geometry;
        template<int,PartitionIteratorType> class Iterator;
        class IntersectionIterator;
        class HierarchicIterator;
        class CpGridData;
        class LevelGlobalIdSet;
-
-        /// @brief
-        /// @todo Doc me!
-        /// @tparam
-        template <int codim> class EntityPointer;
 
 
         /// @brief
@@ -79,12 +73,8 @@ namespace Dune
             enum { mydimension = dimension - codimension };
             enum { dimensionworld = 3 };
 
-
-            typedef cpgrid::EntityPointer<codim> EntityPointerType;
-
             // the official DUNE names
-            typedef EntityPointerType    EntityPointer;
-            typedef EntityPointerType    EntitySeed;
+            typedef Entity    EntitySeed;
 
             /// @brief
             /// @todo Doc me!
@@ -92,7 +82,6 @@ namespace Dune
             template <int cd>
             struct Codim
             {
-                typedef cpgrid::EntityPointer<cd> EntityPointer;
                 typedef cpgrid::Entity<cd> Entity;
             };
 
@@ -191,7 +180,7 @@ namespace Dune
 
             /// Obtain subentity.
             template <int cc>
-            typename Codim<cc>::EntityPointer subEntity(int i) const;
+            typename Codim<cc>::Entity subEntity(int i) const;
 
             /// Start iterator for the cell-cell intersections of this entity.
             inline LevelIntersectionIterator ilevelbegin() const;
@@ -231,9 +220,9 @@ namespace Dune
 
 
             /// Dummy, returning this.
-            EntityPointerType father() const
+            Entity father() const
             {
-                return EntityPointerType(*this);
+                return *this;
             }
 
 
@@ -269,67 +258,6 @@ namespace Dune
             const CpGridData* pgrid_;
         };
 
-
-
-
-        /// \brief Class representing a pointer to an entity.
-        /// Implementation note:
-        /// Since our entities are quite lightweight, we have chosen
-        /// to implement EntityPointer by inheritance from
-        /// Entity. Thus all dereferencing operators return the object
-        /// itself as an Entity.
-        template <int codim>
-        class EntityPointer : public cpgrid::Entity<codim>
-        {
-            friend class LevelGlobalIdSet;
-        public:
-            typedef cpgrid::Entity<codim> Entity;
-            typedef const Entity& Reference;
-
-            /// Construction empty entity pointer
-            EntityPointer() : Entity()
-            {
-            }
-
-            /// Construction from entity.
-            explicit EntityPointer(const Entity& e)
-                : Entity(e)
-            {
-            }
-
-            /// Constructor taking a grid and an entity representation.
-            EntityPointer(const CpGridData& grid, EntityRep<codim> entityrep)
-                : Entity(grid, entityrep)
-            {
-            }
-
-            /// Constructor taking a grid, entity index and orientation.
-            EntityPointer(const CpGridData& grid, int index_arg, bool orientation_arg)
-                : Entity(grid, index_arg, orientation_arg)
-            {
-            }
-
-            /// Const member by pointer operator.
-            const Entity* operator->() const
-            {
-                assert(Entity::isValid());
-                return (this);
-            }
-
-            /// Const dereferencing operator.
-            const Entity& operator*() const
-            {
-                assert(Entity::isValid());
-                return (*this);
-            }
-
-
-            /// Minimizes memory usage.
-            /// Nothing to do in our case.
-            void compactify()
-            {
-            }
-        };
     } // namespace cpgrid
 } // namespace Dune
 
@@ -437,17 +365,17 @@ const typename Entity<codim>::Geometry& Entity<codim>::geometry() const
 
 template <int codim>
 template <int cc>
-typename Entity<codim>::template Codim<cc>::EntityPointer Entity<codim>::subEntity(int i) const
+typename Entity<codim>::template Codim<cc>::Entity Entity<codim>::subEntity(int i) const
 {
     static_assert(codim == 0, "");
     if (cc == 0) {
         assert(i == 0);
-        typename Codim<cc>::EntityPointer se(*pgrid_, EntityRep<codim>::index(), EntityRep<codim>::orientation());
+        typename Codim<cc>::Entity se(*pgrid_, EntityRep<codim>::index(), EntityRep<codim>::orientation());
         return se;
     } else if (cc == 3) {
         assert(i >= 0 && i < 8);
         int corner_index = pgrid_->cell_to_point_[EntityRep<codim>::index()][i];
-        typename Codim<cc>::EntityPointer se(*pgrid_, corner_index, true);
+        typename Codim<cc>::Entity se(*pgrid_, corner_index, true);
         return se;
     } else {
         OPM_THROW(std::runtime_error, "No subentity exists of codimension " << cc);

--- a/opm/grid/cpgrid/Geometry.hpp
+++ b/opm/grid/cpgrid/Geometry.hpp
@@ -15,7 +15,7 @@
 
 /*
   Copyright 2009, 2010, 2011 SINTEF ICT, Applied Mathematics.
-  Copyright 2009, 2010, 2011 Statoil ASA.
+  Copyright 2009, 2010, 2011, 2022 Equinor ASA.
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -99,6 +99,8 @@ namespace Dune
 
             /// Type of Jacobian matrix.
             typedef FieldMatrix< ctype, coorddimension, mydimension >         Jacobian;
+            /// Type of inverse of Jacobian matrix.
+            typedef FieldMatrix< ctype, coorddimension, mydimension >         JacobianInverse;
             /// Type of transposed Jacobian matrix.
             typedef FieldMatrix< ctype, mydimension, coorddimension >         JacobianTransposed;
             /// Type of the inverse of the transposed Jacobian matrix
@@ -170,7 +172,7 @@ namespace Dune
             }
 
             /// This method is meaningless for singular geometries.
-            FieldMatrix<ctype, mydimension, coorddimension>
+            JacobianTransposed
             jacobianTransposed(const LocalCoordinate& /* local */) const
             {
 
@@ -179,13 +181,27 @@ namespace Dune
             }
 
             /// This method is meaningless for singular geometries.
-            FieldMatrix<ctype, coorddimension, mydimension>
+            JacobianInverseTransposed
             jacobianInverseTransposed(const LocalCoordinate& /*local*/) const
             {
                 // Meaningless to call jacobianInverseTransposed() on singular geometries. But we need to make DUNE happy.
                 return FieldMatrix<ctype, coorddimension, mydimension>();
             }
 
+            /// This method is meaningless for singular geometries.
+            Jacobian
+            jacobian(const LocalCoordinate& /*local*/) const
+            {
+                return{};
+            }
+            
+            /// This method is meaningless for singular geometries.
+            JacobianInverse
+            jacobianInverse(const LocalCoordinate& /*local*/) const
+            {
+                return {};
+            }
+            
             /// The mapping implemented by this geometry is constant, therefore affine.
             bool affine() const
             {
@@ -224,6 +240,8 @@ namespace Dune
 
             /// Type of Jacobian matrix.
             typedef FieldMatrix< ctype, coorddimension, mydimension >         Jacobian;
+            /// Type of inverse of Jacobian matrix.
+            typedef FieldMatrix< ctype, coorddimension, mydimension >         JacobianInverse;
             /// Type of transposed Jacobian matrix.
             typedef FieldMatrix< ctype, mydimension, coorddimension >         JacobianTransposed;
             /// Type of the inverse of the transposed Jacobian matrix
@@ -420,6 +438,20 @@ namespace Dune
                 return Jti;
             }
 
+            /// @brief The jacobian.
+            Jacobian
+            jacobian(const LocalCoordinate& local_coord) const
+            {
+                return jacobianTransposed(local_coord).transposed();
+            }
+            
+            /// @brief The inverse of the jacobian
+            JacobianInverse
+            jacobianInverse(const LocalCoordinate& local_coord) const
+            {
+                return jacobianInverseTransposed(local_coord).transposed();
+            }
+            
             /// The mapping implemented by this geometry is not generally affine.
             bool affine() const
             {
@@ -609,6 +641,8 @@ namespace Dune
 
             /// Type of Jacobian matrix.
             typedef FieldMatrix< ctype, coorddimension, mydimension >         Jacobian;
+            /// Type of Jacobian matrix.
+            typedef FieldMatrix< ctype, coorddimension, mydimension >         JacobianInverse;
             /// Type of transposed Jacobian matrix.
             typedef FieldMatrix< ctype, mydimension, coorddimension >         JacobianTransposed;
             /// Type of the inverse of the transposed Jacobian matrix
@@ -696,6 +730,20 @@ namespace Dune
                 OPM_THROW(std::runtime_error, "Meaningless to call jacobianInverseTransposed() on singular geometries.");
             }
 
+            /// @brief The jacobian.
+            Jacobian
+            jacobian(const LocalCoordinate& /*local*/) const
+            {
+                return jacobianTransposed({}).transposed();
+            }
+            
+            /// @brief The inverse of the jacobian
+            JacobianInverse
+            jacobianInverse(const LocalCoordinate& /*local*/) const
+            {
+                return jacobianInverseTransposed({}).transposed();
+            }
+            
             /// Since integrationElement() is constant, returns true.
             bool affine() const
             {

--- a/opm/grid/cpgrid/Geometry.hpp
+++ b/opm/grid/cpgrid/Geometry.hpp
@@ -177,7 +177,7 @@ namespace Dune
             {
 
                 // Meaningless to call jacobianTransposed() on singular geometries. But we need to make DUNE happy.
-                return FieldMatrix<ctype, mydimension, coorddimension>();
+                return {};
             }
 
             /// This method is meaningless for singular geometries.
@@ -185,14 +185,14 @@ namespace Dune
             jacobianInverseTransposed(const LocalCoordinate& /*local*/) const
             {
                 // Meaningless to call jacobianInverseTransposed() on singular geometries. But we need to make DUNE happy.
-                return FieldMatrix<ctype, coorddimension, mydimension>();
+                return {};
             }
 
             /// This method is meaningless for singular geometries.
             Jacobian
             jacobian(const LocalCoordinate& /*local*/) const
             {
-                return{};
+                return {};
             }
             
             /// This method is meaningless for singular geometries.

--- a/opm/grid/cpgrid/Indexsets.hpp
+++ b/opm/grid/cpgrid/Indexsets.hpp
@@ -15,7 +15,7 @@
 
 /*
 Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
-Copyright 2009, 2010 Statoil ASA.
+Copyright 2009, 2010, 2022 Equinor ASA.
 
 This file is part of The Open Porous Media project  (OPM).
 
@@ -302,10 +302,10 @@ namespace Dune
                 assert(view_ == e.pgrid_);
 
                 switch (cc) {
-                case 0: return id(*e.subEntity<0>(i));
+                case 0: return id(e.subEntity<0>(i));
                 //case 1: return id(*e.subEntity<1>(i));
                 //case 2: return id(*e.subEntity<2>(i));
-                case 3: return id(*e.subEntity<3>(i));
+                case 3: return id(e.subEntity<3>(i));
                 default: OPM_THROW(std::runtime_error, "Cannot get subId of codimension " << cc);
                 }
                 return -1;

--- a/opm/grid/cpgrid/Intersection.cpp
+++ b/opm/grid/cpgrid/Intersection.cpp
@@ -1,3 +1,22 @@
+/*
+Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
+Copyright 2009, 2010, 2022 Equinor ASA.
+
+This file is part of The Open Porous Media project  (OPM).
+
+OPM is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+OPM is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
 #ifdef HAVE_CONFIG_H
 #include"config.h"
 #endif
@@ -162,14 +181,14 @@ FieldVector<Intersection::ctype, 3> Intersection::centerUnitOuterNormal() const
     return pgrid_->face_normals_[faces_of_cell_[subindex_]];
 }
 
-Intersection::EntityPointer Intersection::inside() const
+Intersection::Entity Intersection::inside() const
 {
-    return EntityPointer(*pgrid_, index_, true);
+    return Entity(*pgrid_, index_, true);
 }
 
-Intersection::EntityPointer Intersection::outside() const
+Intersection::Entity Intersection::outside() const
 {
-    return EntityPointer(*pgrid_, nbcell(), true);
+    return Entity(*pgrid_, nbcell(), true);
 }
 } // end namespace cpgrid
 } // end namespace Dune

--- a/opm/grid/cpgrid/Intersection.hpp
+++ b/opm/grid/cpgrid/Intersection.hpp
@@ -15,7 +15,7 @@
 
 /*
   Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
-  Copyright 2009, 2010 Statoil ASA.
+  Copyright 2009, 2010, 2022 Equinor ASA.
 
   This file is part of The Open Porous Media project  (OPM).
 
@@ -57,8 +57,6 @@ namespace Dune
     {
     template<int>
     class Entity;
-    template<int>
-    class EntityPointer;
     class CpGridData;
 
         /// @brief
@@ -74,9 +72,8 @@ namespace Dune
             /// @brief
             /// @todo Doc me!
             typedef cpgrid::Entity<0> Entity;
-            typedef cpgrid::EntityPointer<0> EntityPointer;
-             typedef cpgrid::Geometry<2,3> Geometry;
-             typedef cpgrid::Geometry<2,3> LocalGeometry;
+            typedef cpgrid::Geometry<2,3> Geometry;
+            typedef cpgrid::Geometry<2,3> LocalGeometry;
             typedef double ctype;
             typedef FieldVector<ctype, 2> LocalCoordinate;
             typedef FieldVector<ctype, 3> GlobalCoordinate;
@@ -145,12 +142,12 @@ namespace Dune
             /// @brief
             /// @todo Doc me!
             /// @return
-            EntityPointer inside() const;
+            Entity inside() const;
 
             /// @brief
             /// @todo Doc me!
             /// @return
-            EntityPointer outside() const;
+            Entity outside() const;
 
             /// @brief
             /// @todo Doc me!

--- a/opm/grid/cpgrid/Iterators.hpp
+++ b/opm/grid/cpgrid/Iterators.hpp
@@ -15,7 +15,7 @@
 
 /*
 Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
-Copyright 2009, 2010 Statoil ASA.
+Copyright 2009, 2010, 2022 Equinor ASA.
 
 This file is part of The Open Porous Media project  (OPM).
 
@@ -52,9 +52,10 @@ namespace Dune
         /// This could have been a random access iterator, perhaps we will
         /// use a facade to do this later.
         template<int cd, PartitionIteratorType pitype>
-        class Iterator : public EntityPointer<cd>
+        class Iterator : public Entity<cd>
         {
         public:
+            using Reference = const Entity<cd>&;
             /// @brief
             /// @todo Doc me!
             /// @param
@@ -75,6 +76,20 @@ namespace Dune
                     EntityRep<cd>::increment();
                 return *this;
             }
+            /// Const member by pointer operator.
+            const Entity<cd>* operator->() const
+            {
+                assert(Entity<cd>::isValid());
+                return (this);
+            }
+
+            /// Const dereferencing operator.
+            const Entity<cd>& operator*() const
+            {
+                assert(Entity<cd>::isValid());
+                return (*this);
+            }
+
         private:
             /// \brief The number of Entities with codim cd.
             int noEntities_;
@@ -85,14 +100,15 @@ namespace Dune
 
 
         /// Only needs to provide interface for doing nothing.
-        class HierarchicIterator : public EntityPointer<0>
+        class HierarchicIterator : public Entity<0>
         {
         public:
+            using Reference = const Entity<0>&;
             /// @brief
             /// @todo Doc me!
             /// @param
             HierarchicIterator(const CpGridData& grid)
-                : EntityPointer<0>(grid, EntityRep<0>::InvalidIndex, true )
+                : Entity<0>(grid, EntityRep<0>::InvalidIndex, true )
             {
             }
 
@@ -103,6 +119,19 @@ namespace Dune
             {
                 OPM_THROW(std::runtime_error, "Calling operator++() on HierarchicIterator for CpGrid, which has no refinement.");
                 return *this;
+            }
+            /// Const member by pointer operator.
+            const Entity<0>* operator->() const
+            {
+                assert(Entity<0>::isValid());
+                return (this);
+            }
+
+            /// Const dereferencing operator.
+            const Entity<0>& operator*() const
+            {
+                assert(Entity<0>::isValid());
+                return (*this);
             }
         };
 
@@ -147,10 +176,10 @@ namespace cpgrid {
 
 template<int cd, PartitionIteratorType pitype>
 Iterator<cd, pitype>::Iterator(const CpGridData& grid, int index, bool orientation)
-    : EntityPointer<cd>(grid,
-                        // If the partition is empty, goto to end iterator!
-                        EntityRep<cd>(PartitionIteratorRule<pitype>::emptySet?grid.size(cd):index,
-                                      orientation)),
+    : Entity<cd>(grid,
+                 // If the partition is empty, goto to end iterator!
+                 EntityRep<cd>(PartitionIteratorRule<pitype>::emptySet?grid.size(cd):index,
+                               orientation)),
       noEntities_(grid.size(cd))
 {
     if(rule_.fullSet || rule_.emptySet)

--- a/opm/grid/polyhedralgrid/geometry.hh
+++ b/opm/grid/polyhedralgrid/geometry.hh
@@ -110,6 +110,11 @@ namespace Dune
     //! type of jacobian transposed
     typedef FieldMatrix< ctype, mydim, cdim > JacobianTransposed;
 
+    //! type of jacobian inverse transposed
+    using JacobianInverse = FieldMatrix< ctype, mydim, cdim >;
+
+    //! type of jacobian transposed
+    using Jacobian = FieldMatrix< ctype, cdim, mydim >;
 
     typedef Dune::Impl::FieldMatrixHelper< ctype >  MatrixHelperType;
 
@@ -211,6 +216,21 @@ namespace Dune
 
       DUNE_THROW(NotImplemented,"jacobianInverseTransposed not implemented");
       return JacobianInverseTransposed( 0 );
+    }
+
+
+    /// @brief The jacobian.
+    Jacobian
+    jacobian(const LocalCoordinate&  local ) const
+    {
+      return jacobianTransposed(local).transposed();
+    }
+
+    /// @brief The inverse of the jacobian
+    JacobianInverse
+    jacobianInverse(const LocalCoordinate& local) const
+    {
+      return jacobianInverseTransposed(local).transposed();
     }
 
     ExtraData data() const { return storage_.data(); }

--- a/opm/grid/polyhedralgrid/grid.hh
+++ b/opm/grid/polyhedralgrid/grid.hh
@@ -122,7 +122,12 @@ namespace Dune
       typedef GlobalIdSet  LocalIdSet;
 
       typedef Dune::MPIHelper::MPICommunicator MPICommunicator;
-      typedef Dune::CollectiveCommunication<MPICommunicator> CollectiveCommunication;
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+      using Communication = Dune::Communication<MPICommunicator>;
+      using CollectiveCommunication = Dune::Communication<MPICommunicator>;
+#else
+      using CollectiveCommunication = CollectiveCommunication< MPICommunicator>;
+#endif
 
       template< PartitionIteratorType pitype >
       struct Partition
@@ -307,7 +312,13 @@ namespace Dune
     typedef typename Traits::ctype ctype;
 
     //! communicator with all other processes having some part of the grid
-    typedef typename Traits::CollectiveCommunication CollectiveCommunication;
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+    using Communication = typename Traits::Communication;
+    using CommunicationType = Communication;
+#else
+    using CollectiveCommunication = typename Traits::CollectiveCommunication;
+    using CommunicationType = CollectiveCommunication;
+#endif
 
     typedef typename Traits :: GlobalCoordinate GlobalCoordinate;
 
@@ -706,7 +717,7 @@ namespace Dune
      *  \note The CollectiveCommunication object returned is identical to the
      *        one returned by the host grid.
      */
-    const CollectiveCommunication &comm () const
+    const CommunicationType &comm () const
     {
       return comm_;
     }
@@ -1659,7 +1670,7 @@ namespace Dune
     UnstructuredGridPtr gridPtr_;
     const UnstructuredGridType& grid_;
 
-    CollectiveCommunication comm_;
+    CommunicationType comm_;
     std::array< int, 3 > cartDims_;
     std::vector< std::vector< GeometryType > > geomTypes_;
     std::vector< std::vector< int > > cellVertices_;

--- a/opm/grid/polyhedralgrid/gridview.hh
+++ b/opm/grid/polyhedralgrid/gridview.hh
@@ -44,8 +44,14 @@ namespace Dune
     typedef typename Traits::IndexSet IndexSet;
     typedef typename Traits::Intersection Intersection;
     typedef typename Traits::IntersectionIterator IntersectionIterator;
-    typedef typename Traits::CollectiveCommunication CollectiveCommunication;
 
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+    using Communication = typename Traits::Communication;
+    using CollectiveCommunication = Communication; // deprecated
+#else
+    using CollectiveCommunication = Dune::CollectiveCommunication<MPICommunicator>;
+    using Communication = CollectiveCommunication;
+#endif
     template< int codim >
     struct Codim
     : public Traits::template Codim< codim >
@@ -165,7 +171,8 @@ namespace Dune
     typedef Dune::Intersection< const Grid, IntersectionImpl > Intersection;
     typedef Dune::IntersectionIterator< const Grid, IntersectionIteratorImpl, IntersectionImpl > IntersectionIterator;
 
-    typedef typename Grid::CollectiveCommunication CollectiveCommunication;
+    using Communication = typename Grid::Communication;
+    using CollectiveCommunication = Communication;
 
     template< int codim >
     struct Codim

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -445,11 +445,11 @@ BOOST_AUTO_TEST_CASE(compareWithSequential)
                 BOOST_REQUIRE(iit->geometry().volume() == siit->geometry().volume());
                 BOOST_REQUIRE(iit.boundary() == siit.boundary());
                 BOOST_REQUIRE(iit.outerNormal({0, 0}) == siit.outerNormal({0, 0}));
-                BOOST_REQUIRE(idSet.id(*iit.inside()) == seqIdSet.id(*siit.inside()));
+                BOOST_REQUIRE(idSet.id(iit.inside()) == seqIdSet.id(siit.inside()));
                 if (iit->neighbor())
                 {
                     assert(siit->neighbor());
-                    BOOST_REQUIRE(idSet.id(*iit.outside()) == seqIdSet.id(*siit.outside()));
+                    BOOST_REQUIRE(idSet.id(iit.outside()) == seqIdSet.id(siit.outside()));
                 }
             }
 
@@ -793,7 +793,7 @@ BOOST_AUTO_TEST_CASE(intersectionOverlap)
             if (isIt->neighbor())
             {
                 GlobalPosition distVec = eIt->geometry().center() -
-                    isIt->outside()->geometry().center();
+                    isIt->outside().geometry().center();
                 // Make sure that Coordinates of an element and its neighbor are not identical
                 BOOST_REQUIRE(distVec.two_norm2()>=1e-8);
             }

--- a/tests/cpgrid/entity_test.cpp
+++ b/tests/cpgrid/entity_test.cpp
@@ -83,21 +83,6 @@ BOOST_AUTO_TEST_CASE(entity)
     //   ileafend()
 }
 
-
-BOOST_AUTO_TEST_CASE(entity_ptr)
-{
-    cpgrid::CpGridData g;
-    cpgrid::EntityPointer<0> p1(g, 5, true);
-    const cpgrid::EntityPointer<0> p2(g, 42, true);
-//     cpgrid::Entity<0, CpGrid>& e1 = *p1;
-//     const cpgrid::Entity<0, CpGrid>& e2 = *p2;
-//     cpgrid::Entity<0, CpGrid> ee1(g, ~5);
-//     cpgrid::Entity<0, CpGrid> ee2(g, 42);
-//     BOOST_CHECK(e1 == ee1);
-//     BOOST_CHECK(e2 == ee2);
-}
-
-
 bool
 init_unit_test_func()
 {

--- a/tests/test_communication_utils.cpp
+++ b/tests/test_communication_utils.cpp
@@ -23,6 +23,7 @@
 #define BOOST_TEST_MODULE CommunicationUtilities
 #include <boost/test/unit_test.hpp>
 #include <dune/common/parallel/mpihelper.hh>
+#include <dune/common/version.hh>
 #include <opm/grid/common/CommunicationUtils.hpp>
 #include <tuple> // Should be included via CommunicationUtils.hpp but you never know.
 #include <numeric> // Should be included via CommunicationUtils.hpp but you never know.
@@ -182,18 +183,34 @@ void testGatherv(const C& comm)
 
 BOOST_AUTO_TEST_CASE(FakeAllGatherv)
 {
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+    testAllGatherv(Dune::FakeMPIHelper::getCommunication());
+#else
     testAllGatherv(Dune::FakeMPIHelper::getCollectiveCommunication());
+#endif
 }
 BOOST_AUTO_TEST_CASE(FakeGatherv)
 {
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+    testGatherv(Dune::FakeMPIHelper::getCommunication());
+#else
     testGatherv(Dune::FakeMPIHelper::getCollectiveCommunication());
+#endif
 }
 BOOST_AUTO_TEST_CASE(AllGatherv)
 {
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+    testAllGatherv(Dune::MPIHelper::getCommunication());
+#else
     testAllGatherv(Dune::MPIHelper::getCollectiveCommunication());
+#endif
 }
 BOOST_AUTO_TEST_CASE(Gatherv)
 {
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+    testGatherv(Dune::MPIHelper::getCommunication());
+#else
     testGatherv(Dune::MPIHelper::getCollectiveCommunication());
+#endif
 }
 


### PR DESCRIPTION
Added Communication type to GridTraits class, prevents warnings about missing jobian methods in Geometry, and removes Entitypointer (deprecated since at least 2.6).

Compiles now with DUNE 2.6-2.9