### PR TITLE
Use Separate Tag Series for Each P2P Communicator

### DIFF
--- a/opm/grid/common/p2pcommunicator.hh
+++ b/opm/grid/common/p2pcommunicator.hh
@@ -247,25 +247,32 @@ public:
     inline void computeDestinations( const linkage_t& linkage, vector_t& dest );
 
     // return new tag number for the exchange messages
-    static int getMessageTag( const unsigned int increment )
+    int getMessageTag(const unsigned int increment) const
     {
-      static int tag = messagetag + 2 ;
-      // increase tag counter
-      const int retTag = tag;
-      tag += increment ;
-      // the MPI standard guaratees only up to 2^15-1
-      if( tag >= 32767 )
-      {
-        // reset tag to initial value
-        tag = messagetag + 2 ;
-      }
+      const int retTag = this->tag_;
+      this->generateNextMessageTag(increment);
       return retTag;
     }
 
     // return new tag number for the exchange messages
-    static int getMessageTag()
+    int getMessageTag() const
     {
-      return getMessageTag( 1 );
+      return this->getMessageTag(1u);
+    }
+
+  private:
+    mutable int tag_{messagetag + 2};
+
+    void generateNextMessageTag(const unsigned int increment) const
+    {
+      this->tag_ += increment;
+
+      // Reset to initial value if next tag exceeds MPI standard's maximum
+      // message tag guarantee of 2^15-1.
+      if (this->tag_ >= (1 << 15) - 1)
+      {
+        this->tag_ = messagetag + 2;
+      }
     }
   };
 


### PR DESCRIPTION
This PR makes the tag generator into a per-object mechanism. This, in turn, means that there can be multiple P2P communicator objects, possibly amongst subsets of MPI processes, that exchange messages without generating conflicting message tags.

Immediate use case is communicating per-connection result data between processes that happen to share a distrbuted well.

This PR supersedes and closes #596.