### PR TITLE
Checks for the refined topoloy

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -80,6 +80,9 @@
 #include <list>
 #endif
 
+void refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,
+                      const std::array<int, 3>&,
+                      bool);
 namespace Dune
 {
 
@@ -211,6 +214,10 @@ namespace Dune
         friend class cpgrid::CpGridData;
         template<int dim>
         friend cpgrid::Entity<dim> createEntity(const CpGrid&,int,bool);
+        friend
+        void ::refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,
+                                const std::array<int, 3>&,
+                                bool);
 
     public:
 

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -110,7 +110,16 @@ class PartitionTypeIndicator;
 template<int,int> class Geometry;
 template<int> class Entity;
 template<int> class EntityRep;
+}
+}
 
+void refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,
+                      const std::array<int, 3>&,
+                      bool);
+namespace Dune
+{
+namespace cpgrid
+{
 namespace mover
 {
 template<class T, int i> struct Mover;
@@ -125,6 +134,11 @@ class CpGridData
     template<class T, int i> friend struct mover::Mover;
 
     friend class GlobalIdSet;
+
+    friend
+    void ::refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,
+                            const std::array<int, 3>&,
+                            bool);
 
 private:
     CpGridData(const CpGridData& g);

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -70,6 +70,7 @@
 #include <opm/grid/utility/VariableSizeCommunicator.hpp>
 #endif
 #include <dune/grid/common/gridenums.hh>
+#include <dune/geometry/type.hh>
 
 #include <opm/grid/utility/platform_dependent/reenable_warnings.h>
 

--- a/opm/grid/cpgrid/DefaultGeometryPolicy.hpp
+++ b/opm/grid/cpgrid/DefaultGeometryPolicy.hpp
@@ -15,7 +15,7 @@
 
 /*
 Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
-Copyright 2009, 2010 Statoil ASA.
+Copyright 2009, 2010, 2022 Equinor ASA.
 
 This file is part of The Open Porous Media project  (OPM).
 
@@ -36,18 +36,21 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef OPM_DEFAULTGEOMETRYPOLICY_HEADER
 #define OPM_DEFAULTGEOMETRYPOLICY_HEADER
 
-#include "Geometry.hpp"
 #include "EntityRep.hpp"
 
 namespace Dune
 {
     namespace cpgrid
     {
+        template<int mydim, int dim>
+        class Geometry;
         /// @brief
         /// @todo Doc me!
         class DefaultGeometryPolicy
         {
             friend class CpGridData;
+            template<int mydim, int dim>
+            friend class Geometry;
         public:
             /// @brief
             /// @todo Doc me

--- a/opm/grid/cpgrid/EntityRep.hpp
+++ b/opm/grid/cpgrid/EntityRep.hpp
@@ -106,7 +106,7 @@ namespace Dune
             }
             /// @brief Constructor taking an entity index and an orientation.
             /// @param index_arg Entity index
-            /// @param orientation_arg True if the entity's orientations is positive.
+            /// @param orientation_arg True if the entity's orientation is positive.
             EntityRep(int index_arg, bool orientation_arg)
                 : entityrep_(orientation_arg ? index_arg : ~index_arg)
             {
@@ -114,7 +114,7 @@ namespace Dune
             }
             /// @brief Set entity value.
             /// @param index Entity index
-            /// @param orientation True if the entity's orientations is positive.
+            /// @param orientation True if the entity's orientation is positive.
             void setValue(int index_arg, bool orientation_arg)
             {
                 assert(index_arg >= 0);
@@ -231,6 +231,8 @@ namespace Dune
             using V::reserve;
             using V::push_back;
             using V::data;
+            using V::operator[];
+            using V::resize;
 
             /// Default constructor.
             EntityVariableBase()

--- a/opm/grid/cpgrid/Geometry.hpp
+++ b/opm/grid/cpgrid/Geometry.hpp
@@ -351,32 +351,9 @@ namespace Dune
                 return true;
             }
 
-            /* @todiscuss Possible re-definition of the constructor
-            /// @brief Construct from centroid, volume,
-            ///        corners, and '4 corner indices per face'
-            /// @param pos the centroid of the entity
-            /// @param vol the volume(area) of the entity
-            /// @param allcorners array of all corner positions in the grid
-            /// @param face4corners_indices array of 4 indices into allcorners array.
-            Geometry(const GlobalCoordinate& pos,
-                     ctype vol,
-                     const EntityVariable<cpgrid::Geometry<0, 3>, 3>& allcorners,
-                     const int* face4corners_indices)
-                : pos_(pos), vol_(vol), allcorners_(allcorners.data()), cor_idx_(face4corners_indices)
-            {
-                assert(allcorners_ && corner_indices);
-            }
-            /// Default constructor, giving a non-valid geometry.
-            Geometry()
-                : pos_(0.0), vol_(0.0), allcorners_(0), cor_idx_(0)
-            {
-            }*/
-
         private:
             GlobalCoordinate pos_;
             ctype vol_;
-            //const cpgrid::Geometry<0, 3>* allcorners_; @todiscuss
-            // const int* cor_idx_;
         };
 
 
@@ -643,7 +620,6 @@ namespace Dune
             void refine(const std::array<int,3>& cells_per_dim,
                         DefaultGeometryPolicy& all_geom,
                         std::vector<std::array<int,8>>&  global_refined_cell8corners_indices_storage)
-            // std::vector<std::array<int,4>>& global_refined_face4corners_indices_storage) @todiscuss potential extra argument
             {
                 EntityVariableBase<cpgrid::Geometry<0,3>>& global_refined_corners =
                     all_geom.geomVector(std::integral_constant<int,3>());
@@ -770,10 +746,6 @@ namespace Dune
                                     global_refined_face_area += std::fabs(simplex_volume(trian_corners));
                                 } // end edge-for-loop
                                 //
-                                /*/// THINK ABOUT CHANGES IN THE FACE CONSTRUCTOR
-                                // Create a pointer to the first element of "global_refined_face4corners_indices_storage"
-                                // (required as the fourth argement to construct a Geometry<2,3> type object).
-                                int* indices_storage_ptr = global_refined_face4corners_indices_storage[global_refined_face_idx].data(); */
                                 //
                                 // Construct the Geometry<2,3> of the global refined face.
                                 global_refined_faces[idx] = Geometry<2,cdim>(this->global(local_refined_face_centroid),

--- a/opm/grid/cpgrid/Geometry.hpp
+++ b/opm/grid/cpgrid/Geometry.hpp
@@ -634,8 +634,6 @@ namespace Dune
                 // Determine the size of the vector containing all the corners
                 // of all the global refined cells (children cells).
                 global_refined_corners.resize((cells_per_dim[0] + 1) *(cells_per_dim[1] + 1) * (cells_per_dim[2] + 1));
-                // Vector to store the indices of all the global refined corners.
-                std::vector<int> global_refined_corner_indices;
                 // The nummbering starts at the botton, so k=0 (z-axis), and j=0 (y-axis), i=0 (x-axis).
                 // Then, increasing k ('going up'), followed by increasing i ('going right->'),
                 // and finally, increasing j ('going back'). This order criteria for corners
@@ -647,8 +645,6 @@ namespace Dune
                             // Compute the index of each global refined corner associated with 'jik'.
                             int global_refined_corner_idx =
                                 (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k;
-                            // Incorporate the index in "global_refined_corner_indices".
-                            global_refined_corner_indices.push_back(global_refined_corner_idx);
                             // Compute the local refined corner of the unit/reference cube associated with 'jik'.
                             const LocalCoordinate& local_refined_corner = {
                                 double(i)/cells_per_dim[0], double(j)/cells_per_dim[1], double(k)/cells_per_dim[2] };

--- a/opm/grid/cpgrid/Geometry.hpp
+++ b/opm/grid/cpgrid/Geometry.hpp
@@ -49,8 +49,10 @@
 
 #include <opm/grid/cpgrid/EntityRep.hpp>
 #include <opm/grid/cpgrid/DefaultGeometryPolicy.hpp>
+#include <opm/grid/cpgrid/OrientedEntityTable.hpp>
 #include <opm/grid/common/Volumes.hpp>
 #include <opm/grid/utility/platform_dependent/reenable_warnings.h>
+#include <opm/grid/utility/SparseTable.hpp>
 
 #include <opm/grid/utility/ErrorMacros.hpp>
 
@@ -615,12 +617,34 @@ namespace Dune
              *
              * @param cells_per_dim                                The number of sub-cells in each direction,
              * @param all_geom                                     Geometry Policy for the refined geometries. Those will be added there.
+             * @param cell_to_face                                 Mapping from cell to oriented faces.
+             *                                                     later be used to construct inverse map
+             *                                                     with makeInverseRelation.
+             * @param face_to_point                                Map from face to its points.
+             *
              * @param global_refined_cell8corners_indices_storage  A vector to store the indices of the 8 corners of each new cell.
              */
             void refine(const std::array<int,3>& cells_per_dim,
                         DefaultGeometryPolicy& all_geom,
-                        std::vector<std::array<int,8>>&  global_refined_cell8corners_indices_storage)
+                        std::vector<std::array<int,8>>&  global_refined_cell8corners_indices_storage,
+                        cpgrid::OrientedEntityTable<0, 1>& cell_to_face,
+                        Opm::SparseTable<int>& face_to_point)
+            //cpgrid::CpGridData& child_grid)
+            // Don't CpGridData
             {
+                // SOme fake code to demonstrate the usage
+                int next_row_index = face_to_point.size();
+                // Points for next_row_index
+                std::vector<int> points_of_one_face = { 0, 4, 8};
+                // append row with index next_row_index
+                face_to_point.appendRow(points_of_one_face.begin(), points_of_one_face.end());
+                // Now to the OrientEntityTable. Not sure how the orientation is correct, yet.
+                using cpgrid::EntityRep;
+                // first value is index, second is orientation
+                // Still have to find out what the orientation should be.
+                std::vector<cpgrid::EntityRep<1>> faces_of_one_cell = {{3, true}, {4, false}};
+                cell_to_face.appendRow(faces_of_one_cell.begin(), faces_of_one_cell.end());
+                // end fake
                 EntityVariableBase<cpgrid::Geometry<0,3>>& global_refined_corners =
                     all_geom.geomVector(std::integral_constant<int,3>());
                 EntityVariableBase<cpgrid::Geometry<2,3>>& global_refined_faces =

--- a/opm/grid/cpgrid/Geometry.hpp
+++ b/opm/grid/cpgrid/Geometry.hpp
@@ -762,7 +762,7 @@ namespace Dune
                 // "global_refined_cells"'s size is cells_per_dim[0] * cells_per_dim[1] * cells_per_dim[2].
                 // To build each global refined cell, we need
                 // 1. its global refined CENTER
-                // 2. its VOLUME [available in "global_refined_cell_volumes"
+                // 2. its VOLUME
                 // 3. all global refined corners [available in "global_refined_corners"]
                 // 4. indices of its 8 corners [available in "global_refined_corner_indices"]
                 //
@@ -797,10 +797,8 @@ namespace Dune
                 // the 6 corners of the tetrahedron as arguments. Summing up the 24 volumes,
                 // we get the volumne of the hexahedorn (global refined 'cell').
                 //
-                // Vector to store the volumes of the global refined 'cells'.
-                std::vector<double> global_refined_cell_volumes;
-                // Determine the size of "global_refined_cell_volumes" (same as total amount of refined cells).
-                global_refined_cell_volumes.resize(cells_per_dim[0] * cells_per_dim[1] * cells_per_dim[2]);
+                // Sum of all the volumes of all the (children) global refined cells.
+                double sum_all_global_refined_cell_volumes = 0.0;
                 //
                 // For each (global refined 'cell') hexahedron, to create 24 tetrahedra and their volumes,
                 // we introduce
@@ -920,7 +918,7 @@ namespace Dune
                             } // end face-for-loop
                             // Add the volume of the hexahedron (global refined 'cell')
                             // to the container with of all volumes of all the refined cells.
-                            global_refined_cell_volumes[global_refined_cell_idx] = global_refined_cell_volume;
+                            sum_all_global_refined_cell_volumes += global_refined_cell_volume;
                             // Create a pointer to the first element of "global_refined_cell8corners_indices_storage"
                             // (required as the fourth argement to construct a Geometry<3,3> type object).
                             int* indices_storage_ptr = global_refined_cell8corners_indices_storage[global_refined_cell_idx].data();
@@ -935,11 +933,6 @@ namespace Dune
                 } // end k-for-loop
                 // Rescale all volumes if the sum of volume of all the global refined 'cells' does not match the
                 // volume of the 'parent cell'.
-                // Sum of all the volumes of all the (children) global refined cells.
-                double sum_all_global_refined_cell_volumes = 0.0;
-                for (auto& volume : global_refined_cell_volumes) {
-                    sum_all_global_refined_cell_volumes += volume;
-                }
                 // Compare the sum of all the volumes of all refined cells with 'parent cell' volume.
                 if (std::fabs(sum_all_global_refined_cell_volumes - this->volume())
                     > std::numeric_limits<Geometry<3, cdim>::ctype>::epsilon()) {

--- a/opm/grid/cpgrid/Geometry.hpp
+++ b/opm/grid/cpgrid/Geometry.hpp
@@ -59,11 +59,9 @@ namespace Dune
     namespace cpgrid
     {
 
-        //class DefaultGeometryPolicy;
-
-        /// This class encapsulates geometry for both vertices,
-        /// intersections and cells.  The main template is empty,
-        /// the actual dim == 3 (cell), dim == 2 (intersection)
+        /// This class encapsulates geometry for vertices,
+        /// intersections, and cells. The main template is empty,
+        /// the actual dim == 3 (cell), dim == 2 (intersection),
         /// and dim == 0 (vertex) cases have specializations.
         /// For vertices and cells we use the cube type, and provide
         /// constant (vertex) or trilinear (cell) mappings.
@@ -117,7 +115,7 @@ namespace Dune
             {
             }
 
-            /// Default constructor, giving a non-valid geometry.
+            /// @brief Default constructor, giving a non-valid geometry.
             Geometry()
                 : pos_(0.0)
             {
@@ -213,421 +211,7 @@ namespace Dune
 
         private:
             GlobalCoordinate pos_;
-        };
-
-
-
-
-        /// Specialization for 3-dimensional geometries, i.e. cells.
-        template <int cdim>
-        class Geometry<3, cdim>
-        {
-            static_assert(cdim == 3, "");
-        public:
-            /// Dimension of underlying grid.
-            enum { dimension = 3 };
-            /// Dimension of domain space of \see global().
-            enum { mydimension = 3 };
-            /// Dimension of range space of \see global().
-            enum { coorddimension = cdim };
-            /// World dimension of underlying grid.
-            enum { dimensionworld = 3 };
-
-            /// Coordinate element type.
-            typedef double ctype;
-
-            /// Domain type of \see global().
-            typedef FieldVector<ctype, mydimension> LocalCoordinate;
-            /// Range type of \see global().
-            typedef FieldVector<ctype, coorddimension> GlobalCoordinate;
-
-            /// Type of Jacobian matrix.
-            typedef FieldMatrix< ctype, coorddimension, mydimension >         Jacobian;
-            /// Type of inverse of Jacobian matrix.
-            typedef FieldMatrix< ctype, coorddimension, mydimension >         JacobianInverse;
-            /// Type of transposed Jacobian matrix.
-            typedef FieldMatrix< ctype, mydimension, coorddimension >         JacobianTransposed;
-            /// Type of the inverse of the transposed Jacobian matrix
-            typedef FieldMatrix< ctype, coorddimension, mydimension >         JacobianInverseTransposed;
-
-            typedef Dune::Impl::FieldMatrixHelper< double >  MatrixHelperType;
-
-            /// @brief Construct from centroid, volume (1- and 0-moments) and
-            ///        corners.
-            /// @param pos the centroid of the entity
-            /// @param vol the volume(area) of the entity
-            /// @param allcorners array of all corner positions in the grid
-            /// @param corner_indices array of 8 indices into allcorners array. The
-            ///                       indices must be given in lexicographical order
-            ///                       by (kji), i.e. i running fastest.
-            Geometry(const GlobalCoordinate& pos,
-                     ctype vol,
-                     const EntityVariable<cpgrid::Geometry<0, 3>, 3>& allcorners,
-                     const int* corner_indices)
-                : pos_(pos), vol_(vol), allcorners_(allcorners.data()), cor_idx_(corner_indices)
-            {
-                assert(allcorners_ && corner_indices);
-            }
-
-            /// @brief Construct from centroid and volume (1- and
-            ///        0-moments).  Note that since corners are not
-            ///        given, the geometry provides no mappings, and
-            ///        some calls (corner(), global() etc.) will fail.
-            ///        This possibly dangerous constructor is
-            ///        available for the benefit of
-            ///        CpGrid::readSintefLegacyFormat().
-            /// @param pos the centroid of the entity
-            /// @param vol the volume(area) of the entity
-            Geometry(const GlobalCoordinate& pos,
-                     ctype vol)
-                : pos_(pos), vol_(vol)
-            {
-            }
-
-            /// Default constructor, giving a non-valid geometry.
-            Geometry()
-                : pos_(0.0), vol_(0.0), allcorners_(0), cor_idx_(0)
-            {
-            }
-
-            /// Provide a trilinear mapping.
-            /// Note that this does not give a proper space-filling
-            /// embedding of the cell complex in the general (faulted)
-            /// case. We should therefore revisit this at some point.
-            GlobalCoordinate global(const LocalCoordinate& local_coord) const
-            {
-                static_assert(mydimension == 3, "");
-                static_assert(coorddimension == 3, "");
-                // uvw = { (1-u, 1-v, 1-w), (u, v, w) }
-                LocalCoordinate uvw[2] = { LocalCoordinate(1.0), local_coord };
-                uvw[0] -= local_coord;
-                // Access pattern for uvw matching ordering of corners.
-                const int pat[8][3] = { { 0, 0, 0 },
-                                        { 1, 0, 0 },
-                                        { 0, 1, 0 },
-                                        { 1, 1, 0 },
-                                        { 0, 0, 1 },
-                                        { 1, 0, 1 },
-                                        { 0, 1, 1 },
-                                        { 1, 1, 1 } };
-                GlobalCoordinate xyz(0.0);
-                for (int i = 0; i < 8; ++i) {
-                    GlobalCoordinate corner_contrib = corner(i);
-                    double factor = 1.0;
-                    for (int j = 0; j < 3; ++j) {
-                        factor *= uvw[pat[i][j]][j];
-                    }
-                    corner_contrib *= factor;
-                    xyz += corner_contrib;
-                }
-                return xyz;
-            }
-
-            /// Mapping from the cell to the reference domain.
-            /// May be slow.
-            LocalCoordinate local(const GlobalCoordinate& y) const
-            {
-                static_assert(mydimension == 3, "");
-                static_assert(coorddimension == 3, "");
-                // This code is modified from dune/grid/genericgeometry/mapping.hh
-                // \todo: Implement direct computation.
-                const ctype epsilon = 1e-12;
-                auto refElement = Dune::ReferenceElements<ctype, 3>::cube();
-                LocalCoordinate x = refElement.position(0,0);
-                LocalCoordinate dx;
-                do {
-                    // DF^n dx^n = F^n, x^{n+1} -= dx^n
-                    JacobianTransposed JT = jacobianTransposed(x);
-                    GlobalCoordinate z = global(x);
-                    z -= y;
-                    MatrixHelperType::template xTRightInvA<3, 3>(JT, z, dx );
-                    x -= dx;
-                } while (dx.two_norm2() > epsilon*epsilon);
-                return x;
-            }
-
-            /// Equal to \sqrt{\det{J^T J}} where J is the Jacobian.
-            /// J_{ij} = (dg_i/du_j)
-            /// where g is the mapping from the reference domain,
-            /// and {u_j} are the reference coordinates.
-            double integrationElement(const LocalCoordinate& local_coord) const
-            {
-                JacobianTransposed Jt = jacobianTransposed(local_coord);
-                return MatrixHelperType::template sqrtDetAAT<3, 3>(Jt);
-            }
-
-            /// Using the cube type for all entities now (cells and vertices),
-            /// but we use the singular type for intersections.
-            GeometryType type() const
-            {
-                return Dune::GeometryTypes::cube(mydimension);
-            }
-
-            /// The number of corners of this convex polytope.
-            /// Returning 8, since we treat all cells as hexahedral.
-            int corners() const
-            {
-                return 8;
-            }
-
-            /// The 8 corners of the hexahedral base cell.
-            GlobalCoordinate corner(int cor) const
-            {
-                assert(allcorners_ && cor_idx_);
-                return allcorners_[cor_idx_[cor]].center();
-            }
-
-            /// Cell volume.
-            ctype volume() const
-            {
-                return vol_;
-            }
-
-            void set_volume(ctype volume) {
-                vol_ = volume;
-            }
-
-            /// Returns the centroid of the geometry.
-            const GlobalCoordinate& center() const
-            {
-                return pos_;
-            }
-
-            /// @brief Jacobian transposed.
-            /// J^T_{ij} = (dg_j/du_i)
-            /// where g is the mapping from the reference domain,
-            /// and {u_i} are the reference coordinates.
-            const JacobianTransposed
-            jacobianTransposed(const LocalCoordinate& local_coord) const
-            {
-                static_assert(mydimension == 3, "");
-                static_assert(coorddimension == 3, "");
-
-                // uvw = { (1-u, 1-v, 1-w), (u, v, w) }
-                LocalCoordinate uvw[2] = { LocalCoordinate(1.0), local_coord };
-                uvw[0] -= local_coord;
-                // Access pattern for uvw matching ordering of corners.
-                const int pat[8][3] = { { 0, 0, 0 },
-                                        { 1, 0, 0 },
-                                        { 0, 1, 0 },
-                                        { 1, 1, 0 },
-                                        { 0, 0, 1 },
-                                        { 1, 0, 1 },
-                                        { 0, 1, 1 },
-                                        { 1, 1, 1 } };
-                JacobianTransposed  Jt(0.0);
-                for (int i = 0; i < 8; ++i) {
-                    for (int deriv = 0; deriv < 3; ++deriv) {
-                        // This part contributing to dg/du_{deriv}
-                        double factor = 1.0;
-                        for (int j = 0; j < 3; ++j) {
-                            factor *= (j != deriv) ? uvw[pat[i][j]][j]
-                                : (pat[i][j] == 0 ? -1.0 : 1.0);
-                        }
-                        GlobalCoordinate corner_contrib = corner(i);
-                        corner_contrib *= factor;
-                        Jt[deriv] += corner_contrib; // using FieldMatrix row access.
-                    }
-                }
-                return Jt;
-            }
-
-            /// @brief Inverse of Jacobian transposed. \see jacobianTransposed().
-            const JacobianInverseTransposed
-            jacobianInverseTransposed(const LocalCoordinate& local_coord) const
-            {
-                JacobianInverseTransposed Jti = jacobianTransposed(local_coord);
-                Jti.invert();
-                return Jti;
-            }
-
-            /// @brief The jacobian.
-            Jacobian
-            jacobian(const LocalCoordinate& local_coord) const
-            {
-                return jacobianTransposed(local_coord).transposed();
-            }
-            
-            /// @brief The inverse of the jacobian
-            JacobianInverse
-            jacobianInverse(const LocalCoordinate& local_coord) const
-            {
-                return jacobianInverseTransposed(local_coord).transposed();
-            }
-            
-            /// The mapping implemented by this geometry is not generally affine.
-            bool affine() const
-            {
-                return false;
-            }
-
-            /**
-             * @brief Refine a single cell with regular intervals.
-             * 
-             * For each cell to be created, storage must be passed for its corners and the indices. That storage
-             * must be externally managed, since the newly created geometry structures only store pointers and do
-             * not free them on destruction.
-             * 
-             * @param cells_per_dim The number of sub-cells in each direction.
-             * @param corner_storage A vector of mutable references to storage for the corners of each new cell.
-             * @param indices_storage A vector of mutable references to storage for the indices of each new cell.
-             * @return A vector with the created cells.
-             */
-            /// @brief Refine a single cell with regular intervals.
-            /// @param cells The number of sub-cells in each direction,
-            /// @param[out] refined_geom Geometry Policy for the refined geometries. Those will be added there.
-            /// @param[out] indices_storage A vector of mutable references to storage for the indices of each new cell.
-            /// @todo We do not need to return anything here.
-            std::vector<Geometry<3, cdim>> refine(const std::array<int, 3>& cells_per_dim,
-                                                  DefaultGeometryPolicy& all_geom,
-                                                  std::vector<std::array<int, 8>>& indices_storage)
-            {
-
-                //std::vector<EntityVariable<Geometry<0, 3>, 3>>& corner_storage,
-                // Below are basically std::vector of Geometry. Use resize(), reserve(), push_back(), etc.
-                EntityVariable<cpgrid::Geometry<0, 3>, 3>& global_refined_corners = all_geom.geomVector(std::integral_constant<int, 3>()); // was called corner_storage before
-                EntityVariable<cpgrid::Geometry<2, 3>, 1>& refined_faces = all_geom.geomVector(std::integral_constant<int, 1>()); // Missed by Peter, we need to add the faces
-                EntityVariable<cpgrid::Geometry<3, 3>, 0>& refined_cells = all_geom.geomVector(std::integral_constant<int, 0>()); // Put the refined cells here.
-
-                // @todo Maybe use vector::reserve to prevent allocations (or not), and later use push_back to populate.
-
-                // The center of the parent in local coordinates.
-                const Geometry<3, cdim>::LocalCoordinate parent_center(this->local(this->center()));
-
-                // Corners of the parent hexahedron in order, in local coordinates.
-                const Geometry<3, cdim>::LocalCoordinate parent_corners[8] = {
-                    {0.0, 0.0, 0.0},
-                    {1.0, 0.0, 0.0},
-                    {0.0, 1.0, 0.0},
-                    {1.0, 1.0, 0.0},
-                    {0.0, 0.0, 1.0},
-                    {1.0, 0.0, 1.0},
-                    {0.0, 1.0, 1.0},
-                    {1.0, 1.0, 1.0},
-                };
-
-                // Indices of the corners of the 6 faces of the hexahedrons.
-                const int face_corner_indices[6][4] = {
-                    {0, 1, 2, 3},
-                    {0, 1, 4, 5},
-                    {0, 2, 4, 6},
-                    {1, 3, 5, 7},
-                    {2, 3, 6, 7},
-                    {4, 5, 6, 7},
-                };
-
-                // To calculate a refined cell's volume, the hexahedron is
-                // divided in 24 tetrahedrons, each of which is defined by the
-                // center of the cell, the center of one face, and by one edge
-                // of that face. This struct defines that edge for each face,
-                // for each of the four possible tetrahedrons that are based on
-                // that face.
-                const int tetra_edge_indices[6][4][2] = {
-                    {{0, 1}, {0, 2}, {1, 3}, {2, 3}},
-                    {{0, 1}, {0, 4}, {1, 5}, {4, 5}},
-                    {{0, 2}, {0, 4}, {2, 6}, {4, 6}},
-                    {{1, 3}, {1, 5}, {3, 7}, {5, 7}},
-                    {{2, 3}, {2, 6}, {3, 7}, {6, 7}},
-                    {{4, 5}, {4, 6}, {5, 7}, {6, 7}},
-                };
-
-
-                std::vector<Geometry<3, cdim>> result;
-                result.reserve(cells_per_dim[0] * cells_per_dim[1] * cells_per_dim[2]);
-
-                auto pis = indices_storage.begin();
-
-                Geometry<3, cdim>::ctype total_volume = 0.0;
-                for (int k = 0; k < cells_per_dim[2]; k++) {
-                    Geometry<3, cdim>::LocalCoordinate refined_corners[8];
-                    Geometry<3, cdim>::LocalCoordinate refined_center(0.0);
-
-                    refined_center[2] = (parent_center[2] + k) / cells_per_dim[2];
-                    for (int h = 0; h < 8; h++) {
-                        refined_corners[h][2] = (parent_corners[h][2] + k) / cells_per_dim[2];
-                    }
-                    for (int j = 0; j < cells_per_dim[1]; j++) {
-                        refined_center[1] = (parent_center[1] + j) / cells_per_dim[1];
-                        for (int h = 0; h < 8; h++) {
-                            refined_corners[h][1] = (parent_corners[h][1] + j) / cells_per_dim[1];
-                        }
-                        for (int i = 0; i < cells_per_dim[0]; i++) {
-                            refined_center[0] = (parent_center[0] + i) / cells_per_dim[0];
-                            for (int h = 0; h < 8; h++) {
-                                refined_corners[h][0] = (parent_corners[h][0] + i) / cells_per_dim[0];
-                            }
-
-                            for (const auto& corner : refined_corners) {
-                                // @todo Only push new corners.
-                                global_refined_corners.push_back(Geometry<0, 3>(this->global(corner)));
-                                // @todo add the correct index to indices!
-                            }
-
-                            // The indices must match the order of the constant
-                            // arrays containing unit corners, face indices, and
-                            // tetrahedron edge indices. Do not reorder.
-                            auto& indices = *pis++;
-                            // @todo use the correct indices for the corner lookup!
-                            // global_refined_corner[indices[0]] has to be the Geometry of the first corner of the cell!
-                            indices = {0, 1, 2, 3, 4, 5, 6, 7};
-
-                            // Get the center of the cell.
-                            const Geometry<3, cdim>::GlobalCoordinate global_refined_center(
-                                this->global(refined_center));
-
-                            // Calculate the centers of the 6 faces.
-                            const auto& hex_corners = global_refined_corners.data();
-                            Geometry<0, 3>::GlobalCoordinate face_centers[6];
-                            for (int f = 0; f < 6; f++) {
-                                face_centers[f] = hex_corners[face_corner_indices[f][0]].center();
-                                face_centers[f] += hex_corners[face_corner_indices[f][1]].center();
-                                face_centers[f] += hex_corners[face_corner_indices[f][2]].center();
-                                face_centers[f] += hex_corners[face_corner_indices[f][3]].center();
-                                face_centers[f] /= 4;
-                            }
-
-                            // @todo Calculate face volume and add the face geometries to refined_faces!
-
-                            // Calculate the volume of the cell by adding the 4 tetrahedrons at each face.
-                            Geometry<3, cdim>::ctype volume = 0.0;
-                            for (int f = 0; f < 6; f++) {
-                                for (int e = 0; e < 4; e++) {
-                                    const Geometry<0, 3>::GlobalCoordinate tetra_corners[4]
-                                        = {hex_corners[tetra_edge_indices[f][e][0]].center(),
-                                           hex_corners[tetra_edge_indices[f][e][1]].center(),
-                                           face_centers[f],
-                                           global_refined_center};
-                                    volume += std::fabs(simplex_volume(tetra_corners));
-                                }
-                            }
-                            total_volume += volume;
-
-                            // @todo the geometries should go to refined_cells instead
-                            result.push_back(Geometry<3, cdim>(
-                                global_refined_center, volume, global_refined_corners, indices.data()));
-                        }
-                    }
-                }
-
-                // Rescale all volumes if the sum of volumes does not match the parent.
-                if (std::fabs(total_volume - this->volume())
-                    > std::numeric_limits<Geometry<3, cdim>::ctype>::epsilon()) {
-                    Geometry<3, cdim>::ctype correction = this->volume() / total_volume;
-                    for (auto& r : result) {
-                        r.set_volume(r.volume() * correction);
-                    }
-                }
-
-                return result;
-            }
-
-        private:
-            GlobalCoordinate pos_;
-            double vol_;
-            const cpgrid::Geometry<0, 3>* allcorners_; // For dimension 3 only
-            const int* cor_idx_;               // For dimension 3 only
-        };
-
+        };  // class Geometry<0,cdim>
 
 
 
@@ -658,7 +242,7 @@ namespace Dune
 
             /// Type of Jacobian matrix.
             typedef FieldMatrix< ctype, coorddimension, mydimension >         Jacobian;
-            /// Type of Jacobian matrix.
+            /// Type of inverse of Jacobian matrix.
             typedef FieldMatrix< ctype, coorddimension, mydimension >         JacobianInverse;
             /// Type of transposed Jacobian matrix.
             typedef FieldMatrix< ctype, mydimension, coorddimension >         JacobianTransposed;
@@ -760,21 +344,837 @@ namespace Dune
             {
                 return jacobianInverseTransposed({}).transposed();
             }
-            
+
             /// Since integrationElement() is constant, returns true.
             bool affine() const
             {
                 return true;
             }
 
+            /* /// @brief Construct from centroid, volume,
+            ///        corners, and '4 corner indices per face'
+            /// @param pos the centroid of the entity
+            /// @param vol the volume(area) of the entity
+            /// @param allcorners array of all corner positions in the grid
+            /// @param face4corners_indices array of 4 indices into allcorners array.
+            Geometry(const GlobalCoordinate& pos,
+                     ctype vol,
+                     const EntityVariable<cpgrid::Geometry<0, 3>, 3>& allcorners,
+                     const int* face4corners_indices)
+                : pos_(pos), vol_(vol), allcorners_(allcorners.data()), cor_idx_(face4corners_indices)
+            {
+                assert(allcorners_ && corner_indices);
+            }
+
+            /// Default constructor, giving a non-valid geometry.
+            Geometry()
+                : pos_(0.0), vol_(0.0), allcorners_(0), cor_idx_(0)
+            {
+            }*/
+
         private:
             GlobalCoordinate pos_;
             ctype vol_;
+            //const cpgrid::Geometry<0, 3>* allcorners_;
+            // const int* cor_idx_;
         };
 
 
 
 
+
+        /// Specialization for 3-dimensional geometries, i.e. cells.
+        template <int cdim>
+        class Geometry<3, cdim>
+        {
+            static_assert(cdim == 3, "");
+        public:
+            /// Dimension of underlying grid.
+            enum { dimension = 3 };
+            /// Dimension of domain space of \see global().
+            enum { mydimension = 3 };
+            /// Dimension of range space of \see global().
+            enum { coorddimension = cdim };
+            /// World dimension of underlying grid.
+            enum { dimensionworld = 3 };
+
+            /// Coordinate element type.
+            typedef double ctype;
+
+            /// Domain type of \see global().
+            typedef FieldVector<ctype, mydimension> LocalCoordinate;
+            /// Range type of \see global().
+            typedef FieldVector<ctype, coorddimension> GlobalCoordinate;
+
+            /// Type of Jacobian matrix.
+            typedef FieldMatrix< ctype, coorddimension, mydimension >         Jacobian;
+            /// Type of inverse of Jacobian matrix.
+            typedef FieldMatrix< ctype, coorddimension, mydimension >         JacobianInverse;
+            /// Type of transposed Jacobian matrix.
+            typedef FieldMatrix< ctype, mydimension, coorddimension >         JacobianTransposed;
+            /// Type of the inverse of the transposed Jacobian matrix
+            typedef FieldMatrix< ctype, coorddimension, mydimension >         JacobianInverseTransposed;
+
+            typedef Dune::Impl::FieldMatrixHelper< double >  MatrixHelperType;
+
+            /// @brief Construct from center, volume (1- and 0-moments) and
+            ///        corners.
+            /// @param pos the centroid of the entity
+            /// @param vol the volume(area) of the entity
+            /// @param allcorners array of all corner positions in the grid
+            /// @param corner_indices array of 8 indices into allcorners array. The
+            ///                       indices must be given in lexicographical order
+            ///                       by (kji), i.e. i running fastest.
+            Geometry(const GlobalCoordinate& pos,
+                     ctype vol,
+                     const EntityVariable<cpgrid::Geometry<0, 3>, 3>& allcorners,
+                     const int* corner_indices)
+                : pos_(pos), vol_(vol), allcorners_(allcorners.data()), cor_idx_(corner_indices)
+            {
+                assert(allcorners_ && corner_indices);
+            }
+
+            /// @brief Construct from centroid and volume (1- and
+            ///        0-moments).  Note that since corners are not
+            ///        given, the geometry provides no mappings, and
+            ///        some calls (corner(), global() etc.) will fail.
+            ///        This possibly dangerous constructor is
+            ///        available for the benefit of
+            ///        CpGrid::readSintefLegacyFormat().
+            /// @param pos the centroid of the entity
+            /// @param vol the volume(area) of the entity
+            Geometry(const GlobalCoordinate& pos,
+                     ctype vol)
+                : pos_(pos), vol_(vol)
+            {
+            }
+
+            /// Default constructor, giving a non-valid geometry.
+            Geometry()
+                : pos_(0.0), vol_(0.0), allcorners_(0), cor_idx_(0)
+            {
+            }
+
+            /// Provide a trilinear mapping.
+            /// Note that this does not give a proper space-filling
+            /// embedding of the cell complex in the general (faulted)
+            /// case. We should therefore revisit this at some point.
+            /// Map g from (local) reference domain to (global) cell
+            GlobalCoordinate global(const LocalCoordinate& local_coord) const
+            {
+                static_assert(mydimension == 3, "");
+                static_assert(coorddimension == 3, "");
+                // uvw = { (1-u, 1-v, 1-w), (u, v, w) }
+                LocalCoordinate uvw[2] = { LocalCoordinate(1.0), local_coord };
+                uvw[0] -= local_coord;
+                // Access pattern for uvw matching ordering of corners.
+                const int pat[8][3] = { { 0, 0, 0 },
+                                        { 1, 0, 0 },
+                                        { 0, 1, 0 },
+                                        { 1, 1, 0 },
+                                        { 0, 0, 1 },
+                                        { 1, 0, 1 },
+                                        { 0, 1, 1 },
+                                        { 1, 1, 1 } };
+                GlobalCoordinate xyz(0.0);
+                for (int i = 0; i < 8; ++i) {
+                    GlobalCoordinate corner_contrib = corner(i);
+                    double factor = 1.0;
+                    for (int j = 0; j < 3; ++j) {
+                        factor *= uvw[pat[i][j]][j];
+                    }
+                    corner_contrib *= factor;
+                    xyz += corner_contrib;
+                }
+                return xyz;
+            }
+
+            /// Mapping from the cell to the reference domain.
+            /// May be slow.
+            LocalCoordinate local(const GlobalCoordinate& y) const
+            {
+                static_assert(mydimension == 3, "");
+                static_assert(coorddimension == 3, "");
+                // This code is modified from dune/grid/genericgeometry/mapping.hh
+                // \todo: Implement direct computation.
+                const ctype epsilon = 1e-12;
+                auto refElement = Dune::ReferenceElements<ctype, 3>::cube();
+                LocalCoordinate x = refElement.position(0,0);
+                LocalCoordinate dx;
+                do {
+                    // DF^n dx^n = F^n, x^{n+1} -= dx^n
+                    JacobianTransposed JT = jacobianTransposed(x);
+                    GlobalCoordinate z = global(x);
+                    z -= y;
+                    MatrixHelperType::template xTRightInvA<3, 3>(JT, z, dx );
+                    x -= dx;
+                } while (dx.two_norm2() > epsilon*epsilon);
+                return x;
+            }
+
+            /// Equal to \sqrt{\det{J^T J}} where J is the Jacobian.
+            /// J_{ij} = (dg_i/du_j)
+            /// where g is the mapping from the reference domain,
+            /// and {u_j} are the reference coordinates.
+            double integrationElement(const LocalCoordinate& local_coord) const
+            {
+                JacobianTransposed Jt = jacobianTransposed(local_coord);
+                return MatrixHelperType::template sqrtDetAAT<3, 3>(Jt);
+            }
+
+            /// Using the cube type for all entities now (cells and vertices),
+            /// but we use the singular type for intersections.
+            GeometryType type() const
+            {
+                return Dune::GeometryTypes::cube(mydimension);
+            }
+
+            /// The number of corners of this convex polytope.
+            /// Returning 8, since we treat all cells as hexahedral.
+            int corners() const
+            {
+                return 8;
+            }
+
+            /// @brief Get the i-th of 8 corners of the hexahedral base cell.
+            GlobalCoordinate corner(int cor) const
+            {
+                assert(allcorners_ && cor_idx_);
+                return allcorners_[cor_idx_[cor]].center();
+            }
+
+            /// Cell volume.
+            ctype volume() const
+            {
+                return vol_;
+            }
+
+            void set_volume(ctype volume) {
+                vol_ = volume;
+            }
+
+            /// Returns the centroid of the geometry.
+            const GlobalCoordinate& center() const
+            {
+                return pos_;
+            }
+
+            /// @brief Jacobian transposed.
+            /// J^T_{ij} = (dg_j/du_i)
+            /// where g is the mapping from the reference domain,
+            /// and {u_i} are the reference coordinates.
+            /// g = g(u) = (g_1(u), g_2(u), g_3(u)), u=(u_1,u_2,u_3)
+            /// g = map from (local) reference domain to global cell
+            const JacobianTransposed
+            jacobianTransposed(const LocalCoordinate& local_coord) const
+            {
+                static_assert(mydimension == 3, "");
+                static_assert(coorddimension == 3, "");
+
+                // uvw = { (1-u, 1-v, 1-w), (u, v, w) }
+                LocalCoordinate uvw[2] = { LocalCoordinate(1.0), local_coord };
+                uvw[0] -= local_coord;
+                // Access pattern for uvw matching ordering of corners.
+                const int pat[8][3] = { { 0, 0, 0 },
+                                        { 1, 0, 0 },
+                                        { 0, 1, 0 },
+                                        { 1, 1, 0 },
+                                        { 0, 0, 1 },
+                                        { 1, 0, 1 },
+                                        { 0, 1, 1 },
+                                        { 1, 1, 1 } };
+                JacobianTransposed  Jt(0.0);
+                for (int i = 0; i < 8; ++i) {
+                    for (int deriv = 0; deriv < 3; ++deriv) {
+                        // This part contributing to dg/du_{deriv}
+                        double factor = 1.0;
+                        for (int j = 0; j < 3; ++j) {
+                            factor *= (j != deriv) ? uvw[pat[i][j]][j]
+                                : (pat[i][j] == 0 ? -1.0 : 1.0);
+                        }
+                        GlobalCoordinate corner_contrib = corner(i);
+                        corner_contrib *= factor;
+                        Jt[deriv] += corner_contrib; // using FieldMatrix row access.
+                    }
+                }
+                return Jt;
+            }
+
+            /// @brief Inverse of Jacobian transposed. \see jacobianTransposed().
+            const JacobianInverseTransposed
+            jacobianInverseTransposed(const LocalCoordinate& local_coord) const
+            {
+                JacobianInverseTransposed Jti = jacobianTransposed(local_coord);
+                Jti.invert();
+                return Jti;
+            }
+
+            /// @brief The jacobian.
+            Jacobian
+            jacobian(const LocalCoordinate& local_coord) const
+            {
+                return jacobianTransposed(local_coord).transposed();
+            }
+            
+            /// @brief The inverse of the jacobian
+            JacobianInverse
+            jacobianInverse(const LocalCoordinate& local_coord) const
+            {
+                return jacobianInverseTransposed(local_coord).transposed();
+            }
+            
+            /// The mapping implemented by this geometry is not generally affine.
+            bool affine() const
+            {
+                return false;
+            }
+
+            /**
+             * @brief Refine a single cell with regular intervals.
+             *
+             * For each cell to be created, storage must be passed for its corners and the indices. That storage
+             * must be externally managed, since the newly created geometry structures only store pointers and do
+             * not free them on destruction.
+             *
+             * @param      cells_per_dim    The number of sub-cells in each direction,
+             * @param[out] refined_geom     Geometry Policy for the refined geometries. Those will be added there.
+             * @param[out] indices_storage  A vector of mutable references to storage for the indices of each new cell.
+             * @return A vector with the created cells.
+             * @todo We do not need to return anything here.
+             */
+            void refine(const std::array<int, 3>& cells_per_dim,
+                        DefaultGeometryPolicy& all_geom,
+                        std::vector<std::array<int, 8>>&  global_refined_cell8corners_indices_storage)
+            {
+                // Below are basically std::vector of Geometry. Use resize(), reserve(), push_back(), etc.
+                EntityVariableBase<cpgrid::Geometry<0,3>>& global_refined_corners =
+                    all_geom.geomVector(std::integral_constant<int,3>()); // was called corner_storage before
+                EntityVariableBase<cpgrid::Geometry<2,3>>& global_refined_faces =
+                    all_geom.geomVector(std::integral_constant<int,1>()); // Missed by Peter, we need to add the faces
+                EntityVariableBase<cpgrid::Geometry<3,3>>& global_refined_cells =
+                    all_geom.geomVector(std::integral_constant<int,0>()); // Put the refined cells here.
+
+                /// --- GLOBAL REFINED CORNERS ---
+                // The strategy is to compute the local refined corners
+                // of the unit/reference cube, and then apply the map global().
+                // Determine the size of the vector containing all the corners
+                // of all the global refined cells (children cells).
+                global_refined_corners.resize((cells_per_dim[0] + 1) *(cells_per_dim[1] + 1) * (cells_per_dim[2] + 1));
+                // Vector to store the indices of all the global refined corners.
+                std::vector<int> global_refined_corner_indices;
+                // The size of "global_refined_corner_indices" is
+                // (cells_per_dim[0] + 1) *(cells_per_dim[1] + 1) * (cells_per_dim[2] + 1).
+                // The nummbering starts at the botton, so k=0 (z-axis), and j=0 (y-axis), i=0 (x-axis).
+                // Then, increasing k ('going up'), followed by increasing i ('going right->'),
+                // and finally, increasing j ('going back'). This order criteria is consistant
+                // with cpgrid numbering.
+                // 'Up [increasing k]- Right [incresing i]- Back [increasing j]'.
+                for (int j = 0; j < cells_per_dim[1] + 1; ++j) {
+                    for (int i = 0; i < cells_per_dim[0] + 1; ++i) {
+                        for (int k = 0; k < cells_per_dim[2] + 1; ++k) {
+                            // Compute the index of each global refined corner associated with 'jik'.
+                            int global_refined_corner_idx = (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k;
+                            // Incorporate the index in "global_refined_corner_indices".
+                            global_refined_corner_indices.push_back(global_refined_corner_idx);
+                            // Change 'int' type to 'double' for j,i,k.
+                            double jd = j;
+                            double id = i;
+                            double kd = k;
+                            // Compute the local refined corner of the unit/reference cube associated with 'jik'.
+                            const LocalCoordinate& local_refined_corner = { id/cells_per_dim[0], jd/cells_per_dim[1], kd/cells_per_dim[2] };
+                            // Compute the global refined corner 'jik' from the local one and
+                            // add it in its corresponfing entry in "global_refined_corners".
+                            global_refined_corners[global_refined_corner_idx] =
+                                Geometry<0, 3>(this->global(local_refined_corner));
+                        } // end k-for-loop
+                    } // end i-for-loop
+                } // end j-for-loop
+                /// --- END GLOBAL REFINED CORNERS ---
+
+                /// --- GLOBAL REFINED FACES ---
+                // We want to populate "global_refined_faces".
+                // Determine the size of "global_refined_faces".
+                int global_refined_faces_size = (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1)) // 'bottom/top faces'
+                    + (cells_per_dim[0]*(cells_per_dim[1]+1)*cells_per_dim[2]) // 'front/back faces'
+                    + ((cells_per_dim[0]+1)*cells_per_dim[1]*cells_per_dim[2]);  // 'left/right faces'
+                // Reserve that space in "global_refined_faces".
+                global_refined_faces.resize(global_refined_faces_size);
+                // To understand the size, count the 'horizontal(bottom/top)' refined faces on the bottom (k=0),
+                // that is cells_per_dim[0]*cells_per_dim[1]. Now, varying k between 0 and cell_per_dim[2] we
+                // get the third factor of the first term. Similarly with the second and fisrt terms where we
+                // count the 'vertical'-faces front/back(2nd coordinate constant in each face)
+                // and left/right(1st coordinate constant constant in each face) respectively.
+                //
+                // To create a face as a Geometry<2,3> type object we need its CENTROID and its VOLUME(area).
+                // We store the centroids/areas  in the following order:
+                // - Bottom-top faces -> 3rd coordinate constant in each face.
+                // - Front-back faces -> 2nd coordinate constant in each face.
+                // - Left-right faces -> 1st coordinate constant in each face.
+                // Vector to store refined faces indices, called it "global_refined_face_indices".
+                std::vector<int> global_refined_face_indices;
+                // The size of "global_refined_face_indices" (it's the same as the size of "global_refined_faces").
+                // We do not 'reserve/resize' this vector, it will be 'pushed back' later on.
+                //
+                // Container to store, in each entry, the 4 indices of the 4 corners
+                // of each global refined face. We call the container
+                // "global_refined_face4corners_indices_storage" (same size as "global_refined_faces")
+                // and, later on, we call each entry "global_refined_face4corners_indices".
+                std::vector<std::array<int,4>> global_refined_face4corners_indices_storage; // add to constructor!
+                // Determine the size of "global_refined_face4corners_indices_storage".
+                global_refined_face4corners_indices_storage.resize(global_refined_faces_size);
+                //
+                // REFINED FACE AREAS
+                // To compute the area of each face, we divide it in 4 triangles,
+                // compute the area of those with "simplex_volume()", where the arguments
+                // are the 3 corners of each triangle. Then, sum them up to get the area
+                // of the global refined face.
+                // For each face, we construct 4 triangles with
+                // (1) centroid of the face,
+                // (2) one of the edges of the face.
+                //
+                // A triangle has 3 edges. Once we choose a face to base a triangle on,
+                // we choose an edge of that face as one of the edges of the triangle.
+                // The other 2 edges are fixed, since the centroid of the face the triangle
+                // is based on is one of its corners. That's why to identify
+                // a triangle we only need two things:
+                // (1) the face it's based on and
+                // (2) one of the four edges of that face.
+                //
+                // For each face, we need
+                // 1. index of the global refined face
+                //    [available in "global_refined_face_indices"]
+                //    [needed to access indices of the 4 edges of the face in "global_refined_face4edges_indices_storage"]
+                // 2. centroid of the face (common corner of the 4 triangles based on that face).
+                //    [available via "['face'].center()"
+                // 3. container of 4 entries (the 4 edges of the face).
+                //    Each entry consists in the 2 indices defining each edge of the face.
+                //    [available in "global_refined_face4edges_indices_storage"].
+                //
+                // Populate
+                // "global_refined_face_indices"
+                // "global_refined_face4edges_indices_storage"
+                // "global_refined_faces"
+                //
+                // - Faces with 3rd coordinate constant (different constant per face).
+                for (int k = 0; k < cells_per_dim[2] + 1; ++k) {
+                    for (int j = 0; j < cells_per_dim[1]; ++j) {
+                        for (int i = 0; i < cells_per_dim[0]; ++i) {
+                            // Compute the index of the refined face.
+                            int global_refined_face_idx = (k*cells_per_dim[0]*cells_per_dim[1]) + (j*cells_per_dim[0]) + i;
+                            // Add the index to "global_refined_face_indices".
+                            // When this kji-for-loop is done, "global_refined_face_indices"
+                            // has its first (cells_per_dim[2]+1)*cells_per_dim[0]*cells_per_dim[1]
+                            // entries occupied.
+                            global_refined_face_indices.push_back(global_refined_face_idx);
+                            // Change type 'int' by 'double' (only needed for k).
+                            double kd = k;
+                            // Centroid of the face of the local refined cell.
+                            const LocalCoordinate& local_refined_face_centroid = {
+                                (.5 + i)/cells_per_dim[0], (.5 + j)/cells_per_dim[1], kd/cells_per_dim[2]};
+                            // We construct "global_refined_face4corners_indices"
+                            // with the indices of the 4 corners of the refined face.
+                            // The actual 3d corners are available (via these indices)
+                            // in "global_refined_corners".
+                            std::array<int,4> global_refined_face4corners_indices = {
+                                // fake '{0,1,2,3}' for 'bottom' faces (or  fake '{4,5,6,7}' for 'top' faces)
+                                (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k, // fake '0'('4')
+                                (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + ((i+1)*(cells_per_dim[2]+1)) +k, // fake '1'('5')
+                                ((j+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k,// fake '2'('6')
+                                ((j+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + ((i+1)*(cells_per_dim[2]+1)) +k}; // fake '3'('7')
+                            // We add "global_refined_face4corners_indices" in the corresponding entry
+                            // of "global_refined_face4corners_indices_storage".
+                            global_refined_face4corners_indices_storage[global_refined_face_idx] = global_refined_face4corners_indices;
+                            // We construct "global_refined_face4edges_indices"
+                            // with the {edge_indix[0], edge_index[1]} for each edge of the refined face.
+                            std::vector<std::array<int,2>> global_refined_face4edges_indices = {
+                                { global_refined_face4corners_indices[0], global_refined_face4corners_indices[1]}, // fake '{0,1}'('{4,5}')
+                                { global_refined_face4corners_indices[0], global_refined_face4corners_indices[2]}, // fake '{0,2}'('{4,6}')
+                                { global_refined_face4corners_indices[1], global_refined_face4corners_indices[3]}, // fake '{1,3}'('{5,7}')
+                                { global_refined_face4corners_indices[2], global_refined_face4corners_indices[3]}}; // fake '{2,3}'('{6,7}')
+                            // Calculate the AREA of each face of a global refined cell,
+                            // by adding the 4 areas of the triangles partitioning each face.
+                            double global_refined_face_area = 0.0;
+                            for (int edge = 0; edge < 4; ++edge) {
+                                // Construction of each triangle on the current face with one
+                                // of its edges equal to "edge".
+                                const Geometry<0,3>::GlobalCoordinate trian_corners[3] = {
+                                    global_refined_corners[global_refined_face4edges_indices[edge][0]].center(),
+                                    global_refined_corners[global_refined_face4edges_indices[edge][1]].center(),
+                                    this->global(local_refined_face_centroid)};
+                                global_refined_face_area += std::fabs(simplex_volume(trian_corners));
+                            } // end edge-for-loop
+                            //
+                            /*/// THINK ABOUT CHANGES IN THE FACE CONSTRUCTOR
+                            // Create a pointer to the first element of "global_refined_face4corners_indices_storage"
+                            // (required as the fourth argement to construct a Geometry<2,3> type object).
+                            int* indices_storage_ptr = global_refined_face4corners_indices_storage[global_refined_face_idx].data(); */
+                            //
+                            // Construct the Geometry<2,3> of the global refined face.
+                            global_refined_faces[global_refined_face_idx] =
+                                Geometry<2,cdim>(this->global(local_refined_face_centroid),
+                                                 global_refined_face_area);
+                            /// all_geom.geomVector(std::integral_constant<int,3>()), indices_storage_ptr);
+                        } // end i-for-loop
+                    } // end j-for-loop
+                }; // end k-for-loop
+                // - Faces with 2nd coordinate constant (different constant per face).
+                for (int j = 0; j < cells_per_dim[1] + 1; ++j) {
+                    for (int k = 0; k < cells_per_dim[2]; ++k) {
+                        for (int i = 0; i < cells_per_dim[0]; ++i) {
+                            // Compute the index of the refined face.
+                            int global_refined_face_idx =
+                                // the first entries are occupied by the indices of the
+                                // faces with 3rd coordinate constant (different constant in each face)
+                                (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2] +1)) +
+                                // the 'new' indices for faces with 2nd coordinate constant
+                                // (different constant in each face):
+                                (j*cells_per_dim[0]*cells_per_dim[2]) + (k*cells_per_dim[0]) + i;
+                            // Add the index to "global_refined_face_indices".
+                            // When this jki-for-loop is done, "global_refined_face_indices"
+                            // has its first
+                            // cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1) 'from kji-for-loop'
+                            // + cells_per_dim[0]*(cells_per_dim[1]+1)*cells_per_dim[2] 'from this loop: jki'
+                            // entries occupied.
+                            global_refined_face_indices.push_back(global_refined_face_idx);
+                            // Change type 'int' by 'double' (only needed for j).
+                            double jd = j;
+                            // Centroid of the face of the local refined cell.
+                            const LocalCoordinate& local_refined_face_centroid = {
+                                (.5 + i)/cells_per_dim[0], jd/cells_per_dim[1], (.5 + k)/cells_per_dim[2]};
+                            // We construct "global_refined_face4corners_indices"
+                            // with the indices of the 4 corners of the refined face.
+                            // The actual 3d corners are available (via these indices)
+                            // in "global_refined_corners".
+                            std::array<int,4> global_refined_face4corners_indices = {
+                                // fake '{0,1,4,5}' for 'front' faces (or  fake '{2,3,6,7}' for 'back' faces)
+                                (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k, // fake '0'('2')
+                                (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + ((i+1)*(cells_per_dim[2]+1)) +k, // fake '1'('3')
+                                (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k+1, // fake '4'('6')
+                                (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + ((i+1)*(cells_per_dim[2]+1)) +k+1}; // fake '5'('7')
+                            // We add "global_refined_face4corners_indices" in the corresponding entry
+                            // of "global_refined_face4corners_indices_storage".
+                            global_refined_face4corners_indices_storage[global_refined_face_idx] = global_refined_face4corners_indices;
+                            // We construct "global_refined_face4edges_indices"
+                            // with the {edge_indix[0], edge_index[1]} for each edge of the refined face.
+                            std::vector<std::array<int,2>> global_refined_face4edges_indices = {
+                                { global_refined_face4corners_indices[0], global_refined_face4corners_indices[1] }, // fake '{0,1}'('{2,3}')
+                                { global_refined_face4corners_indices[0], global_refined_face4corners_indices[2] }, // fake '{0,4}'('{2,6}')
+                                { global_refined_face4corners_indices[1], global_refined_face4corners_indices[3] }, // fake '{1,5}'('{3,7}')
+                                { global_refined_face4corners_indices[2], global_refined_face4corners_indices[3] } }; // fake '{4,5}'('{6,7}')
+                            // Calculate the AREA of each face of a global refined cell,
+                            // by adding the 4 areas of the triangles partitioning each face.
+                            double global_refined_face_area = 0.0;
+                            for (int edge = 0; edge < 4; edge++) {
+                                // Construction of each triangle on the current face with one
+                                // of its edges equal to "edge".
+                                const Geometry<0,3>::GlobalCoordinate trian_corners[3] = {
+                                    global_refined_corners[global_refined_face4edges_indices[edge][0]].center(),
+                                    global_refined_corners[global_refined_face4edges_indices[edge][1]].center(),
+                                    this->global(local_refined_face_centroid)};
+                                global_refined_face_area += std::fabs(simplex_volume(trian_corners));
+                            } // end edge-for-loop
+                            //
+                            /*/// THINK ABOUT CHANGES IN THE FACE CONSTRUCTOR
+                            // Create a pointer to the first element of "global_refined_face4corners_indices_storage"
+                            // (required as the fourth argement to construct a Geometry<2,3> type object).
+                            int* indices_storage_ptr = global_refined_face4corners_indices_storage[global_refined_face_idx].data();*/
+                            //
+                            // Construct the Geometry<2,3> of the global refined face.
+                            global_refined_faces[global_refined_face_idx] =
+                                Geometry<2,cdim>(this->global(local_refined_face_centroid),
+                                                 global_refined_face_area);
+                            // all_geom.geomVector(std::integral_constant<int,3>()), indices_storage_ptr);
+                        } // end i-for-loop
+                    } // end k-for-loop
+                }; // end j-for-loop
+                // - Faces with 1st coordinate constant (different constant per face).
+                for (int i = 0; i < cells_per_dim[0] + 1; ++i) {
+                    for (int k = 0; k < cells_per_dim[2]; ++k) {
+                        for (int j = 0; j < cells_per_dim[1]; ++j) {
+                            // Compute the index of the refined face.
+                            int global_refined_face_idx =
+                                // the 'first' entries are occupied by the indices of the
+                                // faces with 3rd coordinate constant (different constant in each face)
+                                (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1)) +
+                                // the 'second' entries are occupied by indices of the
+                                // faces with 2nd coordinate constant (different constant in each face)
+                                (cells_per_dim[0]*(cells_per_dim[1]+1)*cells_per_dim[2]) +
+                                // the 'new' indices for faces with 1st coordinate constant
+                                // (different constant in each face):
+                                (i*cells_per_dim[1]*cells_per_dim[2]) + (k*cells_per_dim[0]) + j;
+                            // Add the index to "global_refined_face_indices".
+                            // When this ikj-for-loop is done, "global_refined_face_indices"
+                            // has all its entries occupied.
+                            // cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1) 'from kji-for-loop'
+                            // + cells_per_dim[0]*(cells_per_dim[1]+1)*cells_per_dim[2] 'from jki-for-loop'
+                            // + (cells_per_dim[0]+1)*cells_per_dim[1]*cells_per_dim[2] 'from this loop: ikj'
+                            global_refined_face_indices.push_back(global_refined_face_idx);
+                            // Change type 'int' by 'double' (only needed for i).
+                            double id = i;
+                            // Centroid of the face of the local refined cell.
+                            const LocalCoordinate& local_refined_face_centroid = {
+                                id/cells_per_dim[0], (.5+j)/cells_per_dim[1], (.5 + k)/cells_per_dim[2]};
+                            // We construct "global_refined_face4corners_indices"
+                            // with the indices of the 4 corners of the refined face.
+                            // The actual 3d corners are available (via these indices)
+                            // in "global_refined_corners".
+                            std::array<int,4> global_refined_face4corners_indices = {
+                                // fake {0,2,4,6} for 'left' faces (or fake '{1,3,5,7}' for 'right' faces)
+                                (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k, // fake '0'('1')
+                                ((j+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k,// fake '2'('3')
+                                (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k+1, // fake '4'('5')
+                                ((j+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k+1}; // fake '6'('7')
+                            // We add "global_refined_face4corners_indices" in the corresponding entry
+                            // of "global_refined_face4corners_indices_storage".
+                            global_refined_face4corners_indices_storage[global_refined_face_idx] = global_refined_face4corners_indices;
+                            // We construct "global_refined_face4edges_indices"
+                            // with the {edge_indix[0], edge_index[1]} for each edge of the refined face.
+                            std::vector<std::array<int,2>> global_refined_face4edges_indices = {
+                                { global_refined_face4corners_indices[0], global_refined_face4corners_indices[1]}, // fake '{0,2}'('{1,3}')
+                                { global_refined_face4corners_indices[0], global_refined_face4corners_indices[2]}, // fake '{0,4}'('{1,5}')
+                                { global_refined_face4corners_indices[1], global_refined_face4corners_indices[3]}, // fake '{2,6}'('{3,7}')
+                                { global_refined_face4corners_indices[2], global_refined_face4corners_indices[3]}}; // fake '{4,6}'('{5,7}')
+                            // Calculate the area of each face of a global refined cell,
+                            // by adding the 4 areas of the triangles partitioning each face.
+                            double global_refined_face_area = 0.0;
+                            for (int edge = 0; edge < 4; ++edge) {
+                                // Construction of each triangle on the current face with one
+                                // of its edges equal to "edge".
+                                const Geometry<0, 3>::GlobalCoordinate trian_corners[3] = {
+                                    global_refined_corners[global_refined_face4edges_indices[edge][0]].center(),
+                                    global_refined_corners[global_refined_face4edges_indices[edge][1]].center(),
+                                    this->global(local_refined_face_centroid)};
+                                global_refined_face_area += std::fabs(simplex_volume(trian_corners));
+                            } // end edge-for-loop
+                            //
+                            /*/// THINK ABOUT CHANGES IN THE FACE CONSTRUCTOR
+                            // Create a pointer to the first element of "global_refined_face4corners_indices_storage"
+                            // (required as the fourth argement to construct a Geometry<2,3> type object).
+                            int* indices_storage_ptr = global_refined_face4corners_indices_storage[global_refined_face_idx].data(); */
+                            //
+                            // Construct the Geometry<2,3> of the global refined face.
+                            global_refined_faces[global_refined_face_idx] =
+                                Geometry<2,cdim>(this->global(local_refined_face_centroid),
+                                                 global_refined_face_area);
+                            // all_geom.geomVector(std::integral_constant<int,3>()),  indices_storage_ptr);
+                        } // end j-for-loop
+                    } // end k-for-loop
+                }; // end i-for-loop
+                /// --- END GLOBAL REFINED FACES ---
+
+
+                /// --- GLOBAL REFINED CELLS ---
+                // We need to populate "global_refined_cells"
+                // "global_refined_cells"'s size is cells_per_dim[0] * cells_per_dim[1] * cells_per_dim[2].
+                // To build each global refined cell, we need
+                // 1. its global refined CENTER
+                // 2. its VOLUME [available in "global_refined_cell_volumes"
+                // 3. all global refined corners [available in "global_refined_corners"]
+                // 4. indices of its 8 corners [available in "global_refined_corner_indices"]
+                //
+                // Vector to store, in each entry, the 8 indices of the 8 corners
+                // of each global refined cell.
+                // "global_refined_cell8corners_indices_storage"
+                // Determine the size of "global_refined_cell8corners_indices_storage".
+                global_refined_cell8corners_indices_storage.resize(cells_per_dim[0] * cells_per_dim[1] * cells_per_dim[2]);
+                // same size as "global_refined_cells"
+                //
+                // CENTERS
+                // GLOBAL REFINED CELL CENTERS
+                // The strategy is to compute the centers of the refined local
+                // unit/reference cube, and then apply the map global().
+                //
+                // We can associate each local/global refined cell with an index.
+                // We store all indices in "global_refined_cell_indices" the vector
+                // The numembering starts with index 0 for the refined cell with corners
+                // {0,0,0}, ...,{1/cells_per_dim[0], 1/cells_per_dim[1], 1/cells_per_dim[2]},
+                // then the indices grow first picking the cells in the x-axis (Right, i), then y-axis (Back, j), and
+                // finally, z-axis (Up, k).
+                std::vector<int> global_refined_cell_indices;
+                // "global_refined_cell_indices"'s size is cells_per_dim[0] * cells_per_dim[1] * cells_per_dim[2].
+                // We do not resize this vector, it will be 'pushed back' later on.
+                //
+                // VOLUMES OF THE GLOBAL REFINED CELLS
+                // REMARK: Each global refined 'cell' is a hexahedron since it may not be cube-shaped
+                // since its a 'deformation' of unit/reference cube. We may use 'hexahedron' to refer
+                // to the global refined cell in the computation of its volume.
+                //
+                // The strategy is to construct 24 tetrahedra in each hexahedron.
+                // Each tetrahedron is built with
+                // (1) the center of the hexahedron,
+                // (2) the middle point of the face the tetrahedron is based on, and
+                // (3) one of the edges of the face mentioned in 2.
+                // Each face 'supports' 4 tetrahedra, and we have 6 faces per hexahedron, which
+                // gives us the 24 tetrahedra per 'cell' (hexahedron).
+                //
+                // To compute the volume of each tetrahedron, we use "simplex_volume()" with
+                // the 6 corners of the tetrahedron as arguments. Summing up the 24 volumes,
+                // we get the volumne of the hexahedorn (global refined 'cell').
+                //
+                // Vector to store the volumes of the global refined 'cells'.
+                std::vector<double> global_refined_cell_volumes;
+                // Determine the size of "global_refined_cell_volumes" (same as total amount of refined cells).
+                global_refined_cell_volumes.resize(cells_per_dim[0] * cells_per_dim[1] * cells_per_dim[2]);
+                //
+                // For each (global refined 'cell') hexahedron, to create 24 tetrahedra and their volumes,
+                // we introduce
+                // Vol1. "hexa_face_0to5_indices" (needed to access face centroids).
+                // Vol2. "hexa_face_centroids" (one of the 6 corners of all 4 tetrahedra based on that face).
+                // Vol3.  the center of the global refined 'cell' (hexahedron)
+                //       (common corner of the 24 tetrahedra).
+                // Vol4. "tetra_edge_indices" indices of the 4x6 tetrahedra per 'cell',
+                //        grouped by the face they are based on.
+                // Then we construct and compute the volume of the 24 tetrahedra with mainly
+                // "hexa_face_centroids" (Vol2.), global refined cell center (Vol3.), and "tetra_edge_indices" (Vol4.).
+                //
+                for (int k = 0; k < cells_per_dim[2]; ++k) {
+                    for (int j = 0; j < cells_per_dim[1]; ++j) {
+                        for (int i = 0; i < cells_per_dim[0]; ++i) {
+                            // INDEX of the global refined cell associated with 'kji'.
+                            int global_refined_cell_idx = (k*cells_per_dim[0]*cells_per_dim[1]) + (j*cells_per_dim[0]) +i;
+                            // Incorporate the index in "global_refined_cell_indices".
+                            global_refined_cell_indices.push_back(global_refined_cell_idx);
+                            // 1. CENTER of the global refined cell associated with 'kji' (Vol3.)
+                            // Compute the center of the local refined unit/reference cube associated with 'kji'.
+                            const LocalCoordinate& local_refined_cell_center = {
+                                (.5 + i)/cells_per_dim[0], (.5 + j)/cells_per_dim[1],(.5 + k)/cells_per_dim[2]};
+                            // Obtain the global refined center with 'this->global(local_refined_cell_center)'.
+                            // 2. VOLUME of the global refined 'kji' cell
+                            double global_refined_cell_volume = 0.0; // (computed below!)
+                            // 3. All Global refined corners ("global_refined_corners")
+                            // 4. Indices of the 8 corners of the global refined cell associated with 'kji'.
+                            std::array<int,8> global_refined_cell_corners_indices = { //
+                                (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k, // fake '0' {0,0,0}
+                                (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + ((i+1)*(cells_per_dim[2]+1)) +k, // fake '1' {1,0,0}
+                                ((j+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k, // fake '2' {0,1,0}
+                                ((j+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + ((i+1)*(cells_per_dim[2]+1)) +k, // fake '3' {1,1,0}
+                                (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k+1, // fake '4' {0,0,1}
+                                (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + ((i+1)*(cells_per_dim[2]+1)) +k+1, // fake '5' {1,0,1}
+                                ((j+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k+1, // fake '6' {0,1,1}
+                                ((j+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + ((i+1)*(cells_per_dim[2]+1)) +k+1 // fake '7' {1,1,1}
+                            };
+                            // Add this 8 corners to the corresponding entry of
+                            // "global_refined_cell8corners_indices_storage"
+                            global_refined_cell8corners_indices_storage[global_refined_cell_idx] = global_refined_cell_corners_indices;
+                            //
+                            // VOLUME HEXAHEDRON (GLOBAL REFINED 'CELL')
+                            // Vol1. INDICES ('from 0 to 5') of the faces of the hexahedron (needed to access face centroids).
+                            std::vector<int> hexa_face_0to5_indices = {
+                                // index face '0' bottom
+                                (k*cells_per_dim[0]*cells_per_dim[1]) + (j*cells_per_dim[0]) + i,
+                                // index face '1' front
+                                (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1)) +
+                                (j*cells_per_dim[0]*cells_per_dim[2]) + (k*cells_per_dim[0]) + i,
+                                // index face '2' left
+                                (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1)) +
+                                (cells_per_dim[0]*(cells_per_dim[1]+1)*cells_per_dim[2]) +
+                                (i*cells_per_dim[1]*cells_per_dim[2]) + (k*cells_per_dim[0]) + j,
+                                // index face '3' right
+                                (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1)) +
+                                (cells_per_dim[0]*(cells_per_dim[1]+1)*cells_per_dim[2]) +
+                                ((i+1)*cells_per_dim[1]*cells_per_dim[2]) + (k*cells_per_dim[0]) + j,
+                                // index face '4' back
+                                (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1)) +
+                                ((j+1)*cells_per_dim[0]*cells_per_dim[2]) + (k*cells_per_dim[0]) + i,
+                                // index face '5' top
+                                ((k+1)*cells_per_dim[0]*cells_per_dim[1]) + (j*cells_per_dim[0]) + i};
+                            // Vol2. CENTROIDS of the faces of the hexahedron.
+                            // (one of the 6 corners of all 4 tetrahedra based on that face).
+                            std::vector<Geometry<0,3>::GlobalCoordinate> hexa_face_centroids;
+                            for (auto& idx : hexa_face_0to5_indices) {
+                                //auto aux = ;
+                                hexa_face_centroids.push_back(global_refined_faces[idx].center());
+                            }
+                            // Indices of the 4 edges of each face of the hexahedron.
+                            // A tetrahedron has six edges. Once we choose a face to base a
+                            // tetrahedron on, we choose an edge of that face as one of the
+                            // edges of the tetrahedron. The other five edges are fixed, since
+                            // the center of the hexahedron and the center of the face are
+                            // the reminder 2 corners of the tetrahedron. That's why to identify
+                            // a tetrahedron we only need two things:
+                            // (1) the face it's based on and
+                            // (2) one of the four edges of that face.
+                            //
+                            // Container with 6 entries, one per face. Each entry has the
+                            // 4 indices of the 4 corners of each face.
+                            std::vector<std::array<int,4>> global_refined_cell_face4corners_indices = {
+                                global_refined_face4corners_indices_storage[hexa_face_0to5_indices[0]], // fake '{0,1,2,3}' bottom
+                                global_refined_face4corners_indices_storage[hexa_face_0to5_indices[1]], // fake '{0,1,4,5}' front
+                                global_refined_face4corners_indices_storage[hexa_face_0to5_indices[2]], // fake '{0,2,4,6}' left
+                                global_refined_face4corners_indices_storage[hexa_face_0to5_indices[3]], // fake '{1,3,5,7}' right
+                                global_refined_face4corners_indices_storage[hexa_face_0to5_indices[4]], // fake '{2,3,6,7}' back
+                                global_refined_face4corners_indices_storage[hexa_face_0to5_indices[5]] };// fake '{4,5,6,7}' top
+                            // Vol4. Container with indices of the edges of the 4 tetrahedra per face
+                            // [according to description above]
+                            std::vector<std::vector<std::array<int,2>>> tetra_edge_indices;
+                            tetra_edge_indices.reserve(6);
+                            for (auto& face_indices : global_refined_cell_face4corners_indices)
+                            {
+                                std::vector<std::array<int,2>> face4edges_indices = {
+                                    { face_indices[0], face_indices[1]}, // fake '{0,1}'/'{4,5}'
+                                    { face_indices[0], face_indices[2]}, // fake '{0,2}'/'{4,6}'
+                                    { face_indices[1], face_indices[3]}, // fake '{1,3}'/'{5,7}'
+                                    { face_indices[2], face_indices[3]} }; // fake '{2,3}'/'{6,7}'
+                                tetra_edge_indices.push_back(face4edges_indices);
+                            }
+                            // Sum of the 24 volumes to get the volume of the hexahedron,
+                            // stored in "global_refined_cell_volume".
+                            // Calculate the volume of each hexahedron, by adding
+                            // the 4 tetrahedra at each face (4x6 = 24 tetrahedra).
+                            for (int face = 0; face < 6; ++face) {
+                                for (int edge = 0; edge < 4; ++edge) {
+                                    // Construction of each tetrahedron based on "face" with one
+                                    // of its edges equal to "edge".
+                                    const Geometry<0, 3>::GlobalCoordinate tetra_corners[4] = {
+                                        global_refined_corners[tetra_edge_indices[face][edge][0]].center(),  // (see Vol4.)
+                                        global_refined_corners[tetra_edge_indices[face][edge][1]].center(),  // (see Vol4.)
+                                        hexa_face_centroids[face],  // (see Vol2.)
+                                        // global_refined_cell_center
+                                        this->global(local_refined_cell_center)};  // (see Vol3.)
+                                    global_refined_cell_volume += std::fabs(simplex_volume(tetra_corners));
+                                } // end edge-for-loop
+                            } // end face-for-loop
+                            // Add the volume of the hexahedron (global refined 'cell')
+                            // to the container with of all volumes of all the refined cells.
+                            global_refined_cell_volumes[global_refined_cell_idx] = global_refined_cell_volume;
+                            // Create a pointer to the first element of "global_refined_cell8corners_indices_storage"
+                            // (required as the fourth argement to construct a Geometry<3,3> type object).
+                            int* indices_storage_ptr = global_refined_cell8corners_indices_storage[global_refined_cell_idx].data();
+                            // Construct the Geometry of the refined cell associated with 'kji'.
+                            global_refined_cells.push_back(Geometry<3,cdim>(this->global(local_refined_cell_center),
+                                                                            global_refined_cell_volume,
+                                                                            all_geom.geomVector(std::integral_constant<int,3>()),
+                                                                            indices_storage_ptr));
+                        } // end i-for-loop
+                    }  // end j-for-loop
+                } // end k-for-loop
+                // Rescale all volumes if the sum of volume of all the global refined 'cells' does not match the
+                // volume of the 'parent cell'.
+                // Sum of all the volumes of all the (children) global refined cells.
+                double sum_all_global_refined_cell_volumes = 0.0;
+                for (auto& volume : global_refined_cell_volumes) {
+                    sum_all_global_refined_cell_volumes += volume;
+                };
+                // Compare the sum of all the volumes of all refined cells with 'parent cell' volume.
+                if (std::fabs(sum_all_global_refined_cell_volumes - this->volume())
+                    > std::numeric_limits<Geometry<3, cdim>::ctype>::epsilon()) {
+                    Geometry<3, cdim>::ctype correction = this->volume() / sum_all_global_refined_cell_volumes;
+                    /*for (auto& volume : global_refined_cell_volumes) {
+                      volume *= correction;
+                      }*/
+                    for(auto& cell: global_refined_cells){
+                        cell.vol_ *= correction;
+                    }
+                } // end if-statement
+                /// --- END GLOBAL REFINED CELLS ---
+            } /// --- END of refine()
+
+        private:
+            GlobalCoordinate pos_;
+            double vol_;
+            const cpgrid::Geometry<0, 3>* allcorners_; // For dimension 3 only
+            const int* cor_idx_;               // For dimension 3 only
+        };
 
     } // namespace cpgrid
 

--- a/opm/grid/cpgrid/Geometry.hpp
+++ b/opm/grid/cpgrid/Geometry.hpp
@@ -633,7 +633,7 @@ namespace Dune
                         Opm::SparseTable<int>& face_to_point,
                         cpgrid::OrientedEntityTable<1,0>& face_to_cell,
                         cpgrid::EntityVariable<enum face_tag, 1>& global_refined_face_tags,
-                        cpgrid::SignedEntityVariable<PointType, 1>& global_refined_face_normals)
+                        cpgrid::SignedEntityVariable<PointType, 1>& global_refined_face_normals) const
             {
                 EntityVariableBase<cpgrid::Geometry<0,3>>& global_refined_corners =
                     all_geom.geomVector(std::integral_constant<int,3>());
@@ -1014,7 +1014,7 @@ namespace Dune
             std::tuple< enum face_tag, int,
                         std::array<int, 4>, std::vector<cpgrid::EntityRep<0>>,
                         LocalCoordinate>
-            getIndicesFace(int l, int m, int n, int constant_direction, const std::array<int, 3>& cells_per_dim)
+            getIndicesFace(int l, int m, int n, int constant_direction, const std::array<int, 3>& cells_per_dim) const
             {
                 using cpgrid::EntityRep;
                 std::vector<cpgrid::EntityRep<0>> neighboring_cells_of_one_face; // {index, orientation}

--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -286,18 +286,19 @@ check_refined_grid(const cpgrid::Geometry<3, 3>& parent,
 
 
     // Check that the corresponding refined corners match the
-    // the parent cell corners.
-    // (k *(cells_per_dim[2]-1)* slice) + (j*(cells_per_dim[1]-1) * cells_per_dim[0]) + (i*cells_per_dim[0]-1)
-    auto& cell_corn0 = refined.get(0); // k=0,j=0,i=0
-    auto& cell_corn1 = refined.get(cells_per_dim[0]-1); // k=0,j=0,i=1
-    auto& cell_corn2 = refined.get((cells_per_dim[1]-1) * cells_per_dim[0]); // k=0,j=1,i=0
-    auto& cell_corn3 = refined.get(((cells_per_dim[1]-1) * cells_per_dim[0]) + (cells_per_dim[0]-1)); // k=0,j=1,i=1
-    auto& cell_corn4 = refined.get((cells_per_dim[2]-1)*cells_per_dim[0] * cells_per_dim[1]); // k=1,j=0,i=0
-    auto& cell_corn5 = refined.get(((cells_per_dim[2]-1)*cells_per_dim[0] * cells_per_dim[1]) +(cells_per_dim[0]-1)); // k=1,j=0,i=1
+    // the parent cell corners. Notice that 'each parent corner' coincide with
+    // one refined corner of one of (at most 8 different) refined cells.
+    // (l *(cells_per_dim[2]-1)* slice) + (m*(cells_per_dim[1]-1) * cells_per_dim[0]) + (n*cells_per_dim[0]-1)
+    auto& cell_corn0 = refined.get(0); // l=0,m=0,n=0
+    auto& cell_corn1 = refined.get(cells_per_dim[0]-1); // l=0,m=0,n=1
+    auto& cell_corn2 = refined.get((cells_per_dim[1]-1) * cells_per_dim[0]); // l=0,m=1,n=0
+    auto& cell_corn3 = refined.get(((cells_per_dim[1]-1) * cells_per_dim[0]) + (cells_per_dim[0]-1)); // l=0,m=1,n=1
+    auto& cell_corn4 = refined.get((cells_per_dim[2]-1)*cells_per_dim[0] * cells_per_dim[1]); // l=1,m=0,n=0
+    auto& cell_corn5 = refined.get(((cells_per_dim[2]-1)*cells_per_dim[0] * cells_per_dim[1]) +(cells_per_dim[0]-1)); // l=1,m=0,n=1
     auto& cell_corn6 = refined.get(((cells_per_dim[2]-1)*  cells_per_dim[0] * cells_per_dim[1])
-                                   +((cells_per_dim[1]-1) * cells_per_dim[0])); // k=1,j=1,i=0
+                                   +((cells_per_dim[1]-1) * cells_per_dim[0])); // l=1,m=1,n=0
     auto& cell_corn7 = refined.get(((cells_per_dim[2]-1)*  cells_per_dim[0] * cells_per_dim[1])
-                                   +((cells_per_dim[1]-1) * cells_per_dim[0]) + (cells_per_dim[0]-1)); // k=1,j=1,i=1
+                                   +((cells_per_dim[1]-1) * cells_per_dim[0]) + (cells_per_dim[0]-1)); // l=1,m=1,n=1
     check_coordinates(cell_corn0.corner(0), parent.corner(0));
     check_coordinates(cell_corn1.corner(1), parent.corner(1));
     check_coordinates(cell_corn2.corner(2), parent.corner(2));
@@ -349,14 +350,16 @@ check_refined_grid(const cpgrid::Geometry<3, 3>& parent,
         check_coordinates(r.center(), center);
     }
 
+    //  @todo Current Geometry.hpp does not pass this test:
     // Check that the weighted mean of all centers equals the parent center
     GlobalCoordinate center = {0.0, 0.0, 0.0};
     for (auto r : refined) {
         for (int c = 0; c < 3; c++) {
-            center[c] += r.center()[c] * r.volume() / parent.volume();
+            center[c] += r.center()[c] * r.volume()
+                / parent.volume();
         }
     }
-    check_coordinates(parent.center(), center);
+    check_coordinates(parent.center(), center); 
 
     // Check that mean of all corners equals the center of the parent.
     center = {0.0, 0.0, 0.0};

--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -277,7 +277,7 @@ inline void
 check_coordinates(T c1, T c2)
 {
     for (int c = 0; c < 3; c++) {
-        BOOST_CHECK_CLOSE(c1[c], c2[c], 1e-6);
+        BOOST_TEST(c1[c] == c2[c], boost::test_tools::tolerance(1e-12));
     }
 }
 

--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -424,6 +424,24 @@ void refine_and_check(const cpgrid::Geometry<3, 3>& parent_geometry,
     cpgrid::OrientedEntityTable<1,0> face_to_cell_computed;
     cell_to_face.makeInverseRelation(face_to_cell_computed);
     BOOST_CHECK(face_to_cell_computed == face_to_cell);
+
+    if (is_simple)
+    {
+        // Create a grid that is equivalent to the refinement
+        Dune::CpGrid equivalent_refined_grid;
+        std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+        std::size_t i = 0;
+        for (auto& size: cell_sizes)
+            size /= cells[i++];
+
+        equivalent_refined_grid.createCartesian(cells, cell_sizes);
+
+        // Check that the sizes match
+        BOOST_CHECK(equivalent_refined_grid.size(0) == refined_grid.size(0));
+        BOOST_CHECK(equivalent_refined_grid.size(1) == refined_grid.size(1));
+        BOOST_CHECK(equivalent_refined_grid.size(3) == refined_grid.size(3));
+        //for(const auto elements: child_grid.leafGridView());
+    }
 }
 
 BOOST_AUTO_TEST_CASE(refine_simple_cube)
@@ -452,8 +470,8 @@ BOOST_AUTO_TEST_CASE(refine_simple_cube)
     int cor_idx[8] = {0, 1, 2, 3, 4, 5, 6, 7};
     Geometry g(c, v, pg, cor_idx);
 
-    refine_and_check(g, {1, 1, 1});
-    refine_and_check(g, {2, 3, 4});
+    refine_and_check(g, {1, 1, 1}, true);
+    refine_and_check(g, {2, 3, 4}, true);
 }
 
 

--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -412,12 +412,12 @@ void refine_and_check(const cpgrid::Geometry<3, 3>& parent_geometry,
     cpgrid::OrientedEntityTable<0, 1>& cell_to_face = child_view_data.cell_to_face_;
     Opm::SparseTable<int>& face_to_point = child_view_data.face_to_point_;
     DefaultGeometryPolicy& geometries = child_view_data.geometry_;
-    std::vector<std::array<int, 8>>& ci = child_view_data.cell_to_point_;
+    std::vector<std::array<int, 8>>& cell_to_point = child_view_data.cell_to_point_;
     cpgrid::OrientedEntityTable<1,0>& face_to_cell = child_view_data.face_to_cell_;
     cpgrid::EntityVariable<enum face_tag, 1>& face_tags = child_view_data.face_tag_;
     cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>, 1>& face_normals = child_view_data.face_normals_;
 
-    parent_geometry.refine(cells, geometries, ci,
+    parent_geometry.refine(cells, geometries, cell_to_point,
                            cell_to_face, face_to_point, face_to_cell,
                            face_tags, face_normals);
     check_refined_grid(parent_geometry, geometries.template geomVector<0>(), cells);
@@ -440,6 +440,16 @@ void refine_and_check(const cpgrid::Geometry<3, 3>& parent_geometry,
         BOOST_CHECK(equivalent_refined_grid.size(0) == refined_grid.size(0));
         BOOST_CHECK(equivalent_refined_grid.size(1) == refined_grid.size(1));
         BOOST_CHECK(equivalent_refined_grid.size(3) == refined_grid.size(3));
+
+        // Check that the points (ordering/coordinates) matches
+        auto equiv_point_iter = equivalent_refined_grid.current_view_data_
+            ->geometry_.geomVector<3>().begin();
+        for(const auto& point: geometries.geomVector<3>())
+        {
+            check_coordinates(point.center(), equiv_point_iter->center());
+            ++equiv_point_iter;
+        }
+
         //for(const auto elements: child_grid.leafGridView());
     }
 }

--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -439,6 +439,9 @@ BOOST_AUTO_TEST_CASE(refine_simple_cube)
         g.refine(cells, geometries, ci,
                  cell_to_face, face_to_point, face_to_cell, face_tags, face_normals);//, child_grid);
         check_refined_grid(g, geometries.template geomVector<0>(), cells);
+        auto face_to_cell_computed = face_to_cell;
+        cell_to_face.makeInverseRelation(face_to_cell_computed);
+        BOOST_CHECK(face_to_cell_computed == face_to_cell);
     }
 }
 
@@ -508,5 +511,8 @@ BOOST_AUTO_TEST_CASE(refine_distorted_cube)
         g.refine(cells, geometries, ci,
                  cell_to_face, face_to_point, face_to_cell, face_tags, face_normals);//, child_grid);
         check_refined_grid(g, geometries.template geomVector<0>(), cells);
+        auto face_to_cell_computed = face_to_cell;
+        cell_to_face.makeInverseRelation(face_to_cell_computed);
+        BOOST_CHECK(face_to_cell_computed == face_to_cell);
     }
 }

--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -416,9 +416,13 @@ BOOST_AUTO_TEST_CASE(refine_simple_cube)
         std::array<int, 3> cells = {1, 1, 1};
         DefaultGeometryPolicy geometries;
         std::vector<std::array<int, 8>> ci;
+        cpgrid::OrientedEntityTable<1,0> face_to_cell;
+        cpgrid::EntityVariable<enum face_tag, 1> face_tags;
+        cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>, 1> face_normals;
+        
         //cpgrid::CpGridData child_grid;
         g.refine(cells, geometries, ci,
-                 cell_to_face, face_to_point);// child_grid);
+                 cell_to_face, face_to_point, face_to_cell, face_tags, face_normals);// child_grid);
         check_refined_grid(g, geometries.template geomVector<0>(), cells);
     }
 
@@ -428,9 +432,12 @@ BOOST_AUTO_TEST_CASE(refine_simple_cube)
         std::array<int, 3> cells = {2, 3, 4};
         DefaultGeometryPolicy geometries;
         std::vector<std::array<int, 8>> ci;
-        cpgrid::CpGridData child_grid;
+        cpgrid::OrientedEntityTable<1,0> face_to_cell;
+        cpgrid::EntityVariable<enum face_tag, 1> face_tags;
+        cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>, 1> face_normals;
+        //cpgrid::CpGridData child_grid;
         g.refine(cells, geometries, ci,
-                 cell_to_face, face_to_point);//, child_grid);
+                 cell_to_face, face_to_point, face_to_cell, face_tags, face_normals);//, child_grid);
         check_refined_grid(g, geometries.template geomVector<0>(), cells);
     }
 }
@@ -479,9 +486,12 @@ BOOST_AUTO_TEST_CASE(refine_distorted_cube)
         std::array<int, 3> cells = {1, 1, 1};
         DefaultGeometryPolicy geometries;
         std::vector<std::array<int, 8>> ci;
-        cpgrid::CpGridData child_grid;
+        // cpgrid::CpGridData child_grid;
+        cpgrid::OrientedEntityTable<1,0> face_to_cell;
+        cpgrid::EntityVariable<enum face_tag, 1> face_tags;
+        cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>, 1> face_normals;
         g.refine(cells, geometries, ci,
-                 cell_to_face, face_to_point);//, child_grid);
+                 cell_to_face, face_to_point, face_to_cell, face_tags, face_normals);//, child_grid);
         check_refined_grid(g, geometries.template geomVector<0>(), cells);
     }
 
@@ -491,9 +501,12 @@ BOOST_AUTO_TEST_CASE(refine_distorted_cube)
         std::array<int, 3> cells = {2, 3, 4};
         DefaultGeometryPolicy geometries;
         std::vector<std::array<int, 8>> ci;
-        cpgrid::CpGridData child_grid;
+        // cpgrid::CpGridData child_grid;
+        cpgrid::OrientedEntityTable<1,0> face_to_cell;
+        cpgrid::EntityVariable<enum face_tag, 1> face_tags;
+        cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>, 1> face_normals;
         g.refine(cells, geometries, ci,
-                 cell_to_face, face_to_point);//, child_grid);
+                 cell_to_face, face_to_point, face_to_cell, face_tags, face_normals);//, child_grid);
         check_refined_grid(g, geometries.template geomVector<0>(), cells);
     }
 }

--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -272,14 +272,10 @@ BOOST_AUTO_TEST_CASE(cellgeom)
 }
 
 
-template <typename T>
-inline void
-check_coordinates(T c1, T c2)
-{
-    for (int c = 0; c < 3; c++) {
-        BOOST_TEST(c1[c] == c2[c], boost::test_tools::tolerance(1e-12));
+#define CHECK_COORDINATES(c1, c2)                                        \
+    for (int c = 0; c < 3; c++) {                                        \
+        BOOST_TEST(c1[c] == c2[c], boost::test_tools::tolerance(1e-12)); \
     }
-}
 
 void
 check_refined_grid(const cpgrid::Geometry<3, 3>& parent,
@@ -320,14 +316,14 @@ check_refined_grid(const cpgrid::Geometry<3, 3>& parent,
                                    +((cells_per_dim[1]-1) * cells_per_dim[0])); // l=1,m=1,n=0
     auto& cell_corn7 = refined.get(((cells_per_dim[2]-1)*  cells_per_dim[0] * cells_per_dim[1])
                                    +((cells_per_dim[1]-1) * cells_per_dim[0]) + (cells_per_dim[0]-1)); // l=1,m=1,n=1
-    check_coordinates(cell_corn0.corner(0), parent.corner(0));
-    check_coordinates(cell_corn1.corner(1), parent.corner(1));
-    check_coordinates(cell_corn2.corner(2), parent.corner(2));
-    check_coordinates(cell_corn3.corner(3), parent.corner(3));
-    check_coordinates(cell_corn4.corner(4), parent.corner(4));
-    check_coordinates(cell_corn5.corner(5), parent.corner(5));
-    check_coordinates(cell_corn6.corner(6), parent.corner(6));
-    check_coordinates(cell_corn7.corner(7), parent.corner(7));
+    CHECK_COORDINATES(cell_corn0.corner(0), parent.corner(0));
+    CHECK_COORDINATES(cell_corn1.corner(1), parent.corner(1));
+    CHECK_COORDINATES(cell_corn2.corner(2), parent.corner(2));
+    CHECK_COORDINATES(cell_corn3.corner(3), parent.corner(3));
+    CHECK_COORDINATES(cell_corn4.corner(4), parent.corner(4));
+    CHECK_COORDINATES(cell_corn5.corner(5), parent.corner(5));
+    CHECK_COORDINATES(cell_corn6.corner(6), parent.corner(6));
+    CHECK_COORDINATES(cell_corn7.corner(7), parent.corner(7));
 
     // Make sure the corners of neighboring cells overlap.
     for (int k = 0; k < cells_per_dim[2]; k++) {
@@ -337,24 +333,24 @@ check_refined_grid(const cpgrid::Geometry<3, 3>& parent,
                 auto& r0 = refined.get(k * slice + cells_per_dim[0] * j + i);
                 if (i < cells_per_dim[0] - 1) {
                     auto& r1 = refined.get(k * slice + cells_per_dim[0] * j + i + 1);
-                    check_coordinates(r0.corner(1), r1.corner(0));
-                    check_coordinates(r0.corner(3), r1.corner(2));
-                    check_coordinates(r0.corner(5), r1.corner(4));
-                    check_coordinates(r0.corner(7), r1.corner(6));
+                    CHECK_COORDINATES(r0.corner(1), r1.corner(0));
+                    CHECK_COORDINATES(r0.corner(3), r1.corner(2));
+                    CHECK_COORDINATES(r0.corner(5), r1.corner(4));
+                    CHECK_COORDINATES(r0.corner(7), r1.corner(6));
                 }
                 if (j < cells_per_dim[1] - 1) {
                     auto& r1 = refined.get(k * slice + cells_per_dim[0] * (j + 1) + i);
-                    check_coordinates(r0.corner(2), r1.corner(0));
-                    check_coordinates(r0.corner(3), r1.corner(1));
-                    check_coordinates(r0.corner(6), r1.corner(4));
-                    check_coordinates(r0.corner(7), r1.corner(5));
+                    CHECK_COORDINATES(r0.corner(2), r1.corner(0));
+                    CHECK_COORDINATES(r0.corner(3), r1.corner(1));
+                    CHECK_COORDINATES(r0.corner(6), r1.corner(4));
+                    CHECK_COORDINATES(r0.corner(7), r1.corner(5));
                 }
                 if (k < cells_per_dim[2] - 1) {
                     auto& r1 = refined.get((k + 1) * slice + cells_per_dim[0] * j + i);
-                    check_coordinates(r0.corner(4), r1.corner(0));
-                    check_coordinates(r0.corner(5), r1.corner(1));
-                    check_coordinates(r0.corner(6), r1.corner(2));
-                    check_coordinates(r0.corner(7), r1.corner(3));
+                    CHECK_COORDINATES(r0.corner(4), r1.corner(0));
+                    CHECK_COORDINATES(r0.corner(5), r1.corner(1));
+                    CHECK_COORDINATES(r0.corner(6), r1.corner(2));
+                    CHECK_COORDINATES(r0.corner(7), r1.corner(3));
                 }
             }
         }
@@ -368,7 +364,7 @@ check_refined_grid(const cpgrid::Geometry<3, 3>& parent,
                 center[c] += r.corner(h)[c] / 8.0;
             }
         }
-        check_coordinates(r.center(), center);
+        CHECK_COORDINATES(r.center(), center);
     }
 
     //  @todo Current Geometry.hpp does not pass this test:
@@ -380,7 +376,7 @@ check_refined_grid(const cpgrid::Geometry<3, 3>& parent,
                 / parent.volume();
         }
     }
-    check_coordinates(parent.center(), center); 
+    CHECK_COORDINATES(parent.center(), center);
 
     // Check that mean of all corners equals the center of the parent.
     center = {0.0, 0.0, 0.0};
@@ -391,7 +387,7 @@ check_refined_grid(const cpgrid::Geometry<3, 3>& parent,
             }
         }
     }
-    check_coordinates(parent.center(), center);
+    CHECK_COORDINATES(parent.center(), center);
 
     // Check the total volume against the parent volume.
     Geometry::ctype volume = 0.0;
@@ -446,7 +442,7 @@ void refine_and_check(const cpgrid::Geometry<3, 3>& parent_geometry,
             ->geometry_.geomVector<3>().begin();
         for(const auto& point: geometries.geomVector<3>())
         {
-            check_coordinates(point.center(), equiv_point_iter->center());
+            CHECK_COORDINATES(point.center(), equiv_point_iter->center());
             ++equiv_point_iter;
         }
 
@@ -459,7 +455,7 @@ void refine_and_check(const cpgrid::Geometry<3, 3>& parent_geometry,
             ->geometry_.geomVector<0>().begin();
         for(const auto& cell: geometries.geomVector<0>())
         {
-            check_coordinates(cell.center(), equiv_cell_iter->center());
+            CHECK_COORDINATES(cell.center(), equiv_cell_iter->center());
             BOOST_CHECK_CLOSE(cell.volume(), equiv_cell_iter->volume(), 1e-6);
             ++equiv_cell_iter;
         }
@@ -485,11 +481,12 @@ void refine_and_check(const cpgrid::Geometry<3, 3>& parent_geometry,
                             BOOST_CHECK(intersection_match.indexInOutside() == intersection.indexInOutside());
                         }
 
-                        check_coordinates(intersection_match.centerUnitOuterNormal(), intersection.centerUnitOuterNormal());
+                        CHECK_COORDINATES(intersection_match.centerUnitOuterNormal(), intersection.centerUnitOuterNormal());
                         const auto& geom_match = intersection_match.geometry();
+                        BOOST_TEST(0 == 1e-11, boost::test_tools::tolerance(1e-8));
                         const auto& geom =  intersection.geometry();
                         BOOST_CHECK_CLOSE(geom_match.volume(), geom.volume(), 1e-6);
-                        check_coordinates(geom_match.center(), geom.center());
+                        CHECK_COORDINATES(geom_match.center(), geom.center());
                         BOOST_CHECK(geom_match.corners() == geom.corners());
 
                         decltype(geom.corner(0)) sum_match{}, sum{};
@@ -499,7 +496,7 @@ void refine_and_check(const cpgrid::Geometry<3, 3>& parent_geometry,
                             sum += geom.corner(i);
                             sum_match += geom_match.corner(1);
                         }
-                        check_coordinates(sum, sum_match);
+                        CHECK_COORDINATES(sum, sum_match);
                         matching_intersection_found = true;
                         break;
                     }

--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -27,9 +27,10 @@
 #else
 #include <boost/test/tools/floating_point_comparison.hpp>
 #endif
-#include <opm/grid/cpgrid/Geometry.hpp>
+#include <opm/grid/cpgrid/CpGridData.hpp>
 #include <opm/grid/cpgrid/DefaultGeometryPolicy.hpp>
 #include <opm/grid/cpgrid/EntityRep.hpp>
+#include <opm/grid/cpgrid/Geometry.hpp>
 
 #include <sstream>
 #include <iostream>
@@ -410,18 +411,26 @@ BOOST_AUTO_TEST_CASE(refine_simple_cube)
 
     using cpgrid::DefaultGeometryPolicy;
     {
+        cpgrid::OrientedEntityTable<0, 1> cell_to_face;
+        Opm::SparseTable<int> face_to_point;
         std::array<int, 3> cells = {1, 1, 1};
         DefaultGeometryPolicy geometries;
         std::vector<std::array<int, 8>> ci;
-        g.refine(cells, geometries, ci);
+        //cpgrid::CpGridData child_grid;
+        g.refine(cells, geometries, ci,
+                 cell_to_face, face_to_point);// child_grid);
         check_refined_grid(g, geometries.template geomVector<0>(), cells);
     }
 
     {
+        cpgrid::OrientedEntityTable<0, 1> cell_to_face;
+        Opm::SparseTable<int> face_to_point;
         std::array<int, 3> cells = {2, 3, 4};
         DefaultGeometryPolicy geometries;
         std::vector<std::array<int, 8>> ci;
-        g.refine(cells, geometries, ci);
+        cpgrid::CpGridData child_grid;
+        g.refine(cells, geometries, ci,
+                 cell_to_face, face_to_point);//, child_grid);
         check_refined_grid(g, geometries.template geomVector<0>(), cells);
     }
 }
@@ -465,18 +474,26 @@ BOOST_AUTO_TEST_CASE(refine_distorted_cube)
     using cpgrid::DefaultGeometryPolicy;
 
     {
+        cpgrid::OrientedEntityTable<0, 1> cell_to_face;
+        Opm::SparseTable<int> face_to_point;
         std::array<int, 3> cells = {1, 1, 1};
         DefaultGeometryPolicy geometries;
         std::vector<std::array<int, 8>> ci;
-        g.refine(cells, geometries, ci);
+        cpgrid::CpGridData child_grid;
+        g.refine(cells, geometries, ci,
+                 cell_to_face, face_to_point);//, child_grid);
         check_refined_grid(g, geometries.template geomVector<0>(), cells);
     }
 
     {
+        cpgrid::OrientedEntityTable<0, 1> cell_to_face;
+        Opm::SparseTable<int> face_to_point;
         std::array<int, 3> cells = {2, 3, 4};
         DefaultGeometryPolicy geometries;
         std::vector<std::array<int, 8>> ci;
-        g.refine(cells, geometries, ci);
+        cpgrid::CpGridData child_grid;
+        g.refine(cells, geometries, ci,
+                 cell_to_face, face_to_point);//, child_grid);
         check_refined_grid(g, geometries.template geomVector<0>(), cells);
     }
 }

--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -450,6 +450,19 @@ void refine_and_check(const cpgrid::Geometry<3, 3>& parent_geometry,
             ++equiv_point_iter;
         }
 
+        // Check that cell to point matches (Implicitly checks for correct cell ordering)
+        BOOST_CHECK(refined_grid.current_view_data_->cell_to_point_ ==
+                    equivalent_refined_grid.current_view_data_->cell_to_point_);
+
+        // Check that the cell centers and volume match
+        auto equiv_cell_iter = equivalent_refined_grid.current_view_data_
+            ->geometry_.geomVector<0>().begin();
+        for(const auto& cell: geometries.geomVector<0>())
+        {
+            check_coordinates(cell.center(), equiv_cell_iter->center());
+            BOOST_CHECK_CLOSE(cell.volume(), equiv_cell_iter->volume(), 1e-6);
+            ++equiv_cell_iter;
+        }
         //for(const auto elements: child_grid.leafGridView());
     }
 }

