### PR TITLE
Lgr names added

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -90,7 +90,8 @@ void refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,
 void refinePatch_and_check(Dune::CpGrid&,
                            const std::vector<std::array<int,3>>&,
                            const std::vector<std::array<int,3>>&,
-                           const std::vector<std::array<int,3>>&);
+                           const std::vector<std::array<int,3>>&,
+                           const std::vector<std::string>&);
 
 void refinePatch_and_check(const std::array<int,3>&,
                            const std::array<int,3>&,
@@ -227,7 +228,8 @@ namespace Dune
         void ::refinePatch_and_check(Dune::CpGrid&,
                                      const std::vector<std::array<int,3>>&,
                                      const std::vector<std::array<int,3>>&,
-                                     const std::vector<std::array<int,3>>&);
+                                     const std::vector<std::array<int,3>>&,
+                                     const std::vector<std::string>&);
         friend
         void ::refinePatch_and_check(const std::array<int,3>&,
                                      const std::array<int,3>&,
@@ -460,8 +462,9 @@ namespace Dune
         /// @param [in] startIJK                 Cartesian triplet index where the patch starts.
         /// @param [in] endIJK                   Cartesian triplet index where the patch ends.
         ///                                      Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
+        /// @param [in] lgr_name                 Name (std::string) for the lgr/level1
         void addLgrUpdateLeafView(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK,
-                                  const std::array<int,3>& endIJK);
+                                  const std::array<int,3>& endIJK,  const std::string& lgr_name);
 
         /// @brief Create a grid out of a coarse one and (at most) 2 refinements(LGRs) of selected block-shaped disjoint patches
         ///        of cells from that coarse grid.
@@ -478,9 +481,14 @@ namespace Dune
         /// @param [in] endIJK_vec             Vector of Cartesian triplet indices where each patch ends.
         ///                                    Last cell part of each patch(lgr) will be
         ///                                    {endIJK_vec[<patch-number>][0]-1, ..., endIJK_vec[<patch-number>][2]-1}.
+        /// @param [in] lgr_name_vec           Names (std::string) for the LGRs/levels
         void addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_per_dim_vec,
                                    const std::vector<std::array<int,3>>& startIJK_vec,
-                                   const std::vector<std::array<int,3>>& endIJK_vec);
+                                   const std::vector<std::array<int,3>>& endIJK_vec,
+                                   const std::vector<std::string>& lgr_name_vec);
+
+
+        const std::map<std::string,int>& getLgrNameToLevel() const;
 
         /*  No refinement implemented. GridDefaultImplementation's methods will be used.
 
@@ -1178,10 +1186,12 @@ namespace Dune
         cpgrid::CpGridData* current_view_data_;
         /** @brief The data stored for the distributed grid. */
         std::vector<std::shared_ptr<cpgrid::CpGridData>> distributed_data_;
