### PR TITLE
Allow User-Defined Message Tag in P2PCommunicator::exchange

### DIFF
--- a/opm/grid/common/p2pcommunicator.hh
+++ b/opm/grid/common/p2pcommunicator.hh
@@ -238,6 +238,15 @@ public:
     /** \brief exchange data with peers, handle defines pack and unpack of data */
     virtual void exchange ( DataHandleInterface& ) const;
 
+    /** \brief exchange data with peers, handle defines pack and unpack of
+     * data.  User-defined message tag.
+     *
+     * \param[in,out] handle Message.
+     *
+     * \param[in] tag Message tag.
+     */
+    void exchange( DataHandleInterface& handle, const int tag ) const;
+
     /** \brief exchange data with peers, handle defines pack and unpack of data,
      *  if receive buffers are known from previous run and have not changed
      *  communication could be faster */

--- a/opm/grid/common/p2pcommunicator_impl.hh
+++ b/opm/grid/common/p2pcommunicator_impl.hh
@@ -579,17 +579,26 @@ namespace Dune
   template <class MsgBuffer>
   inline void
   Point2PointCommunicator< MsgBuffer >::
-#if HAVE_MPI
-  exchange( DataHandleInterface& handle) const
-#else
-  exchange( DataHandleInterface&) const
-#endif
+  exchange( [[maybe_unused]] DataHandleInterface& handle,
+            [[maybe_unused]] const int            tag ) const
   {
-    assert( _recvBufferSizes.empty () );
+    assert( this->_recvBufferSizes.empty () );
+
 #if HAVE_MPI
-    NonBlockingExchangeImplementation< ThisType > nonBlockingExchange( *this, getMessageTag() );
+    NonBlockingExchangeImplementation< ThisType > nonBlockingExchange( *this, tag );
     nonBlockingExchange.exchange( handle );
-#endif
+#endif  // HAVE_MPI
+  }
+
+  template <class MsgBuffer>
+  inline void
+  Point2PointCommunicator< MsgBuffer >::
+  exchange( [[maybe_unused]] DataHandleInterface& handle) const
+  {
+    assert( this->_recvBufferSizes.empty () );
+#if HAVE_MPI
+    this->exchange( handle, getMessageTag() );
+#endif  // HAVE_MPI
   }
 
   // --exchange

--- a/tests/p2pcommunicator_test.cc
+++ b/tests/p2pcommunicator_test.cc
@@ -156,6 +156,12 @@ void testCommunicator( const bool output )
     comm.exchange( handle );
   }
 
+  {
+    // use handle with custom message tag to perform the same operations as above
+    DataHandle handle( comm, output );
+    comm.exchange( handle, 1 << 12 );
+  }
+
   for( int i=0; i<5; ++i )
   {
     // use handle to perform the same operations as above


### PR DESCRIPTION
That way we're not necessarily restricted to MPI_COMM_WORLD since we don't rely on a [static variable](https://github.com/OPM/opm-grid/blob/b4b7971e4eaaff4830b9ea5254dc39748092f93d/opm/grid/common/p2pcommunicator.hh#L252) to [create message tags](https://github.com/OPM/opm-grid/blob/b4b7971e4eaaff4830b9ea5254dc39748092f93d/opm/grid/common/p2pcommunicator.hh#L255) for each new message.

The first use case for this is [gathering connection information](https://github.com/OPM/opm-simulators/blob/cf6423bfce2fe7b482fee6a02ef5f5aa5329d382/opm/simulators/wells/WellState.cpp#L316) for distributed wells [light of `data::Connection` having variable-length tracer solution components](https://github.com/OPM/opm-common/issues/2921#issuecomment-1285496321).