--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -506,6 +506,7 @@ void refine_and_check(const cpgrid::Geometry<3, 3>& parent_geometry,
                 }
                 BOOST_CHECK(matching_intersection_found);
             }
+            ++equiv_element_iter;
         }
     }
 }

--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -488,7 +488,7 @@ void refine_and_check(const cpgrid::Geometry<3, 3>& parent_geometry,
                         check_coordinates(intersection_match.centerUnitOuterNormal(), intersection.centerUnitOuterNormal());
                         const auto& geom_match = intersection_match.geometry();
                         const auto& geom =  intersection.geometry();
-                        BOOST_CHECK(geom_match.volume() == geom.volume());
+                        BOOST_CHECK_CLOSE(geom_match.volume(), geom.volume(), 1e-6);
                         check_coordinates(geom_match.center(), geom.center());
                         BOOST_CHECK(geom_match.corners() == geom.corners());
 


### PR DESCRIPTION
This is based on #594 and its purpose to more thoroughly check the implemented refinement for one cell. We do that for the case where we refine an axis-parallel cell. For the check we build an equivalent cartesian grid to get the geometry of the other codims and the topology for free. Then we compare the data produced by the refinement with this one.

Note that we do not insist on the exact same numbering of the face as we hope that OPM never would rely on this.

Marked as draft as the other PRs should probably be merged first and we might want to squash the commits of this one.