### PR TITLE
[bugfix] Prevent deadlock for accidentally distributed wells.

### DIFF
--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -116,6 +116,8 @@ makeImportAndExportLists(const Dune::CpGrid& cpgrid,
 
 #ifndef NDEBUG
             int index = 0;
+            std::unordered_set<int> distributed_wells;
+
             for( auto well : gridAndWells->getWellsGraph() )
             {
                 int part=parts[index];
@@ -129,10 +131,19 @@ makeImportAndExportLists(const Dune::CpGrid& cpgrid,
                 }
                 if ( cells_on_other.size() )
                 {
-                    OPM_THROW(std::domain_error, "Well is distributed between processes, which should not be the case!");
+                    distributed_wells.insert(index);
                 }
                 ++index;
             }
+            auto num_dist_wells = cc.sum(distributed_wells.size());
+            if (num_dist_wells) {
+                OPM_THROW(std::domain_error,
+                          std::to_string(num_dist_wells) + " well"
+                              +  ((num_dist_wells >= 2) ? "s are" : " is")
+                              + " distributed between processes, which should not be the case!");
+            }
+
+
 #endif
         }
     }


### PR DESCRIPTION
If distributed wells are not allowed, we try to move all perforated cells those wells to one process. We throw an exception if that was not successful. That exception was only thrown on one process causing OPM flow to hang afterwards. This is fixed by this change that throws on all processes.

Drive-by fix while working on the real stuff.