### PR TITLE
Expand Left-Handed vs Right-Handed Inference

### DIFF
--- a/opm/grid/cornerpoint_grid.c
+++ b/opm/grid/cornerpoint_grid.c
@@ -173,7 +173,13 @@ create_grid_cornerpoint(const struct grdecl *in, double tol)
        return NULL;
    }
 
-   process_grdecl(in, tol, NULL, &pg, false);
+   ok = process_grdecl(in, tol, NULL, &pg, false);
+   if (!ok)
+   {
+       free_processed_grid(&pg);
+       destroy_grid(g);
+       return NULL;
+   }
 
    /*
     *  Convert "struct processed_grid" to "struct UnstructuredGrid".

--- a/opm/grid/cpgpreprocess/preprocess.h
+++ b/opm/grid/cpgpreprocess/preprocess.h
@@ -145,13 +145,12 @@ extern "C" {
      *                  call to function process_grdecl().
      */
     void free_processed_grid(struct processed_grid *g);
+
 #ifdef __cplusplus
 }
 #endif
 
-
 #endif /* OPM_PREPROCESS_HEADER */
-
 
 /* Local Variables:    */
 /* c-basic-offset:4    */

--- a/opm/grid/cpgpreprocess/preprocess.h
+++ b/opm/grid/cpgpreprocess/preprocess.h
@@ -127,12 +127,15 @@ extern "C" {
      *                    mapping.
      * @param[in] pinchActive Whether cells with zero volume should be pinched out
      *                    and neighboring cells should be connected.
+     *
+     * @return One (1, true) if grid successfully generated, zero (0, false)
+     * otherwise.
      */
-    void process_grdecl(const struct grdecl   *g  ,
-                        double                 tol,
-                        const int*   is_aquifer_cell,
-                        struct processed_grid *out,
-                        int pinchActive);
+    int process_grdecl(const struct grdecl   *g,
+                       double                 tol,
+                       const int             *is_aquifer_cell,
+                       struct processed_grid *out,
+                       int                    pinchActive);
 
     /**
      * Release memory resources acquired in previous grid processing using

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -263,7 +263,10 @@ namespace cpgrid
 #ifdef VERBOSE
         std::cout << "Processing eclipse data." << std::endl;
 #endif
+
         processed_grid output;
+        int process_ok;
+
 #if HAVE_ECL_INPUT
         if (ecl_state && ecl_state->aquifer().hasNumericalAquifer()) {
             const auto aquifer_cell_volumes = ecl_state->aquifer().numericalAquifers().aquiferCellVolumes();
@@ -272,10 +275,18 @@ namespace cpgrid
             for ([[maybe_unused]]const auto&[global_index, volume] : aquifer_cell_volumes) {
                 is_aquifer_cell[global_index] = 1;
             }
-            process_grdecl(&input_data, 0, is_aquifer_cell.data(), &output, pinchActive);
+            process_ok = process_grdecl(&input_data, 0, is_aquifer_cell.data(), &output, pinchActive);
         } else
 #endif
-            process_grdecl(&input_data, 0, nullptr, &output, pinchActive);
+        {
+            process_ok = process_grdecl(&input_data, 0, nullptr, &output, pinchActive);
+        }
+
+        if (process_ok == 0) {
+            OPM_THROW(std::runtime_error,
+                      "Failed to build unstructured "
+                      "grid from COORD/ZCORN");
+        }
 
         if (remove_ij_boundary) {
             removeOuterCellLayer(output);


### PR DESCRIPTION
This PR switches the `is_lefthanded()` predicate into a coordinate system classifier.  Rename the function according to its new responsibility.  We determine if the geometry's coordinate system is right-handed (most common) or left-handed, and add a fall-back state of "inconclusive" if the type cannot be fully determined.

In that case, we fall back to a more expensive algorithm that considers every active cell.  The existing classifier tried to form a bounding box for the entire model and then to calculate the triple product of that bounding box.  This approach, while inexpensive when it works, is too fragile.  There are modelling tools which place multiple cell columns in the same physical location if there are no active cells within the column.  This, in turn, leads to zero-sized bounding boxes in the original implementation and an inconclusive result.

The fall-back strategies computes the triple product for each active cell and infers "left-handed" vs. "right-handed" coordinate systems for the complete geometry based on the proportion of left-handed vs. right-handed individual cells.

While here, also make function `process_grdecl()` return a status code of zero if we fail to construct a 'processed_grid' object and update callers to use this new information. Typical causes for failing to construct the grid is

  * Failing to conclusively determine if the grid's coordinate system is right-handed or left-handed.
  * Failing to allocate memory (malloc/realloc)

There are still a couple of malloc failures that end up calling `exit()`, but we will address those in follow-up work.