### PR TITLE
changed: disable shifted_cart_test, grid_lgr_test and geometry_test with boost <= 1.53

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -88,11 +88,8 @@ list (APPEND TEST_SOURCE_FILES
   tests/cpgrid/entityrep_test.cpp
   tests/cpgrid/entity_test.cpp
   tests/cpgrid/facetag_test.cpp
-  tests/cpgrid/geometry_test.cpp
-  tests/cpgrid/grid_lgr_test.cpp
   tests/cpgrid/orientedentitytable_test.cpp
   tests/cpgrid/partition_iterator_test.cpp
-  tests/cpgrid/shifted_cart_test.cpp
   tests/cpgrid/zoltan_test.cpp
   tests/test_geom2d.cpp
   tests/test_gridutilities.cpp
@@ -104,6 +101,14 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_quadratures.cpp
   tests/test_compressed_cartesian_mapping.cpp
 	)
+
+if(BOOST_VERSION VERSION_GREATER 1.53)
+	list(APPEND TEST_SOURCE_FILES
+	  tests/cpgrid/geometry_test.cpp
+	  tests/cpgrid/grid_lgr_test.cpp
+	  tests/cpgrid/shifted_cart_test.cpp
+  )
+endif()
 
 if(HAVE_ECL_INPUT)
   list(APPEND TEST_SOURCE_FILES


### PR DESCRIPTION
They fail to build due to using symbols only in newer boosts. Any modern system should not be affected, it is only relevant for the rhel packaging, so simply disable the tests. Not worth the hassle to rewrite them.