+        /** @brief To get the level given the lgr-name. Default, {"GLOBAL", 0}. */
+        std::map<std::string,int> lgr_names_ = {{"GLOBAL", 0}};
         /**
          * @brief Interface for scattering and gathering cell data.
          *
-         * @warning Will only update owner cells
+         * @warning Will only update owner cells.
          */
         std::shared_ptr<InterfaceMap> cell_scatter_gather_interfaces_;
         /*

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1434,6 +1434,7 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
         (*data_[patch +1]).level_ = patch +1;
         // Add the name of each LGR in this->lgr_names_
         this -> lgr_names_[lgr_name_vec[patch]] = patch +1; // {"name_lgr", level}
+        std::vector<int> l_global_cell(data_[patch+1]->size(0), 0); 
         std::iota(l_global_cell.begin()+1, l_global_cell.end(), 1); // from entry[1], adds +1 per entry: {0,1,2,3,...}
         (*data_[patch+1]).global_cell_ = l_global_cell;
         //          index_set_

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -101,7 +101,8 @@ void refinePatch_and_check(const std::array<int,3>&,
 void refinePatch_and_check(Dune::CpGrid&,
                            const std::vector<std::array<int,3>>&,
                            const std::vector<std::array<int,3>>&,
-                           const std::vector<std::array<int,3>>&);
+                           const std::vector<std::array<int,3>>&,
+                           const std::vector<std::string>&);
 
 void check_global_refine(const Dune::CpGrid&,
                          const Dune::CpGrid&);
@@ -140,7 +141,8 @@ class CpGridData
     void ::refinePatch_and_check(Dune::CpGrid&,
                                  const std::vector<std::array<int,3>>&,
                                  const std::vector<std::array<int,3>>&,
-                                 const std::vector<std::array<int,3>>&);
+                                 const std::vector<std::array<int,3>>&,
+                                 const std::vector<std::string>&);
     
     friend
     void ::check_global_refine(const Dune::CpGrid&,

--- a/tests/cpgrid/grid_lgr_test.cpp
+++ b/tests/cpgrid/grid_lgr_test.cpp
@@ -128,7 +128,7 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
                                     (*data[level]).geometry_.template geomVector<1>(),
                                     (*data[level]).geometry_.template geomVector<3>());
             BOOST_CHECK( (*data[level]).parent_to_children_cells_.empty());
-            BOOST_CHECK(coarse_grid.lgr_names_[lgr_name_vec[level-1]] == level);
+            BOOST_CHECK(coarse_grid.lgr_names_[lgr_name_vec[level-1]] == static_cast<int>(level));
 
             const auto& patch_cells = (*data[0]).getPatchCells(startIJK_vec[level-1], endIJK_vec[level-1]);
 

--- a/tests/cpgrid/grid_lgr_test.cpp
+++ b/tests/cpgrid/grid_lgr_test.cpp
@@ -107,17 +107,18 @@ void check_refinedPatch_grid(const std::array<int,3> cells_per_dim,
 void refinePatch_and_check(Dune::CpGrid& coarse_grid,
                            const std::vector<std::array<int,3>>& cells_per_dim_vec,
                            const std::vector<std::array<int,3>>& startIJK_vec,
-                           const std::vector<std::array<int,3>>& endIJK_vec)
+                           const std::vector<std::array<int,3>>& endIJK_vec,
+                           const std::vector<std::string>& lgr_name_vec)
 {
     auto& data = coarse_grid.data_;
     // Add LGRs and update grid.
     const bool are_disjoint = (*data[0]).disjointPatches(startIJK_vec, endIJK_vec);
     if (are_disjoint){
-        coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec);
+        coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
 
         BOOST_CHECK(data.size() == startIJK_vec.size() + 2);
         BOOST_CHECK( (*data[0]).child_to_parent_cells_.empty());
-
+        BOOST_CHECK(coarse_grid.lgr_names_["GLOBAL"] == 0);
         const auto& all_parent_cell_indices = (*data[0]).getPatchesCells(startIJK_vec, endIJK_vec);
 
         for (long unsigned int level = 1; level < startIJK_vec.size() +1; ++level) // only 1 when there is only 1 patch
@@ -127,6 +128,7 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
                                     (*data[level]).geometry_.template geomVector<1>(),
                                     (*data[level]).geometry_.template geomVector<3>());
             BOOST_CHECK( (*data[level]).parent_to_children_cells_.empty());
+            BOOST_CHECK(coarse_grid.lgr_names_[lgr_name_vec[level-1]] == level);
 
             const auto& patch_cells = (*data[0]).getPatchCells(startIJK_vec[level-1], endIJK_vec[level-1]);
 
@@ -412,70 +414,74 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
     }
 }
 
-
 BOOST_AUTO_TEST_CASE(refine_patch)
 {
     // Create a grid
     Dune::CpGrid coarse_grid;
-    std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim_patch = {2,2,2};
-    std::array<int, 3> start_ijk = {1,0,1};
-    std::array<int, 3> end_ijk = {3,2,3};  // patch_dim = {3-1, 2-0, 3-1} ={2,2,2}
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {2,2,2};
+    const std::array<int, 3> startIJK = {1,0,1};
+    const std::array<int, 3> endIJK = {3,2,3};  // patch_dim = {3-1, 2-0, 3-1} ={2,2,2}
+    const std::string lgr_name = {"LGR1"};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
-    refinePatch_and_check(coarse_grid, {cells_per_dim_patch}, {start_ijk}, {end_ijk});
+    refinePatch_and_check(coarse_grid, {cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
 }
 
 BOOST_AUTO_TEST_CASE(refine_patch_one_cell)
 {
     // Create a grid
     Dune::CpGrid coarse_grid;
-    std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim_patch = {2,2,2};
-    std::array<int, 3> start_ijk = {1,0,1};
-    std::array<int, 3> end_ijk = {2,1,2};  // patch_dim = {2-1, 1-0, 2-1} ={1,1,1} -> Single Cell!
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {2,2,2};
+    const std::array<int, 3> startIJK = {1,0,1};
+    const std::array<int, 3> endIJK = {2,1,2};  // patch_dim = {2-1, 1-0, 2-1} ={1,1,1} -> Single Cell!
+    const std::string lgr_name = {"LGR1"};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
-    refinePatch_and_check(coarse_grid, {cells_per_dim_patch}, {start_ijk}, {end_ijk});
+    refinePatch_and_check(coarse_grid, {cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
 }
 
 BOOST_AUTO_TEST_CASE(lgrs_disjointPatches)
 {
     // Create a grid
     Dune::CpGrid coarse_grid;
-    std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
     const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}, {4,4,4}};
     const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,2}, {3,2,2}};
     const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {1,1,3}, {4,3,3}};
-    refinePatch_and_check(coarse_grid, cells_per_dim_vec, startIJK_vec, endIJK_vec);
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
+    refinePatch_and_check(coarse_grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
 }
 
 BOOST_AUTO_TEST_CASE(lgrs_disjointPatchesB)
 {
     // Create a grid
     Dune::CpGrid coarse_grid;
-    std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
     const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}};
     const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {3,2,0}};
     const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1}, {4,3,3}};
-    refinePatch_and_check(coarse_grid, cells_per_dim_vec, startIJK_vec, endIJK_vec);
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2"};
+    refinePatch_and_check(coarse_grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec); 
 }
 
 BOOST_AUTO_TEST_CASE(patches_share_corner)
 {
     // Create a grid
     Dune::CpGrid coarse_grid;
-    std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
     const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}, {4,4,4}};
     const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {1,1,1}, {3,2,2}};
     const std::vector<std::array<int,3>> endIJK_vec = {{1,1,1}, {2,2,2}, {4,3,3}};
-    BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec), std::logic_error);
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
+    BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec), std::logic_error);
     std::cout << "Patches are NOT disjoint" << "\n";
 }
 
@@ -483,13 +489,14 @@ BOOST_AUTO_TEST_CASE(patches_share_corners)
 {
     // Create a grid
     Dune::CpGrid coarse_grid;
-    std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
     const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {2,2,2}, {2,2,2}};
     const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {2,0,1}, {3,2,2}};
     const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {3,1,1}, {4,3,3}};
-    BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec), std::logic_error);
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
+    BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec), std::logic_error);
     std::cout << "Patches are NOT disjoint" << "\n";
 }
 
@@ -497,13 +504,14 @@ BOOST_AUTO_TEST_CASE(pathces_share_face)
 {
     // Create a grid
     Dune::CpGrid coarse_grid;
-    std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
     const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {2,2,2}, {2,2,2}};
     const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {2,0,0}, {3,2,2}};
     const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {3,1,1}, {4,3,3}};
-    BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec), std::logic_error);
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
+    BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec), std::logic_error);
     std::cout << "Patches are NOT disjoint" << "\n";
 }
 
@@ -511,13 +519,14 @@ BOOST_AUTO_TEST_CASE(pathces_share_faceB)
 {
     // Create a grid
     Dune::CpGrid coarse_grid;
-    std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
     const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {2,2,2}, {2,2,2}};
     const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,1}, {1,1,2}};
     const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1}, {3,2,1}, {4,3,3}};
-    BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec), std::logic_error);
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
+    BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec), std::logic_error);
     std::cout << "Patches are NOT disjoint" << "\n";
 }
 
@@ -614,18 +623,19 @@ BOOST_AUTO_TEST_CASE(global_refine)
     // Create a 4x3x3 grid with length 4x3x3
     // and refine each cells into 4 children cells
     Dune::CpGrid coarse_grid;
-    std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    std::array<int, 3> grid_dim = {4,3,3};
-    std::array<int, 3> cells_per_dim_patch = {2,2,2};
-    std::array<int, 3> start_ijk = {0,0,0};
-    std::array<int, 3> end_ijk = {4,3,3};
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {2,2,2};
+    const std::array<int, 3> startIJK = {0,0,0};
+    const std::array<int, 3> endIJK = {4,3,3};
+    const std::string lgr_name = "LGR";
     coarse_grid.createCartesian(grid_dim, cell_sizes);
-    coarse_grid.addLgrsUpdateLeafView({cells_per_dim_patch}, {start_ijk}, {end_ijk});
+    coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
 
     // Create a 8x6x6 grid with length 4x3x3
     Dune::CpGrid fine_grid;
-    std::array<double, 3> fine_cell_sizes = {0.5, 0.5, 0.5};
-    std::array<int, 3> fine_grid_dim = {8,6,6};
+    const std::array<double, 3> fine_cell_sizes = {0.5, 0.5, 0.5};
+    const std::array<int, 3> fine_grid_dim = {8,6,6};
     fine_grid.createCartesian(fine_grid_dim, fine_cell_sizes);
 
     check_global_refine(coarse_grid, fine_grid);
@@ -637,18 +647,19 @@ BOOST_AUTO_TEST_CASE(global_norefine)
     // Create a 4x3x3 grid with length 4x3x3
     // and refine each cells into 4 children cells
     Dune::CpGrid coarse_grid;
-    std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    std::array<int, 3> grid_dim = {4,3,3};
-    std::array<int, 3> cells_per_dim_patch = {1,1,1};
-    std::array<int, 3> start_ijk = {0,0,0};
-    std::array<int, 3> end_ijk = {4,3,3};
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {1,1,1};
+    const std::array<int, 3> startIJK = {0,0,0};
+    const std::array<int, 3> endIJK = {4,3,3};
+    const std::string lgr_name = "LGR";
     coarse_grid.createCartesian(grid_dim, cell_sizes);
-    coarse_grid.addLgrsUpdateLeafView({cells_per_dim_patch}, {start_ijk}, {end_ijk});
+    coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
 
     // Create a 8x6x6 grid with length 4x3x3
     Dune::CpGrid fine_grid;
-    std::array<double, 3> fine_cell_sizes = {1.0, 1.0, 1.0};
-    std::array<int, 3> fine_grid_dim = {4,3,3};
+    const std::array<double, 3> fine_cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> fine_grid_dim = {4,3,3};
     fine_grid.createCartesian(fine_grid_dim, fine_cell_sizes);
 
     check_global_refine(coarse_grid, fine_grid);


### PR DESCRIPTION
New member data in CpGrid class, to map the lgr names and their levels (lgr_names_). When creating a grid with refinement of a patch of cells from the global grid ("level 0"), via createGridWithLgr() method, a string-parameter is passed to call the resulting LGR. Tested for level 0 ("GLOBAL") and level 1 (given/parameter).  A method getLgrNameToLevel() has been added as well. 