### PR TITLE
[bugfix] Fix cases with MINPV without PINCH or MINPV with PINCH NOGAP

### DIFF
--- a/opm/grid/MinpvProcessor.hpp
+++ b/opm/grid/MinpvProcessor.hpp
@@ -223,8 +223,12 @@ namespace Opm
                                 }
                             }
 
+                            bool c_thin = thickness[c] < z_tolerance;
                             // Add a connection if the cell above and below is active and has porv > minpv
-                            if ((actnum.empty() || (actnum[c_above] && actnum[c_below])) && pv[c_above] > minpvv[c_above] && pv[c_below] > minpvv[c_below]) {
+                            // In the case of PichNOGAP this cell must be thin, too.
+                            if ( (! pinchNOGAP || c_thin) &&
+                                 (actnum.empty() || (actnum[c_above] && actnum[c_below])) &&
+                                 pv[c_above] > minpvv[c_above] && pv[c_below] > minpvv[c_below]) {
                                 result.add_nnc(c_above, c_below);
                             }
                         }

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -157,7 +157,7 @@ namespace cpgrid
                 thickness[i] = ecl_grid.getCellThickness(i);
             }
             const double z_tolerance = ecl_grid.isPinchActive() ?  ecl_grid.getPinchThresholdThickness() : 0.0;
-            const bool nogap = ecl_grid.getPinchGapMode() ==  Opm::PinchMode::NOGAP;
+            const bool nogap = !pinchActive || ecl_grid.getPinchGapMode() ==  Opm::PinchMode::NOGAP;
             const auto& poreVolume = ecl_state->fieldProps().porv(true);
             minpv_result = mp.process(thickness, z_tolerance, poreVolume, ecl_grid.getMinpvVector(), actnumData, false, zcornData.data(), nogap);
             if (!minpv_result.nnc.empty()) {

--- a/tests/cpgrid/grid_nnc.cpp
+++ b/tests/cpgrid/grid_nnc.cpp
@@ -195,7 +195,8 @@ BOOST_FIXTURE_TEST_CASE(NNCWithPINCH, Fixture)
 BOOST_FIXTURE_TEST_CASE(NNCWithPINCHNOGAP, Fixture)
 {
     Opm::NNC nnc;
-    testCase("FIVE_PINCH_NOGAP.DATA", nnc, 4, 4 * 6 + 1, 2 * (4 + 5) + 1, { {0,1}, {1,2}, {2,3} }, true);
+    // Cell with cartindex 1 is isolated because of PINCH NOGAP
+    testCase("FIVE_PINCH_NOGAP.DATA", nnc, 4, 4 * 6, 2 * (4 + 5) + 2, { {1,2}, {2,3} }, true);
 }
 
 BOOST_FIXTURE_TEST_CASE(NNCWithPINCHNOGAP2, Fixture)

--- a/tests/test_minpvprocessor.cpp
+++ b/tests/test_minpvprocessor.cpp
@@ -67,9 +67,9 @@ BOOST_AUTO_TEST_CASE(Pinch)
     pinch_no_gap = true;
     minpv_result = mp1.process(thickness, z_threshold, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
     BOOST_CHECK_EQUAL_COLLECTIONS(z1.begin(), z1.end(), zcornAfter.begin(), zcornAfter.end());
-    BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 1);
+    BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 0); // No nnc because deactivated cell thickness is too high
 
-    z_threshold = 0.4;
+    z_threshold = 0.51;
     pinch_no_gap = true;
     minpvv = std::vector(4, 0.6);
     z1 = zcorn;
@@ -77,6 +77,16 @@ BOOST_AUTO_TEST_CASE(Pinch)
 
     BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 1);
     BOOST_CHECK_EQUAL(minpv_result.nnc[0], 2);
+    BOOST_CHECK(minpv_result.removed_cells == std::vector<std::size_t>{1});
+    BOOST_CHECK_EQUAL_COLLECTIONS(z1.begin(), z1.end(), zcornAfter.begin(), zcornAfter.end());
+
+    z_threshold = 0.4;
+    pinch_no_gap = false;
+    minpvv = std::vector(4, 0.6);
+    z1 = zcorn;
+    minpv_result = mp1.process(thickness, z_threshold, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
+
+    BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 1);
     BOOST_CHECK(minpv_result.removed_cells == std::vector<std::size_t>{1});
     BOOST_CHECK_EQUAL_COLLECTIONS(z1.begin(), z1.end(), zcornAfter.begin(), zcornAfter.end());
 
@@ -88,6 +98,24 @@ BOOST_AUTO_TEST_CASE(Pinch)
 
     BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 0);
     BOOST_CHECK_EQUAL_COLLECTIONS(z1.begin(), z1.end(), zcorn.begin(), zcorn.end());
+
+    z_threshold = 1.1;
+    pinch_no_gap = false;
+    minpvv = std::vector(4, 1.1);
+    z1 = zcorn;
+    minpv_result = mp1.process(thickness, z_threshold, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
+    zcornAfter =
+        {0, 0, 0, 0,
+         2, 2, 2, 2,
+         2, 2, 2, 2,
+         2, 2, 2, 2,
+         2.5, 2.5, 2.5, 2.5,
+         2.5, 2.5, 2.5, 2.5,
+         3.5, 3.5, 3.5, 3.5,
+         6, 6, 6, 6
+        };
+    BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 1);
+    BOOST_CHECK_EQUAL_COLLECTIONS(z1.begin(), z1.end(), zcornAfter.begin(), zcornAfter.end());
 
     z_threshold = 1.1;
     pinch_no_gap = true;
@@ -106,6 +134,10 @@ BOOST_AUTO_TEST_CASE(Pinch)
         };
     BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 1);
     BOOST_CHECK_EQUAL_COLLECTIONS(z1.begin(), z1.end(), zcornAfter.begin(), zcornAfter.end());
+    auto exp =  std::vector<std::size_t>{1, 2};
+    BOOST_CHECK(minpv_result.removed_cells == exp);
+    BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 1u);
+    BOOST_CHECK_EQUAL(minpv_result.nnc[0], 3);
 }
 
 BOOST_AUTO_TEST_CASE(Processing)


### PR DESCRIPTION
For MINPV without PINCH OPM flow still silent assumed there was "PINCH GAP" specified when processing MINPV and created NNC where none should have been created.
For the case where only one cell was deactivated we also missed checking whether the thickness of this cell was below the threshold for "PINCH NOGAP" before creating an NCC over it.

I am sligtly nervous that I needed to change our test of FIVE_PINCH_NOGAP.DATA, where we no don't create an NNC anymore. Somebody should double check that with the other simulator. Maybe that test was wrong all the time.

This fixes the problem for PINCH10_NOPINCH in OPM/opm-tests#886