### PR TITLE
[bugfix] Move cells of wells correctly if multiple wells perforate the same cell.

### DIFF
--- a/opm/grid/common/WellConnections.hpp
+++ b/opm/grid/common/WellConnections.hpp
@@ -162,6 +162,7 @@ postProcessPartitioningForWells(std::vector<int>& parts,
                                 std::function<int(int)> gid,
                                 const std::vector<OpmWellType>&  wells,
                                 const WellConnections& well_connections,
+                                const std::vector<std::set<int> >& wellGraph,
                                 std::vector<std::tuple<int,int,char>>& exportList,
                                 std::vector<std::tuple<int,int,char,int>>& importList,
 #if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)

--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -110,12 +110,13 @@ makeImportAndExportLists(const Dune::CpGrid& cpgrid,
                                                 gidGetter,
                                                 *wells,
                                                 gridAndWells->getWellConnections(),
+                                                gridAndWells->getWellsGraph(),
                                                 myExportList, myImportList,
                                                 cc);
 
 
 #ifndef NDEBUG
-            int index = 0;
+            std::size_t index = 0;
             std::unordered_set<int> distributed_wells;
 
             for( auto well : gridAndWells->getWellsGraph() )


### PR DESCRIPTION
Previously, we only moved the perforated cells of one well to the new partition. In the case that a cell was also perforated by another cell we might have moved only a few cells of that other well. The rest would remain where they were previously. Hence the well might (still) be distributed between multiple processors and the user would see the following exception:
```
Error: [opm/grid/common/ZoltanPartition.cpp:132] Well is distributed between processes, which should not be the case!
```

To solve this problem we now make a breadth first search in the well graph starting with a cell of the well to be moved. This will effective move the cells of all wells whose cells are reachable via the well graph. As a result there should be no distributed wells, anymore.

based on #620, which should be moved first (just in case we experience changes in the parallel results).