### PR TITLE
Mark Independent Partitioning Routine 'const'

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1196,9 +1196,11 @@ namespace Dune
          /// \param transmissibilities The transmissibilities used to calculate the edge weights.
          /// \param numParts Number of parts in the partition.
          /// \return An array with the domain index for each cell.
-         std::vector<int> zoltanPartitionWithoutScatter(const std::vector<cpgrid::OpmWellType> * wells,
-                                                        const double* transmissibilities, int numParts,
-                                                        const double zoltanImbalanceTol);
+         std::vector<int>
+         zoltanPartitionWithoutScatter(const std::vector<cpgrid::OpmWellType>* wells,
+                                       const double* transmissibilities,
+                                       const int     numParts,
+                                       const double  zoltanImbalanceTol) const;
 
         /// The new communication interface.
         /// \brief communicate objects for all codims on a given level

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -140,23 +140,20 @@ namespace Dune
     {}
 
 std::vector<int>
-CpGrid::zoltanPartitionWithoutScatter([[maybe_unused]] const std::vector<cpgrid::OpmWellType> * wells,
+CpGrid::zoltanPartitionWithoutScatter([[maybe_unused]] const std::vector<cpgrid::OpmWellType>* wells,
                                       [[maybe_unused]] const double* transmissibilities,
-                                      [[maybe_unused]] int numParts,
-                                      [[maybe_unused]] const double zoltanImbalanceTol)
+                                      [[maybe_unused]] const int numParts,
+                                      [[maybe_unused]] const double zoltanImbalanceTol) const
 {
-    std::vector<int> cell_part(this->numCells());
-#if HAVE_MPI
-    auto& cc = data_[0]->ccobj_;
-#ifdef HAVE_ZOLTAN
-    EdgeWeightMethod met = EdgeWeightMethod(1);
+#if HAVE_MPI && HAVE_ZOLTAN
+    const auto met = EdgeWeightMethod(1);
 
-    return cpgrid::zoltanGraphPartitionGridForJac(*this, wells, transmissibilities, cc, met, 0,
-                                                  numParts, zoltanImbalanceTol);
-
+    return cpgrid::zoltanGraphPartitionGridForJac(*this, wells, transmissibilities,
+                                                  this->data_[0]->ccobj_, met,
+                                                  0, numParts, zoltanImbalanceTol);
+#else
+    return std::vector<int>(this->numCells(), 0);
 #endif
-#endif
-    return cell_part;
 }
 
 


### PR DESCRIPTION
The `zoltanPartitionWithoutScatter()` member function does not alter the `CpGrid` instance so we can mark it as `const` to make it usable in more contexts.