### PR TITLE
[cleanup] Entity::count() removed (gone since DUNE 2.5)

### DIFF
--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -173,11 +173,7 @@ namespace Dune
 
             /// The count of subentities of codimension cc
             unsigned int subEntities ( const unsigned int cc ) const;
-
-            /// The count of subentities of codimension cc
-            template <int cc>
-            int count() const { return subEntities( cc ); }
-
+            
             /// Obtain subentity.
             template <int cc>
             typename Codim<cc>::Entity subEntity(int i) const;


### PR DESCRIPTION
Unnecessary member count() removed (use subEntitites(), if needed). It has been removed from the DUNE grid interface in version 2.5 already.