### PR TITLE
[followed-up] Create grid with LGR (Cartesian type) 

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -89,6 +89,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/cpgrid/entity_test.cpp
   tests/cpgrid/facetag_test.cpp
   tests/cpgrid/geometry_test.cpp
+  tests/cpgrid/grid_lgr_test.cpp
   tests/cpgrid/orientedentitytable_test.cpp
   tests/cpgrid/partition_iterator_test.cpp
   tests/cpgrid/shifted_cart_test.cpp

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -566,6 +566,7 @@ namespace Dune
         /// @param [in] cells_per_dim            Number of (refined) cells in each direction that each parent cell should be refined to.
         /// @param [in] startIJK                 Cartesian triplet index where the patch starts.
         /// @param [in] endIJK                   Cartesian triplet index where the patch ends.
+        ///                                      Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
         void createGridWithLgr(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK, const std::array<int,3>& endIJK)
         {
             if (!distributed_data_.empty()){

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -580,8 +580,14 @@ namespace Dune
             (this-> data_).push_back(level1_ptr);
             // To store the leaf view (mixed grid, with coarse and refined entities).
             typedef Dune::FieldVector<double,3> PointType;
+            #if HAVE_MPI
             std::shared_ptr<Dune::cpgrid::CpGridData> leaf_view_ptr =
                 std::make_shared<Dune::cpgrid::CpGridData>((*(this-> data_[0])).ccobj_);
+            #else
+            // DUNE 2.7 is missing convertion to NO_COMM
+            std::shared_ptr<Dune::cpgrid::CpGridData> leaf_view_ptr =
+                std::make_shared<Dune::cpgrid::CpGridData>();
+            #endif
             auto& leaf_view = *leaf_view_ptr;
             Dune::cpgrid::DefaultGeometryPolicy& leaf_geometries = leaf_view.geometry_;
             std::vector<std::array<int,8>>& leaf_cell_to_point = leaf_view.cell_to_point_;

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -473,7 +473,12 @@ public:
     refineSingleCell(const std::array<int,3>& cells_per_dim, const int& parent_idx) const
     {
         // To store the LGR/refined-grid.
-        std::shared_ptr<CpGridData> refined_grid_ptr = std::make_shared<CpGridData>(ccobj_);
+        #if HAVE_MPI
+         std::shared_ptr<CpGridData> refined_grid_ptr = std::make_shared<CpGridData>(ccobj_);
+        #else
+        // DUNE 2.7 is missing convertion to NO_COMM
+         std::shared_ptr<CpGridData> refined_grid_ptr = std::make_shared<CpGridData>();
+        #endif
         auto& refined_grid = *refined_grid_ptr;
         DefaultGeometryPolicy& refined_geometries = refined_grid.geometry_;
         std::vector<std::array<int,8>>& refined_cell_to_point = refined_grid.cell_to_point_;
@@ -633,7 +638,12 @@ public:
             OPM_THROW(std::logic_error, "Grid is not Cartesian. Patch cannot be refined.");
         }
         // To store LGR/refined-grid.
-        std::shared_ptr<CpGridData> refined_grid_ptr = std::make_shared<CpGridData>(ccobj_);
+        #if HAVE_MPI
+         std::shared_ptr<CpGridData> refined_grid_ptr = std::make_shared<CpGridData>(ccobj_);
+        #else
+        // DUNE 2.7 is missing convertion to NO_COMM
+         std::shared_ptr<CpGridData> refined_grid_ptr = std::make_shared<CpGridData>();
+        #endif
         auto& refined_grid = *refined_grid_ptr;
         DefaultGeometryPolicy& refined_geometries = refined_grid.geometry_;
         std::vector<std::array<int,8>>& refined_cell_to_point = refined_grid.cell_to_point_;

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -125,6 +125,9 @@ void refinePatch_and_check(Dune::CpGrid&,
                            const std::array<int,3>&,
                            const std::array<int,3>&);
 
+void check_global_refine(const Dune::CpGrid&,
+                         const Dune::CpGrid&);
+
 namespace Dune
 {
 namespace cpgrid
@@ -158,6 +161,10 @@ class CpGridData
                                  const std::array<int,3>&,
                                  const std::array<int,3>&,
                                  const std::array<int,3>&);
+    
+    friend
+    void ::check_global_refine(const Dune::CpGrid&,
+                               const Dune::CpGrid&);
 
 private:
     CpGridData(const CpGridData& g);
@@ -278,299 +285,189 @@ public:
         ijk[2] = gc / logical_cartesian_size_[1];
     }
 
-    // Given a start {i,j,k} and an end {i,j,k}, compute the dimension of the patch, i.e.
-    // aomunt of cells in each direction. 
-    const std::array<int,3> getPatchDim(const std::array<int,3>& start_ijk, const std::array<int,3>& end_ijk) const
+private:
+    /// @brief Compute amount of cells in each direction of a patch of cells. (Cartesian grid required).
+    ///
+    /// @param [in]  startIJK  Cartesian triplet index where the patch starts.
+    /// @param [in]  endIJK    Cartesian triplet index where the patch ends.
+    ///
+    /// @return patch_dim Patch dimension {#cells in x-direction, #cells in y-direction, #cells in z-direction}.
+    const std::array<int,3> getPatchDim(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
     {
-        return {end_ijk[0]-start_ijk[0], end_ijk[1]-start_ijk[1], end_ijk[2]-start_ijk[2]};
-    } 
-    
-    const std::array<std::vector<int>,3> getPatchGeomIndices(const std::array<int,3>& start_ijk, const std::array<int,3>& end_ijk) const
+        return {endIJK[0]-startIJK[0], endIJK[1]-startIJK[1], endIJK[2]-startIJK[2]};
+    }
+
+    /// @brief Compute corner, face, and cell indices of a patch of cells. (Cartesian grid required).
+    ///
+    /// @param [in]  startIJK  Cartesian triplet index where the patch starts.
+    /// @param [in]  endIJK    Cartesian triplet index where the patch ends.
+    ///
+    /// @return {patch_corners, patch_faces, patch_cells} Indices of corners, faces, and cells of the patch of cells.
+    const std::array<std::vector<int>,3> getPatchGeomIndices(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
     {
         // Get the patch dimension (total cells in each direction). Used to 'reserve vectors'.
-        const std::array<int,3> patch_dim = getPatchDim(start_ijk, end_ijk);
-        // Get grid dim
-        const std::array<int,3> grid_dim = this -> logicalCartesianSize();
-        // CORNERS
+        const std::array<int,3>& patch_dim = getPatchDim(startIJK, endIJK);
+        // Get grid dimension (total cells in each direction).
+        const std::array<int,3>& grid_dim = this -> logicalCartesianSize();
+        /// PATCH CORNERS
         std::vector<int> patch_corners;
         patch_corners.reserve((patch_dim[0]+1)*(patch_dim[1]+1)*(patch_dim[2]+1));
-        for (int j = start_ijk[1]; j < end_ijk[1]+1; ++j) {
-            for (int i = start_ijk[0]; i < end_ijk[0]+1; ++i) {
-                for (int k = start_ijk[2]; k < end_ijk[2]+1; ++k) {
+        for (int j = startIJK[1]; j < endIJK[1]+1; ++j) {
+            for (int i = startIJK[0]; i < endIJK[0]+1; ++i) {
+                for (int k = startIJK[2]; k < endIJK[2]+1; ++k) {
                     patch_corners.push_back((j*(grid_dim[0]+1)*(grid_dim[2]+1)) + (i*(grid_dim[2]+1))+k);
                 } // end i-for-loop
             } // end j-for-loop
         } // end k-for-loop
-        // FACES
+        /// PATCH FACES
         std::vector<int> patch_faces;
-        // Integers to reserve patch_faces.
-        int i_patch_faces = (patch_dim[0]+1)*patch_dim[1]*patch_dim[2];
-        int j_patch_faces = patch_dim[0]*(patch_dim[1]+1)*patch_dim[2];
-        int k_patch_faces = patch_dim[0]*patch_dim[1]*(patch_dim[2]+1);
-        patch_faces.reserve(i_patch_faces +j_patch_faces +k_patch_faces);
-        // Integers to compute face indices.
-        int i_grid_faces = (grid_dim[0]+1)*grid_dim[1]*grid_dim[2];
-        int j_grid_faces = grid_dim[0]*(grid_dim[1]+1)*grid_dim[2];
+        patch_faces.reserve(((patch_dim[0]+1)*patch_dim[1]*patch_dim[2])     // i_patch_faces
+                            + (patch_dim[0]*(patch_dim[1]+1)*patch_dim[2])   // j_patch_faces
+                            + (patch_dim[0]*patch_dim[1]*(patch_dim[2]+1))); // k_patch_faces
         // I_FACES
-        for (int j = start_ijk[1]; j < end_ijk[1]; ++j) {
-            for (int i = start_ijk[0]; i < end_ijk[0]+1; ++i) {
-                for (int k = start_ijk[2]; k < end_ijk[2]; ++k) {
-                    int face_idx = (j*grid_dim[1]*grid_dim[2]) + (i*grid_dim[2])+ k;
-                    patch_faces.push_back(face_idx);          
+        for (int j = startIJK[1]; j < endIJK[1]; ++j) {
+            for (int i = startIJK[0]; i < endIJK[0]+1; ++i) {
+                for (int k = startIJK[2]; k < endIJK[2]; ++k) {
+                    patch_faces.push_back((j*(grid_dim[0]+1)*grid_dim[2]) +(i*grid_dim[2]) + k);
                 } // end k-for-loop
-            } // end i-for-loop     
+            } // end i-for-loop
         } // end j-for-loop
         // J_FACES
-        for (int j = start_ijk[1]; j < end_ijk[1]+1; ++j) {
-            for (int i = start_ijk[0]; i < end_ijk[0]; ++i) {
-                for (int k = start_ijk[2]; k < end_ijk[2]; ++k) {
-                    int face_idx = i_grid_faces + (j*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2])+ k; 
-                    patch_faces.push_back(face_idx);          
+        for (int j = startIJK[1]; j < endIJK[1]+1; ++j) {
+            for (int i = startIJK[0]; i < endIJK[0]; ++i) {
+                for (int k = startIJK[2]; k < endIJK[2]; ++k) {
+                    patch_faces.push_back(((grid_dim[0]+1)*grid_dim[1]*grid_dim[2]) // i_grid_faces
+                                          + (j*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2]) + k);
                 } // end k-for-loop
-            } // end i-for-loop     
+            } // end i-for-loop
         } // end j-for-loop
-         // K_FACES
-        for (int j = start_ijk[1]; j < end_ijk[1]; ++j) {
-            for (int i = start_ijk[0]; i < end_ijk[0]; ++i) {
-                for (int k = start_ijk[2]; k < end_ijk[2]+1; ++k) {
-                    int face_idx = j_grid_faces + i_grid_faces + (j*grid_dim[0]*(grid_dim[2]+1)) + (i*(grid_dim[2]+1))+ k;
-                    patch_faces.push_back(face_idx);          
+        // K_FACES
+        for (int j = startIJK[1]; j < endIJK[1]; ++j) {
+            for (int i = startIJK[0]; i < endIJK[0]; ++i) {
+                for (int k = startIJK[2]; k < endIJK[2]+1; ++k) {
+                    patch_faces.push_back((grid_dim[0]*(grid_dim[1]+1)*grid_dim[2]) //j_grid_faces
+                                          + ((grid_dim[0]+1)*grid_dim[1]*grid_dim[2])          // i_grid_faces
+                                          + (j*grid_dim[0]*(grid_dim[2]+1)) + (i*(grid_dim[2]+1))+ k);
                 } // end k-for-loop
-            } // end i-for-loop     
+            } // end i-for-loop
         } // end j-for-loop
-
-        // CELLS
+        /// PATCH CELLS
         std::vector<int> patch_cells;
         patch_cells.reserve(patch_dim[0]*patch_dim[1]*patch_dim[2]);
-        for (int k = start_ijk[2]; k < end_ijk[2]; ++k) {
-            for (int j = start_ijk[1]; j < end_ijk[1]; ++j) {
-                for (int i = start_ijk[0]; i < end_ijk[0]; ++i) {
-                    patch_cells.push_back((k*grid_dim[0]*grid_dim[1]) + (j*grid_dim[1]) +i);
+        for (int k = startIJK[2]; k < endIJK[2]; ++k) {
+            for (int j = startIJK[1]; j < endIJK[1]; ++j) {
+                for (int i = startIJK[0]; i < endIJK[0]; ++i) {
+                    patch_cells.push_back((k*grid_dim[0]*grid_dim[1]) + (j*grid_dim[0]) +i);
                 } // end i-for-loop
             } // end j-for-loop
         } // end k-for-loop
         return {patch_corners, patch_faces, patch_cells};
     }
 
-    // Construct a 'huge cell' out of a patch of connected (consecutive in each direction) cells.
-    // CELL-FICATION OF A PATCH
-    // This function takes a patch and build a cell out of it.
-    // The function takes a connected patch formed by the product of consecutive cells in each direction, and
-    // returns a Geometry<3,3> object, 'a patch cell', or 'a cellFIED patch'.
-    // Idea: Select 8 corners of the boundary of the patch, compute center and volume.
-    // @param patch_cells_indices           Indices of the cells from the grid that we want to refine, or, equivalently,
-    //                                      indices of the cells that belong to the patch.
-    // @param cellfiedPatch_to_point        Indices of the 8 corners of each parent cell.
-    // @param cellfied_patch_geometry
-    Geometry<3,3> cellfyPatch(const std::vector<int> patch_cells_indices)
+    /// @brief Construct a 'fake cell (Geometry<3,3> object)' out of a patch of cells.(Cartesian grid required).
+    ///
+    /// cellifyPatch() builds a Geometry<3,3> object, 'a celliFIED patch', from a connected patch formed
+    /// by the product of consecutive cells in each direction; selecting 8 corners of the patch boundary,
+    /// computing center and volume.
+    ///
+    /// @param [in] startIJK                   Cartesian triplet index where the patch starts.
+    /// @param [in] endIJK                     Cartesian triplet index where the patch ends.
+    /// @param [in] patch_cells                Cell indices from the block-shaped patch.
+    /// @param [out] cellifiedPatch_geometry   Required as an argument when creating a Geomtry<3,3> object.
+    /// @param [out] cellifiedPatch_to_point   To store the 8 corners of the created cellifiedPatch.
+    /// @param [out] allcorners_cellifiedPatch Required to build a Geometry<3,3> object.
+    ///
+    /// @return 'cellifiedPatchCell'         Geometry<3,3> object.
+    const Geometry<3,3> cellifyPatch(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK,
+                                     const std::vector<int>& patch_cells, DefaultGeometryPolicy& cellifiedPatch_geometry,
+                                     std::array<int,8>& cellifiedPatch_to_point,
+                                     std::array<int,8>& allcorners_cellifiedPatch) const
     {
-        if (patch_cells_indices.empty()){
+        if (patch_cells.empty()){
             OPM_THROW(std::logic_error, "Empty patch. Cannot convert patch into cell.");
         }
-        DefaultGeometryPolicy cellfied_patch_geometry;
-        // Get the minimum and maximum of "patch_cells_indices"
-        // to find the min_i, max_i, min_j, max_j, min_k, max_k,
-        // to 'cell-fy' the patch (treating the patch as a 'huge cell')
-        const std::array<int,2> min_max_indices = {
-            *std::min_element(patch_cells_indices.begin(), patch_cells_indices.end()),
-            *std::max_element(patch_cells_indices.begin(), patch_cells_indices.end())};
-        // Get grid dim
-        const std::array<int,3> grid_dim = this -> logicalCartesianSize();
-        // Get min/max-ijk indices out of "min_max_indices"
-        std::vector<std::array<int,3>> min_max_ijk_indices;
-        min_max_ijk_indices.reserve(2);
-        for (auto& idx : min_max_indices) {
-            int i = idx/grid_dim[0]; // i
-            int j = ((idx - i)/grid_dim[0])/grid_dim[1]; // j
-            int k = (((idx - i)/grid_dim[0]) -j)/grid_dim[1]; // k
-            min_max_ijk_indices.push_back({i,j,k});
-        }
-        // Get indices of (at most) 8 selected cells located on the boundary of the patch.
-        /* std::array<int,8> selected_boundary_cell_indices = {
-            // Index of the boundary cell from where corner '0' will be extracted.
-            min_max_indices[0],
-            // Index of the boundary cell from where corner '1' will be extracted: '{max_i, min_j, min_k}'
-            (min_max_ijk_indices[0][2]*grid_dim[0]*grid_dim[1]) + (min_max_ijk_indices[0][1]*grid_dim[0])
-            + min_max_ijk_indices[1][0],
-            // Index of the bounday cell from where corner '2' will be extracted: '{min_i, max_j, min_k}'
-            (min_max_ijk_indices[0][2]*grid_dim[0]*grid_dim[1]) + (min_max_ijk_indices[1][1]*grid_dim[0])
-            + min_max_ijk_indices[0][0],
-            // Index of the boundary cell from where corner '3' will be extracted: '{max_i, max_j, min_k}'
-            (min_max_ijk_indices[0][2]*grid_dim[0]*grid_dim[1]) + (min_max_ijk_indices[1][1]*grid_dim[0])
-            + min_max_ijk_indices[1][0],
-            // Index of the bounday cell from where corner '4' will be extracted: '{min_i, min_j, max_k}'
-            (min_max_ijk_indices[1][2]*grid_dim[0]*grid_dim[1]) + (min_max_ijk_indices[0][1]*grid_dim[0])
-            + min_max_ijk_indices[0][0],
-            // Index of the boundary cell from where corner '5' will be extracted: '{max_i, min_j, max_k}'
-            (min_max_ijk_indices[1][2]*grid_dim[0]*grid_dim[1]) + (min_max_ijk_indices[0][1]*grid_dim[0])
-            + min_max_ijk_indices[1][0],
-            // Index of the bounday cell from where corner '6' will be extracted: '{min_i, max_j, max_k}'
-            (min_max_ijk_indices[1][2]*grid_dim[0]*grid_dim[1]) + (min_max_ijk_indices[1][1]*grid_dim[0])
-            + min_max_ijk_indices[0][0],
-            // Index of the boundary cell from where corner '7' will be extracted.
-            min_max_indices[1]}; */
-        EntityVariableBase<cpgrid::Geometry<0,3>>& cellfiedPatch_corners =
-                    cellfied_patch_geometry.geomVector(std::integral_constant<int,3>());
-        cellfiedPatch_corners.resize(8);
-        // Get the 8 corner indices of the 'cellFIED patch'
-         std::array<int,8> cellfiedPatch_to_point = { //  corner indices: (J*(grid_dim[0]+1)*(grid_dim[2]+1)) + (I*(grid_dim[2]+1)) +K
-            // Index of corner '0' {min_i, min_j, min_k}
-            (min_max_ijk_indices[0][1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (min_max_ijk_indices[0][0]*(grid_dim[2]+1))
-            +min_max_ijk_indices[0][2],
-            // Index of corner '1' '{max_i +1, min_j, min_k}'
-            (min_max_ijk_indices[0][1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + ((min_max_ijk_indices[1][0] +1)*(grid_dim[2]+1))
-            + min_max_ijk_indices[0][2],
-            // Index of corner '2' '{min_i, max_j +1, min_k}'
-            ((min_max_ijk_indices[1][1] +1)*(grid_dim[0]+1)*(grid_dim[2]+1)) + (min_max_ijk_indices[0][0]*(grid_dim[2]+1))
-            + min_max_ijk_indices[0][2],
-            // Index of corner '3' '{max_i +1, max_j +1, min_k}'
-            ((min_max_ijk_indices[1][1] +1)*(grid_dim[0]+1)*(grid_dim[2]+1)) + ((min_max_ijk_indices[1][0] +1)*(grid_dim[2]+1))
-             + min_max_ijk_indices[0][2],
-             // Index of corner '4' '{min_i, min_j, max_k +1}'
-             (min_max_ijk_indices[0][1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (min_max_ijk_indices[0][0]*(grid_dim[2]+1))
-             + min_max_ijk_indices[1][2],
-             // Index of corner '5' '{max_i +1, min_j, max_k +1}'
-             (min_max_ijk_indices[0][1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + ((min_max_ijk_indices[1][0] +1)*(grid_dim[2]+1))
-             + min_max_ijk_indices[1][2] +1,
-             // Index of corner '6' '{min_i, max_j +1, max_k +1}'
-             ((min_max_ijk_indices[1][1] +1)*(grid_dim[0]+1)*(grid_dim[2]+1)) + (min_max_ijk_indices[0][0]*(grid_dim[2]+1))
-             + min_max_ijk_indices[1][2] +1,
-             // Index of corner '7' {max_i +1, max_j +1, max_k +1}
-             ((min_max_ijk_indices[1][1]+1)*(grid_dim[0]+1)*(grid_dim[2]+1)) + ((min_max_ijk_indices[1][0]+1)*(grid_dim[2]+1))
-             + min_max_ijk_indices[1][2] +1};
-            // Center of the cell'fied' patch
-            Geometry<0,3>::GlobalCoordinate cellfiedPatch_center = {0., 0.,0.};
-            for (int corn; corn < 8; ++corn) {
-                cellfiedPatch_center +=
-                    (this -> geometry_.geomVector(std::integral_constant<int,3>()).get(cellfiedPatch_to_point[corn]).center())/8.;
-                cellfiedPatch_corners[corn] =
-                    this -> geometry_.geomVector(std::integral_constant<int,3>()).get(cellfiedPatch_to_point[corn]).center();
+        else{
+            // Get grid dimension.
+            const std::array<int,3>& grid_dim = this -> logicalCartesianSize();
+            // Select 8 corners of the patch boundary to be the 8 corners of the 'cellified patch'.
+            cellifiedPatch_to_point = { // Corner-index: (J*(grid_dim[0]+1)*(grid_dim[2]+1)) + (I*(grid_dim[2]+1)) +K
+                // Index of corner '0' {startI, startJ, startK}
+                (startIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (startIJK[0]*(grid_dim[2]+1)) + startIJK[2],
+                // Index of corner '1' '{endI, startJ, startK}'
+                (startIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (endIJK[0]*(grid_dim[2]+1)) + startIJK[2],
+                // Index of corner '2' '{startI, endJ, startK}'
+                (endIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (startIJK[0]*(grid_dim[2]+1)) + startIJK[2],
+                // Index of corner '3' '{endI, endJ, startK}'
+                (endIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (endIJK[0]*(grid_dim[2]+1)) + startIJK[2],
+                // Index of corner '4' '{startI, startJ, endK}'
+                (startIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (startIJK[0]*(grid_dim[2]+1))+ endIJK[2],
+                // Index of corner '5' '{endI, startJ, endK}'
+                (startIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (endIJK[0]*(grid_dim[2]+1)) + endIJK[2],
+                // Index of corner '6' '{startI, endJ, endK}'
+                (endIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (startIJK[0]*(grid_dim[2]+1)) + endIJK[2],
+                // Index of corner '7' {endI, endJ, endK}
+                (endIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (endIJK[0]*(grid_dim[2]+1)) + endIJK[2]};
+            EntityVariableBase<cpgrid::Geometry<0,3>>& cellifiedPatch_corners =
+                cellifiedPatch_geometry.geomVector(std::integral_constant<int,3>());
+            cellifiedPatch_corners.resize(8);
+            // Compute the center of the 'cellified patch' and its corners.
+            Geometry<0,3>::GlobalCoordinate cellifiedPatch_center = {0., 0.,0.};
+            for (int corn = 0; corn < 8; ++corn) {
+                cellifiedPatch_center +=
+                    (this -> geometry_.geomVector(std::integral_constant<int,3>()).get(cellifiedPatch_to_point[corn]).center())/8.;
+                cellifiedPatch_corners[corn] =
+                    this -> geometry_.geomVector(std::integral_constant<int,3>()).get(cellifiedPatch_to_point[corn]);
             }
-            // Volume of the cell'fied' patch
-            double cellfiedPatch_volume = 0.;
-            for (auto idx : patch_cells_indices) {
-                cellfiedPatch_volume += (this -> geometry_.geomVector(std::integral_constant<int,0>())
-                                         [EntityRep<0>(idx, true)]).volume();
+            // Compute the volume of the 'cellified patch'.
+            double cellifiedPatch_volume = 0.;
+            for (const auto& idx : patch_cells) {
+                cellifiedPatch_volume += (this -> geometry_.geomVector(std::integral_constant<int,0>())
+                                          [EntityRep<0>(idx, true)]).volume();
             }
-            // Create a pointer to the first element of "cellfiedPatch_to_point"
-            // (required as the fourth argement to construct a Geometry<3,3> type object).
-            int* cellfiedPatch_indices_storage_ptr = &cellfiedPatch_to_point[0];
-            // Construct (and return) the Geometry of the CEELfied PATCH.
-            return Geometry<3,3>(cellfiedPatch_center, cellfiedPatch_volume,
-                                 cellfied_patch_geometry.geomVector(std::integral_constant<int,3>()),
-                                 cellfiedPatch_indices_storage_ptr);
+            // Indices of 'all the corners', in this case, 0-7 (required to construct a Geometry<3,3> object).
+            allcorners_cellifiedPatch = {0,1,2,3,4,5,6,7};
+            // Create a pointer to the first element of "cellfiedPatch_to_point" (required to construct a Geometry<3,3> object).
+            const int* cellifiedPatch_indices_storage_ptr = &allcorners_cellifiedPatch[0];
+            // Construct (and return) the Geometry<3,3> of the 'cellified patch'.
+            return Geometry<3,3>(cellifiedPatch_center, cellifiedPatch_volume,
+                                 cellifiedPatch_geometry.geomVector(std::integral_constant<int,3>()), cellifiedPatch_indices_storage_ptr);
         }
-   
-    
-    
-    /*  // AREA (via sum of 4 triangles) and CENTROID of a face given its 4 corners.
-    // ----------- IN PROGRESS --------------
-    std::tuple<double,Geometry<0,3>::GlobalCoordinate> getFaceAreaCentroid(const std::array<int,4> corners)
-    {
-        // AREA
-        double face_area = 0.;
-        // Face CENTROID.
-        Geometry<0,3>::GlobalCoordinate face_centroid = {0.,0.,0.};
-        for (auto& corner : corners)
-        {
-            face_centroid += (this -> geometry_.geomVector(std::integral_constant<int,1>()).get(corner).center())/4.;
-        }
-        
-        return {face_area, face_centroid};
-        
-        }*/
-    
-    // VOLUME (via sum of 24 tetrahedra)  and CENTER of a hexaedron
-    // given its corner and face indices.
-    std::tuple<double,Geometry<0,3>::GlobalCoordinate>
-    getHexaVolumeCenter(const std::array<int,8> corners, const std::array<int,6> faces)
-    {
-        // VOLUME HEXAHEDRON
-        double hexa_volume = 0.0;
-        // Hexa center.
-        Geometry<0,3>::GlobalCoordinate hexa_center = {0.,0.,0.};
-        for (auto& corner : corners)
-        {
-            hexa_center += (this -> geometry_.geomVector(std::integral_constant<int,3>()).get(corner).center())/8.;
-        }
-        // CENTROIDS of the faces of the hexahedron.
-        // (one of the 6 corners of all 4 tetrahedra based on that face).
-        std::vector<Geometry<0,3>::GlobalCoordinate> face_centroids;
-        face_centroids.resize(6);
-        for (auto& face : faces) {
-            face_centroids.push_back(this -> geometry_.geomVector(std::integral_constant<int,1>())
-                                     [Dune::cpgrid::EntityRep<1>(face, true)].center());
-        }
-        // Container with 6 entries, one per face. Each entry has the
-        // 4 indices of the 4 corners of each face.
-        std::vector<std::array<int,4>> hexa_face_to_point;
-        hexa_face_to_point.reserve(6);
-        for (int face = 0; face < 6;  ++face) {
-            hexa_face_to_point.push_back(//this -> face_to_point_[faces[face]]);
-            { this -> face_to_point_[faces[face]][0],
-             this -> face_to_point_[faces[face]][1],
-            this -> face_to_point_[faces[face]][2],
-            this -> face_to_point_[faces[face]][3]});
-        }
-        // Container with indices of the edges of the 4 tetrahedra per face
-        // [according to description above]
-        std::vector<std::vector<std::array<int,2>>> tetra_edges;
-        tetra_edges.reserve(6);
-        for (auto& face4corners : hexa_face_to_point)
-        {
-            std::vector<std::array<int,2>> face4edges = {
-                { face4corners[0], face4corners[1]}, // fake '{0,1}'/'{4,5}'
-                { face4corners[0], face4corners[2]}, // fake '{0,2}'/'{4,6}'
-                { face4corners[1], face4corners[3]}, // fake '{1,3}'/'{5,7}'
-                { face4corners[2], face4corners[3]} }; // fake '{2,3}'/'{6,7}'
-            tetra_edges.push_back(face4edges);
-        }
-        // Sum of the 24 volumes to get the volume of the hexahedron,
-        // stored in "refined_cell_volume".
-        // Calculate the volume of each hexahedron, by adding
-        // the 4 tetrahedra at each face (4x6 = 24 tetrahedra).
-        for (int face = 0; face < 6; ++face) {
-            for (int edge = 0; edge < 4; ++edge) {
-                // Construction of each tetrahedron based on "face" with one
-                // of its edges equal to "edge".
-                const Geometry<0, 3>::GlobalCoordinate tetra_corners[4] = {
-                    this ->geometry_.geomVector(std::integral_constant<int,3>()).get(tetra_edges[face][edge][0]).center(),  
-                    this ->geometry_.geomVector(std::integral_constant<int,3>()).get(tetra_edges[face][edge][1]).center(), 
-                    face_centroids[face],
-                    hexa_center};  
-                hexa_volume += std::fabs(simplex_volume(tetra_corners));
-            } // end edge-for-loop
-        } // end face-for-loop
-        return {hexa_volume, hexa_center};    
     }
-    
-    // Refine a single cell and return a shared pointer of CpGridData type.
-    // REFINE A SINGLE CELL
-    // @param cells_per_dim                 Number of sub-cells in each direction.
-    // @param parent_idx                    Parent index.
-    // @return refined_grid_ptr             Shared pointer pointing at refined_grid.
-    //         parent_to_redined_corners    For each corner of the parent cell, we store the index of the
-    //                                      refined corner that coincides with the old one.
-    //                                      We assume they are ordered 0,1,..7
-    //                                                              6---7
-    //                                                      2---3   |   | TOP FACE
-    //                                                      |   |   4---5
-    //                                                      0---1 BOTTOM FACE
-    //         parent_to_children_faces/cellFor each parent face/cell, we store its child face indices.
-    //                                      {parent face/cell index in coarse level, {indices of its children in refined level}}
-    //         child_to_parent_faces/cells  {child index, parent index}
-    //         isParent_faces               True when the face got refined.
-    //         isParent_cells               True when the cell got refined (here only "parent cell").
-    std::tuple< const std::shared_ptr<CpGridData>,
-                const std::vector<std::array<int,2>>,                // parent_to_refined_corners(~boundary_old_to_new_corners)
-                const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces (~boundary_old_to_new_faces)
-                const std::tuple<int, std::vector<int>>,             // parent_to_children_cells
-                const std::vector<std::array<int,2>>,                // child_to_parent_faces
-                const std::vector<std::array<int,2>>,                // child_to_parent_cells
-                const std::map<int,bool>,                            // isParent_faces
-                const std::map<int,bool>>                            // isParent_cells
-    refineSingleCell(const std::array<int,3>& cells_per_dim, const int& parent_idx)
+
+public:
+    /// @brief Refine a single cell and return a shared pointer of CpGridData type.
+    ///
+    /// refineSingleCell() takes a cell and refines it in a chosen amount of cells (per direction); creating the
+    /// geometries, topological relations, etc. Stored in a CpGridData object. Additionally, containers for
+    /// parent-to-new-born entities are buil, as well as, new-born-to-parent. Maps(<int,bool>) to detect parent
+    /// faces or cells are also provided. (Cell with 6 faces required).
+    ///
+    /// @param [in] cells_per_dim                 Number of (refined) cells in each direction that each parent cell should be refined to.
+    /// @param [in] parent_idx                    Parent cell index, cell to be refined.
+    ///
+    /// @return refined_grid_ptr             Shared pointer pointing at refined_grid.
+    /// @return parent_to_refined_corners    For each corner of the parent cell, we store the index of the
+    ///                                           refined corner that coincides with the old one.
+    ///                                           We assume they are ordered 0,1,..7
+    ///                                                              6---7
+    ///                                                      2---3   |   | TOP FACE
+    ///                                                      |   |   4---5
+    ///                                                      0---1 BOTTOM FACE
+    /// @return parent_to_children_faces/cell For each parent face/cell, we store its child-face/cell indices.
+    ///                                            {parent face/cell index in coarse level, {indices of its children in refined level}}
+    /// @return child_to_parent_faces/cells   {child index, parent index}
+    /// @return isParent_faces/cells          Map with all the face/cell indices. True when the face/cell got refined.
+    const std::tuple< const std::shared_ptr<CpGridData>,
+                      const std::vector<std::array<int,2>>,                // parent_to_refined_corners(~boundary_old_to_new_corners)
+                      const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces (~boundary_old_to_new_faces)
+                      const std::tuple<int, std::vector<int>>,             // parent_to_children_cells
+                      const std::vector<std::array<int,2>>,                // child_to_parent_faces
+                      const std::vector<std::array<int,2>>,                // child_to_parent_cells
+                      const std::vector<int>,                              // isParent_faces
+                      const std::vector<int>>                               // isParent_cells
+    refineSingleCell(const std::array<int,3>& cells_per_dim, const int& parent_idx) const
     {
+        // To store the LGR/refined-grid.
         std::shared_ptr<CpGridData> refined_grid_ptr = std::make_shared<CpGridData>(ccobj_);
         auto& refined_grid = *refined_grid_ptr;
         DefaultGeometryPolicy& refined_geometries = refined_grid.geometry_;
@@ -581,173 +478,155 @@ public:
         cpgrid::EntityVariable<enum face_tag,1>& refined_face_tags = refined_grid.face_tag_;
         cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>,1>& refined_face_normals = refined_grid.face_normals_;
         // Get parent cell
-        cpgrid::Geometry<3,3> parent_cell = geometry_.geomVector(std::integral_constant<int,0>())[EntityRep<0>(parent_idx, true)];
-        // Refine parent cell
-        parent_cell.refine(cells_per_dim,
-                           refined_geometries,
-                           refined_cell_to_point,
-                           refined_cell_to_face,
-                           refined_face_to_point,
-                           refined_face_to_cell,
-                           refined_face_tags,
-                           refined_face_normals);
-
+        const cpgrid::Geometry<3,3>& parent_cell = geometry_.geomVector(std::integral_constant<int,0>())[EntityRep<0>(parent_idx, true)];
         // Get parent cell corners.
-        std::array<int,8> parent_to_point = this->cell_to_point_[parent_idx];
-        std::vector<std::array<int,2>> parent_to_refined_corners{
-            // replacing parent-cell corner '0'
+        const std::array<int,8>& parent_to_point = this->cell_to_point_[parent_idx];
+        if (parent_to_point.size() != 8){
+            OPM_THROW(std::logic_error, "Cell is not a hexahedron. Cannot be refined (yet).");
+        }
+        // Refine parent cell
+        parent_cell.refine(cells_per_dim, refined_geometries, refined_cell_to_point, refined_cell_to_face,
+                           refined_face_to_point, refined_face_to_cell, refined_face_tags, refined_face_normals);
+        const std::vector<std::array<int,2>>& parent_to_refined_corners{
+            // corIdx (J*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (I*(cells_per_dim[2]+1)) +K
+            // replacing parent-cell corner '0' {0,0,0}
             {parent_to_point[0], 0},
-            // replacing parent-cell corner '1'
+                // replacing parent-cell corner '1' {cells_per_dim[0], 0, 0}
             {parent_to_point[1], cells_per_dim[0]*(cells_per_dim[2]+1)},
-            // replacing parent-cell corner '2'
+                // replacing parent-cell corner '2' {0, cells_perd_dim[1], 0}
             {parent_to_point[2], cells_per_dim[1]*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)},
-            // replacing parent-cell corner '3'
+                // replacing parent-cell corner '3' {cells_per_dim[0], cells_per_dim[1], 0}
             {parent_to_point[3], (cells_per_dim[1]*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (cells_per_dim[0]*(cells_per_dim[2]+1))},
-            // replacing parent-cell corner '4'
+                // replacing parent-cell corner '4' {0, 0, cells_per_dim[2]}
             {parent_to_point[4], cells_per_dim[2]},
-            // replacing parent-cell corner '5'
+                // replacing parent-cell corner '5' {cells_per_dim[0], 0, cells_per_dim[2]}
             {parent_to_point[5], (cells_per_dim[0]*(cells_per_dim[2]+1)) + cells_per_dim[2]},
-            // replacing parent-cell corner '6'
-            {parent_to_point[6], cells_per_dim[1]*(cells_per_dim[0]+1)*(cells_per_dim[2]+1) + cells_per_dim[2]},
-            // replacing parent-cell corner '7'
+                // replacing parent-cell corner '6' {0, cells_per_dim[1], cells_per_dim[2]}
+            {parent_to_point[6], (cells_per_dim[1]*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + cells_per_dim[2]},
+                // replacing parent-cell corner '7' {cells_per_dim[0], cells_per_dim[1], cells_per_dim[2]}
             {parent_to_point[7], (cells_per_dim[1]*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (cells_per_dim[0]*(cells_per_dim[2]+1))
-             + cells_per_dim[2]}};
-        // Get relation old face -> new born faces (children faces)
+                    + cells_per_dim[2]}};
+        // Get parent_cell_to_face = { {face, orientation}, {another face, its orientation}, ...}.
+        const auto& parent_cell_to_face = (this-> cell_to_face_[EntityRep<0>(parent_idx, true)]);
+        // To store relation old-face to new-born-faces (children faces).
         std::vector<std::tuple<int,std::vector<int>>>  parent_to_children_faces;
-        // Get parent_cell_to_face = { {face, orientation}, {another face, its orientation}, ...}
-        auto parent_cell_to_face = (this-> cell_to_face_[EntityRep<0>(parent_idx, true)]);
-        //
+        parent_to_children_faces.reserve(6);
+        // To store child-to-parent-face relation. Child-faces ordered with the criteria introduced in refine()(Geometry.hpp)K,I,Jfaces.
         std::vector<std::array<int,2>> child_to_parent_faces;
         child_to_parent_faces.reserve(refined_face_to_cell.size());
-        // Children faces are ordered following the criteria introduced in refine(), Geometry.hpp.
-        // First K_FACES, then I_FACES, then J_FACES.
-        int k_faces = cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1);
-        int i_faces = (cells_per_dim[0]+1)*cells_per_dim[1]*cells_per_dim[2];
-        for (auto& face : parent_cell_to_face) {
+        // Auxiliary integers to simplify new-born-face-index notation.
+        const int& k_faces = cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1);
+        const int& i_faces = (cells_per_dim[0]+1)*cells_per_dim[1]*cells_per_dim[2];
+        // Populate parent_to_children_faces and child_to_parent_faces.
+        for (const auto& face : parent_cell_to_face) {
             // Check face tag to identify the type of face (bottom, top, left, right, front, or back).
-            auto parent_face_tag = (this-> face_tag_[Dune::cpgrid::EntityRep<1>(face.index(), true)]);
+            auto& parent_face_tag = (this-> face_tag_[Dune::cpgrid::EntityRep<1>(face.index(), true)]);
             // To store the new born faces for each face.
-            std::vector<int> children_faces;
+            std::vector<int> children_faces; // Cannot reserve/resize "now", it depends of the type of face.
             // K_FACES
             if (parent_face_tag == face_tag::K_FACE) {
                 children_faces.reserve(cells_per_dim[0]*cells_per_dim[1]);
                 for (int j = 0; j < cells_per_dim[1]; ++j) {
                     for (int i = 0; i < cells_per_dim[0]; ++i) {
-                        if (!face.orientation()) { // false -> BOTTOM FACE -> k=0
-                            children_faces.push_back((j*cells_per_dim[0]) + i);
-                            child_to_parent_faces.push_back({(j*cells_per_dim[0]) + i, face.index()});
-                        }
-                        else { // true -> TOP FACE -> k=cells_per_dim[2]
-                            children_faces.push_back((cells_per_dim[2]*cells_per_dim[0]*cells_per_dim[1])
-                                                     +(j*cells_per_dim[0]) + i);
-                            child_to_parent_faces.push_back({(cells_per_dim[2]*cells_per_dim[0]*cells_per_dim[1])
-                                    +(j*cells_per_dim[0]) + i, face.index()});
-                        }
-                    }
-                }
-            }
+                        int child_face;
+                        if (!face.orientation()) // false -> BOTTOM FACE -> k=0
+                            child_face = (j*cells_per_dim[0]) + i;
+                        else // true -> TOP FACE -> k=cells_per_dim[2]
+                            child_face = (cells_per_dim[2]*cells_per_dim[0]*cells_per_dim[1]) +(j*cells_per_dim[0]) + i;
+                        children_faces.push_back(child_face);
+                        child_to_parent_faces.push_back({child_face, face.index()});
+                    } // i-for-lopp
+                } //j-for-loop
+            } // if-K_FACE
             // I_FACES
             if (parent_face_tag == face_tag::I_FACE) {
                 children_faces.reserve(cells_per_dim[1]*cells_per_dim[2]);
                 for (int k = 0; k < cells_per_dim[2]; ++k) {
                     for (int j = 0; j < cells_per_dim[1]; ++j) {
-                        if (!face.orientation()) { // false -> LEFT FACE -> i=0
-                            children_faces.push_back(k_faces + (k*cells_per_dim[1]) + j);
-                            child_to_parent_faces.push_back({k_faces + (k*cells_per_dim[1]) + j, face.index()});
-                        }
-                        else { // true -> RIGHT FACE -> i=cells_per_dim[0]
-                            children_faces.push_back(k_faces + (cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2])
-                                                     + (k*cells_per_dim[1]) + j);
-                            child_to_parent_faces.push_back({k_faces + (cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2])
-                                    + (k*cells_per_dim[1]) + j, face.index()});
-                        }
-                    }
-                }
-            }
+                        int child_face;
+                        if (!face.orientation()) // false -> LEFT FACE -> i=0
+                            child_face = k_faces + (k*cells_per_dim[1]) + j;
+                        else // true -> RIGHT FACE -> i=cells_per_dim[0]
+                            child_face = k_faces + (cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]) + (k*cells_per_dim[1]) + j;
+                        children_faces.push_back(child_face);
+                        child_to_parent_faces.push_back({child_face, face.index()});
+                    } // j-for-loop
+                } // k-for-loop
+            } // if-I_FACE
             // J_FACES
             if (parent_face_tag == face_tag::J_FACE) {
                 children_faces.reserve(cells_per_dim[0]*cells_per_dim[2]);
                 for (int i = 0; i < cells_per_dim[0]; ++i) {
                     for (int k = 0; k < cells_per_dim[2]; ++k) {
-                        if (!face.orientation()) { // false -> FRONT FACE -> j=0
-                            children_faces.push_back(k_faces + i_faces + (i*cells_per_dim[2]) + k);
-                            child_to_parent_faces.push_back({k_faces + i_faces + (i*cells_per_dim[2]) + k, face.index()});
-                        }
-                        else { // true -> BACK FACE -> j=cells_per_dim[1]
-                            children_faces.push_back(k_faces + i_faces  + (cells_per_dim[1]*cells_per_dim[0]*cells_per_dim[2])
-                                                     + (i*cells_per_dim[2]) + k);
-                            child_to_parent_faces.push_back({k_faces + i_faces  + (cells_per_dim[1]*cells_per_dim[0]*cells_per_dim[2])
-                                    + (i*cells_per_dim[2]) + k, face.index()});
-                        }
-                    }
-                }
-            }
-            std::tuple<int,std::vector<int>> aux_tuple = std::make_tuple(face.index(), children_faces);
-            parent_to_children_faces.push_back(aux_tuple);
+                        int child_face;
+                        if (!face.orientation()) // false -> FRONT FACE -> j=0
+                            child_face = k_faces + i_faces + (i*cells_per_dim[2]) + k;
+                        else  // true -> BACK FACE -> j=cells_per_dim[1]
+                            child_face = k_faces + i_faces  + (cells_per_dim[1]*cells_per_dim[0]*cells_per_dim[2])
+                                + (i*cells_per_dim[2]) + k;
+                        children_faces.push_back(child_face);
+                        child_to_parent_faces.push_back({child_face, face.index()});
+                    } // k-for-loop
+                } // i-for-loop
+            } // if-J_FACE
+            parent_to_children_faces.push_back(std::make_tuple(face.index(), children_faces));
         }
-        // PARENT TO CHILDREN CELLS
-        std::vector<int> children_cells;
-        // Child to parent cell
-        std::vector<std::array<int, 2>> child_to_parent_cell;
+        std::tuple<int, std::vector<int>> parent_to_children_cells;
+        auto& [ parent_index, children_cells ] = parent_to_children_cells;
         children_cells.reserve(cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]);
+        // To store the child to parent cell relation.
+        std::vector<std::array<int,2>> child_to_parent_cell;
         child_to_parent_cell.reserve(cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]);
+        // Populate children_cells and child_to_parent_cell.
         for (int cell = 0; cell < cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]; ++cell) {
             children_cells.push_back(cell);
             child_to_parent_cell.push_back({cell, parent_idx});
         }
-
-
-        std::tuple<int, std::vector<int>> parent_to_children_cells =
-            std::make_tuple(parent_idx, children_cells);
-        // IS PARENT - FACES
-        // Map {index face, true/false}
-        // true-> the face got refined (has children), false -> the face hasn't been refined (does not have children).
-        std::map<int,bool> isParent_faces;
-        for (int face = 0; face < this-> face_to_cell_.size(); ++face) {
-            isParent_faces[face] = false;
-        }
+        // To identify a parent face {index face, true/false}. True when it got refined.
+        std::vector<int> isParent_faces(face_to_cell_.size(), false);
         // Rewrite the entries of the map for those faces that got refined.
-        for (auto& face : parent_cell_to_face) {
+        for (const auto& face : parent_cell_to_face) {
             isParent_faces[face.index()] = true;
         }
-        // IS PARENT - CELLS
-        // Map {index cell, true/false}
-        // true-> cell got refined (has children), false -> cell hasn't been refined (does not have children).
-        std::map<int,bool> isParent_cells;
-        for (int cell = 0; cell < this-> size(0); ++cell) {
-            isParent_cells[cell] = false;
-        }
-        // Rewrite the entries of the map for those faces that got refined.
+        // To identify the parent cell (only one in this case). {index cell, true/false}. True when it got refined.
+        std::vector<int> isParent_cells(this-> size(0), false);
+        // Rewrite the entry of the map for the single parent cell that got refined.
         isParent_cells[parent_idx] = true;
-
-        return {refined_grid_ptr, parent_to_refined_corners,
-            parent_to_children_faces, parent_to_children_cells, child_to_parent_faces, child_to_parent_cell,
-            isParent_faces, isParent_cells};
+        return {refined_grid_ptr, parent_to_refined_corners, parent_to_children_faces, parent_to_children_cells,
+            child_to_parent_faces, child_to_parent_cell, isParent_faces, isParent_cells};
     }
-    // Refine a (connected block of cells) patch
-    // REFINE A PATCH of CONNECTED (CONSECUTIVE in each direction) cells with 'uniform' regular intervals.
-    // (meaning that the amount of children per cell is the same for all parent cells (cells of the patch)).
-    // @param cells_per_dim                       Number of sub-cells in each direction (for each cell).
-    // @param start_ijk                           Minimum values of i,j,k to construct the patch (start).
-    // @param end_ijk                             Maximum values of i,j,k to construct the patch (end).
-    // @return refined_grid_ptr                   Shared pointer of CpGridData type, pointing at the refined_grid
-    //         boundary_old_to_new_corners/faces  Corners/faces on the boundary of the patch get replaced by new born refined one(s).
-    //         parent_to_children_faces/cells     To store the indices of 'all the face/cell children' of each parent.
-    //         child_to_parent_faces/cells        For each child-face, we store its parent face index.
-    //         isParent_faces/cells               True for each face/cell that got refined.
 
-    std::tuple<std::shared_ptr<CpGridData>,
-               const std::vector<std::array<int,2>>,                // boundary_old_to_new_corners
-               const std::vector<std::tuple<int,std::vector<int>>>, // boundary_old_to_new_faces
-               const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces
-               const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_cell
-               const std::vector<std::array<int,2>>,                // child_to_parent_faces
-               const std::vector<std::array<int,2>>,                // child_to_parent_cells
-               const std::map<int,bool>,                            // isParent_faces
-               const std::map<int,bool>>                            // isParent_cells
-    refineBlockPatch(const std::array<int,3>& cells_per_dim,
-                     const std::array<int,3>& start_ijk, const std::array<int,3>& end_ijk)
+    /// @brief Refine a (connected block-shaped) patch of cells. Based on the patch, a Geometry<3,3> object is created and refined.
+    ///
+    /// @param [in] cells_per_dim            Number of (refined) cells in each direction that each parent cell should be refined to.
+    /// @param [in] startIJK                 Cartesian triplet index where the patch starts.
+    /// @param [in] endIJK                   Cartesian triplet index where the patch ends.
+    ///
+    /// @return refined_grid_ptr                   Shared pointer of CpGridData type, pointing at the refined_grid
+    /// @return boundary_old_to_new_corners/faces  Corner/face indices on the patch-boundary associated with new-born-entity indices.
+    /// @return parent_to_children_faces/cell      For each parent face/cell, we store its child-face/cell indices.
+    ///                                            {parent face/cell index in coarse level, {indices of its children in refined level}}
+    /// @return child_to_parent_faces/cells        {child index, parent index}
+    /// @return isParent_faces/cells               Map with all the face/cell indices. True when the face/cell got refined.
+    const std::tuple<std::shared_ptr<CpGridData>,
+                     const std::vector<std::array<int,2>>,                // boundary_old_to_new_corners
+                     const std::vector<std::tuple<int,std::vector<int>>>, // boundary_old_to_new_faces
+                     const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces
+                     const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_cell
+                     const std::vector<std::array<int,2>>,                // child_to_parent_faces
+                     const std::vector<std::array<int,2>>,                // child_to_parent_cells
+                     const std::vector<int>,                            // isParent_faces
+                     const std::vector<int>>                            // isParent_cells
+    refinePatch(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
     {
+        // Coarse grid dimension (amount of cells in each direction).
+        const std::array<int,3>& grid_dim = this -> logicalCartesianSize();
+        // Check that the grid is a Cartesian one.
+        long unsigned int gXYZ = grid_dim[0]*grid_dim[1]*grid_dim[2];
+        if (global_cell_.size() != gXYZ){
+            OPM_THROW(std::logic_error, "Grid is not Cartesian. Patch cannot be refined.");
+        }
+        // To store LGR/refined-grid.
         std::shared_ptr<CpGridData> refined_grid_ptr = std::make_shared<CpGridData>(ccobj_);
         auto& refined_grid = *refined_grid_ptr;
         DefaultGeometryPolicy& refined_geometries = refined_grid.geometry_;
@@ -757,115 +636,105 @@ public:
         cpgrid::OrientedEntityTable<1,0>& refined_face_to_cell = refined_grid.face_to_cell_;
         cpgrid::EntityVariable<enum face_tag,1>& refined_face_tags = refined_grid.face_tag_;
         cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>,1>& refined_face_normals = refined_grid.face_normals_;
-
-        // Patch information (built from the grid).
-        const auto& patch_dim = getPatchDim(start_ijk, end_ijk);
-        // Coarse grid dimension
-        const std::array<int,3>& grid_dim = this -> logicalCartesianSize();
-        // If the patch contains only one cell:
+        // Patch dimension (amount of cells in each direction).
+        const auto& patch_dim = getPatchDim(startIJK, endIJK);
+        // If the patch contains only one cell, use refineSingleCell() to avoid unnecessary computations.
         if ((patch_dim[0] == 1) && (patch_dim[1] == 1) && (patch_dim[2] == 1)){
-            const int& parent_cell = (start_ijk[2]*grid_dim[0]*grid_dim[1]) + (start_ijk[1]*grid_dim[0]) +start_ijk[0];
             auto [refined_grid_ptr0, parent_to_refined_corners,
                   parent_to_children_faces, parent_to_children_cells,child_to_parent_faces, child_to_parent_cell,
-                  isParent_faces, isParent_cells] = this->refineSingleCell(cells_per_dim, parent_cell);
-            // When the patch is only one cell,
+                  isParent_faces, isParent_cells] =
+                this->refineSingleCell(cells_per_dim,(startIJK[2]*grid_dim[0]*grid_dim[1]) + (startIJK[1]*grid_dim[0]) + startIJK[0]);
+            // When the patch contains only one cell:
             // - boundary_old_to_new_corners == parent_to_refined_corners.
             // - boundary_old_to_new_faces == parent_to_children_faces.
             // Fix the type of parent_to_children_cells to return it correctly.
-            std::vector<std::tuple<int, std::vector<int>>> parent_to_children_cells_vec = {parent_to_children_cells};
-            return {refined_grid_ptr0, parent_to_refined_corners,
-                parent_to_children_faces, parent_to_children_faces, parent_to_children_cells_vec,
-                child_to_parent_faces, child_to_parent_cell,
-                isParent_faces, isParent_cells};
+            const std::vector<std::tuple<int, std::vector<int>>> parent_to_children_cells_vec = {parent_to_children_cells};
+            return {refined_grid_ptr0, parent_to_refined_corners, parent_to_children_faces, parent_to_children_faces,
+                parent_to_children_cells_vec, child_to_parent_faces, child_to_parent_cell, isParent_faces, isParent_cells};
         }
         // When the patch consists in more than one cell:
         else {
-            const auto& [patch_corners, patch_faces, patch_cells] = getPatchGeomIndices(start_ijk, end_ijk); 
-            // Construct the Geometry of the CEELfied PATCH.
-            cpgrid::Geometry<3,3> cellfied_patch = this -> cellfyPatch(patch_cells);
-            
+            const auto& [patch_corners, patch_faces, patch_cells] = getPatchGeomIndices(startIJK, endIJK);
+            // Construct the Geometry of the cellified patch.
+            DefaultGeometryPolicy cellified_patch_geometry;
+            std::array<int,8> cellifiedPatch_to_point;
+            std::array<int,8> allcorners_cellifiedPatch;
+            cpgrid::Geometry<3,3> cellified_patch = this -> cellifyPatch(startIJK, endIJK, patch_cells, cellified_patch_geometry,
+                                                                         cellifiedPatch_to_point, allcorners_cellifiedPatch);
             // Some integers to reduce notation later.
-            int xfactor = cells_per_dim[0]*patch_dim[0];
-            int yfactor = cells_per_dim[1]*patch_dim[1];
-            int zfactor = cells_per_dim[2]*patch_dim[2];
-            // Refine the cell "cellfied_patch"
-            cellfied_patch.refine({xfactor, yfactor, zfactor},
-                                  refined_geometries,
-                                  refined_cell_to_point,
-                                  refined_cell_to_face,
-                                  refined_face_to_point,
-                                  refined_face_to_cell,
-                                  refined_face_tags,
-                                  refined_face_normals);
-            // For each cell of the patch, we select the 8 refined corners that coincide with the
-            // original cell corners, and the refined child-faces that ('all' together) 'coincide' with
-            // each of the 6 original faces of the cell.
-            // To store the 8 new refined corners coinciding with the 8 original corners of each cell of the patch,
-            // we choose a map, key = cell index in the coarse grid, value = {{old corner '0', new corner '0'}, ...}
+            const int& xfactor = cells_per_dim[0]*patch_dim[0];
+            const int& yfactor = cells_per_dim[1]*patch_dim[1];
+            const int& zfactor = cells_per_dim[2]*patch_dim[2];
+            // Refine the "cellified_patch".
+            cellified_patch.refine({xfactor, yfactor, zfactor}, refined_geometries, refined_cell_to_point, refined_cell_to_face,
+                                   refined_face_to_point, refined_face_to_cell, refined_face_tags, refined_face_normals);
+            // To store the relation between old-corner-indices and the equivalent new-born ones (laying on the patch boundary).
             std::vector<std::array<int,2>> boundary_old_to_new_corners;
-            // RESERVE?
-            for (int j = start_ijk[1]; j < end_ijk[1]+1; ++j) {
-                for (int i = start_ijk[0]; i < end_ijk[0]+1; ++i) {
-                    for (int k = start_ijk[2]; k < end_ijk[2]+1; ++k) {
-                        // WE ARE ASSUMING THE GRID FROM LEVEL 0 HAS THE DUNE NUMBERING FOR CORNERS.
-                        if ( (j == start_ijk[1]) || (j == end_ijk[1]) ){
-                            int old_corner_idx = (j*(grid_dim[2]+1)*(grid_dim[0]+1)) + (i*(grid_dim[2]+1)) + k;
-                            int new_corner_idx = (cells_per_dim[1]*(j-start_ijk[1])*(xfactor +1)*(zfactor +1))
-                                + (cells_per_dim[0]*(i-start_ijk[0])*(zfactor +1))
-                                + (cells_per_dim[2]*(k-start_ijk[2]));
-                            boundary_old_to_new_corners.push_back({old_corner_idx, new_corner_idx});
+            boundary_old_to_new_corners.reserve((2*(cells_per_dim[0]+1)*(cells_per_dim[2]+1))
+                                                + (2*(cells_per_dim[1]-1)*(cells_per_dim[2]+1))
+                                                + (2*(cells_per_dim[0]-1)*(cells_per_dim[1]-1)));
+            for (int j = startIJK[1]; j < endIJK[1]+1; ++j) {
+                for (int i = startIJK[0]; i < endIJK[0]+1; ++i) {
+                    for (int k = startIJK[2]; k < endIJK[2]+1; ++k) {
+                        if ( (j == startIJK[1]) || (j == endIJK[1]) ){ // Corners in the front/back of the patch.
+                            boundary_old_to_new_corners.push_back({
+                                    // Old corner index
+                                    (j*(grid_dim[2]+1)*(grid_dim[0]+1)) + (i*(grid_dim[2]+1)) + k,
+                                    // New-born corner index (equivalent corner).
+                                    (cells_per_dim[1]*(j-startIJK[1])*(xfactor +1)*(zfactor +1))
+                                    + (cells_per_dim[0]*(i-startIJK[0])*(zfactor +1))
+                                    + (cells_per_dim[2]*(k-startIJK[2])) });
                         }
-                        if ( (i == start_ijk[0]) || (i == end_ijk[0]) ) {
-                            int old_corner_idx = (j*(grid_dim[2]+1)*(grid_dim[0]+1)) + (i*(grid_dim[2]+1)) + k;
-                            int new_corner_idx = (cells_per_dim[1]*(j-start_ijk[1])*(xfactor +1)*(zfactor +1))
-                                + (cells_per_dim[0]*(i-start_ijk[0])*(zfactor +1))
-                                + (cells_per_dim[2]*(k-start_ijk[2]));
-                            boundary_old_to_new_corners.push_back({old_corner_idx, new_corner_idx});
+                        if ( (i == startIJK[0]) || (i == endIJK[0]) ) { // Corners in the left/right of the patch.
+                            boundary_old_to_new_corners.push_back({
+                                    // Old corner index.
+                                    (j*(grid_dim[2]+1)*(grid_dim[0]+1)) + (i*(grid_dim[2]+1)) + k,
+                                    // New-born corner index (equivalent corner).
+                                    (cells_per_dim[1]*(j-startIJK[1])*(xfactor +1)*(zfactor +1))
+                                    + (cells_per_dim[0]*(i-startIJK[0])*(zfactor +1))
+                                    + (cells_per_dim[2]*(k-startIJK[2]))});
                         }
-                        if ( (k == start_ijk[2]) || (k == end_ijk[2]) ) {
-                            int old_corner_idx = (j*(grid_dim[2]+1)*(grid_dim[0]+1)) + (i*(grid_dim[2]+1)) + k;
-                            int new_corner_idx = (cells_per_dim[1]*(j-start_ijk[1])*(xfactor +1)*(zfactor +1))
-                                + (cells_per_dim[0]*(i-start_ijk[0])*(zfactor +1))
-                                + (cells_per_dim[2]*(k-start_ijk[2]));
-                            boundary_old_to_new_corners.push_back({old_corner_idx, new_corner_idx});
+                        if ( (k == startIJK[2]) || (k == endIJK[2]) ) { // Corners in the bottom/top of the patch.
+                            boundary_old_to_new_corners.push_back({
+                                    // Old corner index.
+                                    (j*(grid_dim[2]+1)*(grid_dim[0]+1)) + (i*(grid_dim[2]+1)) + k,
+                                    // New-born corner index (equivalent corner)
+                                    (cells_per_dim[1]*(j-startIJK[1])*(xfactor +1)*(zfactor +1))
+                                    + (cells_per_dim[0]*(i-startIJK[0])*(zfactor +1))
+                                    + (cells_per_dim[2]*(k-startIJK[2]))});
                         }
                     } // end k-for-loop
                 } // end i-for-loop
             } // end j-for-loop
-
-            // FACE STUFF
-            // Boundary patch faces.
+            // To store face-indices of faces on the boundary of the patch.
             std::vector<int> boundary_patch_faces;
             // Auxiliary integers to simplify notation.
-            int bound_patch_faces = 2*patch_dim[1]*patch_dim[2] // left/right boundary
-            +  patch_dim[0]*2*patch_dim[2] // front/back boundary
-            + patch_dim[0]*patch_dim[1]*2; // bottom/top boundary
+            const int& bound_patch_faces = (2*patch_dim[1]*patch_dim[2]) + (patch_dim[0]*2*patch_dim[2]) + (patch_dim[0]*patch_dim[1]*2);
             boundary_patch_faces.reserve(bound_patch_faces);
-            // Boundary old faces associated with its (new born) children faces.
-            std::vector<std::tuple<int, std::vector<int>>> boundary_old_to_new_faces; // {face index, its children indices}
+            // To store relation between old-face-index and its new-born-face indices.
+            std::vector<std::tuple<int, std::vector<int>>> boundary_old_to_new_faces; // {face index, its children-indices}
             boundary_old_to_new_faces.reserve(bound_patch_faces);
             // Auxiliary integers to simplify notation.
-            int i_grid_faces =  (grid_dim[0]+1)*grid_dim[1]*grid_dim[2];
-            int j_grid_faces =  grid_dim[0]*(grid_dim[1]+1)*grid_dim[2];
-            // Parent to children faces (all faces of the patch, not only the ones on the boundary).
+            const int& i_grid_faces =  (grid_dim[0]+1)*grid_dim[1]*grid_dim[2];
+            const int& j_grid_faces =  grid_dim[0]*(grid_dim[1]+1)*grid_dim[2];
+            // To store relation bewteen parent face and its children (all faces of the patch, not only the ones on the boundary).
             std::vector<std::tuple<int,std::vector<int>>> parent_to_children_faces;
             parent_to_children_faces.reserve(patch_faces.size());
-            // For each child, we associate it with its parent.
+            // To store relation child-face-index and its parent-face-index.
             std::vector<std::array<int,2>> child_to_parent_faces; // {child index (in 'level 1'), parent index (in 'level 0')}
             child_to_parent_faces.reserve(refined_face_to_cell.size());
+            // Populate child_to_parent_faces, parent_to_children_faces, boundary_old_to_new_faces, boundary_faces.
             // I_FACES
-            for (int j = start_ijk[1]; j < end_ijk[1]; ++j) {
-                for (int i = start_ijk[0]; i < end_ijk[0]+1; ++i) {
-                    for (int k = start_ijk[2]; k < end_ijk[2]; ++k) {
+            for (int j = startIJK[1]; j < endIJK[1]; ++j) {
+                for (int i = startIJK[0]; i < endIJK[0]+1; ++i) {
+                    for (int k = startIJK[2]; k < endIJK[2]; ++k) {
                         int face_idx = (j*grid_dim[1]*grid_dim[2]) + (i*grid_dim[2])+ k;
-                        // Vector to store new born faces, per face.
-                        // CHILDREN FACES ARE ORDERED AS IN refine(), Geometry.hpp
+                        // To store new born faces, per face. CHILDREN-FACES ARE ORDERED AS IN refine(), Geometry.hpp
                         std::vector<int> children_list;  // I_FACE ikj (xzy-direction)
-                        // l,m,n play the role of 'x,y,z-direction'
-                        // lnm = fake ikj (how I_FACES are 'ordered' in refine())
-                        for (int l = (i-start_ijk[0])*cells_per_dim[0]; l < (i-start_ijk[0]+1)*cells_per_dim[0]; ++l) {
-                            for (int n = (k-start_ijk[2])*cells_per_dim[2];n < (k-start_ijk[2]+1)*cells_per_dim[2]; ++n) {
-                                for (int m = (j-start_ijk[1])*cells_per_dim[1]; m < (j-start_ijk[1]+1)*cells_per_dim[1]; ++m) {
+                        // l,m,n play the role of 'x,y,z-direction', lnm = fake ikj (how I_FACES are 'ordered' in refine())
+                        for (int l = (i-startIJK[0])*cells_per_dim[0]; l < (i-startIJK[0]+1)*cells_per_dim[0]; ++l) {
+                            for (int n = (k-startIJK[2])*cells_per_dim[2];n < (k-startIJK[2]+1)*cells_per_dim[2]; ++n) {
+                                for (int m = (j-startIJK[1])*cells_per_dim[1]; m < (j-startIJK[1]+1)*cells_per_dim[1]; ++m) {
                                     children_list.push_back((xfactor*yfactor*(zfactor+1)) +(l*yfactor*zfactor) + (n*yfactor) + m);
                                     child_to_parent_faces.push_back({(xfactor*yfactor*(zfactor+1)) +(l*yfactor*zfactor)
                                             + (n*yfactor) + m, face_idx});
@@ -874,7 +743,7 @@ public:
                         } // end l-for-loop
                         // Add parent information of each face to "parent_to_children_faces".
                         parent_to_children_faces.push_back(std::make_tuple(face_idx, children_list));
-                        if ((i == start_ijk[0]) || (i == end_ijk[0])) {
+                        if ((i == startIJK[0]) || (i == endIJK[0])) { // Detecting if the face is on the patch boundary.
                             boundary_patch_faces.push_back(face_idx);
                             // Associate each old face on the boundary of the patch with the new born ones.
                             boundary_old_to_new_faces.push_back(std::make_tuple(face_idx, children_list));
@@ -883,18 +752,16 @@ public:
                 } // end i-for-loop
             } // end j-for-loop
             // J_FACES
-            for (int j = start_ijk[1]; j < end_ijk[1]+1; ++j) {
-                for (int i = start_ijk[0]; i < end_ijk[0]; ++i) {
-                    for (int k = start_ijk[2]; k < end_ijk[2]; ++k) {
+            for (int j = startIJK[1]; j < endIJK[1]+1; ++j) {
+                for (int i = startIJK[0]; i < endIJK[0]; ++i) {
+                    for (int k = startIJK[2]; k < endIJK[2]; ++k) {
                         int face_idx = i_grid_faces + (j*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2])+ k;
-                        // Vector to store new born faces, per face.
-                        // CHILDREN FACES ARE ORDERED AS IN refine(), Geometry.hpp
+                        // To store new born faces, per face. CHILDREN FACES ARE ORDERED AS IN refine(), Geometry.hpp
                         std::vector<int> children_list;  // J_FACE jik (yxz-direction)
-                        // l,m,n play the role of 'x,y,z-direction'
-                        // mln = fake jik (how J_FACES are 'ordered' in refine())
-                        for (int m = (j-start_ijk[1])*cells_per_dim[1]; m < (j-start_ijk[1]+1)*cells_per_dim[1]; ++m) {
-                            for (int l = (i-start_ijk[0])*cells_per_dim[0]; l < (i-start_ijk[0]+1)*cells_per_dim[0]; ++l) {
-                                for (int n = (k-start_ijk[2])*cells_per_dim[2]; n < (k-start_ijk[2]+1)*cells_per_dim[2]; ++n) {
+                        // l,m,n play the role of 'x,y,z-direction', mln = fake jik (how J_FACES are 'ordered' in refine())
+                        for (int m = (j-startIJK[1])*cells_per_dim[1]; m < (j-startIJK[1]+1)*cells_per_dim[1]; ++m) {
+                            for (int l = (i-startIJK[0])*cells_per_dim[0]; l < (i-startIJK[0]+1)*cells_per_dim[0]; ++l) {
+                                for (int n = (k-startIJK[2])*cells_per_dim[2]; n < (k-startIJK[2]+1)*cells_per_dim[2]; ++n) {
                                     children_list.push_back((xfactor*yfactor*(zfactor+1)) + ((xfactor+1)*yfactor*zfactor)
                                                             + (m*xfactor*zfactor) + (l*zfactor)+n);
                                     child_to_parent_faces.push_back({(xfactor*yfactor*(zfactor+1)) + ((xfactor+1)*yfactor*zfactor)
@@ -904,7 +771,7 @@ public:
                         } // end m-for-loop
                         // Add parent information of each face to "parent_to_children_faces".
                         parent_to_children_faces.push_back(std::make_tuple(face_idx, children_list));
-                        if ((j == start_ijk[1]) || (j == end_ijk[1])) {
+                        if ((j == startIJK[1]) || (j == endIJK[1])) { // Detecting if face is on the patch boundary.
                             boundary_patch_faces.push_back(face_idx);
                             // Associate each old face on the boundary of the patch with the new born ones.
                             boundary_old_to_new_faces.push_back(std::make_tuple(face_idx, children_list));
@@ -913,18 +780,16 @@ public:
                 } // end i-for-loop
             } // end j-for-loop
             // K_FACES
-            for (int j = start_ijk[1]; j < end_ijk[1]; ++j) {
-                for (int i = start_ijk[0]; i < end_ijk[0]; ++i) {
-                    for (int k = start_ijk[2]; k < end_ijk[2]+1; ++k) {
+            for (int j = startIJK[1]; j < endIJK[1]; ++j) {
+                for (int i = startIJK[0]; i < endIJK[0]; ++i) {
+                    for (int k = startIJK[2]; k < endIJK[2]+1; ++k) {
                         int face_idx = i_grid_faces + j_grid_faces + (j*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2])+ k;
-                        // Vector to store new born faces, per face.
-                        // CHILDREN FACES ARE ORDERED AS IN refine(), Geometry.hpp
+                        // To store new born faces, per face. CHILDREN FACES ARE ORDERED AS IN refine(), Geometry.hpp
                         std::vector<int> children_list;  // K_FACE kji (zyx-direction)
-                        // l,m,n play the role of 'x,y,z-direction'
-                        // nml = fake kji (how K_FACES are 'ordered' in refine())
-                        for (int n = (k-start_ijk[2])*cells_per_dim[2]; n < (k-start_ijk[2]+1)*cells_per_dim[2]; ++n) {
-                            for (int m = (j-start_ijk[1])*cells_per_dim[1]; m < (j-start_ijk[1]+1)*cells_per_dim[1]; ++m) {
-                                for (int l = (i-start_ijk[0])*cells_per_dim[0]; l < (i-start_ijk[0]+1)*cells_per_dim[0]; ++l) {
+                        // l,m,n play the role of 'x,y,z-direction', nml = fake kji (how K_FACES are 'ordered' in refine())
+                        for (int n = (k-startIJK[2])*cells_per_dim[2]; n < (k-startIJK[2]+1)*cells_per_dim[2]; ++n) {
+                            for (int m = (j-startIJK[1])*cells_per_dim[1]; m < (j-startIJK[1]+1)*cells_per_dim[1]; ++m) {
+                                for (int l = (i-startIJK[0])*cells_per_dim[0]; l < (i-startIJK[0]+1)*cells_per_dim[0]; ++l) {
                                     children_list.push_back((n*xfactor*yfactor) + (m*xfactor)+ l);
                                     child_to_parent_faces.push_back({(n*xfactor*yfactor) + (m*xfactor)+ l, face_idx});
                                 } // end m-for-loop
@@ -932,7 +797,7 @@ public:
                         } // end l-for-loop
                           // Add parent information of each face to "parent_to_children_faces".
                         parent_to_children_faces.push_back(std::make_tuple(face_idx, children_list));
-                        if ((k == start_ijk[2]) || (k == end_ijk[2])) {
+                        if ((k == startIJK[2]) || (k == endIJK[2])) { // Detecting if the face is on the patch boundary.
                             boundary_patch_faces.push_back(face_idx);
                             // Associate each old face on the boundary of the patch with the new born ones.
                             boundary_old_to_new_faces.push_back(std::make_tuple(face_idx, children_list));
@@ -940,29 +805,23 @@ public:
                     } // end k-for-loop
                 } // end i-for-loop
             } // end j-for-loop
-            //--- END PARENT TO CHILDREN FACES / child_to_parent_faces ---
-
-            // PARENT TO CHILDREN - CELLS  / child_to_parent_cells
-            //
-            // To store children indices for each parent. Each entry looks like
-            // {parent index in the patch (coarse grid), index of one of its children in the refined grid}
+            // To store the relation between parent cell and its new-born-cells.
+            // {parent index (coarse grid), {child 0 index, child 1 index, ... (refined grid)}}
             std::vector<std::tuple<int,std::vector<int>>> parent_to_children_cells;
             parent_to_children_cells.reserve(patch_dim[0]*patch_dim[1]*patch_dim[2]);
-            // To store parent index for each child. The children are numbering
-            // following the rule of moving first in the x-axes (from left to right),
-            // then y-axes (from front to back), finally z-axes (from bottom to top).
-            std::vector<std::array<int,2>> child_to_parent_cells; // {child index (in 'level 1'), parent cell index (in 'level 0')}
+            // To store the relation between a new-born-cell and its parent cell.
+            std::vector<std::array<int,2>> child_to_parent_cells; // {child index (refined grid), parent cell index (coarse grid)}
             child_to_parent_cells.reserve(xfactor*yfactor*zfactor);
             for (int k = 0; k < grid_dim[2]; ++k) {
                 for (int j = 0; j < grid_dim[1]; ++j) {
                     for (int i = 0; i < grid_dim[0]; ++i) {
                         int cell_idx = (k*grid_dim[0]*grid_dim[1]) + (j*grid_dim[0]) +i;
                         std::vector<int> children_list;
-                        if ( (i > start_ijk[0]-1) && (i < end_ijk[0]) && (j > start_ijk[1]-1) && (j < end_ijk[1])
-                             && (k > start_ijk[2]-1) && (k < end_ijk[2])) {
-                            for (int n = (k-start_ijk[2])*cells_per_dim[2]; n < (k-start_ijk[2]+1)*cells_per_dim[2]; ++n) {
-                                for (int m = (j-start_ijk[1])*cells_per_dim[1]; m < (j-start_ijk[1]+1)*cells_per_dim[1]; ++m) {
-                                    for (int l = (i-start_ijk[0])*cells_per_dim[0]; l < (i-start_ijk[0]+1)*cells_per_dim[0]; ++l) {
+                        if ( (i > startIJK[0]-1) && (i < endIJK[0]) && (j > startIJK[1]-1) && (j < endIJK[1])
+                             && (k > startIJK[2]-1) && (k < endIJK[2])) {
+                            for (int n = (k-startIJK[2])*cells_per_dim[2]; n < (k-startIJK[2]+1)*cells_per_dim[2]; ++n) {
+                                for (int m = (j-startIJK[1])*cells_per_dim[1]; m < (j-startIJK[1]+1)*cells_per_dim[1]; ++m) {
+                                    for (int l = (i-startIJK[0])*cells_per_dim[0]; l < (i-startIJK[0]+1)*cells_per_dim[0]; ++l) {
                                         children_list.push_back((n*xfactor*yfactor) + (m*xfactor) + l);
                                         child_to_parent_cells.push_back({(n*xfactor*yfactor) + (m*xfactor) + l, cell_idx});
                                     }// end l-for-loop
@@ -973,35 +832,22 @@ public:
                     } // end i-for-loop
                 } // end j-for-loop
             } // end k-for-loop
-
-            // IS PARENT - FACES
-            // Map {index face, true/false}
-            // true-> the face got refined (has children), false -> the face hasn't been refined (does not have children).
-            std::map<int,bool> isParent_faces;
-            for (int face = 0; face < this-> face_to_cell_.size(); ++face) {
-                isParent_faces[face] = false;
-            }
+            // To identify parent faces. {index face, true/false}. True when a face got refined.
+            std::vector<int> isParent_faces(this->face_to_cell_.size(), false);
             // Rewrite the entries of the map for those faces that got refined.
-            for (auto& face : patch_faces) {
+            for (const auto& face : patch_faces) {
                 isParent_faces[face] = true;
             }
-            // IS PARENT - CELLS
-            // Map {index cell, true/false}
-            // true-> cell got refined (has children), false -> cell hasn't been refined (does not have children).
-            std::map<int,bool> isParent_cells;
-            for (int cell = 0; cell < this-> size(0); ++cell) {
-                isParent_cells[cell] = false;
-            }
-            // Rewrite the entries of the map for those faces that got refined.
-            for (auto& cell : patch_cells) {
+            // To identify parent cells. {index cell, true/false}. True when the cell got refined.
+            std::vector<int> isParent_cells(this->size(0), false);
+            // Rewrite the entries of the map for those cells that got refined.
+            for (const auto& cell : patch_cells) {
                 isParent_cells[cell] = true;
             }
-            return {refined_grid_ptr, boundary_old_to_new_corners, boundary_old_to_new_faces,
-                parent_to_children_faces, parent_to_children_cells, child_to_parent_faces, child_to_parent_cells,
-                isParent_faces, isParent_cells};
+            return {refined_grid_ptr, boundary_old_to_new_corners, boundary_old_to_new_faces, parent_to_children_faces,
+                parent_to_children_cells, child_to_parent_faces, child_to_parent_cells, isParent_faces, isParent_cells};
         }
     }
-
     
     // Make unique boundary ids for all intersections.
     void computeUniqueBoundaryIds();

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -90,6 +90,8 @@
 #include "Entity2IndexDataHandle.hpp"
 #include "DataHandleWrappers.hpp"
 #include "GlobalIdMapping.hpp"
+#include "Geometry.hpp"
+
 namespace Opm
 {
 class EclipseState;
@@ -113,7 +115,16 @@ template<int> class EntityRep;
 
 void refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,
                       const std::array<int, 3>&,
-                      bool);
+                    bool);
+void refinePatch_and_check(const std::array<int,3>&,
+                           const std::array<int,3>&,
+                           const std::array<int,3>&);
+
+void refinePatch_and_check(Dune::CpGrid&,
+                           const std::array<int,3>&,
+                           const std::array<int,3>&,
+                           const std::array<int,3>&);
+
 namespace Dune
 {
 namespace cpgrid
@@ -132,11 +143,21 @@ class CpGridData
     template<class T, int i> friend struct mover::Mover;
 
     friend class GlobalIdSet;
-
+    
     friend
     void ::refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,
                             const std::array<int, 3>&,
                             bool);
+    friend
+    void::refinePatch_and_check(const std::array<int,3>&,
+                        const std::array<int,3>&,
+                        const std::array<int,3>&);
+
+    friend
+    void ::refinePatch_and_check(Dune::CpGrid&,
+                                 const std::array<int,3>&,
+                                 const std::array<int,3>&,
+                                 const std::array<int,3>&);
 
 private:
     CpGridData(const CpGridData& g);
@@ -158,7 +179,7 @@ public:
         /// communicating. Uses the define MAX_DATA_COMMUNICATED_PER_ENTITY.
         MAX_DATA_PER_CELL = MAX_DATA_COMMUNICATED_PER_ENTITY
 #endif
-    };
+    };     
 
     /// Constructor for parallel grid data.
     /// \param comm The MPI communicator
@@ -257,6 +278,731 @@ public:
         ijk[2] = gc / logical_cartesian_size_[1];
     }
 
+    // Given a start {i,j,k} and an end {i,j,k}, compute the dimension of the patch, i.e.
+    // aomunt of cells in each direction. 
+    const std::array<int,3> getPatchDim(const std::array<int,3>& start_ijk, const std::array<int,3>& end_ijk) const
+    {
+        return {end_ijk[0]-start_ijk[0], end_ijk[1]-start_ijk[1], end_ijk[2]-start_ijk[2]};
+    } 
+    
+    const std::array<std::vector<int>,3> getPatchGeomIndices(const std::array<int,3>& start_ijk, const std::array<int,3>& end_ijk) const
+    {
+        // Get the patch dimension (total cells in each direction). Used to 'reserve vectors'.
+        const std::array<int,3> patch_dim = getPatchDim(start_ijk, end_ijk);
+        // Get grid dim
+        const std::array<int,3> grid_dim = this -> logicalCartesianSize();
+        // CORNERS
+        std::vector<int> patch_corners;
+        patch_corners.reserve((patch_dim[0]+1)*(patch_dim[1]+1)*(patch_dim[2]+1));
+        for (int j = start_ijk[1]; j < end_ijk[1]+1; ++j) {
+            for (int i = start_ijk[0]; i < end_ijk[0]+1; ++i) {
+                for (int k = start_ijk[2]; k < end_ijk[2]+1; ++k) {
+                    patch_corners.push_back((j*(grid_dim[0]+1)*(grid_dim[2]+1)) + (i*(grid_dim[2]+1))+k);
+                } // end i-for-loop
+            } // end j-for-loop
+        } // end k-for-loop
+        // FACES
+        std::vector<int> patch_faces;
+        // Integers to reserve patch_faces.
+        int i_patch_faces = (patch_dim[0]+1)*patch_dim[1]*patch_dim[2];
+        int j_patch_faces = patch_dim[0]*(patch_dim[1]+1)*patch_dim[2];
+        int k_patch_faces = patch_dim[0]*patch_dim[1]*(patch_dim[2]+1);
+        patch_faces.reserve(i_patch_faces +j_patch_faces +k_patch_faces);
+        // Integers to compute face indices.
+        int i_grid_faces = (grid_dim[0]+1)*grid_dim[1]*grid_dim[2];
+        int j_grid_faces = grid_dim[0]*(grid_dim[1]+1)*grid_dim[2];
+        // I_FACES
+        for (int j = start_ijk[1]; j < end_ijk[1]; ++j) {
+            for (int i = start_ijk[0]; i < end_ijk[0]+1; ++i) {
+                for (int k = start_ijk[2]; k < end_ijk[2]; ++k) {
+                    int face_idx = (j*grid_dim[1]*grid_dim[2]) + (i*grid_dim[2])+ k;
+                    patch_faces.push_back(face_idx);          
+                } // end k-for-loop
+            } // end i-for-loop     
+        } // end j-for-loop
+        // J_FACES
+        for (int j = start_ijk[1]; j < end_ijk[1]+1; ++j) {
+            for (int i = start_ijk[0]; i < end_ijk[0]; ++i) {
+                for (int k = start_ijk[2]; k < end_ijk[2]; ++k) {
+                    int face_idx = i_grid_faces + (j*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2])+ k; 
+                    patch_faces.push_back(face_idx);          
+                } // end k-for-loop
+            } // end i-for-loop     
+        } // end j-for-loop
+         // K_FACES
+        for (int j = start_ijk[1]; j < end_ijk[1]; ++j) {
+            for (int i = start_ijk[0]; i < end_ijk[0]; ++i) {
+                for (int k = start_ijk[2]; k < end_ijk[2]+1; ++k) {
+                    int face_idx = j_grid_faces + i_grid_faces + (j*grid_dim[0]*(grid_dim[2]+1)) + (i*(grid_dim[2]+1))+ k;
+                    patch_faces.push_back(face_idx);          
+                } // end k-for-loop
+            } // end i-for-loop     
+        } // end j-for-loop
+
+        // CELLS
+        std::vector<int> patch_cells;
+        patch_cells.reserve(patch_dim[0]*patch_dim[1]*patch_dim[2]);
+        for (int k = start_ijk[2]; k < end_ijk[2]; ++k) {
+            for (int j = start_ijk[1]; j < end_ijk[1]; ++j) {
+                for (int i = start_ijk[0]; i < end_ijk[0]; ++i) {
+                    patch_cells.push_back((k*grid_dim[0]*grid_dim[1]) + (j*grid_dim[1]) +i);
+                } // end i-for-loop
+            } // end j-for-loop
+        } // end k-for-loop
+        return {patch_corners, patch_faces, patch_cells};
+    }
+
+    // Construct a 'huge cell' out of a patch of connected (consecutive in each direction) cells.
+    // CELL-FICATION OF A PATCH
+    // This function takes a patch and build a cell out of it.
+    // The function takes a connected patch formed by the product of consecutive cells in each direction, and
+    // returns a Geometry<3,3> object, 'a patch cell', or 'a cellFIED patch'.
+    // Idea: Select 8 corners of the boundary of the patch, compute center and volume.
+    // @param patch_cells_indices           Indices of the cells from the grid that we want to refine, or, equivalently,
+    //                                      indices of the cells that belong to the patch.
+    // @param cellfiedPatch_to_point        Indices of the 8 corners of each parent cell.
+    // @param cellfied_patch_geometry
+    Geometry<3,3> cellfyPatch(const std::vector<int> patch_cells_indices)
+    {
+        if (patch_cells_indices.empty()){
+            OPM_THROW(std::logic_error, "Empty patch. Cannot convert patch into cell.");
+        }
+        DefaultGeometryPolicy cellfied_patch_geometry;
+        // Get the minimum and maximum of "patch_cells_indices"
+        // to find the min_i, max_i, min_j, max_j, min_k, max_k,
+        // to 'cell-fy' the patch (treating the patch as a 'huge cell')
+        const std::array<int,2> min_max_indices = {
+            *std::min_element(patch_cells_indices.begin(), patch_cells_indices.end()),
+            *std::max_element(patch_cells_indices.begin(), patch_cells_indices.end())};
+        // Get grid dim
+        const std::array<int,3> grid_dim = this -> logicalCartesianSize();
+        // Get min/max-ijk indices out of "min_max_indices"
+        std::vector<std::array<int,3>> min_max_ijk_indices;
+        min_max_ijk_indices.reserve(2);
+        for (auto& idx : min_max_indices) {
+            int i = idx/grid_dim[0]; // i
+            int j = ((idx - i)/grid_dim[0])/grid_dim[1]; // j
+            int k = (((idx - i)/grid_dim[0]) -j)/grid_dim[1]; // k
+            min_max_ijk_indices.push_back({i,j,k});
+        }
+        // Get indices of (at most) 8 selected cells located on the boundary of the patch.
+        /* std::array<int,8> selected_boundary_cell_indices = {
+            // Index of the boundary cell from where corner '0' will be extracted.
+            min_max_indices[0],
+            // Index of the boundary cell from where corner '1' will be extracted: '{max_i, min_j, min_k}'
+            (min_max_ijk_indices[0][2]*grid_dim[0]*grid_dim[1]) + (min_max_ijk_indices[0][1]*grid_dim[0])
+            + min_max_ijk_indices[1][0],
+            // Index of the bounday cell from where corner '2' will be extracted: '{min_i, max_j, min_k}'
+            (min_max_ijk_indices[0][2]*grid_dim[0]*grid_dim[1]) + (min_max_ijk_indices[1][1]*grid_dim[0])
+            + min_max_ijk_indices[0][0],
+            // Index of the boundary cell from where corner '3' will be extracted: '{max_i, max_j, min_k}'
+            (min_max_ijk_indices[0][2]*grid_dim[0]*grid_dim[1]) + (min_max_ijk_indices[1][1]*grid_dim[0])
+            + min_max_ijk_indices[1][0],
+            // Index of the bounday cell from where corner '4' will be extracted: '{min_i, min_j, max_k}'
+            (min_max_ijk_indices[1][2]*grid_dim[0]*grid_dim[1]) + (min_max_ijk_indices[0][1]*grid_dim[0])
+            + min_max_ijk_indices[0][0],
+            // Index of the boundary cell from where corner '5' will be extracted: '{max_i, min_j, max_k}'
+            (min_max_ijk_indices[1][2]*grid_dim[0]*grid_dim[1]) + (min_max_ijk_indices[0][1]*grid_dim[0])
+            + min_max_ijk_indices[1][0],
+            // Index of the bounday cell from where corner '6' will be extracted: '{min_i, max_j, max_k}'
+            (min_max_ijk_indices[1][2]*grid_dim[0]*grid_dim[1]) + (min_max_ijk_indices[1][1]*grid_dim[0])
+            + min_max_ijk_indices[0][0],
+            // Index of the boundary cell from where corner '7' will be extracted.
+            min_max_indices[1]}; */
+        EntityVariableBase<cpgrid::Geometry<0,3>>& cellfiedPatch_corners =
+                    cellfied_patch_geometry.geomVector(std::integral_constant<int,3>());
+        cellfiedPatch_corners.resize(8);
+        // Get the 8 corner indices of the 'cellFIED patch'
+         std::array<int,8> cellfiedPatch_to_point = { //  corner indices: (J*(grid_dim[0]+1)*(grid_dim[2]+1)) + (I*(grid_dim[2]+1)) +K
+            // Index of corner '0' {min_i, min_j, min_k}
+            (min_max_ijk_indices[0][1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (min_max_ijk_indices[0][0]*(grid_dim[2]+1))
+            +min_max_ijk_indices[0][2],
+            // Index of corner '1' '{max_i +1, min_j, min_k}'
+            (min_max_ijk_indices[0][1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + ((min_max_ijk_indices[1][0] +1)*(grid_dim[2]+1))
+            + min_max_ijk_indices[0][2],
+            // Index of corner '2' '{min_i, max_j +1, min_k}'
+            ((min_max_ijk_indices[1][1] +1)*(grid_dim[0]+1)*(grid_dim[2]+1)) + (min_max_ijk_indices[0][0]*(grid_dim[2]+1))
+            + min_max_ijk_indices[0][2],
+            // Index of corner '3' '{max_i +1, max_j +1, min_k}'
+            ((min_max_ijk_indices[1][1] +1)*(grid_dim[0]+1)*(grid_dim[2]+1)) + ((min_max_ijk_indices[1][0] +1)*(grid_dim[2]+1))
+             + min_max_ijk_indices[0][2],
+             // Index of corner '4' '{min_i, min_j, max_k +1}'
+             (min_max_ijk_indices[0][1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (min_max_ijk_indices[0][0]*(grid_dim[2]+1))
+             + min_max_ijk_indices[1][2],
+             // Index of corner '5' '{max_i +1, min_j, max_k +1}'
+             (min_max_ijk_indices[0][1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + ((min_max_ijk_indices[1][0] +1)*(grid_dim[2]+1))
+             + min_max_ijk_indices[1][2] +1,
+             // Index of corner '6' '{min_i, max_j +1, max_k +1}'
+             ((min_max_ijk_indices[1][1] +1)*(grid_dim[0]+1)*(grid_dim[2]+1)) + (min_max_ijk_indices[0][0]*(grid_dim[2]+1))
+             + min_max_ijk_indices[1][2] +1,
+             // Index of corner '7' {max_i +1, max_j +1, max_k +1}
+             ((min_max_ijk_indices[1][1]+1)*(grid_dim[0]+1)*(grid_dim[2]+1)) + ((min_max_ijk_indices[1][0]+1)*(grid_dim[2]+1))
+             + min_max_ijk_indices[1][2] +1};
+            // Center of the cell'fied' patch
+            Geometry<0,3>::GlobalCoordinate cellfiedPatch_center = {0., 0.,0.};
+            for (int corn; corn < 8; ++corn) {
+                cellfiedPatch_center +=
+                    (this -> geometry_.geomVector(std::integral_constant<int,3>()).get(cellfiedPatch_to_point[corn]).center())/8.;
+                cellfiedPatch_corners[corn] =
+                    this -> geometry_.geomVector(std::integral_constant<int,3>()).get(cellfiedPatch_to_point[corn]).center();
+            }
+            // Volume of the cell'fied' patch
+            double cellfiedPatch_volume = 0.;
+            for (auto idx : patch_cells_indices) {
+                cellfiedPatch_volume += (this -> geometry_.geomVector(std::integral_constant<int,0>())
+                                         [EntityRep<0>(idx, true)]).volume();
+            }
+            // Create a pointer to the first element of "cellfiedPatch_to_point"
+            // (required as the fourth argement to construct a Geometry<3,3> type object).
+            int* cellfiedPatch_indices_storage_ptr = &cellfiedPatch_to_point[0];
+            // Construct (and return) the Geometry of the CEELfied PATCH.
+            return Geometry<3,3>(cellfiedPatch_center, cellfiedPatch_volume,
+                                 cellfied_patch_geometry.geomVector(std::integral_constant<int,3>()),
+                                 cellfiedPatch_indices_storage_ptr);
+        }
+   
+    
+    
+    /*  // AREA (via sum of 4 triangles) and CENTROID of a face given its 4 corners.
+    // ----------- IN PROGRESS --------------
+    std::tuple<double,Geometry<0,3>::GlobalCoordinate> getFaceAreaCentroid(const std::array<int,4> corners)
+    {
+        // AREA
+        double face_area = 0.;
+        // Face CENTROID.
+        Geometry<0,3>::GlobalCoordinate face_centroid = {0.,0.,0.};
+        for (auto& corner : corners)
+        {
+            face_centroid += (this -> geometry_.geomVector(std::integral_constant<int,1>()).get(corner).center())/4.;
+        }
+        
+        return {face_area, face_centroid};
+        
+        }*/
+    
+    // VOLUME (via sum of 24 tetrahedra)  and CENTER of a hexaedron
+    // given its corner and face indices.
+    std::tuple<double,Geometry<0,3>::GlobalCoordinate>
+    getHexaVolumeCenter(const std::array<int,8> corners, const std::array<int,6> faces)
+    {
+        // VOLUME HEXAHEDRON
+        double hexa_volume = 0.0;
+        // Hexa center.
+        Geometry<0,3>::GlobalCoordinate hexa_center = {0.,0.,0.};
+        for (auto& corner : corners)
+        {
+            hexa_center += (this -> geometry_.geomVector(std::integral_constant<int,3>()).get(corner).center())/8.;
+        }
+        // CENTROIDS of the faces of the hexahedron.
+        // (one of the 6 corners of all 4 tetrahedra based on that face).
+        std::vector<Geometry<0,3>::GlobalCoordinate> face_centroids;
+        face_centroids.resize(6);
+        for (auto& face : faces) {
+            face_centroids.push_back(this -> geometry_.geomVector(std::integral_constant<int,1>())
+                                     [Dune::cpgrid::EntityRep<1>(face, true)].center());
+        }
+        // Container with 6 entries, one per face. Each entry has the
+        // 4 indices of the 4 corners of each face.
+        std::vector<std::array<int,4>> hexa_face_to_point;
+        hexa_face_to_point.reserve(6);
+        for (int face = 0; face < 6;  ++face) {
+            hexa_face_to_point.push_back(//this -> face_to_point_[faces[face]]);
+            { this -> face_to_point_[faces[face]][0],
+             this -> face_to_point_[faces[face]][1],
+            this -> face_to_point_[faces[face]][2],
+            this -> face_to_point_[faces[face]][3]});
+        }
+        // Container with indices of the edges of the 4 tetrahedra per face
+        // [according to description above]
+        std::vector<std::vector<std::array<int,2>>> tetra_edges;
+        tetra_edges.reserve(6);
+        for (auto& face4corners : hexa_face_to_point)
+        {
+            std::vector<std::array<int,2>> face4edges = {
+                { face4corners[0], face4corners[1]}, // fake '{0,1}'/'{4,5}'
+                { face4corners[0], face4corners[2]}, // fake '{0,2}'/'{4,6}'
+                { face4corners[1], face4corners[3]}, // fake '{1,3}'/'{5,7}'
+                { face4corners[2], face4corners[3]} }; // fake '{2,3}'/'{6,7}'
+            tetra_edges.push_back(face4edges);
+        }
+        // Sum of the 24 volumes to get the volume of the hexahedron,
+        // stored in "refined_cell_volume".
+        // Calculate the volume of each hexahedron, by adding
+        // the 4 tetrahedra at each face (4x6 = 24 tetrahedra).
+        for (int face = 0; face < 6; ++face) {
+            for (int edge = 0; edge < 4; ++edge) {
+                // Construction of each tetrahedron based on "face" with one
+                // of its edges equal to "edge".
+                const Geometry<0, 3>::GlobalCoordinate tetra_corners[4] = {
+                    this ->geometry_.geomVector(std::integral_constant<int,3>()).get(tetra_edges[face][edge][0]).center(),  
+                    this ->geometry_.geomVector(std::integral_constant<int,3>()).get(tetra_edges[face][edge][1]).center(), 
+                    face_centroids[face],
+                    hexa_center};  
+                hexa_volume += std::fabs(simplex_volume(tetra_corners));
+            } // end edge-for-loop
+        } // end face-for-loop
+        return {hexa_volume, hexa_center};    
+    }
+    
+    // Refine a single cell and return a shared pointer of CpGridData type.
+    // REFINE A SINGLE CELL
+    // @param cells_per_dim                 Number of sub-cells in each direction.
+    // @param parent_idx                    Parent index.
+    // @return refined_grid_ptr             Shared pointer pointing at refined_grid.
+    //         parent_to_redined_corners    For each corner of the parent cell, we store the index of the
+    //                                      refined corner that coincides with the old one.
+    //                                      We assume they are ordered 0,1,..7
+    //                                                              6---7
+    //                                                      2---3   |   | TOP FACE
+    //                                                      |   |   4---5
+    //                                                      0---1 BOTTOM FACE
+    //         parent_to_children_faces/cellFor each parent face/cell, we store its child face indices.
+    //                                      {parent face/cell index in coarse level, {indices of its children in refined level}}
+    //         child_to_parent_faces/cells  {child index, parent index}
+    //         isParent_faces               True when the face got refined.
+    //         isParent_cells               True when the cell got refined (here only "parent cell").
+    std::tuple< const std::shared_ptr<CpGridData>,
+                const std::vector<std::array<int,2>>,                // parent_to_refined_corners(~boundary_old_to_new_corners)
+                const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces (~boundary_old_to_new_faces)
+                const std::tuple<int, std::vector<int>>,             // parent_to_children_cells
+                const std::vector<std::array<int,2>>,                // child_to_parent_faces
+                const std::vector<std::array<int,2>>,                // child_to_parent_cells
+                const std::map<int,bool>,                            // isParent_faces
+                const std::map<int,bool>>                            // isParent_cells
+    refineSingleCell(const std::array<int,3>& cells_per_dim, const int& parent_idx)
+    {
+        std::shared_ptr<CpGridData> refined_grid_ptr = std::make_shared<CpGridData>(ccobj_);
+        auto& refined_grid = *refined_grid_ptr;
+        DefaultGeometryPolicy& refined_geometries = refined_grid.geometry_;
+        std::vector<std::array<int,8>>& refined_cell_to_point = refined_grid.cell_to_point_;
+        cpgrid::OrientedEntityTable<0,1>& refined_cell_to_face = refined_grid.cell_to_face_;
+        Opm::SparseTable<int>& refined_face_to_point = refined_grid.face_to_point_;
+        cpgrid::OrientedEntityTable<1,0>& refined_face_to_cell = refined_grid.face_to_cell_;
+        cpgrid::EntityVariable<enum face_tag,1>& refined_face_tags = refined_grid.face_tag_;
+        cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>,1>& refined_face_normals = refined_grid.face_normals_;
+        // Get parent cell
+        cpgrid::Geometry<3,3> parent_cell = geometry_.geomVector(std::integral_constant<int,0>())[EntityRep<0>(parent_idx, true)];
+        // Refine parent cell
+        parent_cell.refine(cells_per_dim,
+                           refined_geometries,
+                           refined_cell_to_point,
+                           refined_cell_to_face,
+                           refined_face_to_point,
+                           refined_face_to_cell,
+                           refined_face_tags,
+                           refined_face_normals);
+
+        // Get parent cell corners.
+        std::array<int,8> parent_to_point = this->cell_to_point_[parent_idx];
+        std::vector<std::array<int,2>> parent_to_refined_corners{
+            // replacing parent-cell corner '0'
+            {parent_to_point[0], 0},
+            // replacing parent-cell corner '1'
+            {parent_to_point[1], cells_per_dim[0]*(cells_per_dim[2]+1)},
+            // replacing parent-cell corner '2'
+            {parent_to_point[2], cells_per_dim[1]*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)},
+            // replacing parent-cell corner '3'
+            {parent_to_point[3], (cells_per_dim[1]*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (cells_per_dim[0]*(cells_per_dim[2]+1))},
+            // replacing parent-cell corner '4'
+            {parent_to_point[4], cells_per_dim[2]},
+            // replacing parent-cell corner '5'
+            {parent_to_point[5], (cells_per_dim[0]*(cells_per_dim[2]+1)) + cells_per_dim[2]},
+            // replacing parent-cell corner '6'
+            {parent_to_point[6], cells_per_dim[1]*(cells_per_dim[0]+1)*(cells_per_dim[2]+1) + cells_per_dim[2]},
+            // replacing parent-cell corner '7'
+            {parent_to_point[7], (cells_per_dim[1]*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (cells_per_dim[0]*(cells_per_dim[2]+1))
+             + cells_per_dim[2]}};
+        // Get relation old face -> new born faces (children faces)
+        std::vector<std::tuple<int,std::vector<int>>>  parent_to_children_faces;
+        // Get parent_cell_to_face = { {face, orientation}, {another face, its orientation}, ...}
+        auto parent_cell_to_face = (this-> cell_to_face_[EntityRep<0>(parent_idx, true)]);
+        //
+        std::vector<std::array<int,2>> child_to_parent_faces;
+        child_to_parent_faces.reserve(refined_face_to_cell.size());
+        // Children faces are ordered following the criteria introduced in refine(), Geometry.hpp.
+        // First K_FACES, then I_FACES, then J_FACES.
+        int k_faces = cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1);
+        int i_faces = (cells_per_dim[0]+1)*cells_per_dim[1]*cells_per_dim[2];
+        for (auto& face : parent_cell_to_face) {
+            // Check face tag to identify the type of face (bottom, top, left, right, front, or back).
+            auto parent_face_tag = (this-> face_tag_[Dune::cpgrid::EntityRep<1>(face.index(), true)]);
+            // To store the new born faces for each face.
+            std::vector<int> children_faces;
+            // K_FACES
+            if (parent_face_tag == face_tag::K_FACE) {
+                children_faces.reserve(cells_per_dim[0]*cells_per_dim[1]);
+                for (int j = 0; j < cells_per_dim[1]; ++j) {
+                    for (int i = 0; i < cells_per_dim[0]; ++i) {
+                        if (!face.orientation()) { // false -> BOTTOM FACE -> k=0
+                            children_faces.push_back((j*cells_per_dim[0]) + i);
+                            child_to_parent_faces.push_back({(j*cells_per_dim[0]) + i, face.index()});
+                        }
+                        else { // true -> TOP FACE -> k=cells_per_dim[2]
+                            children_faces.push_back((cells_per_dim[2]*cells_per_dim[0]*cells_per_dim[1])
+                                                     +(j*cells_per_dim[0]) + i);
+                            child_to_parent_faces.push_back({(cells_per_dim[2]*cells_per_dim[0]*cells_per_dim[1])
+                                    +(j*cells_per_dim[0]) + i, face.index()});
+                        }
+                    }
+                }
+            }
+            // I_FACES
+            if (parent_face_tag == face_tag::I_FACE) {
+                children_faces.reserve(cells_per_dim[1]*cells_per_dim[2]);
+                for (int k = 0; k < cells_per_dim[2]; ++k) {
+                    for (int j = 0; j < cells_per_dim[1]; ++j) {
+                        if (!face.orientation()) { // false -> LEFT FACE -> i=0
+                            children_faces.push_back(k_faces + (k*cells_per_dim[1]) + j);
+                            child_to_parent_faces.push_back({k_faces + (k*cells_per_dim[1]) + j, face.index()});
+                        }
+                        else { // true -> RIGHT FACE -> i=cells_per_dim[0]
+                            children_faces.push_back(k_faces + (cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2])
+                                                     + (k*cells_per_dim[1]) + j);
+                            child_to_parent_faces.push_back({k_faces + (cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2])
+                                    + (k*cells_per_dim[1]) + j, face.index()});
+                        }
+                    }
+                }
+            }
+            // J_FACES
+            if (parent_face_tag == face_tag::J_FACE) {
+                children_faces.reserve(cells_per_dim[0]*cells_per_dim[2]);
+                for (int i = 0; i < cells_per_dim[0]; ++i) {
+                    for (int k = 0; k < cells_per_dim[2]; ++k) {
+                        if (!face.orientation()) { // false -> FRONT FACE -> j=0
+                            children_faces.push_back(k_faces + i_faces + (i*cells_per_dim[2]) + k);
+                            child_to_parent_faces.push_back({k_faces + i_faces + (i*cells_per_dim[2]) + k, face.index()});
+                        }
+                        else { // true -> BACK FACE -> j=cells_per_dim[1]
+                            children_faces.push_back(k_faces + i_faces  + (cells_per_dim[1]*cells_per_dim[0]*cells_per_dim[2])
+                                                     + (i*cells_per_dim[2]) + k);
+                            child_to_parent_faces.push_back({k_faces + i_faces  + (cells_per_dim[1]*cells_per_dim[0]*cells_per_dim[2])
+                                    + (i*cells_per_dim[2]) + k, face.index()});
+                        }
+                    }
+                }
+            }
+            std::tuple<int,std::vector<int>> aux_tuple = std::make_tuple(face.index(), children_faces);
+            parent_to_children_faces.push_back(aux_tuple);
+        }
+        // PARENT TO CHILDREN CELLS
+        std::vector<int> children_cells;
+        // Child to parent cell
+        std::vector<std::array<int, 2>> child_to_parent_cell;
+        children_cells.reserve(cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]);
+        child_to_parent_cell.reserve(cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]);
+        for (int cell = 0; cell < cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]; ++cell) {
+            children_cells.push_back(cell);
+            child_to_parent_cell.push_back({cell, parent_idx});
+        }
+
+
+        std::tuple<int, std::vector<int>> parent_to_children_cells =
+            std::make_tuple(parent_idx, children_cells);
+        // IS PARENT - FACES
+        // Map {index face, true/false}
+        // true-> the face got refined (has children), false -> the face hasn't been refined (does not have children).
+        std::map<int,bool> isParent_faces;
+        for (int face = 0; face < this-> face_to_cell_.size(); ++face) {
+            isParent_faces[face] = false;
+        }
+        // Rewrite the entries of the map for those faces that got refined.
+        for (auto& face : parent_cell_to_face) {
+            isParent_faces[face.index()] = true;
+        }
+        // IS PARENT - CELLS
+        // Map {index cell, true/false}
+        // true-> cell got refined (has children), false -> cell hasn't been refined (does not have children).
+        std::map<int,bool> isParent_cells;
+        for (int cell = 0; cell < this-> size(0); ++cell) {
+            isParent_cells[cell] = false;
+        }
+        // Rewrite the entries of the map for those faces that got refined.
+        isParent_cells[parent_idx] = true;
+
+        return {refined_grid_ptr, parent_to_refined_corners,
+            parent_to_children_faces, parent_to_children_cells, child_to_parent_faces, child_to_parent_cell,
+            isParent_faces, isParent_cells};
+    }
+    // Refine a (connected block of cells) patch
+    // REFINE A PATCH of CONNECTED (CONSECUTIVE in each direction) cells with 'uniform' regular intervals.
+    // (meaning that the amount of children per cell is the same for all parent cells (cells of the patch)).
+    // @param cells_per_dim                       Number of sub-cells in each direction (for each cell).
+    // @param start_ijk                           Minimum values of i,j,k to construct the patch (start).
+    // @param end_ijk                             Maximum values of i,j,k to construct the patch (end).
+    // @return refined_grid_ptr                   Shared pointer of CpGridData type, pointing at the refined_grid
+    //         boundary_old_to_new_corners/faces  Corners/faces on the boundary of the patch get replaced by new born refined one(s).
+    //         parent_to_children_faces/cells     To store the indices of 'all the face/cell children' of each parent.
+    //         child_to_parent_faces/cells        For each child-face, we store its parent face index.
+    //         isParent_faces/cells               True for each face/cell that got refined.
+
+    std::tuple<std::shared_ptr<CpGridData>,
+               const std::vector<std::array<int,2>>,                // boundary_old_to_new_corners
+               const std::vector<std::tuple<int,std::vector<int>>>, // boundary_old_to_new_faces
+               const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces
+               const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_cell
+               const std::vector<std::array<int,2>>,                // child_to_parent_faces
+               const std::vector<std::array<int,2>>,                // child_to_parent_cells
+               const std::map<int,bool>,                            // isParent_faces
+               const std::map<int,bool>>                            // isParent_cells
+    refineBlockPatch(const std::array<int,3>& cells_per_dim,
+                     const std::array<int,3>& start_ijk, const std::array<int,3>& end_ijk)
+    {
+        std::shared_ptr<CpGridData> refined_grid_ptr = std::make_shared<CpGridData>(ccobj_);
+        auto& refined_grid = *refined_grid_ptr;
+        DefaultGeometryPolicy& refined_geometries = refined_grid.geometry_;
+        std::vector<std::array<int,8>>& refined_cell_to_point = refined_grid.cell_to_point_;
+        cpgrid::OrientedEntityTable<0,1>& refined_cell_to_face = refined_grid.cell_to_face_;
+        Opm::SparseTable<int>& refined_face_to_point = refined_grid.face_to_point_;
+        cpgrid::OrientedEntityTable<1,0>& refined_face_to_cell = refined_grid.face_to_cell_;
+        cpgrid::EntityVariable<enum face_tag,1>& refined_face_tags = refined_grid.face_tag_;
+        cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>,1>& refined_face_normals = refined_grid.face_normals_;
+
+        // Patch information (built from the grid).
+        const auto& patch_dim = getPatchDim(start_ijk, end_ijk);
+        // Coarse grid dimension
+        const std::array<int,3>& grid_dim = this -> logicalCartesianSize();
+        // If the patch contains only one cell:
+        if ((patch_dim[0] == 1) && (patch_dim[1] == 1) && (patch_dim[2] == 1)){
+            const int& parent_cell = (start_ijk[2]*grid_dim[0]*grid_dim[1]) + (start_ijk[1]*grid_dim[0]) +start_ijk[0];
+            auto [refined_grid_ptr0, parent_to_refined_corners,
+                  parent_to_children_faces, parent_to_children_cells,child_to_parent_faces, child_to_parent_cell,
+                  isParent_faces, isParent_cells] = this->refineSingleCell(cells_per_dim, parent_cell);
+            // When the patch is only one cell,
+            // - boundary_old_to_new_corners == parent_to_refined_corners.
+            // - boundary_old_to_new_faces == parent_to_children_faces.
+            // Fix the type of parent_to_children_cells to return it correctly.
+            std::vector<std::tuple<int, std::vector<int>>> parent_to_children_cells_vec = {parent_to_children_cells};
+            return {refined_grid_ptr0, parent_to_refined_corners,
+                parent_to_children_faces, parent_to_children_faces, parent_to_children_cells_vec,
+                child_to_parent_faces, child_to_parent_cell,
+                isParent_faces, isParent_cells};
+        }
+        // When the patch consists in more than one cell:
+        else {
+            const auto& [patch_corners, patch_faces, patch_cells] = getPatchGeomIndices(start_ijk, end_ijk); 
+            // Construct the Geometry of the CEELfied PATCH.
+            cpgrid::Geometry<3,3> cellfied_patch = this -> cellfyPatch(patch_cells);
+            
+            // Some integers to reduce notation later.
+            int xfactor = cells_per_dim[0]*patch_dim[0];
+            int yfactor = cells_per_dim[1]*patch_dim[1];
+            int zfactor = cells_per_dim[2]*patch_dim[2];
+            // Refine the cell "cellfied_patch"
+            cellfied_patch.refine({xfactor, yfactor, zfactor},
+                                  refined_geometries,
+                                  refined_cell_to_point,
+                                  refined_cell_to_face,
+                                  refined_face_to_point,
+                                  refined_face_to_cell,
+                                  refined_face_tags,
+                                  refined_face_normals);
+            // For each cell of the patch, we select the 8 refined corners that coincide with the
+            // original cell corners, and the refined child-faces that ('all' together) 'coincide' with
+            // each of the 6 original faces of the cell.
+            // To store the 8 new refined corners coinciding with the 8 original corners of each cell of the patch,
+            // we choose a map, key = cell index in the coarse grid, value = {{old corner '0', new corner '0'}, ...}
+            std::vector<std::array<int,2>> boundary_old_to_new_corners;
+            // RESERVE?
+            for (int j = start_ijk[1]; j < end_ijk[1]+1; ++j) {
+                for (int i = start_ijk[0]; i < end_ijk[0]+1; ++i) {
+                    for (int k = start_ijk[2]; k < end_ijk[2]+1; ++k) {
+                        // WE ARE ASSUMING THE GRID FROM LEVEL 0 HAS THE DUNE NUMBERING FOR CORNERS.
+                        if ( (j == start_ijk[1]) || (j == end_ijk[1]) ){
+                            int old_corner_idx = (j*(grid_dim[2]+1)*(grid_dim[0]+1)) + (i*(grid_dim[2]+1)) + k;
+                            int new_corner_idx = (cells_per_dim[1]*(j-start_ijk[1])*(xfactor +1)*(zfactor +1))
+                                + (cells_per_dim[0]*(i-start_ijk[0])*(zfactor +1))
+                                + (cells_per_dim[2]*(k-start_ijk[2]));
+                            boundary_old_to_new_corners.push_back({old_corner_idx, new_corner_idx});
+                        }
+                        if ( (i == start_ijk[0]) || (i == end_ijk[0]) ) {
+                            int old_corner_idx = (j*(grid_dim[2]+1)*(grid_dim[0]+1)) + (i*(grid_dim[2]+1)) + k;
+                            int new_corner_idx = (cells_per_dim[1]*(j-start_ijk[1])*(xfactor +1)*(zfactor +1))
+                                + (cells_per_dim[0]*(i-start_ijk[0])*(zfactor +1))
+                                + (cells_per_dim[2]*(k-start_ijk[2]));
+                            boundary_old_to_new_corners.push_back({old_corner_idx, new_corner_idx});
+                        }
+                        if ( (k == start_ijk[2]) || (k == end_ijk[2]) ) {
+                            int old_corner_idx = (j*(grid_dim[2]+1)*(grid_dim[0]+1)) + (i*(grid_dim[2]+1)) + k;
+                            int new_corner_idx = (cells_per_dim[1]*(j-start_ijk[1])*(xfactor +1)*(zfactor +1))
+                                + (cells_per_dim[0]*(i-start_ijk[0])*(zfactor +1))
+                                + (cells_per_dim[2]*(k-start_ijk[2]));
+                            boundary_old_to_new_corners.push_back({old_corner_idx, new_corner_idx});
+                        }
+                    } // end k-for-loop
+                } // end i-for-loop
+            } // end j-for-loop
+
+            // FACE STUFF
+            // Boundary patch faces.
+            std::vector<int> boundary_patch_faces;
+            // Auxiliary integers to simplify notation.
+            int bound_patch_faces = 2*patch_dim[1]*patch_dim[2] // left/right boundary
+            +  patch_dim[0]*2*patch_dim[2] // front/back boundary
+            + patch_dim[0]*patch_dim[1]*2; // bottom/top boundary
+            boundary_patch_faces.reserve(bound_patch_faces);
+            // Boundary old faces associated with its (new born) children faces.
+            std::vector<std::tuple<int, std::vector<int>>> boundary_old_to_new_faces; // {face index, its children indices}
+            boundary_old_to_new_faces.reserve(bound_patch_faces);
+            // Auxiliary integers to simplify notation.
+            int i_grid_faces =  (grid_dim[0]+1)*grid_dim[1]*grid_dim[2];
+            int j_grid_faces =  grid_dim[0]*(grid_dim[1]+1)*grid_dim[2];
+            // Parent to children faces (all faces of the patch, not only the ones on the boundary).
+            std::vector<std::tuple<int,std::vector<int>>> parent_to_children_faces;
+            parent_to_children_faces.reserve(patch_faces.size());
+            // For each child, we associate it with its parent.
+            std::vector<std::array<int,2>> child_to_parent_faces; // {child index (in 'level 1'), parent index (in 'level 0')}
+            child_to_parent_faces.reserve(refined_face_to_cell.size());
+            // I_FACES
+            for (int j = start_ijk[1]; j < end_ijk[1]; ++j) {
+                for (int i = start_ijk[0]; i < end_ijk[0]+1; ++i) {
+                    for (int k = start_ijk[2]; k < end_ijk[2]; ++k) {
+                        int face_idx = (j*grid_dim[1]*grid_dim[2]) + (i*grid_dim[2])+ k;
+                        // Vector to store new born faces, per face.
+                        // CHILDREN FACES ARE ORDERED AS IN refine(), Geometry.hpp
+                        std::vector<int> children_list;  // I_FACE ikj (xzy-direction)
+                        // l,m,n play the role of 'x,y,z-direction'
+                        // lnm = fake ikj (how I_FACES are 'ordered' in refine())
+                        for (int l = (i-start_ijk[0])*cells_per_dim[0]; l < (i-start_ijk[0]+1)*cells_per_dim[0]; ++l) {
+                            for (int n = (k-start_ijk[2])*cells_per_dim[2];n < (k-start_ijk[2]+1)*cells_per_dim[2]; ++n) {
+                                for (int m = (j-start_ijk[1])*cells_per_dim[1]; m < (j-start_ijk[1]+1)*cells_per_dim[1]; ++m) {
+                                    children_list.push_back((xfactor*yfactor*(zfactor+1)) +(l*yfactor*zfactor) + (n*yfactor) + m);
+                                    child_to_parent_faces.push_back({(xfactor*yfactor*(zfactor+1)) +(l*yfactor*zfactor)
+                                            + (n*yfactor) + m, face_idx});
+                                } // end m-for-loop
+                            } // end n-for-loop
+                        } // end l-for-loop
+                        // Add parent information of each face to "parent_to_children_faces".
+                        parent_to_children_faces.push_back(std::make_tuple(face_idx, children_list));
+                        if ((i == start_ijk[0]) || (i == end_ijk[0])) {
+                            boundary_patch_faces.push_back(face_idx);
+                            // Associate each old face on the boundary of the patch with the new born ones.
+                            boundary_old_to_new_faces.push_back(std::make_tuple(face_idx, children_list));
+                        }
+                    } // end k-for-loop
+                } // end i-for-loop
+            } // end j-for-loop
+            // J_FACES
+            for (int j = start_ijk[1]; j < end_ijk[1]+1; ++j) {
+                for (int i = start_ijk[0]; i < end_ijk[0]; ++i) {
+                    for (int k = start_ijk[2]; k < end_ijk[2]; ++k) {
+                        int face_idx = i_grid_faces + (j*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2])+ k;
+                        // Vector to store new born faces, per face.
+                        // CHILDREN FACES ARE ORDERED AS IN refine(), Geometry.hpp
+                        std::vector<int> children_list;  // J_FACE jik (yxz-direction)
+                        // l,m,n play the role of 'x,y,z-direction'
+                        // mln = fake jik (how J_FACES are 'ordered' in refine())
+                        for (int m = (j-start_ijk[1])*cells_per_dim[1]; m < (j-start_ijk[1]+1)*cells_per_dim[1]; ++m) {
+                            for (int l = (i-start_ijk[0])*cells_per_dim[0]; l < (i-start_ijk[0]+1)*cells_per_dim[0]; ++l) {
+                                for (int n = (k-start_ijk[2])*cells_per_dim[2]; n < (k-start_ijk[2]+1)*cells_per_dim[2]; ++n) {
+                                    children_list.push_back((xfactor*yfactor*(zfactor+1)) + ((xfactor+1)*yfactor*zfactor)
+                                                            + (m*xfactor*zfactor) + (l*zfactor)+n);
+                                    child_to_parent_faces.push_back({(xfactor*yfactor*(zfactor+1)) + ((xfactor+1)*yfactor*zfactor)
+                                            + (m*xfactor*zfactor) + (l*zfactor)+n, face_idx});
+                                } // end n-for-loop
+                            } // end l-for-loop
+                        } // end m-for-loop
+                        // Add parent information of each face to "parent_to_children_faces".
+                        parent_to_children_faces.push_back(std::make_tuple(face_idx, children_list));
+                        if ((j == start_ijk[1]) || (j == end_ijk[1])) {
+                            boundary_patch_faces.push_back(face_idx);
+                            // Associate each old face on the boundary of the patch with the new born ones.
+                            boundary_old_to_new_faces.push_back(std::make_tuple(face_idx, children_list));
+                        }
+                    } // end k-for-loop
+                } // end i-for-loop
+            } // end j-for-loop
+            // K_FACES
+            for (int j = start_ijk[1]; j < end_ijk[1]; ++j) {
+                for (int i = start_ijk[0]; i < end_ijk[0]; ++i) {
+                    for (int k = start_ijk[2]; k < end_ijk[2]+1; ++k) {
+                        int face_idx = i_grid_faces + j_grid_faces + (j*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2])+ k;
+                        // Vector to store new born faces, per face.
+                        // CHILDREN FACES ARE ORDERED AS IN refine(), Geometry.hpp
+                        std::vector<int> children_list;  // K_FACE kji (zyx-direction)
+                        // l,m,n play the role of 'x,y,z-direction'
+                        // nml = fake kji (how K_FACES are 'ordered' in refine())
+                        for (int n = (k-start_ijk[2])*cells_per_dim[2]; n < (k-start_ijk[2]+1)*cells_per_dim[2]; ++n) {
+                            for (int m = (j-start_ijk[1])*cells_per_dim[1]; m < (j-start_ijk[1]+1)*cells_per_dim[1]; ++m) {
+                                for (int l = (i-start_ijk[0])*cells_per_dim[0]; l < (i-start_ijk[0]+1)*cells_per_dim[0]; ++l) {
+                                    children_list.push_back((n*xfactor*yfactor) + (m*xfactor)+ l);
+                                    child_to_parent_faces.push_back({(n*xfactor*yfactor) + (m*xfactor)+ l, face_idx});
+                                } // end m-for-loop
+                            } // end n-for-loop
+                        } // end l-for-loop
+                          // Add parent information of each face to "parent_to_children_faces".
+                        parent_to_children_faces.push_back(std::make_tuple(face_idx, children_list));
+                        if ((k == start_ijk[2]) || (k == end_ijk[2])) {
+                            boundary_patch_faces.push_back(face_idx);
+                            // Associate each old face on the boundary of the patch with the new born ones.
+                            boundary_old_to_new_faces.push_back(std::make_tuple(face_idx, children_list));
+                        }
+                    } // end k-for-loop
+                } // end i-for-loop
+            } // end j-for-loop
+            //--- END PARENT TO CHILDREN FACES / child_to_parent_faces ---
+
+            // PARENT TO CHILDREN - CELLS  / child_to_parent_cells
+            //
+            // To store children indices for each parent. Each entry looks like
+            // {parent index in the patch (coarse grid), index of one of its children in the refined grid}
+            std::vector<std::tuple<int,std::vector<int>>> parent_to_children_cells;
+            parent_to_children_cells.reserve(patch_dim[0]*patch_dim[1]*patch_dim[2]);
+            // To store parent index for each child. The children are numbering
+            // following the rule of moving first in the x-axes (from left to right),
+            // then y-axes (from front to back), finally z-axes (from bottom to top).
+            std::vector<std::array<int,2>> child_to_parent_cells; // {child index (in 'level 1'), parent cell index (in 'level 0')}
+            child_to_parent_cells.reserve(xfactor*yfactor*zfactor);
+            for (int k = 0; k < grid_dim[2]; ++k) {
+                for (int j = 0; j < grid_dim[1]; ++j) {
+                    for (int i = 0; i < grid_dim[0]; ++i) {
+                        int cell_idx = (k*grid_dim[0]*grid_dim[1]) + (j*grid_dim[0]) +i;
+                        std::vector<int> children_list;
+                        if ( (i > start_ijk[0]-1) && (i < end_ijk[0]) && (j > start_ijk[1]-1) && (j < end_ijk[1])
+                             && (k > start_ijk[2]-1) && (k < end_ijk[2])) {
+                            for (int n = (k-start_ijk[2])*cells_per_dim[2]; n < (k-start_ijk[2]+1)*cells_per_dim[2]; ++n) {
+                                for (int m = (j-start_ijk[1])*cells_per_dim[1]; m < (j-start_ijk[1]+1)*cells_per_dim[1]; ++m) {
+                                    for (int l = (i-start_ijk[0])*cells_per_dim[0]; l < (i-start_ijk[0]+1)*cells_per_dim[0]; ++l) {
+                                        children_list.push_back((n*xfactor*yfactor) + (m*xfactor) + l);
+                                        child_to_parent_cells.push_back({(n*xfactor*yfactor) + (m*xfactor) + l, cell_idx});
+                                    }// end l-for-loop
+                                } // end m-for-loop
+                            } // end n-for-loop
+                            parent_to_children_cells.push_back(std::make_tuple(cell_idx, children_list));
+                        }// end if 'patch cells'
+                    } // end i-for-loop
+                } // end j-for-loop
+            } // end k-for-loop
+
+            // IS PARENT - FACES
+            // Map {index face, true/false}
+            // true-> the face got refined (has children), false -> the face hasn't been refined (does not have children).
+            std::map<int,bool> isParent_faces;
+            for (int face = 0; face < this-> face_to_cell_.size(); ++face) {
+                isParent_faces[face] = false;
+            }
+            // Rewrite the entries of the map for those faces that got refined.
+            for (auto& face : patch_faces) {
+                isParent_faces[face] = true;
+            }
+            // IS PARENT - CELLS
+            // Map {index cell, true/false}
+            // true-> cell got refined (has children), false -> cell hasn't been refined (does not have children).
+            std::map<int,bool> isParent_cells;
+            for (int cell = 0; cell < this-> size(0); ++cell) {
+                isParent_cells[cell] = false;
+            }
+            // Rewrite the entries of the map for those faces that got refined.
+            for (auto& cell : patch_cells) {
+                isParent_cells[cell] = true;
+            }
+            return {refined_grid_ptr, boundary_old_to_new_corners, boundary_old_to_new_faces,
+                parent_to_children_faces, parent_to_children_cells, child_to_parent_faces, child_to_parent_cells,
+                isParent_faces, isParent_cells};
+        }
+    }
+
+    
     // Make unique boundary ids for all intersections.
     void computeUniqueBoundaryIds();
 
@@ -576,6 +1322,8 @@ private:
     friend class Intersection;
     friend class PartitionTypeIndicator;
 };
+
+
 
 #if HAVE_MPI
 

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -290,6 +290,10 @@ private:
     ///
     /// @param [in]  startIJK  Cartesian triplet index where the patch starts.
     /// @param [in]  endIJK    Cartesian triplet index where the patch ends.
+    ///                        Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
+
+
+
     ///
     /// @return patch_dim Patch dimension {#cells in x-direction, #cells in y-direction, #cells in z-direction}.
     const std::array<int,3> getPatchDim(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
@@ -301,6 +305,7 @@ private:
     ///
     /// @param [in]  startIJK  Cartesian triplet index where the patch starts.
     /// @param [in]  endIJK    Cartesian triplet index where the patch ends.
+    ///                        Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
     ///
     /// @return {patch_corners, patch_faces, patch_cells} Indices of corners, faces, and cells of the patch of cells.
     const std::array<std::vector<int>,3> getPatchGeomIndices(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
@@ -601,6 +606,7 @@ public:
     /// @param [in] cells_per_dim            Number of (refined) cells in each direction that each parent cell should be refined to.
     /// @param [in] startIJK                 Cartesian triplet index where the patch starts.
     /// @param [in] endIJK                   Cartesian triplet index where the patch ends.
+    ///                                      Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
     ///
     /// @return refined_grid_ptr                   Shared pointer of CpGridData type, pointing at the refined_grid
     /// @return boundary_old_to_new_corners/faces  Corner/face indices on the patch-boundary associated with new-born-entity indices.
@@ -848,7 +854,7 @@ public:
                 parent_to_children_cells, child_to_parent_faces, child_to_parent_cells, isParent_faces, isParent_cells};
         }
     }
-    
+
     // Make unique boundary ids for all intersections.
     void computeUniqueBoundaryIds();
 

--- a/opm/grid/cpgrid/DefaultGeometryPolicy.hpp
+++ b/opm/grid/cpgrid/DefaultGeometryPolicy.hpp
@@ -40,6 +40,9 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace Dune
 {
+
+    class CpGrid;
+
     namespace cpgrid
     {
         template<int mydim, int dim>
@@ -51,6 +54,7 @@ namespace Dune
             friend class CpGridData;
             template<int mydim, int dim>
             friend class Geometry;
+            friend class ::Dune::CpGrid;
         public:
             /// @brief
             /// @todo Doc me

--- a/opm/grid/cpgrid/EntityRep.hpp
+++ b/opm/grid/cpgrid/EntityRep.hpp
@@ -76,9 +76,10 @@ namespace Dune
 /// The namespace Dune is the main namespace for all Dune code.
 namespace Dune
 {
+
     namespace cpgrid
     {
-
+    
         /// @brief Represents an entity of a given codim, with positive or negative orientation.
         ///
         /// This class is not a part of the Dune interface, but of our implementation.
@@ -92,7 +93,7 @@ namespace Dune
         /// We may consider changing this representation to using something like a
         /// std::pair<int, bool> instead.
         /// @tparam codim Codimension
-
+    
         template <int codim>
         class EntityRep
         {

--- a/opm/grid/cpgrid/EntityRep.hpp
+++ b/opm/grid/cpgrid/EntityRep.hpp
@@ -79,7 +79,7 @@ namespace Dune
 
     namespace cpgrid
     {
-    
+
         /// @brief Represents an entity of a given codim, with positive or negative orientation.
         ///
         /// This class is not a part of the Dune interface, but of our implementation.
@@ -93,7 +93,7 @@ namespace Dune
         /// We may consider changing this representation to using something like a
         /// std::pair<int, bool> instead.
         /// @tparam codim Codimension
-    
+
         template <int codim>
         class EntityRep
         {

--- a/opm/grid/cpgrid/Geometry.hpp
+++ b/opm/grid/cpgrid/Geometry.hpp
@@ -718,10 +718,10 @@ namespace Dune
                 // "refined_faces".
                 //
                 for (int constant_direction = 0; constant_direction < 3; ++constant_direction){
-                    // adding %3 and r, we go through the 3 type of faces.
-                    // r = 0 -> 3rd coordinate constant: l('k') < cells_per_dim[2]+1, m('j') < cells_per_dim[1], n('i') < cells_per_dim[0]
-                    // r = 1 -> 1rt coordinate constant: l('i') < cells_per_dim[0]+1, m('k') < cells_per_dim[2], n('j') < cells_per_dim[1]
-                    // r = 2 -> 2nd coordinate constant: l('j') < cells_per_dim[1]+1, m('i') < cells_per_dim[0], n('k') < cells_per_dim[2]
+                    // adding %3 and constant_direction, we go through the 3 type of faces.
+                    // 0 -> 3rd coordinate constant: l('k') < cells_per_dim[2]+1, m('j') < cells_per_dim[1], n('i') < cells_per_dim[0]
+                    // 1 -> 1rt coordinate constant: l('i') < cells_per_dim[0]+1, m('k') < cells_per_dim[2], n('j') < cells_per_dim[1]
+                    // 2 -> 2nd coordinate constant: l('j') < cells_per_dim[1]+1, m('i') < cells_per_dim[0], n('k') < cells_per_dim[2]
                     std::array<int,3> cells_per_dim_mixed = {
                         cells_per_dim[(2+constant_direction)%3],
                         cells_per_dim[(1+constant_direction)%3],
@@ -729,7 +729,7 @@ namespace Dune
                     for (int l = 0; l < cells_per_dim_mixed[0] + 1; ++l) {
                         for (int m = 0; m < cells_per_dim_mixed[1]; ++m) {
                             for (int n = 0; n < cells_per_dim_mixed[2]; ++n) {
-                                // Compute the index of the face and its 4 corners.
+                                // Compute the face data.
                                 auto [face_type, idx, face4corners,
                                       neighboring_cells_of_one_face, local_refined_face_centroid] =
                                     getIndicesFace(l, m, n, constant_direction, cells_per_dim);
@@ -785,7 +785,7 @@ namespace Dune
                     } // end l-for-loop
                 } // end r-for-loop
                 /// --- END REFINED FACES ---
-
+                
                 /// --- REFINED CELLS ---
                 // We need to populate "refined_cells"
                 // "refined_cells"'s size is cells_per_dim[0] * cells_per_dim[1] * cells_per_dim[2].
@@ -986,7 +986,7 @@ namespace Dune
                 } // end if-statement
                 /// --- END REFINED CELLS ---
             } /// --- END of refine()
-
+            
         private:
             GlobalCoordinate pos_;
             double vol_;

--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -279,20 +279,19 @@ BOOST_AUTO_TEST_CASE(cellgeom)
 
 void
 check_refined_grid(const cpgrid::Geometry<3, 3>& parent,
-                   const cpgrid::EntityVariable<cpgrid::Geometry<3, 3>, 0>& refined,
-                   // const cpgrid::DefaultGeometryPolicy& refined_faces,
+                   const cpgrid::EntityVariable<cpgrid::Geometry<3, 3>,0>& refined,
+                   const cpgrid::EntityVariable<cpgrid::Geometry<2,3>,1>& refined_faces,
+                   const cpgrid::EntityVariableBase<cpgrid::Geometry<0,3>>& refined_corners,
                    const std::array<int, 3>& cells_per_dim)
 {
-    // Check for faces
-    //
-    // @todo Check amount of refined faces.
-    /* int count_faces = (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1)) // 'bottom/top faces'
+    // Check amount of refined faces.
+    int count_faces = (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1)) // 'bottom/top faces'
                     + (cells_per_dim[0]*(cells_per_dim[1]+1)*cells_per_dim[2]) // 'front/back faces'
                     + ((cells_per_dim[0]+1)*cells_per_dim[1]*cells_per_dim[2]);  // 'left/right faces'
-                    BOOST_CHECK_EQUAL(refined_faces.size(), count_faces);*/
-    // @todo Check centroids of refined faces.
-    // @todo Check volume (area) of (corresponding) children faces sum up area of parent face.
-    // @todo Check the corners of the refined faces that coincide with parent face corners.
+    BOOST_CHECK_EQUAL(refined_faces.size(), count_faces);
+    // Check amount of refined corners.
+    int count_corners = (cells_per_dim[0]+1)*(cells_per_dim[1]+1)*(cells_per_dim[2]+1);
+    BOOST_CHECK_EQUAL(refined_corners.size(), count_corners);
 
 
     using Geometry = cpgrid::Geometry<3, 3>;
@@ -367,7 +366,6 @@ check_refined_grid(const cpgrid::Geometry<3, 3>& parent,
         CHECK_COORDINATES(r.center(), center);
     }
 
-    //  @todo Current Geometry.hpp does not pass this test:
     // Check that the weighted mean of all centers equals the parent center
     GlobalCoordinate center = {0.0, 0.0, 0.0};
     for (auto r : refined) {
@@ -395,7 +393,6 @@ check_refined_grid(const cpgrid::Geometry<3, 3>& parent,
         volume += r.volume();
     }
     BOOST_CHECK_CLOSE(volume, parent.volume(), 1e-6);
-
 }
 
 void refine_and_check(const cpgrid::Geometry<3, 3>& parent_geometry,
@@ -416,7 +413,9 @@ void refine_and_check(const cpgrid::Geometry<3, 3>& parent_geometry,
     parent_geometry.refine(cells, geometries, cell_to_point,
                            cell_to_face, face_to_point, face_to_cell,
                            face_tags, face_normals);
-    check_refined_grid(parent_geometry, geometries.template geomVector<0>(), cells);
+    check_refined_grid(parent_geometry, geometries.template geomVector<0>(),
+                       geometries.template geomVector<1>(),
+                       geometries.template geomVector<3>(), cells);
     cpgrid::OrientedEntityTable<1,0> face_to_cell_computed;
     cell_to_face.makeInverseRelation(face_to_cell_computed);
     BOOST_CHECK(face_to_cell_computed == face_to_cell);
@@ -506,6 +505,32 @@ void refine_and_check(const cpgrid::Geometry<3, 3>& parent_geometry,
             ++equiv_element_iter;
         }
     }
+    // Create a grid that is equivalent to the refinement
+    /*  Dune::CpGrid coarse_grid;
+    std::array<double, 3> cell_sizes_new = {1.0, 1.0, 1.0};
+    std::array<int, 3> coarse_grid_dim = {4,3,3};
+    std::array<int, 3> cells_per_dim_patch = {2,2,2};
+    std::array<int, 3> start_ijk = {1,0,1};
+    std::array<int, 3> end_ijk = {3,2,3};  // then patch_dim = {3-1,2-0,3-1} ={2,2,2}
+    coarse_grid.createCartesian(coarse_grid_dim, cell_sizes_new);
+    // Call refinedBlockPatch()
+    coarse_grid.current_view_data_->refineBlockPatch(cells_per_dim_patch, start_ijk, end_ijk);
+    // Create a pointer pointing at the CpGridData object coarse_grid.current_view_data_.
+    std::shared_ptr<Dune::cpgrid::CpGridData> coarse_grid_ptr =  std::make_shared<Dune::cpgrid::CpGridData>();
+    *coarse_grid.current_view_data_ = *coarse_grid_ptr;
+    // Create a vector of shared pointers of CpGridData type.
+    std::vector<std::shared_ptr<Dune::cpgrid::CpGridData>> data;
+    // Add coarse_grid_ptr to data.
+    data.push_back(coarse_grid_ptr);
+    // Call getLeafView2Levels()
+    coarse_grid.getLeafView2Levels(data, cells_per_dim_patch, start_ijk, end_ijk);
+    // Call addLevel()
+    const int level_to_refine = 0;
+    std::vector<std::array<int,2>> future_leaf_corners;
+    std::vector<std::array<int,2>> future_leaf_faces;
+    std::vector<std::array<int,2>> future_leaf_cells;
+    coarse_grid.addLevel(data, level_to_refine, cells_per_dim_patch, start_ijk, end_ijk,
+    future_leaf_corners, future_leaf_faces, future_leaf_cells);*/
 }
 
 BOOST_AUTO_TEST_CASE(refine_simple_cube)
@@ -576,4 +601,26 @@ BOOST_AUTO_TEST_CASE(refine_distorted_cube)
     Geometry g(center, v, pg, cor_idx);
     refine_and_check(g, {1, 1, 1});
     refine_and_check(g, {2, 3, 4});
+
+}
+
+void refinePatch_and_check(const std::array<int,3>&,
+                           const std::array<int,3>&,
+                           const std::array<int,3>&)
+{
+    // Create a grid that is equivalent to the refinement
+    Dune::CpGrid coarse_grid;
+    std::array<double, 3> cell_sizes_new = {1.0, 1.0, 1.0};
+    std::array<int, 3> coarse_grid_dim = {4,3,3};
+    std::array<int, 3> cells_per_dim_patch = {2,2,2};
+    std::array<int, 3> start_ijk = {1,0,1};
+    std::array<int, 3> end_ijk = {3,2,3};  // then patch_dim = {3-1,2-0,3-1} ={2,2,2}
+    coarse_grid.createCartesian(coarse_grid_dim, cell_sizes_new);
+    // Call refinedBlockPatch()
+    coarse_grid.current_view_data_->refineBlockPatch(cells_per_dim_patch, start_ijk, end_ijk);
+
+}
+BOOST_AUTO_TEST_CASE(refine_patch)
+{
+    refinePatch_and_check({}, {}, {});
 }

--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -505,32 +505,6 @@ void refine_and_check(const cpgrid::Geometry<3, 3>& parent_geometry,
             ++equiv_element_iter;
         }
     }
-    // Create a grid that is equivalent to the refinement
-    /*  Dune::CpGrid coarse_grid;
-    std::array<double, 3> cell_sizes_new = {1.0, 1.0, 1.0};
-    std::array<int, 3> coarse_grid_dim = {4,3,3};
-    std::array<int, 3> cells_per_dim_patch = {2,2,2};
-    std::array<int, 3> start_ijk = {1,0,1};
-    std::array<int, 3> end_ijk = {3,2,3};  // then patch_dim = {3-1,2-0,3-1} ={2,2,2}
-    coarse_grid.createCartesian(coarse_grid_dim, cell_sizes_new);
-    // Call refinedBlockPatch()
-    coarse_grid.current_view_data_->refineBlockPatch(cells_per_dim_patch, start_ijk, end_ijk);
-    // Create a pointer pointing at the CpGridData object coarse_grid.current_view_data_.
-    std::shared_ptr<Dune::cpgrid::CpGridData> coarse_grid_ptr =  std::make_shared<Dune::cpgrid::CpGridData>();
-    *coarse_grid.current_view_data_ = *coarse_grid_ptr;
-    // Create a vector of shared pointers of CpGridData type.
-    std::vector<std::shared_ptr<Dune::cpgrid::CpGridData>> data;
-    // Add coarse_grid_ptr to data.
-    data.push_back(coarse_grid_ptr);
-    // Call getLeafView2Levels()
-    coarse_grid.getLeafView2Levels(data, cells_per_dim_patch, start_ijk, end_ijk);
-    // Call addLevel()
-    const int level_to_refine = 0;
-    std::vector<std::array<int,2>> future_leaf_corners;
-    std::vector<std::array<int,2>> future_leaf_faces;
-    std::vector<std::array<int,2>> future_leaf_cells;
-    coarse_grid.addLevel(data, level_to_refine, cells_per_dim_patch, start_ijk, end_ijk,
-    future_leaf_corners, future_leaf_faces, future_leaf_cells);*/
 }
 
 BOOST_AUTO_TEST_CASE(refine_simple_cube)
@@ -616,8 +590,8 @@ void refinePatch_and_check(const std::array<int,3>&,
     std::array<int, 3> start_ijk = {1,0,1};
     std::array<int, 3> end_ijk = {3,2,3};  // then patch_dim = {3-1,2-0,3-1} ={2,2,2}
     coarse_grid.createCartesian(coarse_grid_dim, cell_sizes_new);
-    // Call refinedBlockPatch()
-    coarse_grid.current_view_data_->refineBlockPatch(cells_per_dim_patch, start_ijk, end_ijk);
+    // Call refinePatch()
+    coarse_grid.current_view_data_->refinePatch(cells_per_dim_patch, start_ijk, end_ijk);
 
 }
 BOOST_AUTO_TEST_CASE(refine_patch)

--- a/tests/cpgrid/grid_lgr_test.cpp
+++ b/tests/cpgrid/grid_lgr_test.cpp
@@ -1,0 +1,117 @@
+/*
+  Copyright 2022-2023 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#define BOOST_TEST_MODULE LGRTests
+#include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
+#include <opm/grid/CpGrid.hpp>
+#include <opm/grid/cpgrid/CpGridData.hpp>
+#include <opm/grid/cpgrid/DefaultGeometryPolicy.hpp>
+#include <opm/grid/cpgrid/EntityRep.hpp>
+#include <opm/grid/cpgrid/Geometry.hpp>
+
+#include <sstream>
+#include <iostream>
+struct Fixture
+{
+    Fixture()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        Dune::MPIHelper::instance(m_argc, m_argv);
+        Opm::OpmLog::setupSimpleDefaultLogging();
+    }
+
+    static int rank()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        return Dune::MPIHelper::instance(m_argc, m_argv).rank();
+    }
+};
+
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+void check_refinedPatch_grid(const std::array<int,3>& cells_per_dim,
+                             const std::array<int,3>& start_ijk,
+                             const std::array<int,3>& end_ijk,
+                             const Dune::cpgrid::EntityVariable<Dune::cpgrid::Geometry<3, 3>,0>& refined_cells,
+                             const Dune::cpgrid::EntityVariable<Dune::cpgrid::Geometry<2,3>,1>& refined_faces,
+                             const Dune::cpgrid::EntityVariableBase<Dune::cpgrid::Geometry<0,3>>& refined_corners)
+{
+    const std::array<int,3> patch_dim = {end_ijk[0]-start_ijk[0], end_ijk[1]-start_ijk[1], end_ijk[2]-start_ijk[2]};
+    if ((patch_dim[0] == 0) || (patch_dim[1] == 0) || (patch_dim[2] == 0)) {
+                    OPM_THROW(std::logic_error, "Empty patch. Cannot convert patch into cell.");
+    }
+    // Check amount of refined faces.
+    int count_faces = (cells_per_dim[0]*patch_dim[0]*cells_per_dim[1]*patch_dim[1]*((cells_per_dim[2]*patch_dim[2])+1)) // 'bottom/top faces'
+        +  (((cells_per_dim[0]*patch_dim[0])+1)*cells_per_dim[1]*patch_dim[1]*cells_per_dim[2]*patch_dim[2]) // 'front/back faces'
+        + (cells_per_dim[0]*patch_dim[0]*((cells_per_dim[1]*patch_dim[1]) +1)*cells_per_dim[2]*patch_dim[2]);  // 'left/right faces'
+    BOOST_CHECK_EQUAL(refined_faces.size(), count_faces);
+    // Check amount of refined corners.
+    int count_corners = ((cells_per_dim[0]*patch_dim[0])+1)*((cells_per_dim[1]*patch_dim[1])+1)*((cells_per_dim[2]*patch_dim[2])+1);
+    BOOST_CHECK_EQUAL(refined_corners.size(), count_corners);
+
+    int count_cells = cells_per_dim[0]*patch_dim[0]*cells_per_dim[1]*patch_dim[1]*cells_per_dim[2]*patch_dim[2];
+    BOOST_CHECK_EQUAL(refined_cells.size(), count_cells);
+}
+
+
+void refinePatch_and_check(Dune::CpGrid& coarse_grid,
+                           const std::array<int, 3>& cells_per_dim,
+                           const std::array<int,3>& start_ijk,
+                           const std::array<int,3>& end_ijk)
+{
+    
+    // Call getLeafView2LevelsPatch()
+    auto& data = coarse_grid.data_;
+    coarse_grid.getLeafView2LevelsPatch(cells_per_dim, start_ijk, end_ijk);
+    BOOST_CHECK(data.size()==3);
+    check_refinedPatch_grid(cells_per_dim, start_ijk, end_ijk,
+                            (*data[1]).geometry_.template geomVector<0>(),
+                            (*data[1]).geometry_.template geomVector<1>(),
+                            (*data[1]).geometry_.template geomVector<3>());
+    
+    /*  cpgrid::OrientedEntityTable<1,0> face_to_cell_computed;
+    cell_to_face.makeInverseRelation(face_to_cell_computed);
+    BOOST_CHECK(face_to_cell_computed == face_to_cell); */
+} 
+
+BOOST_AUTO_TEST_CASE(refine_patch)
+{
+     // Create a grid
+    Dune::CpGrid coarse_grid;
+    std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    std::array<int, 3> grid_dim = {4,3,3};
+    std::array<int, 3> cells_per_dim_patch = {2,2,2};   
+    std::array<int, 3> start_ijk = {1,0,1};
+    std::array<int, 3> end_ijk = {3,2,3};  // then patch_dim = {3-1, 2-0, 3-1} ={2,2,2}
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+    refinePatch_and_check(coarse_grid,
+                          cells_per_dim_patch,
+                          start_ijk,
+                          end_ijk);
+}
+


### PR DESCRIPTION
Issue related to calling CpGridData constructor whit or without MPI fixed. Sequential build passes now.  Followed-up of  Create grid with LGR (Cartesian type) #626 (which has been reverted in #629). 