### PR TITLE
Inheritance methods from the Dune interface added for (one) LGR

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -34,6 +34,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/grid/cpgrid/CpGrid.cpp
   opm/grid/cpgrid/DataHandleWrappers.cpp
   opm/grid/cpgrid/GridHelpers.cpp
+  opm/grid/cpgrid/Iterators.cpp
   opm/grid/cpgrid/PartitionTypeIndicator.cpp
   opm/grid/cpgrid/processEclipseFormat.cpp
   opm/grid/cpgrid/readSintefLegacyFormat.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -164,7 +164,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/grid/common/WellConnections.hpp
   opm/grid/cpgrid/CartesianIndexMapper.hpp
   opm/grid/cpgrid/CpGridData.hpp
-  opm/grid/cpgrid/CpGridDataTraits
+  opm/grid/cpgrid/CpGridDataTraits.hpp
   opm/grid/cpgrid/DataHandleWrappers.hpp
   opm/grid/cpgrid/DefaultGeometryPolicy.hpp
   opm/grid/cpgrid/dgfparser.hh

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -104,7 +104,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_compressed_cartesian_mapping.cpp
 	)
 
-if(BOOST_VERSION VERSION_GREATER 1.53)
+if(BOOST_VERSION VERSION_GREATER 1.53 OR Boost_VERSION VERSION_GREATER 1.53)
 	list(APPEND TEST_SOURCE_FILES
 	  tests/cpgrid/geometry_test.cpp
 	  tests/cpgrid/grid_lgr_test.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -35,6 +35,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/grid/cpgrid/DataHandleWrappers.cpp
   opm/grid/cpgrid/GridHelpers.cpp
   opm/grid/cpgrid/Iterators.cpp
+  opm/grid/cpgrid/Indexsets.cpp
   opm/grid/cpgrid/PartitionTypeIndicator.cpp
   opm/grid/cpgrid/processEclipseFormat.cpp
   opm/grid/cpgrid/readSintefLegacyFormat.cpp
@@ -163,6 +164,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/grid/common/WellConnections.hpp
   opm/grid/cpgrid/CartesianIndexMapper.hpp
   opm/grid/cpgrid/CpGridData.hpp
+  opm/grid/cpgrid/CpGridDataTraits
   opm/grid/cpgrid/DataHandleWrappers.hpp
   opm/grid/cpgrid/DefaultGeometryPolicy.hpp
   opm/grid/cpgrid/dgfparser.hh

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -462,7 +462,7 @@ namespace Dune
         /// @param [in] startIJK                 Cartesian triplet index where the patch starts.
         /// @param [in] endIJK                   Cartesian triplet index where the patch ends.
         ///                                      Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
-        void createGridWithLgr(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK, const std::array<int,3>& endIJK);
+        void addLgrUpdateLeafView(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK, const std::array<int,3>& endIJK);
 
         /*  No refinement implemented. GridDefaultImplementation's methods will be used.
 

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -38,14 +38,14 @@
 #ifndef OPM_CPGRID_HEADER
 #define OPM_CPGRID_HEADER
 
-#include <string>
-#include <map>
-#include <array>
-#include <unordered_set>
-#include <opm/common/ErrorMacros.hpp>
+//#include <string>  //OK
+//#include <map>  // OK
+//#include <array> // OK
+//#include <unordered_set>  // OK
+//#include <opm/common/ErrorMacros.hpp> // OK
 
 // Warning suppression for Dune includes.
-#include <opm/grid/utility/platform_dependent/disable_warnings.h>
+//#include <opm/grid/utility/platform_dependent/disable_warnings.h>  // OK
 
 #include <dune/common/version.hh>
 
@@ -57,23 +57,19 @@
 #endif
 #endif
 
-#include <dune/grid/common/capabilities.hh>
-#include <dune/grid/common/grid.hh>
-#include <dune/grid/common/gridenums.hh>
-
-#include <opm/grid/utility/platform_dependent/reenable_warnings.h>
-
-#include "cpgrid/Intersection.hpp"
-#include "cpgrid/Entity.hpp"
-#include "cpgrid/Geometry.hpp"
+//#include <dune/grid/common/capabilities.hh> // OK
+#include <dune/grid/common/grid.hh>  // 
+//#include <dune/grid/common/gridenums.hh> // OK
 #include "cpgrid/CpGridData.hpp"
-#include "cpgrid/Iterators.hpp"
-#include "cpgrid/Indexsets.hpp"
-#include "cpgrid/DefaultGeometryPolicy.hpp"
-#include "common/GridEnums.hpp"
-#include "common/Volumes.hpp"
-#include <opm/grid/cpgpreprocess/preprocess.h>
-#include <opm/grid/utility/OpmWellType.hpp>
+//#include <opm/grid/utility/platform_dependent/reenable_warnings.h> // OK
+//#include "cpgrid/Intersection.hpp"   // OK
+//#include "cpgrid/Geometry.hpp"   // OK
+//#include "cpgrid/Indexsets.hpp"  // OK global_id_set_ turned into shared-pointer. 
+//#include "cpgrid/DefaultGeometryPolicy.hpp"  // OK
+#include "common/GridEnums.hpp"   // OK
+//#include "common/Volumes.hpp"   // OK
+//#include <opm/grid/cpgpreprocess/preprocess.h>  // OK
+#include <opm/grid/utility/OpmWellType.hpp>  // OK
 
 #include <iostream>
 #if ! HAVE_MPI
@@ -87,7 +83,14 @@ namespace Dune
 
     namespace cpgrid
     {
-        class CpGridData;
+    class CpGridData;
+    template <int> class Entity;
+    template<int,int> class Geometry;
+    class HierarchicIterator;
+    class IntersectionIterator;
+    template<int, PartitionIteratorType> class Iterator;
+    class LevelGlobalIdSet;
+    
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -162,9 +165,9 @@ namespace Dune
         };
 
         /// \brief The type of the level grid view associated with this partition type.
-        typedef Dune::GridView<DefaultLevelGridViewTraits<CpGrid> > LevelGridView;
+        typedef Dune::GridView<DefaultLevelGridViewTraits<CpGrid>> LevelGridView;
         /// \brief The type of the leaf grid view associated with this partition type.
-        typedef Dune::GridView<DefaultLeafGridViewTraits<CpGrid> > LeafGridView;
+        typedef Dune::GridView<DefaultLeafGridViewTraits<CpGrid>> LeafGridView;
 
         /// \brief The type of the level index set.
         typedef cpgrid::IndexSet LevelIndexSet;
@@ -206,14 +209,18 @@ namespace Dune
 
     /// \brief [<em> provides \ref Dune::Grid </em>]
     class CpGrid
-        : public GridDefaultImplementation<3, 3, double, CpGridFamily >
+        : public GridDefaultImplementation<3, 3, double, CpGridFamily>
     {
         friend class cpgrid::CpGridData;
+        friend class cpgrid::Entity<0>;
+        friend class cpgrid::Entity<1>;
+        friend class cpgrid::Entity<2>;
+        friend class cpgrid::Entity<3>;
         template<int dim>
         friend cpgrid::Entity<dim> createEntity(const CpGrid&,int,bool);
         friend
-        void ::refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,
-                                const std::array<int, 3>&,
+        void ::refine_and_check(const Dune::cpgrid::Geometry<3,3>&,
+                                const std::array<int,3>&,
                                 bool);
         friend
         void ::refinePatch_and_check(Dune::CpGrid&,
@@ -335,10 +342,7 @@ namespace Dune
         /// The logical cartesian size of the global grid.
         /// This function is not part of the Dune grid interface,
         /// and should be used with caution.
-        const std::array<int, 3>& logicalCartesianSize() const
-        {
-            return current_view_data_->logical_cartesian_size_;
-        }
+        const std::array<int, 3>& logicalCartesianSize() const;
 
         /// Retrieve mapping from internal ("compressed") active grid
         /// cells to external ("uncompressed") cells.  Specifically,
@@ -347,10 +351,7 @@ namespace Dune
         /// only be used by classes which really need it, such as
         /// those dealing with permeability fields from the input deck
         /// from whence the current CpGrid was constructed.
-        const std::vector<int>& globalCell() const
-        {
-            return current_view_data_->global_cell_;
-        }
+        const std::vector<int>& globalCell() const;
 
         /// @brief
         ///    Extract Cartesian index triplet (i,j,k) of an active cell.
@@ -359,26 +360,18 @@ namespace Dune
         ///    Active cell index.
         ///
         /// @param [out] ijk  Cartesian index triplet
-        void getIJK(const int c, std::array<int,3>& ijk) const
-        {
-            current_view_data_->getIJK(c, ijk);
-        }
+        void getIJK(const int c, std::array<int,3>& ijk) const;
         //@}
 
         /// Is the grid currently using unique boundary ids?
         /// \return true if each boundary intersection has a unique id
         ///         false if we use the (default) 1-6 ids for i- i+ j- j+ k- k+ boundaries.
-        bool uniqueBoundaryIds() const
-        {
-            return current_view_data_->uniqueBoundaryIds();
-        }
+        bool uniqueBoundaryIds() const;
 
         /// Set whether we want to have unique boundary ids.
         /// \param uids if true, each boundary intersection will have a unique boundary id.
-        void setUniqueBoundaryIds(bool uids)
-        {
-            current_view_data_->setUniqueBoundaryIds(uids);
-        }
+        void setUniqueBoundaryIds(bool uids);
+       
 
         // --- Dune interface below ---
 
@@ -388,173 +381,72 @@ namespace Dune
         ///
         /// It's the same as the class name.
         /// What did you expect, something funny?
-        std::string name() const
-        {
-            return "CpGrid";
-        }
-
-
-        /// Return maximum level defined in this grid. Levels are numbered
-        /// 0 ... maxlevel with 0 the coarsest level.
-        int maxLevel() const
-        {
-            return 0;
-        }
-
+        std::string name() const;
+        
+        /// Return maximum level defined in this grid. Levels are 0 and 1,  maxlevel = 1 (not counting leafview), 0 = the coarsest level.
+        int maxLevel() const;
 
         /// Iterator to first entity of given codim on level
         template<int codim>
-        typename Traits::template Codim<codim>::LevelIterator lbegin (int level) const
-        {
-            if (level<0 || level>maxLevel())
-                DUNE_THROW(GridError, "levelIndexSet of nonexisting level " << level << " requested!");
-            return cpgrid::Iterator<codim, All_Partition>(*current_view_data_, 0, true);
-        }
-
-
+        typename Traits::template Codim<codim>::LevelIterator lbegin (int level) const;
         /// one past the end on this level
         template<int codim>
-        typename Traits::template Codim<codim>::LevelIterator lend (int level) const
-        {
-            if (level<0 || level>maxLevel())
-                DUNE_THROW(GridError, "levelIndexSet of nonexisting level " << level << " requested!");
-            return cpgrid::Iterator<codim,All_Partition>(*current_view_data_, size(codim), true );
-
-        }
-
-
-        /// Iterator to first entity of given codim on level
+        typename Traits::template Codim<codim>::LevelIterator lend (int level) const;
+        
+        /// Iterator to first entity of given codim on level and PartitionIteratorType
         template<int codim, PartitionIteratorType PiType>
-        typename Traits::template Codim<codim>::template Partition<PiType>::LevelIterator lbegin (int level) const
-        {
-            if (level<0 || level>maxLevel())
-                DUNE_THROW(GridError, "levelIndexSet of nonexisting level " << level << " requested!");
-            return cpgrid::Iterator<codim,PiType>(*current_view_data_, 0, true );
-        }
-
-
+        typename Traits::template Codim<codim>::template Partition<PiType>::LevelIterator lbegin (int level) const;
         /// one past the end on this level
         template<int codim, PartitionIteratorType PiType>
-        typename Traits::template Codim<codim>::template Partition<PiType>::LevelIterator lend (int level) const
-        {
-            if (level<0 || level>maxLevel())
-                DUNE_THROW(GridError, "levelIndexSet of nonexisting level " << level << " requested!");
-            return cpgrid::Iterator<codim,PiType>(*current_view_data_, size(codim), true);
-        }
-
+        typename Traits::template Codim<codim>::template Partition<PiType>::LevelIterator lend (int level) const;
 
         /// Iterator to first leaf entity of given codim
         template<int codim>
-        typename Traits::template Codim<codim>::LeafIterator leafbegin() const
-        {
-            return cpgrid::Iterator<codim, All_Partition>(*current_view_data_, 0, true);
-        }
-
-
+        typename Traits::template Codim<codim>::LeafIterator leafbegin() const;
         /// one past the end of the sequence of leaf entities
         template<int codim>
-        typename Traits::template Codim<codim>::LeafIterator leafend() const
-        {
-            return cpgrid::Iterator<codim, All_Partition>(*current_view_data_, size(codim), true);
-        }
-
-
-        /// Iterator to first leaf entity of given codim
+        typename Traits::template Codim<codim>::LeafIterator leafend() const;
+        
+        /// Iterator to first leaf entity of given codim and PartitionIteratorType
         template<int codim, PartitionIteratorType PiType>
-        typename Traits::template Codim<codim>::template Partition<PiType>::LeafIterator leafbegin() const
-        {
-            return cpgrid::Iterator<codim, PiType>(*current_view_data_, 0, true);
-        }
-
-
+        typename Traits::template Codim<codim>::template Partition<PiType>::LeafIterator leafbegin() const;
         /// one past the end of the sequence of leaf entities
         template<int codim, PartitionIteratorType PiType>
-        typename Traits::template Codim<codim>::template Partition<PiType>::LeafIterator leafend() const
-        {
-            return cpgrid::Iterator<codim, PiType>(*current_view_data_, size(codim), true);
-        }
-
+        typename Traits::template Codim<codim>::template Partition<PiType>::LeafIterator leafend() const;
 
         /// \brief Number of grid entities per level and codim
-        int size (int level, int codim) const
-        {
-            if (level<0 || level>maxLevel())
-                DUNE_THROW(GridError, "levelIndexSet of nonexisting level " << level << " requested!");
-            return size(codim);
-        }
-
+        int size (int level, int codim) const;
 
         /// number of leaf entities per codim in this process
-        int size (int codim) const
-        {
-            return current_view_data_->size(codim);
-        }
-
+        int size (int codim) const;
 
         /// number of entities per level and geometry type in this process
-        int size (int level, GeometryType type) const
-        {
-            if (level<0 || level>maxLevel())
-                DUNE_THROW(GridError, "levelIndexSet of nonexisting level " << level << " requested!");
-            return size(type);
-        }
-
+        int size (int level, GeometryType type) const;
 
         /// number of leaf entities per geometry type in this process
-        int size (GeometryType type) const
-        {
-            return current_view_data_->size(type);
-        }
-
+        int size (GeometryType type) const;
 
         /// \brief Access to the GlobalIdSet
-        const Traits::GlobalIdSet& globalIdSet() const
-        {
-            return global_id_set_;
-        }
-
+        const Traits::GlobalIdSet& globalIdSet() const;
 
         /// \brief Access to the LocalIdSet
-        const Traits::LocalIdSet& localIdSet() const
-        {
-            return global_id_set_;
-        }
-
-
+        const Traits::LocalIdSet& localIdSet() const;
+        
         /// \brief Access to the LevelIndexSets
-        const Traits::LevelIndexSet& levelIndexSet(int level) const
-        {
-            if (level<0 || level>maxLevel())
-                DUNE_THROW(GridError, "levelIndexSet of nonexisting level " << level << " requested!");
-            return *current_view_data_->index_set_;
-        }
-
+        const Traits::LevelIndexSet& levelIndexSet(int level) const;
 
         /// \brief Access to the LeafIndexSet
-        const Traits::LeafIndexSet& leafIndexSet() const
-        {
-            return *current_view_data_->index_set_;
-        }
-
+        const Traits::LeafIndexSet& leafIndexSet() const;
 
         /// global refinement
-        void globalRefine (int)
-        {
-            std::cout << "Warning: Global refinement not implemented, yet." << std::endl;
-        }
+        void globalRefine (int);
 
-        const std::vector< Dune :: GeometryType >& geomTypes( const int codim ) const
-        {
-          return leafIndexSet().geomTypes( codim );
-        }
+        const std::vector<Dune::GeometryType>& geomTypes(const int) const;
 
         /// given an EntitySeed (or EntityPointer) return an entity object
         template <int codim>
-        cpgrid::Entity<codim> entity( const cpgrid::Entity< codim >& seed ) const
-        {
-            return seed;
-        }
-
+        cpgrid::Entity<codim> entity(const cpgrid::Entity< codim >&) const;
+           
         /// @brief Create a grid out of a coarse one and a refinement(LGR) of a selected block-shaped patch of cells from that coarse grid.
         ///
         /// Level0 refers to the coarse grid, assumed to be this-> data_[0]. Level1 refers to the LGR (stored in this->data_[1]).
@@ -567,266 +459,13 @@ namespace Dune
         /// @param [in] startIJK                 Cartesian triplet index where the patch starts.
         /// @param [in] endIJK                   Cartesian triplet index where the patch ends.
         ///                                      Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
-        void createGridWithLgr(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK, const std::array<int,3>& endIJK)
-        {
-            if (!distributed_data_.empty()){
-                OPM_THROW(std::logic_error, "Grid has been distributed. Cannot created LGR.");
-            }
-            // Build the LGR/level1 from the selected patch of cells from level0 (level0 = this->data_[0]).
-            const auto& [level1_ptr, boundary_old_to_new_corners, boundary_old_to_new_faces, parent_to_children_faces,
-                         parent_to_children_cells, child_to_parent_faces, child_to_parent_cells, isParent_faces, isParent_cells]
-                = (*(this-> data_[0])).refinePatch(cells_per_dim, startIJK, endIJK);
-            // Add level 1 to "data".
-            (this-> data_).push_back(level1_ptr);
-            // To store the leaf view (mixed grid, with coarse and refined entities).
-            typedef Dune::FieldVector<double,3> PointType;
+        void createGridWithLgr(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK, const std::array<int,3>& endIJK);
             #if HAVE_MPI
-            std::shared_ptr<Dune::cpgrid::CpGridData> leaf_view_ptr =
-                std::make_shared<Dune::cpgrid::CpGridData>((*(this-> data_[0])).ccobj_);
             #else
             // DUNE 2.7 is missing convertion to NO_COMM
             std::shared_ptr<Dune::cpgrid::CpGridData> leaf_view_ptr =
                 std::make_shared<Dune::cpgrid::CpGridData>();
             #endif
-            auto& leaf_view = *leaf_view_ptr;
-            Dune::cpgrid::DefaultGeometryPolicy& leaf_geometries = leaf_view.geometry_;
-            std::vector<std::array<int,8>>& leaf_cell_to_point = leaf_view.cell_to_point_;
-            cpgrid::OrientedEntityTable<0,1>& leaf_cell_to_face = leaf_view.cell_to_face_;
-            Opm::SparseTable<int>& leaf_face_to_point = leaf_view.face_to_point_;
-            cpgrid::OrientedEntityTable<1,0>& leaf_face_to_cell = leaf_view.face_to_cell_;
-            cpgrid::EntityVariable<enum face_tag,1>& leaf_face_tags = leaf_view.face_tag_;
-            cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>,1>& leaf_face_normals = leaf_view.face_normals_;
-            // Mutable containers for leaf view corners, faces, cells, face tags, and face normals.
-            Dune::cpgrid::EntityVariableBase<cpgrid::Geometry<0,3>>& leaf_corners =
-                leaf_geometries.geomVector(std::integral_constant<int,3>());
-            Dune::cpgrid::EntityVariableBase<cpgrid::Geometry<2,3>>& leaf_faces =
-                leaf_geometries.geomVector(std::integral_constant<int,1>());
-            Dune::cpgrid::EntityVariableBase<cpgrid::Geometry<3,3>>& leaf_cells =
-                leaf_geometries.geomVector(std::integral_constant<int,0>());
-            Dune::cpgrid::EntityVariableBase<enum face_tag>& mutable_face_tags = leaf_face_tags;
-            Dune::cpgrid::EntityVariableBase<PointType>& mutable_face_normals = leaf_face_normals;
-            // Get patch corner, face, and cell indices.
-            const auto& [patch_corners, patch_faces, patch_cells] = (*(this->data_[0])).getPatchGeomIndices(startIJK, endIJK);
-            // Integer to count leaf view corners (mixed between corners from level0 not involved in LGR, and new-born-corners).
-            int corner_count = 0;
-            // Map between {level0/level1, old-corner-index/new-born-corner-index}  and its corresponding leafview-corner-index.
-            std::map<std::array<int,2>, int> level_to_leaf_corners;
-            // Corners coming from the level0, excluding patch_corners, i.e., the old-corners involved in the LGR.
-            for (int corner = 0; corner < this-> data_[0]->size(3); ++corner) {
-                // Auxiliary bool to discard patch corners.
-                bool is_there_corn = false;
-                for(const auto& patch_corn : patch_corners) {
-                    is_there_corn = is_there_corn || (corner == patch_corn); //true->corn coincides with one patch corner
-                    if (is_there_corn)
-                        break;
-                }
-                if(!is_there_corn) { // corner is not involved in refinement, so we store it.
-                    level_to_leaf_corners[{0, corner}] = corner_count;
-                    corner_count +=1;
-                }
-            }
-            // Corners coming from level1, i.e. refined (new-born) corners.
-            for (int corner = 0; corner < this -> data_[1]->size(3); ++corner) {
-                level_to_leaf_corners[{1, corner}] = corner_count;
-                corner_count +=1;
-            }
-            // Resize the container of the leaf view corners.
-            leaf_corners.resize(corner_count);
-            for (const auto& [level_cornIdx, leafCornIdx] : level_to_leaf_corners) { // level_cornIdx = {level, corner index}
-                const auto& level_data = *(this->data_[level_cornIdx[0]]);
-                leaf_corners[leafCornIdx] = level_data.geometry_.geomVector(std::integral_constant<int,3>()).get(level_cornIdx[1]);
-            }
-            // Map to relate boundary patch corners with their equivalent refined/new-born ones. {0,oldCornerIdx} -> {1,newCornerIdx}
-            std::map<std::array<int,2>, std::array<int,2>> old_to_new_boundaryPatchCorners;
-            // To store (indices of) boundary patch corners.
-            std::vector<int> boundary_patch_corners;
-            boundary_patch_corners.reserve(boundary_old_to_new_corners.size());
-            for (long unsigned int corner = 0; corner < boundary_old_to_new_corners.size(); ++corner) {
-                old_to_new_boundaryPatchCorners[{0, boundary_old_to_new_corners[corner][0]}] = {1, boundary_old_to_new_corners[corner][1]};
-                boundary_patch_corners.push_back(boundary_old_to_new_corners[corner][0]);
-            }
-            // Integer to count leaf view faces (mixed between faces from level0 not involved in LGR, and new-born-faces).
-            int face_count = 0;
-            // Map between {level0/level1, old-face-index/new-born-face-index}  and its corresponding leafview-face-index.
-            std::map<std::array<int,2>, int> level_to_leaf_faces;
-            // Faces coming from the level0, that do not belong to the patch.
-            for (int face = 0; face < this->data_[0]->face_to_cell_.size(); ++face) {
-                // Auxiliary bool to discard patch faces.
-                bool is_there_face = false;
-                for(const auto& patch_face : patch_faces) {
-                    is_there_face = is_there_face || (face == patch_face); //true->face coincides with one patch faces
-                    if (is_there_face)
-                        break;
-                }
-                if(!is_there_face) { // false-> face was not involved in the LGR, so we store it.
-                    level_to_leaf_faces[{0, face}] = face_count;
-                    face_count +=1;
-                }
-            }
-            // Faces coming from level1, i.e. refined faces.
-            for (int face = 0; face < this->data_[1]-> face_to_cell_.size(); ++face) {
-                level_to_leaf_faces[{1, face}] = face_count;
-                face_count +=1;
-            }
-            // Resize leaf_faces, mutable_face_tags, and mutable_face_normals.
-            leaf_faces.resize(face_count);
-            mutable_face_tags.resize(face_count);
-            mutable_face_normals.resize(face_count);
-            // Auxiliary integer to count all the points in leaf_face_to_point.
-            int num_points = 0;
-            // Auxiliary vector to store face_to_point with non consecutive indices.
-            std::vector<std::vector<int>> aux_face_to_point;
-            aux_face_to_point.resize(face_count);
-            for (const auto& [level_faceIdx, leafFaceIdx] : level_to_leaf_faces) { // level_faceIdx = {level0/1, face index }
-                // Get the level data.
-                const auto& level_data = *(this->data_[level_faceIdx[0]]);
-                // Get the (face) entity (from level data).
-                const auto& entity = Dune::cpgrid::EntityRep<1>(level_faceIdx[1], true);
-                // Get the face geometry.
-                leaf_faces[leafFaceIdx] = level_data.geometry_.geomVector(std::integral_constant<int,1>())[entity];
-                // Get the face tag.
-                mutable_face_tags[leafFaceIdx] = level_data.face_tag_[entity];
-                // Get the face normal.
-                mutable_face_normals[leafFaceIdx] = level_data.face_normals_[entity];
-                // Get old_face_to_point.
-                auto old_face_to_point = level_data.face_to_point_[level_faceIdx[1]];
-                aux_face_to_point[leafFaceIdx].reserve(old_face_to_point.size());
-                // Add the amount of points to the count num_points.
-                num_points += old_face_to_point.size();
-                if (level_faceIdx[0] == 0) { // Face comes from level0, check if some of its corners got refined.
-                    for (int corn = 0; corn < 4; ++corn) {
-                        // Auxiliary bool to identify boundary patch corners.
-                        bool is_there_bound_corn = false;
-                        for(const auto& bound_corn : boundary_patch_corners) {
-                            is_there_bound_corn = is_there_bound_corn || (corn == bound_corn); //true-> boundary patch corner
-                            if (is_there_bound_corn)
-                                break;
-                        }
-                        if(!is_there_bound_corn) {  // If it does not belong to the boundary of the patch:
-                            aux_face_to_point[leafFaceIdx].push_back(level_to_leaf_corners[{0, old_face_to_point[corn]}]);
-                        }
-                        else { // If the corner was involved in the refinement (corner on the boundary of the patch):
-                            aux_face_to_point[leafFaceIdx].push_back(level_to_leaf_corners
-                                                                     [old_to_new_boundaryPatchCorners[{0, old_face_to_point[corn]}]]);
-                        }
-                    }
-                }
-                else { // Face comes from level1/LGR
-                    for (long unsigned int corn = 0; corn < old_face_to_point.size(); ++corn) {
-                        aux_face_to_point[leafFaceIdx].push_back(level_to_leaf_corners[{1, old_face_to_point[corn]}]);
-                    }
-                }
-            }
-            // Leaf view face_to_point.
-            leaf_face_to_point.reserve(face_count, num_points);
-            for (int face = 0; face < face_count; ++face) {
-                leaf_face_to_point.appendRow(aux_face_to_point[face].begin(), aux_face_to_point[face].end());
-            }
-            // Map to relate boundary patch faces with their children refined/new-born ones. {0,oldFaceIdx} -> {1,newFaceIdx}
-            std::map<std::array<int,2>,std::vector<std::array<int,2>>> old_to_new_boundaryPatchFaces;
-            // To store (indices of) boundary patch faces.
-            std::vector<int> boundary_patch_faces;
-            boundary_patch_faces.reserve(boundary_old_to_new_faces.size());
-            for (long unsigned int face = 0; face < boundary_old_to_new_faces.size(); ++face) {
-                for (const auto& child : std::get<1>(boundary_old_to_new_faces[face])) {
-                    old_to_new_boundaryPatchFaces[{0, std::get<0>(boundary_old_to_new_faces[face])}].push_back({1, child});
-                }
-                boundary_patch_faces.push_back(std::get<0>(boundary_old_to_new_faces[face]));
-            }
-            // Integer to count leaf view cells (mixed between cells from level0 not involved in LGR, and new-born-cells).
-            int cell_count = 0;
-            // Map between {level0/level1, old-cell-index/new-born-cell-index}  and its corresponding leafview-cell-index.
-            std::map<std::array<int,2>, int> level_to_leaf_cells;
-            // Cells coming from the level0, that do not belong to the patch.
-            for (int cell = 0; cell < this->data_[0]-> size(0); ++cell) {
-                // Auxiliary bool to identify cells of the patch.
-                bool is_there_cell = false;
-                for(const auto& patch_cell : patch_cells) {
-                    is_there_cell = is_there_cell || (cell == patch_cell); //true-> coincides with one patch cell
-                    if (is_there_cell)
-                        break;
-                }
-                if(!is_there_cell) {// Cell does not belong to the patch, so we store it.
-                    level_to_leaf_cells[{0, cell}] = cell_count;
-                    cell_count +=1;
-                }
-            }
-            // Cells coming from level1, i.e. refined cells.
-            for (int cell = 0; cell < this->data_[1]-> size(0); ++cell) {
-                level_to_leaf_cells[{1, cell}] = cell_count;
-                cell_count +=1;
-            }
-            leaf_cells.resize(cell_count);
-            leaf_cell_to_point.resize(cell_count);
-            // Auxiliary vector to store cell_to_face with non consecutive indices.
-            std::map<int,std::vector<cpgrid::EntityRep<1>>> aux_cell_to_face;
-            for (const auto& [level_cellIdx, leafCellIdx] : level_to_leaf_cells) {// level_cellIdx = {level0/1, cell index}
-                const auto& level_data =  *(this->data_[level_cellIdx[0]]);
-                const auto& entity =  Dune::cpgrid::EntityRep<0>(level_cellIdx[1], true);
-                // Get the cell geometry.
-                leaf_cells[leafCellIdx] = level_data.geometry_.geomVector(std::integral_constant<int,0>())[entity];
-                // Get old corners of the cell that will be replaced with leaf view ones.
-                auto old_cell_to_point = level_data.cell_to_point_[level_cellIdx[1]];
-                // Get old faces of the cell that will be replaced with leaf view ones.
-                auto old_cell_to_face = level_data.cell_to_face_[entity];
-                if (level_cellIdx[0] == 0) { // Cell comes from level0
-                    // Cell to point.
-                    for (int corn = 0; corn < 8; ++corn) {
-                        // Auxiliary bool to identity boundary patch corners
-                        bool is_there_corn = false;
-                        for(const auto& patch_corn : patch_corners) {
-                            is_there_corn = is_there_corn || (old_cell_to_point[corn] == patch_corn);
-                            if (is_there_corn)//true-> coincides with one boundary patch corner
-                                break;
-                        }
-                        if(is_there_corn) { // Corner belongs to the patch boundary.
-                            leaf_cell_to_point[leafCellIdx][corn] =
-                                level_to_leaf_corners[old_to_new_boundaryPatchCorners[{0, old_cell_to_point[corn]}]];
-                        }
-                        else { // Corner does not belong to the patch boundary.
-                            leaf_cell_to_point[leafCellIdx][corn] = level_to_leaf_corners[{0, old_cell_to_point[corn]}];
-                        }
-                    }
-                    // Cell to face.
-                    for (const auto& face : old_cell_to_face)
-                    {   // Auxiliary bool to identity boundary patch faces
-                        bool is_there_face = false;
-                        for(const auto& bound_face : boundary_patch_faces) {
-                            is_there_face = is_there_face || (face.index() == bound_face); //true-> coincides with one boundary patch face
-                            if (is_there_face)
-                                break;
-                        }
-                        if(is_there_face) { // Face belongs to the patch boundary.
-                            for (const auto& level_newFace : old_to_new_boundaryPatchFaces[{0, face.index()}]) {
-                                aux_cell_to_face[leafCellIdx].push_back({level_to_leaf_faces[level_newFace], face.orientation()});
-                            }
-                        }
-                        else { // Face does not belong to the patch boundary.
-                            aux_cell_to_face[leafCellIdx].push_back({level_to_leaf_faces[{0, face.index()}], face.orientation()});
-                        }
-                    }
-                }
-                else { // Refined cells.
-                    // Cell to point.
-                    for (int corn = 0; corn < 8; ++corn) {
-                        leaf_cell_to_point[leafCellIdx][corn] = level_to_leaf_corners[{1, old_cell_to_point[corn]}];
-                    }
-                    // Cell to face.
-                    for (auto& face : old_cell_to_face) {
-                        aux_cell_to_face[leafCellIdx].push_back({level_to_leaf_faces[{1, face.index()}], face.orientation()});
-                    }
-                }
-            }
-            // Leaf view cell to face.
-            for (int cell = 0; cell < cell_count; ++cell) {
-                leaf_cell_to_face.appendRow(aux_cell_to_face[cell].begin(), aux_cell_to_face[cell].end());
-            }
-            // Leaf view face to cell.
-            leaf_cell_to_face.makeInverseRelation(leaf_face_to_cell);
-            //  Add Leaf View to data_.
-            (this-> data_).push_back(leaf_view_ptr);
-            current_view_data_ = data_[2].get();
-        }
 
         /*  No refinement implemented. GridDefaultImplementation's methods will be used.
 
@@ -874,53 +513,23 @@ namespace Dune
         end of refinement section */
 
         /// \brief Size of the overlap on the leaf level
-        unsigned int overlapSize(int) const {
-            return 1;
-        }
+        unsigned int overlapSize(int) const;
 
 
         /// \brief Size of the ghost cell layer on the leaf level
-        unsigned int ghostSize(int) const {
-            return 0;
-        }
-
-
+        unsigned int ghostSize(int) const;
+        
         /// \brief Size of the overlap on a given level
-        unsigned int overlapSize(int, int) const {
-            return 1;
-        }
-
+        unsigned int overlapSize(int, int) const;
 
         /// \brief Size of the ghost cell layer on a given level
-        unsigned int ghostSize(int, int) const {
-            return 0;
-        }
+        unsigned int ghostSize(int, int) const;
 
         /// \brief returns the number of boundary segments within the macro grid
-        unsigned int numBoundarySegments() const
-        {
-            if( uniqueBoundaryIds() )
-            {
-                return current_view_data_->unique_boundary_ids_.size();
-            }
-            else
-            {
-                unsigned int numBndSegs = 0;
-                const int num_faces = numFaces();
-                for (int i = 0; i < num_faces; ++i) {
-                    cpgrid::EntityRep<1> face(i, true);
-                    if (current_view_data_->face_to_cell_[face].size() == 1) {
-                        ++numBndSegs;
-                    }
-                }
-                return numBndSegs;
-            }
-        }
+        unsigned int numBoundarySegments() const;
 
-        void setZoltanParams(const std::map<std::string,std::string>& params)
-        {
-          zoltanParams = params;
-        }
+        void setZoltanParams(const std::map<std::string,std::string>& params); 
+      
 
         // loadbalance is not part of the grid interface therefore we skip it.
 
@@ -956,7 +565,7 @@ namespace Dune
         /// \return A pair consisting of a boolean indicating whether loadbalancing actually happened and
         ///         a vector containing a pair of name and a boolean, indicating whether this well has
         ///         perforated cells local to the process, for all wells (sorted by name)
-        std::pair<bool, std::vector<std::pair<std::string,bool> > >
+        std::pair<bool,std::vector<std::pair<std::string,bool>>>
         loadBalance(const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities = nullptr,
                     int overlapLayers=1, bool useZoltan=true)
@@ -989,7 +598,7 @@ namespace Dune
         /// \return A pair consisting of a boolean indicating whether loadbalancing actually happened and
         ///         a vector containing a pair of name and a boolean, indicating whether this well has
         ///         perforated cells local to the process, for all wells (sorted by name)
-        std::pair<bool, std::vector<std::pair<std::string,bool> > >
+        std::pair<bool,std::vector<std::pair<std::string,bool>>>
         loadBalance(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities = nullptr, bool ownersFirst=false,
                     bool addCornerCells=false, int overlapLayers=1,
@@ -1229,10 +838,7 @@ namespace Dune
         }
 
         /// \brief Get the collective communication object.
-        const typename CpGridTraits::Communication& comm () const
-        {
-            return current_view_data_->ccobj_;
-        }
+const typename CpGridTraits::Communication& comm () const;
         //@}
 
         // ------------ End of Dune interface, start of simplified interface --------------
@@ -1248,52 +854,38 @@ namespace Dune
         typedef Dune::FieldVector<double, 3> Vector;
 
 
-        const std::vector<double>& zcornData() const {
-            return current_view_data_->zcornData();
-        }
+const std::vector<double>& zcornData() const;
 
 
         // Topology
         /// \brief Get the number of cells.
-        int numCells() const
-        {
-            return current_view_data_->cell_to_face_.size();
-        }
+int numCells() const;
+
         /// \brief Get the number of faces.
-        int numFaces() const
-        {
-            return current_view_data_->face_to_cell_.size();
-        }
+int numFaces() const;
+
         /// \brief Get The number of vertices.
-        int numVertices() const
-        {
-            return current_view_data_->geomVector<3>().size();
-        }
+int numVertices() const;
+
+
         /// \brief Get the number of faces of a cell.
         ///
         /// Due to faults, and collapsing vertices (along pillars) this
         /// number is quite arbitrary. Its lower bound is 4, but there is
         /// no upper bound.
         /// \parame cell the index identifying the cell.
-        int numCellFaces(int cell) const
-        {
-            return current_view_data_->cell_to_face_[cpgrid::EntityRep<0>(cell, true)].size();
-        }
+int numCellFaces(int cell) const;
+
         /// \brief Get a specific face of a cell.
         /// \param cell The index identifying the cell.
         /// \param local_index The local index (in [0,numFaces(cell))) of the face in this cell.
         /// \return The index identifying the face.
-        int cellFace(int cell, int local_index) const
-        {
-            return current_view_data_->cell_to_face_[cpgrid::EntityRep<0>(cell, true)][local_index].index();
-        }
+int cellFace(int cell, int local_index) const;
 
         /// \brief Get a list of indices identifying all faces of a cell.
         /// \param cell The index identifying the cell.
-        const cpgrid::OrientedEntityTable<0,1>::row_type cellFaceRow(int cell) const
-        {
-            return current_view_data_->cell_to_face_[cpgrid::EntityRep<0>(cell, true)];
-        }
+const cpgrid::OrientedEntityTable<0,1>::row_type cellFaceRow(int cell) const;
+
         /// \brief Get the index identifying a cell attached to a face.
         ///
         /// Note that a face here is always oriented. If there are two
@@ -1304,211 +896,60 @@ namespace Dune
         /// \return The index identifying a cell or -1 if there is no such
         /// cell due the face being part of the grid boundary or the
         /// cell being stored on another process.
-        int faceCell(int face, int local_index) const
-        {
-            // In the parallel case we store non-existent cells for faces along
-            // the front region. Theses marked with index std::numeric_limits<int>::max(),
-            // orientation might be arbitrary, though.
-            cpgrid::OrientedEntityTable<1,0>::row_type r
-                = current_view_data_->face_to_cell_[cpgrid::EntityRep<1>(face, true)];
-            bool a = (local_index == 0);
-            bool b = r[0].orientation();
-            bool use_first = a ? b : !b;
-            // The number of valid cells.
-            int r_size = r.size();
-            // In the case of only one valid cell, this is the index of it.
-            int index = 0;
-            if(r[0].index()==std::numeric_limits<int>::max()){
-                assert(r_size==2);
-                --r_size;
-                index=1;
-            }
-            if(r.size()>1 && r[1].index()==std::numeric_limits<int>::max())
-            {
-                assert(r_size==2);
-                --r_size;
-            }
-            if (r_size == 2) {
-                return use_first ? r[0].index() : r[1].index();
-            } else {
-                return use_first ? r[index].index() : -1;
-            }
-        }
+int faceCell(int face, int local_index) const;
+      
         /// \brief Get the sum of all faces attached to all cells.
         ///
         /// Each face identified by a unique index is counted as often
         /// as there are neigboring cells attached to it.
         /// \f$ numCellFaces()=\sum_{c} numCellFaces(c) \f$
         /// \see numCellFaces(int)const
-        int numCellFaces() const
-        {
-            return current_view_data_->cell_to_face_.dataSize();
-        }
-        int numFaceVertices(int face) const
-        {
-            return current_view_data_->face_to_point_[face].size();
-        }
+int numCellFaces() const;
+
+int numFaceVertices(int face) const;
+
         /// \brief Get the index identifying a vertex of a face.
         /// \param cell The index identifying the face.
         /// \param local_index The local_index (in [0,numFaceVertices(vertex) - 1]])
         ///  of the vertex.
-        int faceVertex(int face, int local_index) const
-        {
-            return current_view_data_->face_to_point_[face][local_index];
-        }
+int faceVertex(int face, int local_index) const;
+
         /// \brief Get vertical position of cell center ("zcorn" average).
         /// \brief cell_index The index of the specific cell.
-        double cellCenterDepth(int cell_index) const
-        {
-            // Here cell center depth is computed as a raw average of cell corner depths.
-            // This generally gives slightly different results than using the cell centroid.
-            double zz = 0.0;
-            const int nv = current_view_data_->cell_to_point_[cell_index].size();
-            const int nd = 3;
-            for (int i=0; i<nv; ++i) {
-                zz += vertexPosition(current_view_data_->cell_to_point_[cell_index][i])[nd-1];
-            }
-            return zz/nv;
-        }
-
-        const Vector faceCenterEcl(int cell_index, int face) const
-        {
-            // This method is an alternative to the method faceCentroid(...).
-            // The face center is computed as a raw average of cell corners.
-            // For faulted cells this gives different results then average of face nodes
-            // that seems to agree more with eclipse.
-            // This assumes the cell nodes are ordered
-            // 6---7
-            // | T |
-            // 4---5
-            //   2---3
-            //   | B |
-            //   0---1
-
-            // this follows the DUNE reference cube
-            static const int faceVxMap[ 6 ][ 4 ] = { {0, 2, 4, 6}, // face 0
-                                                     {1, 3, 5, 7}, // face 1
-                                                     {0, 1, 4, 5}, // face 2
-                                                     {2, 3, 6, 7}, // face 3
-                                                     {0, 1, 2, 3}, // face 4
-                                                     {4, 5, 6, 7}  // face 5
-                                                   };
+double cellCenterDepth(int cell_index) const;
 
 
-            assert (current_view_data_->cell_to_point_[cell_index].size() == 8);
-            Vector center(0.0);
-            for( int i=0; i<4; ++i )
-            {
-               center += vertexPosition(current_view_data_->cell_to_point_[cell_index][ faceVxMap[ face ][ i ] ]);
-            }
+const Vector faceCenterEcl(int cell_index, int face) const;
 
-            for (int i=0; i<3; ++i) {
-                center[i] /= 4;
-            }
-            return center;
+const Vector faceAreaNormalEcl(int face) const;
 
-        }
-
-        const Vector faceAreaNormalEcl(int face) const
-        {
-            // same implementation as ResInsight
-            const int nd = Vector::dimension;
-            const int nv =  numFaceVertices(face);
-            switch (nv)
-            {
-            case 0:
-            case 1:
-            case 2:
-                {
-                    return Vector(0.0);
-                }
-                break;
-            case 3:
-                {
-                Vector a = vertexPosition(current_view_data_->face_to_point_[face][0]) - vertexPosition(current_view_data_->face_to_point_[face][2]);
-                Vector b = vertexPosition(current_view_data_->face_to_point_[face][1]) - vertexPosition(current_view_data_->face_to_point_[face][2]);
-                Vector areaNormal = cross(a,b);
-                for (int i=0; i<nd; ++i) {
-                    areaNormal[i] /= 2;
-                }
-                return areaNormal;
-            }
-                                break;
-            case 4:
-                {
-                Vector a = vertexPosition(current_view_data_->face_to_point_[face][0]) - vertexPosition(current_view_data_->face_to_point_[face][2]);
-                Vector b = vertexPosition(current_view_data_->face_to_point_[face][1]) - vertexPosition(current_view_data_->face_to_point_[face][3]);
-                Vector areaNormal = cross(a,b);
-                areaNormal *= 0.5;
-                return areaNormal;
-                }
-                break;
-            default:
-                {
-                    int h = (nv - 1)/2;
-                    int k = (nv % 2) ? 0 : nv - 1;
-
-                    Vector areaNormal(0.0);
-                    // First quads
-                    for (int i = 1; i < h; ++i)
-                    {
-                        Vector a = vertexPosition(current_view_data_->face_to_point_[face][2*i]) - vertexPosition(current_view_data_->face_to_point_[face][0]);
-                        Vector b = vertexPosition(current_view_data_->face_to_point_[face][2*i+1]) - vertexPosition(current_view_data_->face_to_point_[face][2*i-1]);
-                        areaNormal += cross(a,b);
-                    }
-
-                    // Last triangle or quad
-                    Vector a = vertexPosition(current_view_data_->face_to_point_[face][2*h]) - vertexPosition(current_view_data_->face_to_point_[face][0]);
-                    Vector b = vertexPosition(current_view_data_->face_to_point_[face][k]) - vertexPosition(current_view_data_->face_to_point_[face][2*h-1]);
-                    areaNormal += cross(a,b);
-
-                    areaNormal *= 0.5;
-
-                    return areaNormal;
-                }
-
-            }
-        }
 
         // Geometry
         /// \brief Get the Position of a vertex.
         /// \param cell The index identifying the cell.
         /// \return The coordinates of the vertex.
-        const Vector& vertexPosition(int vertex) const
-        {
-            return current_view_data_->geomVector<3>()[cpgrid::EntityRep<3>(vertex, true)].center();
-        }
+const Vector& vertexPosition(int vertex) const;
+
         /// \brief Get the area of a face.
         /// \param cell The index identifying the face.
-        double faceArea(int face) const
-        {
-            return current_view_data_->geomVector<1>()[cpgrid::EntityRep<1>(face, true)].volume();
-        }
+double faceArea(int face) const;
+
         /// \brief Get the coordinates of the center of a face.
         /// \param cell The index identifying the face.
-        const Vector& faceCentroid(int face) const
-        {
-            return current_view_data_->geomVector<1>()[cpgrid::EntityRep<1>(face, true)].center();
-        }
+const Vector& faceCentroid(int face) const;
+
         /// \brief Get the unit normal of a face.
         /// \param cell The index identifying the face.
         /// \see faceCell
-        const Vector& faceNormal(int face) const
-        {
-            return current_view_data_->face_normals_.get(face);
-        }
+const Vector& faceNormal(int face) const;
+
         /// \brief Get the volume of the cell.
         /// \param cell The index identifying the cell.
-        double cellVolume(int cell) const
-        {
-            return current_view_data_->geomVector<0>()[cpgrid::EntityRep<0>(cell, true)].volume();
-        }
+double cellVolume(int cell) const;
+
         /// \brief Get the coordinates of the center of a cell.
         /// \param cell The index identifying the face.
-        const Vector& cellCentroid(int cell) const
-        {
-            return current_view_data_->geomVector<0>()[cpgrid::EntityRep<0>(cell, true)].center();
-        }
+const Vector& cellCentroid(int cell) const;
 
         /// \brief An iterator over the centroids of the geometry of the entities.
         /// \tparam codim The co-dimension of the entities.
@@ -1528,7 +969,7 @@ namespace Dune
             : iter_(iter)
             {}
 
-            const FieldVector<double, 3>& dereference() const
+            const FieldVector<double,3>& dereference() const
             {
                 return iter_->center();
             }
@@ -1536,12 +977,11 @@ namespace Dune
             {
                 ++iter_;
             }
-            const FieldVector<double, 3>& elementAt(int n)
+            const FieldVector<double,3>& elementAt(int n)
             {
                 return iter_[n]->center();
             }
-            void advance(int n)
-            {
+            void advance(int n){
                 iter_+=n;
             }
             void decrement()
@@ -1552,8 +992,7 @@ namespace Dune
             {
                 return o-iter_;
             }
-            bool equals(const CentroidIterator& o) const
-            {
+            bool equals(const CentroidIterator& o) const{
                 return o==iter_;
             }
         private:
@@ -1561,60 +1000,14 @@ namespace Dune
             GeometryIterator iter_;
         };
 
-        /// \brief Get an iterator over the cell centroids positioned at the first one.
-        CentroidIterator<0> beginCellCentroids() const
-        {
-            return CentroidIterator<0>(current_view_data_->geomVector<0>().begin());
-        }
+/// \brief Get an iterator over the cell centroids positioned at the first one.
+CentroidIterator<0> beginCellCentroids() const;
 
-        /// \brief Get an iterator over the face centroids positioned at the first one.
-        CentroidIterator<1> beginFaceCentroids() const
-        {
-            return CentroidIterator<1>(current_view_data_->geomVector<1>().begin());
-        }
+/// \brief Get an iterator over the face centroids positioned at the first one.
+CentroidIterator<1> beginFaceCentroids() const;
 
-        // Extra
-        int boundaryId(int face) const
-        {
-            // Note that this relies on the following implementation detail:
-            // The grid is always construct such that the faces where
-            // orientation() returns true are oriented along the positive IJK
-            // direction. Oriented means that the first cell attached to face
-            // has the lower index.
-            int ret = 0;
-            cpgrid::EntityRep<1> f(face, true);
-            if (current_view_data_->face_to_cell_[f].size() == 1) {
-                if (current_view_data_->uniqueBoundaryIds()) {
-                    // Use the unique boundary ids.
-                    ret = current_view_data_->unique_boundary_ids_[f];
-                } else {
-                    // Use the face tag based ids, i.e. 1-6 for i-, i+, j-, j+, k-, k+.
-                    const bool normal_is_in =
-                        !(current_view_data_->face_to_cell_[f][0].orientation());
-                    enum face_tag tag = current_view_data_->face_tag_[f];
-                    switch (tag) {
-                    case I_FACE:
-                        //                   LEFT : RIGHT
-                        ret = normal_is_in ? 1    : 2; // min(I) : max(I)
-                        break;
-                    case J_FACE:
-                        //                   BACK : FRONT
-                        ret = normal_is_in ? 3    : 4; // min(J) : max(J)
-                        break;
-                    case K_FACE:
-                        // Note: TOP at min(K) as 'z' measures *depth*.
-                        //                   TOP  : BOTTOM
-                        ret = normal_is_in ? 5    : 6; // min(K) : max(K)
-                        break;
-                    case NNC_FACE:
-                        // This should not be possible, as NNC "faces" always
-                        // have two cell neighbours.
-                        OPM_THROW(std::logic_error, "NNC face at boundary. This should never happen!");
-                    }
-                }
-            }
-            return ret;
-        }
+// Extra
+int boundaryId(int face) const;
 
         /// \brief Get the cartesian tag associated with a face tag.
         ///
@@ -1774,31 +1167,25 @@ namespace Dune
         ///                                       grid.cellScatterGatherInterface());
         /// comm.forward(handle);
         /// \endcode
-        const InterfaceMap& cellScatterGatherInterface() const
+const InterfaceMap& cellScatterGatherInterface() const;
+/*
         {
             return *cell_scatter_gather_interfaces_;
-        }
+            }*/
 
         /// \brief Get an interface for gathering/scattering data attached to points with communication.
         /// \see cellScatterGatherInterface
-        const InterfaceMap& pointScatterGatherInterface() const
-        {
+const InterfaceMap& pointScatterGatherInterface() const;
+
+/*  {
             return *point_scatter_gather_interfaces_;
-        }
+            }*/
 
         /// \brief Switch to the global view.
-        void switchToGlobalView()
-        {
-            current_view_data_=data_[0].get();
-        }
+void switchToGlobalView();
 
         /// \brief Switch to the distributed view.
-        void switchToDistributedView()
-        {
-            if (distributed_data_.empty())
-                OPM_THROW(std::logic_error, "No distributed view available in grid");
-            current_view_data_=distributed_data_[0].get();
-        }
+void switchToDistributedView();
         //@}
 
 #if HAVE_MPI
@@ -1813,38 +1200,19 @@ namespace Dune
         /// \brief Get the owner-overlap-copy communication for cells
         ///
         /// Suitable e.g. for parallel linear algebra used by CCFV
-        const CommunicationType& cellCommunication() const
-        {
-            return current_view_data_->cellCommunication();
-        }
+const CommunicationType& cellCommunication() const;
 
-        ParallelIndexSet& getCellIndexSet()
-        {
-            return current_view_data_->cellIndexSet();
-        }
+ParallelIndexSet& getCellIndexSet();
 
-        RemoteIndices& getCellRemoteIndices()
-        {
-            return current_view_data_->cellRemoteIndices();
-        }
+RemoteIndices& getCellRemoteIndices();
 
-        const ParallelIndexSet& getCellIndexSet() const
-        {
-            return current_view_data_->cellIndexSet();
-        }
+const ParallelIndexSet& getCellIndexSet() const;
 
-        const RemoteIndices& getCellRemoteIndices() const
-        {
-            return current_view_data_->cellRemoteIndices();
-        }
-
+const RemoteIndices& getCellRemoteIndices() const;
 #endif
 
         /// \brief Get sorted active cell indices of numerical aquifer
-       const std::vector<int>& sortedNumAquiferCells() const
-       {
-           return current_view_data_->sortedNumAquiferCells();
-       }
+const std::vector<int>& sortedNumAquiferCells() const;
 
     private:
         /// \brief Scatter a global grid to all processors.
@@ -1909,7 +1277,9 @@ namespace Dune
         /**
          * @brief The global id set (also used as local one).
          */
-        cpgrid::GlobalIdSet global_id_set_;
+// cpgrid::GlobalIdSet global_id_set_;
+std::shared_ptr<cpgrid::GlobalIdSet> global_id_set_ptr_;
+
 
         /**
          * @brief Zoltan partitioning parameters
@@ -1918,6 +1288,17 @@ namespace Dune
 
     }; // end Class CpGrid
 
+
+#include <opm/grid/cpgrid/Entity.hpp>
+#include <opm/grid/cpgrid/Iterators.hpp>
+/*#include <opm/grid/cpgrid/PersistentContainer.hpp>
+#include <opm/grid/cpgrid/CartesianIndexMapper.hpp>
+#include <opm/grid/cpgrid/GridHelpers.hpp>
+//#include <attic/BuildCpGrid.hpp> ../..
+#include <opm/grid/common/ZoltanPartition.hpp>
+#include <opm/grid/common/ZoltanGraphFunctions.hpp>
+#include <opm/grid/common/GridAdapter.hpp>
+#include <opm/grid/common/WellConnections.hpp>*/
 
 
     namespace Capabilities
@@ -1957,12 +1338,8 @@ namespace Dune
 
     }
 
-
     template<int dim>
-    cpgrid::Entity<dim> createEntity(const CpGrid& grid,int index,bool orientation)
-    {
-        return cpgrid::Entity<dim>(*grid.current_view_data_, index, orientation);
-    }
+    cpgrid::Entity<dim> createEntity(const CpGrid&, int, bool);
 
 } // namespace Dune
 

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -463,12 +463,6 @@ namespace Dune
         /// @param [in] endIJK                   Cartesian triplet index where the patch ends.
         ///                                      Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
         void createGridWithLgr(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK, const std::array<int,3>& endIJK);
-            #if HAVE_MPI
-            #else
-            // DUNE 2.7 is missing convertion to NO_COMM
-            std::shared_ptr<Dune::cpgrid::CpGridData> leaf_view_ptr =
-                std::make_shared<Dune::cpgrid::CpGridData>();
-            #endif
 
         /*  No refinement implemented. GridDefaultImplementation's methods will be used.
 

--- a/opm/grid/common/GridPartitioning.cpp
+++ b/opm/grid/common/GridPartitioning.cpp
@@ -41,7 +41,7 @@
 #include <dune/istl/owneroverlapcopy.hh>
 #include "GridPartitioning.hpp"
 #include <opm/grid/CpGrid.hpp>
-#include <opm/grid/cpgrid/CpGridData.hpp>
+#include <opm/grid/cpgrid/CpGridDataTraits.hpp>
 #include <opm/grid/common/ZoltanPartition.hpp>
 #include <stack>
 
@@ -293,7 +293,7 @@ void addOverlapCornerCell(const CpGrid& grid, int owner,
     //  I I O E         I I O E 
     //  O O O E         O O E E
     //  E E E E         E E E E
-    using AttributeSet = Dune::cpgrid::CpGridData::AttributeSet;
+    using AttributeSet = Dune::cpgrid::CpGridDataTraits::AttributeSet;
     const CpGrid::LeafIndexSet& ix = grid.leafIndexSet();
     int my_index = ix.index(from);
     int nb_index = ix.index(neighbor);
@@ -382,7 +382,7 @@ void addOverlapLayer(const CpGrid& grid, int index, const CpGrid::Codim<0>::Enti
                          std::vector<std::tuple<int,int,char>>& exportList,
                          bool addCornerCells, int recursion_deps)
     {
-        using AttributeSet = Dune::cpgrid::CpGridData::AttributeSet;
+        using AttributeSet = Dune::cpgrid::CpGridDataTraits::AttributeSet;
         const CpGrid::LeafIndexSet& ix = grid.leafIndexSet();
         for (CpGrid::LeafIntersectionIterator iit = e.ileafbegin(); iit != e.ileafend(); ++iit) {
             if ( iit->neighbor() ) {

--- a/opm/grid/common/ZoltanGraphFunctions.cpp
+++ b/opm/grid/common/ZoltanGraphFunctions.cpp
@@ -23,12 +23,12 @@
 #endif
 #include <limits>
 
+
+#if defined(HAVE_ZOLTAN) && defined(HAVE_MPI)
 #include <opm/grid/utility/OpmWellType.hpp>
 
 #include <opm/grid/common/ZoltanGraphFunctions.hpp>
 #include <dune/common/parallel/indexset.hh>
-
-#if defined(HAVE_ZOLTAN) && defined(HAVE_MPI)
 
 namespace Dune
 {
@@ -404,4 +404,4 @@ void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz,
 }
 } // end namespace cpgrid
 } // end namespace Dune
-#endif // HAVE_ZOLTAN
+#endif // defined(HAVE_ZOLTAN) && defined(HAVE_MPI)

--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -20,12 +20,14 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
+#if HAVE_MPI // no code in this file without MPI. Skip includes-
 #include <opm/grid/common/ZoltanPartition.hpp>
 #include <opm/grid/utility/OpmWellType.hpp>
 #include <opm/grid/cpgrid/CpGridData.hpp>
 #include <opm/grid/cpgrid/Entity.hpp>
 #include <algorithm>
 #include <type_traits>
+#endif
 
 namespace Dune
 {
@@ -630,4 +632,4 @@ zoltanGraphPartitionGridForJac(const CpGrid& cpgrid,
 
 } // namespace cpgrid
 } // namespace Dune
-#endif // HAVE_ZOLTAN
+#endif // defined(HAVE_ZOLTAN) && defined(HAVE_MPI)

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1356,7 +1356,7 @@ template cpgrid::Entity<3> Dune::createEntity(const CpGrid&, int, bool);
 template cpgrid::Entity<1> Dune::createEntity(const CpGrid&, int, bool); // needed in distribution_test.cpp 
 
 
-void CpGrid::createGridWithLgr(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK, const std::array<int,3>& endIJK)
+void CpGrid::addLgrUpdateLeafView(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK, const std::array<int,3>& endIJK)
 {
     if (!distributed_data_.empty()){
         if (comm().rank()==0)

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1379,7 +1379,7 @@ void CpGrid::createGridWithLgr(const std::array<int,3>& cells_per_dim, const std
     (this-> data_).push_back(level1_ptr);
     //
     // LEVEL 0, definition/declaration of some members:
-    (*data_[0]).data_copy_ = &(this -> data_);
+    (*data_[0]).level_data_ptr_ = &(this -> data_);
     (*data_[0]).level_ = 0;
     // Relation between level and leafview cell indices.
     std::map<int,int>& l0_to_leaf_cells = (*data_[0]).level_to_leaf_cells_;
@@ -1409,7 +1409,7 @@ void CpGrid::createGridWithLgr(const std::array<int,3>& cells_per_dim, const std
         }
     }
     // LEVEL 1, definition/declaration of some members:
-    (*data_[1]).data_copy_ = &(this -> data_);
+    (*data_[1]).level_data_ptr_ = &(this -> data_);
     (*data_[1]).level_ = 1;
     // Relation between level and leafview cell indices.
     std::map<int,int>& l1_to_leaf_cells = (*data_[1]).level_to_leaf_cells_;

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -610,6 +610,9 @@ typename CpGridTraits::template Codim<codim>::LevelIterator CpGrid::lbegin (int 
         return cpgrid::Iterator<codim, All_Partition>(*data_[level], 0, true);
     }
 }
+template typename CpGridTraits::template Codim<0>::LevelIterator CpGrid::lbegin<0>(int) const;
+template typename CpGridTraits::template Codim<1>::LevelIterator CpGrid::lbegin<1>(int) const;
+template typename CpGridTraits::template Codim<3>::LevelIterator CpGrid::lbegin<3>(int) const;
 
 template<int codim>
 typename CpGridTraits::template Codim<codim>::LevelIterator CpGrid::lend (int level) const
@@ -623,6 +626,9 @@ typename CpGridTraits::template Codim<codim>::LevelIterator CpGrid::lend (int le
         return cpgrid::Iterator<codim,All_Partition>(*data_[level], size(level, codim), true );
     }
 }
+template typename CpGridTraits::template Codim<0>::LevelIterator CpGrid::lend<0>(int) const;
+template typename CpGridTraits::template Codim<1>::LevelIterator CpGrid::lend<1>(int) const;
+template typename CpGridTraits::template Codim<3>::LevelIterator CpGrid::lend<3>(int) const;
 
 template<int codim>
 typename CpGridTraits::template Codim<codim>::LeafIterator CpGrid::leafbegin() const

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1357,7 +1357,6 @@ void CpGrid::createGridWithLgr(const std::array<int,3>& cells_per_dim, const std
     (this-> data_).push_back(level1_ptr);
     //
     // LEVEL 0, definition/declaration of some members:
-    // std::vector<std::shared_ptr<CpGridData>> l0_data;
     (*data_[0]).data_copy_ = &(this -> data_);
     (*data_[0]).level_ = 0;
     // Relation between level and leafview cell indices.
@@ -1389,7 +1388,6 @@ void CpGrid::createGridWithLgr(const std::array<int,3>& cells_per_dim, const std
     }
     // LEVEL 1, definition/declaration of some members:
     (*data_[1]).data_copy_ = &(this -> data_);
-    //std::vector<std::shared_ptr<Dune::cpgrid::CpGridData>> l1_data = this -> data_;
     (*data_[1]).level_ = 1;
     // Relation between level and leafview cell indices.
     std::map<int,int>& l1_to_leaf_cells = (*data_[1]).level_to_leaf_cells_;
@@ -1413,7 +1411,6 @@ void CpGrid::createGridWithLgr(const std::array<int,3>& cells_per_dim, const std
     cpgrid::EntityVariable<enum face_tag,1>& leaf_face_tags = leaf_view.face_tag_;
     cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>,1>& leaf_face_normals = leaf_view.face_normals_;
     //
-    //leaf_view.grid_ = this;
     std::vector<std::array<int,2>>& leaf_to_level_cells = leaf_view.leaf_to_level_cells_; // {level, cell index in that level}
     // leaf_child_to_parent_cells[ cell index ] must be {-1,-1} when the cell has no father.
     std::vector<std::array<int,2>>& leaf_child_to_parent_cells = leaf_view.child_to_parent_cells_;
@@ -1659,7 +1656,7 @@ void CpGrid::createGridWithLgr(const std::array<int,3>& cells_per_dim, const std
     //  Add Leaf View to data_.
     (this-> data_).push_back(leaf_view_ptr);
     current_view_data_ = data_[2].get();
-    (*data_[2]).level_ = 2;
+    (*data_[2]).level_ = 2; // LeafView 'does not have an actual "level"'. "Temporary" assignment.TO BE MODIFIED.
 }
 
 

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -50,15 +50,15 @@
 #include "../CpGrid.hpp"
 #include "CpGridData.hpp"
 #include <opm/grid/common/ZoltanPartition.hpp>
-#include <opm/grid/common/ZoltanGraphFunctions.hpp>
+//#include <opm/grid/common/ZoltanGraphFunctions.hpp>
 #include <opm/grid/common/GridPartitioning.hpp>
-#include <opm/grid/common/WellConnections.hpp>
-
+//#include <opm/grid/common/WellConnections.hpp>
 #include <opm/grid/common/CommunicationUtils.hpp>
-#include <fstream>
-#include <iostream>
+
+//#include <fstream>
+//#include <iostream>
 #include <iomanip>
-#include <tuple>
+//#include <tuple>
 
 namespace
 {
@@ -120,24 +120,34 @@ void setupRecvInterface(const std::vector<std::tuple<int, int, char, int> >& lis
 namespace Dune
 {
 
-    CpGrid::CpGrid()
-        : data_({std::make_shared<cpgrid::CpGridData>()}),
-          current_view_data_(data_[0].get()),
-          distributed_data_(),
-          cell_scatter_gather_interfaces_(new InterfaceMap),
-          point_scatter_gather_interfaces_(new InterfaceMap),
-          global_id_set_(*current_view_data_)
-    {}
+CpGrid::CpGrid()
+    : //data_({std::make_shared<cpgrid::CpGridData>()}), // data_
+    //data_(),
+    current_view_data_(),// (data_[0].get()),
+      distributed_data_(),
+      cell_scatter_gather_interfaces_(new InterfaceMap),
+      point_scatter_gather_interfaces_(new InterfaceMap),
+    global_id_set_ptr_()//std::make_shared<cpgrid::GlobalIdSet>(*current_view_data_))
+{
+    data_.push_back(std::make_shared<cpgrid::CpGridData>(data_));
+    current_view_data_ = data_[0].get();
+    global_id_set_ptr_ = std::make_shared<cpgrid::GlobalIdSet>(*current_view_data_);
+    
+}
 
-
-    CpGrid::CpGrid(MPIHelper::MPICommunicator comm)
-        : data_({std::make_shared<cpgrid::CpGridData>(comm)}),
-          current_view_data_(data_[0].get()),
-          distributed_data_(),
-          cell_scatter_gather_interfaces_(new InterfaceMap),
-          point_scatter_gather_interfaces_(new InterfaceMap),
-          global_id_set_(*current_view_data_)
-    {}
+CpGrid::CpGrid(MPIHelper::MPICommunicator comm)
+    : //data_({std::make_shared<cpgrid::CpGridData>(comm)}),
+    current_view_data_(),//(data_[0].get()),
+      distributed_data_(),
+      cell_scatter_gather_interfaces_(new InterfaceMap),
+      point_scatter_gather_interfaces_(new InterfaceMap),
+    global_id_set_ptr_()//std::make_shared<cpgrid::GlobalIdSet>(*current_view_data_))
+{
+    data_.push_back(std::make_shared<cpgrid::CpGridData>(comm, data_));
+    current_view_data_= data_[0].get();
+    global_id_set_ptr_ = std::make_shared<cpgrid::GlobalIdSet>(*current_view_data_);
+    
+}
 
 std::vector<int>
 CpGrid::zoltanPartitionWithoutScatter([[maybe_unused]] const std::vector<cpgrid::OpmWellType>* wells,
@@ -293,9 +303,9 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
         // importList contains all the indices that will be here.
         auto compareImport = [](const std::tuple<int,int,char,int>& t1,
                                 const std::tuple<int,int,char,int>&t2)
-                             {
-                                 return std::get<0>(t1) < std::get<0>(t2);
-                             };
+        {
+            return std::get<0>(t1) < std::get<0>(t2);
+        };
 
         if ( ! ownersFirst )
         {
@@ -412,9 +422,9 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
 
         if (procsWithZeroCells) {
             std::string msg = "At least one process has zero cells. Aborting. \n"
-                     " Try decreasing the imbalance tolerance for zoltan with \n"
-                     " --zoltan-imbalance-tolerance. The current value is "
-                     + std::to_string(zoltanImbalanceTol);
+                " Try decreasing the imbalance tolerance for zoltan with \n"
+                " --zoltan-imbalance-tolerance. The current value is "
+                + std::to_string(zoltanImbalanceTol);
             if (cc.rank()==0)
             {
                 OPM_THROW(std::runtime_error, msg );
@@ -427,16 +437,20 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
 
 
         // distributed_data should be empty at this point.
-        distributed_data_.push_back(std::make_shared<cpgrid::CpGridData>(cc));
+        distributed_data_.push_back(std::make_shared<cpgrid::CpGridData>(cc, distributed_data_)); 
         distributed_data_[0]->setUniqueBoundaryIds(data_[0]->uniqueBoundaryIds());
+       
         // Just to be sure we assume that only master knows
         cc.broadcast(&distributed_data_[0]->use_unique_boundary_ids_, 1, 0);
+        
+
 
         // Create indexset
         distributed_data_[0]->cellIndexSet().beginResize();
         for(const auto& entry: importList)
         {
-            distributed_data_[0]->cellIndexSet().add(std::get<0>(entry), ParallelIndexSet::LocalIndex(std::get<3>(entry), AttributeSet(std::get<2>(entry)), true));
+            distributed_data_[0]->cellIndexSet()
+                .add(std::get<0>(entry),ParallelIndexSet::LocalIndex(std::get<3>(entry),AttributeSet(std::get<2>(entry)), true));
         }
         distributed_data_[0]->cellIndexSet().endResize();
         // add an interface for gathering/scattering data with communication
@@ -446,7 +460,11 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
         setupRecvInterface(importList, *cell_scatter_gather_interfaces_);
 
         distributed_data_[0]->distributeGlobalGrid(*this,*this->current_view_data_, computedCellPart);
-        global_id_set_.insertIdSet(*distributed_data_[0]);
+        // global_id_set_.insertIdSet(*distributed_data_[0]);
+        (*global_id_set_ptr_).insertIdSet(*distributed_data_[0]);
+        distributed_data_[0]-> index_set_.reset(new cpgrid::IndexSet(distributed_data_[0]->cell_to_face_.size(),
+                                                                     distributed_data_[0]-> geomVector<3>().size()));
+       
 
 
         current_view_data_ = distributed_data_[0].get();
@@ -467,129 +485,1207 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
 }
 
 
-    void CpGrid::createCartesian(const std::array<int, 3>& dims,
-                                 const std::array<double, 3>& cellsize,
-                                 const std::array<int, 3>& shift)
+void CpGrid::createCartesian(const std::array<int, 3>& dims,
+                             const std::array<double, 3>& cellsize,
+                             const std::array<int, 3>& shift)
+{
+    if ( current_view_data_->ccobj_.rank() != 0 )
     {
-        if ( current_view_data_->ccobj_.rank() != 0 )
-        {
-            // global grid only on rank 0
-            current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
-                                                 current_view_data_->logical_cartesian_size_.size(),
-                                                 0);
-            return;
-        }
-
-        // Make the grdecl format arrays.
-        // Pillar coords.
-        std::vector<double> coord;
-        coord.reserve(6*(dims[0] + 1)*(dims[1] + 1));
-        double bot = 0.0+shift[2]*cellsize[2];
-        double top = (dims[2]+shift[2])*cellsize[2];
-        // i runs fastest for the pillars.
-        for (int j = 0; j < dims[1] + 1; ++j) {
-            double y = (j+shift[1])*cellsize[1];
-            for (int i = 0; i < dims[0] + 1; ++i) {
-                double x = (i+shift[0])*cellsize[0];
-                double pillar[6] = { x, y, bot, x, y, top };
-                coord.insert(coord.end(), pillar, pillar + 6);
-            }
-        }
-        std::vector<double> zcorn(8*dims[0]*dims[1]*dims[2]);
-        const int num_per_layer = 4*dims[0]*dims[1];
-        double* offset = &zcorn[0];
-        for (int k = 0; k < dims[2]; ++k) {
-            double zlow = (k+shift[2])*cellsize[2];
-            std::fill(offset, offset + num_per_layer, zlow);
-            offset += num_per_layer;
-            double zhigh = (k+1+shift[2])*cellsize[2];
-            std::fill(offset, offset + num_per_layer, zhigh);
-            offset += num_per_layer;
-        }
-        std::vector<int> actnum(dims[0]*dims[1]*dims[2], 1);
-
-        // Process them.
-        grdecl g;
-        g.dims[0] = dims[0];
-        g.dims[1] = dims[1];
-        g.dims[2] = dims[2];
-        g.coord = &coord[0];
-        g.zcorn = &zcorn[0];
-        g.actnum = &actnum[0];
-        using NNCMap = std::set<std::pair<int, int>>;
-        using NNCMaps = std::array<NNCMap, 2>;
-        NNCMaps nnc;
-        current_view_data_->processEclipseFormat(g,
-#if HAVE_ECL_INPUT
-                                                 nullptr,
-#endif
-                                                 nnc, false, false, false);
         // global grid only on rank 0
         current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
                                              current_view_data_->logical_cartesian_size_.size(),
                                              0);
+        return;
     }
 
-    void CpGrid::readSintefLegacyFormat(const std::string& grid_prefix)
-    {
-        if ( current_view_data_->ccobj_.rank() == 0 )
-        {
-            current_view_data_->readSintefLegacyFormat(grid_prefix);
-        }
-        current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
-                                             current_view_data_->logical_cartesian_size_.size(),
-                                             0);
-    }
-    void CpGrid::writeSintefLegacyFormat(const std::string& grid_prefix) const
-    {
-        // Only rank 0 has the full data. Use that for writing.
-        if ( current_view_data_->ccobj_.rank() == 0 )
-        {
-            data_[0]->writeSintefLegacyFormat(grid_prefix);
+    // Make the grdecl format arrays.
+    // Pillar coords.
+    std::vector<double> coord;
+    coord.reserve(6*(dims[0] + 1)*(dims[1] + 1));
+    double bot = 0.0+shift[2]*cellsize[2];
+    double top = (dims[2]+shift[2])*cellsize[2];
+    // i runs fastest for the pillars.
+    for (int j = 0; j < dims[1] + 1; ++j) {
+        double y = (j+shift[1])*cellsize[1];
+        for (int i = 0; i < dims[0] + 1; ++i) {
+            double x = (i+shift[0])*cellsize[0];
+            double pillar[6] = { x, y, bot, x, y, top };
+            coord.insert(coord.end(), pillar, pillar + 6);
         }
     }
+    std::vector<double> zcorn(8*dims[0]*dims[1]*dims[2]);
+    const int num_per_layer = 4*dims[0]*dims[1];
+    double* offset = &zcorn[0];
+    for (int k = 0; k < dims[2]; ++k) {
+        double zlow = (k+shift[2])*cellsize[2];
+        std::fill(offset, offset + num_per_layer, zlow);
+        offset += num_per_layer;
+        double zhigh = (k+1+shift[2])*cellsize[2];
+        std::fill(offset, offset + num_per_layer, zhigh);
+        offset += num_per_layer;
+    }
+    std::vector<int> actnum(dims[0]*dims[1]*dims[2], 1);
+
+    // Process them.
+    grdecl g;
+    g.dims[0] = dims[0];
+    g.dims[1] = dims[1];
+    g.dims[2] = dims[2];
+    g.coord = &coord[0];
+    g.zcorn = &zcorn[0];
+    g.actnum = &actnum[0];
+    using NNCMap = std::set<std::pair<int, int>>;
+    using NNCMaps = std::array<NNCMap, 2>;
+    NNCMaps nnc;
+    current_view_data_->processEclipseFormat(g,
+#if HAVE_ECL_INPUT
+                                             nullptr,
+#endif
+                                             nnc, false, false, false);
+    // global grid only on rank 0
+    current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
+                                         current_view_data_->logical_cartesian_size_.size(),
+                                         0);
+}
+
+const std::array<int, 3>& CpGrid::logicalCartesianSize() const
+{
+    return current_view_data_->logical_cartesian_size_;
+}
+
+const std::vector<int>& CpGrid::globalCell() const
+{
+    return current_view_data_->global_cell_;
+}
+
+void CpGrid::getIJK(const int c, std::array<int,3>& ijk) const
+{
+    current_view_data_->getIJK(c, ijk);
+}
+
+bool CpGrid::uniqueBoundaryIds() const
+{
+    return current_view_data_->uniqueBoundaryIds();
+}
+
+void CpGrid::setUniqueBoundaryIds(bool uids)
+{
+    current_view_data_->setUniqueBoundaryIds(uids);
+}
+
+std::string CpGrid::name() const
+{
+    return "CpGrid";
+}
+
+int CpGrid::maxLevel() const
+{
+    if (!distributed_data_.empty()){
+        return 0;
+    }
+    else { // add assert to check data_.size() =  1 or 3 ? If 1, maxLevel =0, if 3, maxLevel =1. 
+        return double(this -> data_.size() - 1)/2; // last entry is leafView, and it starts in level 0 
+    } // Assuming last entry of data_ is the LeafView, recall it starts with level 0
+}
+
+template<int codim>
+typename CpGridTraits::template Codim<codim>::LevelIterator CpGrid::lbegin (int level) const{
+    if (level<0 || level>maxLevel())
+        DUNE_THROW(GridError, "levelIndexSet of nonexisting level " << level << " requested!");
+    if (!distributed_data_.empty()){
+        return cpgrid::Iterator<codim, All_Partition>(*current_view_data_, 0, true);
+    }
+    else{
+        return cpgrid::Iterator<codim, All_Partition>(*data_[level], 0, true);
+    }
+}
+
+template<int codim>
+typename CpGridTraits::template Codim<codim>::LevelIterator CpGrid::lend (int level) const
+{
+    if (level<0 || level>maxLevel())
+        DUNE_THROW(GridError, "levelIndexSet of nonexisting level " << level << " requested!");
+    if (!distributed_data_.empty()){
+        return cpgrid::Iterator<codim, All_Partition>(*current_view_data_, size(codim), true);
+    }
+    else{
+        return cpgrid::Iterator<codim,All_Partition>(*data_[level], size(level, codim), true );
+    }
+}
+
+template<int codim>
+typename CpGridTraits::template Codim<codim>::LeafIterator CpGrid::leafbegin() const
+{
+    return cpgrid::Iterator<codim, All_Partition>(*current_view_data_, 0, true);
+}
+template typename CpGridTraits::template Codim<0>::LeafIterator CpGrid::leafbegin<0>() const;
+template typename CpGridTraits::template Codim<1>::LeafIterator CpGrid::leafbegin<1>() const;
+template typename CpGridTraits::template Codim<3>::LeafIterator CpGrid::leafbegin<3>() const;
+
+
+template<int codim>
+typename CpGridTraits::template Codim<codim>::LeafIterator CpGrid::leafend() const
+{
+    return cpgrid::Iterator<codim, All_Partition>(*current_view_data_, size(codim), true);
+}
+template typename CpGridTraits::template Codim<0>::LeafIterator CpGrid::leafend<0>() const;
+template typename CpGridTraits::template Codim<1>::LeafIterator CpGrid::leafend<1>() const;
+template typename CpGridTraits::template Codim<3>::LeafIterator CpGrid::leafend<3>() const;
+
+template<int codim, PartitionIteratorType PiType>
+typename CpGridTraits::template Codim<codim>::template Partition<PiType>::LevelIterator CpGrid::lbegin (int level) const
+{
+    if (level<0 || level>maxLevel())
+        DUNE_THROW(GridError, "levelIndexSet of nonexisting level " << level << " requested!");
+    if (!distributed_data_.empty()){
+        return cpgrid::Iterator<codim,PiType>(*current_view_data_, 0, true);
+    }
+    else{
+        return cpgrid::Iterator<codim,PiType>(*data_[level], 0, true);
+    }
+}
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::Interior_Partition>::LevelIterator
+CpGrid::lbegin<0,Dune::Interior_Partition>(int) const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::InteriorBorder_Partition>::LevelIterator
+CpGrid::lbegin<0,Dune::InteriorBorder_Partition>(int) const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::Overlap_Partition>::LevelIterator
+CpGrid::lbegin<0,Dune::Overlap_Partition>(int) const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::OverlapFront_Partition>::LevelIterator
+CpGrid::lbegin<0,Dune::OverlapFront_Partition>(int) const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::All_Partition>::LevelIterator
+CpGrid::lbegin<0,Dune::All_Partition>(int) const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::Ghost_Partition>::LevelIterator
+CpGrid::lbegin<0,Dune::Ghost_Partition>(int) const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::Interior_Partition>::LevelIterator
+CpGrid::lbegin<1,Dune::Interior_Partition>(int) const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::InteriorBorder_Partition>::LevelIterator
+CpGrid::lbegin<1,Dune::InteriorBorder_Partition>(int) const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::Overlap_Partition>::LevelIterator
+CpGrid::lbegin<1,Dune::Overlap_Partition>(int) const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::OverlapFront_Partition>::LevelIterator
+CpGrid::lbegin<1,Dune::OverlapFront_Partition>(int) const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::All_Partition>::LevelIterator
+CpGrid::lbegin<1,Dune::All_Partition>(int) const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::Ghost_Partition>::LevelIterator
+CpGrid::lbegin<1,Dune::Ghost_Partition>(int) const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::Interior_Partition>::LevelIterator
+CpGrid::lbegin<3,Dune::Interior_Partition>(int) const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::InteriorBorder_Partition>::LevelIterator
+CpGrid::lbegin<3,Dune::InteriorBorder_Partition>(int) const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::Overlap_Partition>::LevelIterator
+CpGrid::lbegin<3,Dune::Overlap_Partition>(int) const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::OverlapFront_Partition>::LevelIterator
+CpGrid::lbegin<3,Dune::OverlapFront_Partition>(int) const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::All_Partition>::LevelIterator
+CpGrid::lbegin<3,Dune::All_Partition>(int) const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::Ghost_Partition>::LevelIterator
+CpGrid::lbegin<3,Dune::Ghost_Partition>(int) const;
+
+template<int codim, PartitionIteratorType PiType>
+typename CpGridTraits::template Codim<codim>::template Partition<PiType>::LevelIterator CpGrid::lend (int level) const
+{
+    if (level<0 || level>maxLevel())
+        DUNE_THROW(GridError, "levelIndexSet of nonexisting level " << level << " requested!");
+    if (!distributed_data_.empty()){
+        return cpgrid::Iterator<codim,PiType>(*current_view_data_, size(codim), true);
+    }
+    else{
+        return cpgrid::Iterator<codim,PiType>(*data_[level], size(level, codim), true);
+    }
+
+}
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::Interior_Partition>::LevelIterator
+CpGrid::lend<0,Dune::Interior_Partition>(int) const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::InteriorBorder_Partition>::LevelIterator
+CpGrid::lend<0,Dune::InteriorBorder_Partition>(int) const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::Overlap_Partition>::LevelIterator
+CpGrid::lend<0,Dune::Overlap_Partition>(int) const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::OverlapFront_Partition>::LevelIterator
+CpGrid::lend<0,Dune::OverlapFront_Partition>(int) const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::All_Partition>::LevelIterator
+CpGrid::lend<0,Dune::All_Partition>(int) const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::Ghost_Partition>::LevelIterator
+CpGrid::lend<0,Dune::Ghost_Partition>(int) const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::Interior_Partition>::LevelIterator
+CpGrid::lend<1,Dune::Interior_Partition>(int) const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::InteriorBorder_Partition>::LevelIterator
+CpGrid::lend<1,Dune::InteriorBorder_Partition>(int) const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::Overlap_Partition>::LevelIterator
+CpGrid::lend<1,Dune::Overlap_Partition>(int) const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::OverlapFront_Partition>::LevelIterator
+CpGrid::lend<1,Dune::OverlapFront_Partition>(int) const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::All_Partition>::LevelIterator
+CpGrid::lend<1,Dune::All_Partition>(int) const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::Ghost_Partition>::LevelIterator
+CpGrid::lend<1,Dune::Ghost_Partition>(int) const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::Interior_Partition>::LevelIterator
+CpGrid::lend<3,Dune::Interior_Partition>(int) const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::InteriorBorder_Partition>::LevelIterator
+CpGrid::lend<3,Dune::InteriorBorder_Partition>(int) const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::Overlap_Partition>::LevelIterator
+CpGrid::lend<3,Dune::Overlap_Partition>(int) const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::OverlapFront_Partition>::LevelIterator
+CpGrid::lend<3,Dune::OverlapFront_Partition>(int) const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::All_Partition>::LevelIterator
+CpGrid::lend<3,Dune::All_Partition>(int) const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::Ghost_Partition>::LevelIterator
+CpGrid::lend<3,Dune::Ghost_Partition>(int) const;
+
+template<int codim, PartitionIteratorType PiType>
+typename CpGridFamily::Traits::template Codim<codim>::template Partition<PiType>::LeafIterator CpGrid::leafbegin() const
+{
+    return cpgrid::Iterator<codim, PiType>(*current_view_data_, 0, true);
+}
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::Interior_Partition>::LeafIterator
+CpGrid::leafbegin<0,Dune::Interior_Partition>() const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::InteriorBorder_Partition>::LeafIterator
+CpGrid::leafbegin<0,Dune::InteriorBorder_Partition>() const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::Overlap_Partition>::LeafIterator
+CpGrid::leafbegin<0,Dune::Overlap_Partition>() const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::OverlapFront_Partition>::LeafIterator
+CpGrid::leafbegin<0,Dune::OverlapFront_Partition>() const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::All_Partition>::LeafIterator
+CpGrid::leafbegin<0,Dune::All_Partition>() const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::Ghost_Partition>::LeafIterator
+CpGrid::leafbegin<0,Dune::Ghost_Partition>() const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::Interior_Partition>::LeafIterator
+CpGrid::leafbegin<1,Dune::Interior_Partition>() const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::InteriorBorder_Partition>::LeafIterator
+CpGrid::leafbegin<1,Dune::InteriorBorder_Partition>() const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::Overlap_Partition>::LeafIterator
+CpGrid::leafbegin<1,Dune::Overlap_Partition>() const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::OverlapFront_Partition>::LeafIterator
+CpGrid::leafbegin<1,Dune::OverlapFront_Partition>() const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::All_Partition>::LeafIterator
+CpGrid::leafbegin<1,Dune::All_Partition>() const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::Ghost_Partition>::LeafIterator
+CpGrid::leafbegin<1,Dune::Ghost_Partition>() const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::Interior_Partition>::LeafIterator
+CpGrid::leafbegin<3,Dune::Interior_Partition>() const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::InteriorBorder_Partition>::LeafIterator
+CpGrid::leafbegin<3,Dune::InteriorBorder_Partition>() const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::Overlap_Partition>::LeafIterator
+CpGrid::leafbegin<3,Dune::Overlap_Partition>() const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::OverlapFront_Partition>::LeafIterator
+CpGrid::leafbegin<3,Dune::OverlapFront_Partition>() const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::All_Partition>::LeafIterator
+CpGrid::leafbegin<3,Dune::All_Partition>() const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::Ghost_Partition>::LeafIterator
+CpGrid::leafbegin<3,Dune::Ghost_Partition>() const;
+
+template<int codim, PartitionIteratorType PiType>
+typename CpGridFamily::Traits::template Codim<codim>::template Partition<PiType>::LeafIterator CpGrid::leafend() const
+{
+    return cpgrid::Iterator<codim, PiType>(*current_view_data_, size(codim), true);
+}
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::Interior_Partition>::LeafIterator
+CpGrid::leafend<0,Dune::Interior_Partition>() const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::InteriorBorder_Partition>::LeafIterator
+CpGrid::leafend<0,Dune::InteriorBorder_Partition>() const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::Overlap_Partition>::LeafIterator
+CpGrid::leafend<0,Dune::Overlap_Partition>() const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::OverlapFront_Partition>::LeafIterator
+CpGrid::leafend<0,Dune::OverlapFront_Partition>() const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::All_Partition>::LeafIterator
+CpGrid::leafend<0,Dune::All_Partition>() const;
+template typename CpGridTraits::template Codim<0>::template Partition<Dune::Ghost_Partition>::LeafIterator
+CpGrid::leafend<0,Dune::Ghost_Partition>() const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::Interior_Partition>::LeafIterator
+CpGrid::leafend<1,Dune::Interior_Partition>() const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::InteriorBorder_Partition>::LeafIterator
+CpGrid::leafend<1,Dune::InteriorBorder_Partition>() const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::Overlap_Partition>::LeafIterator
+CpGrid::leafend<1,Dune::Overlap_Partition>() const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::OverlapFront_Partition>::LeafIterator
+CpGrid::leafend<1,Dune::OverlapFront_Partition>() const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::All_Partition>::LeafIterator
+CpGrid::leafend<1,Dune::All_Partition>() const;
+template typename CpGridTraits::template Codim<1>::template Partition<Dune::Ghost_Partition>::LeafIterator
+CpGrid::leafend<1,Dune::Ghost_Partition>() const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::Interior_Partition>::LeafIterator
+CpGrid::leafend<3,Dune::Interior_Partition>() const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::InteriorBorder_Partition>::LeafIterator
+CpGrid::leafend<3,Dune::InteriorBorder_Partition>() const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::Overlap_Partition>::LeafIterator
+CpGrid::leafend<3,Dune::Overlap_Partition>() const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::OverlapFront_Partition>::LeafIterator
+CpGrid::leafend<3,Dune::OverlapFront_Partition>() const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::All_Partition>::LeafIterator
+CpGrid::leafend<3,Dune::All_Partition>() const;
+template typename CpGridTraits::template Codim<3>::template Partition<Dune::Ghost_Partition>::LeafIterator
+CpGrid::leafend<3,Dune::Ghost_Partition>() const;
+
+int CpGrid::size (int level, int codim) const
+{
+    if (level<0 || level>maxLevel())
+        DUNE_THROW(GridError, "levelIndexSet of nonexisting level " << level << " requested!");
+    return data_[level]-> size(codim);
+}
+
+int CpGrid::size (int codim) const
+{
+    return current_view_data_->size(codim);
+}
+
+int CpGrid::size (int level, GeometryType type) const
+{
+    if (level<0 || level>maxLevel())
+        DUNE_THROW(GridError, "levelIndexSet of nonexisting level " << level << " requested!");
+    return data_[level] -> size(type);
+}
+
+int CpGrid::size (GeometryType type) const
+{
+    return current_view_data_->size(type);
+}
+
+const CpGridFamily::Traits::GlobalIdSet& CpGrid::globalIdSet() const
+{
+    return  *global_id_set_ptr_; //global_id_set_;
+}
+
+const CpGridFamily::Traits::LocalIdSet& CpGrid::localIdSet() const
+{
+    return *global_id_set_ptr_;//global_id_set_;
+}
+
+const CpGridFamily::Traits::LevelIndexSet& CpGrid::levelIndexSet(int level) const
+{
+    if (level<0 || level>maxLevel())
+        DUNE_THROW(GridError, "levelIndexSet of nonexisting level " << level << " requested!");
+    return *current_view_data_->index_set_;
+}
+
+const CpGridFamily::Traits::LeafIndexSet& CpGrid::leafIndexSet() const
+{
+    return *current_view_data_->index_set_;
+}
+
+void CpGrid::globalRefine (int)
+{
+    std::cout << "Warning: Global refinement not implemented, yet." << std::endl;
+}
+
+const std::vector< Dune :: GeometryType >& CpGrid::geomTypes( const int codim ) const
+{
+    return leafIndexSet().geomTypes( codim );
+}
+
+template <int codim>
+cpgrid::Entity<codim> CpGrid::entity( const cpgrid::Entity< codim >& seed ) const
+{
+    return seed;
+}
+template cpgrid::Entity<0> CpGrid::entity<0>( const cpgrid::Entity<0>&) const;
+template cpgrid::Entity<3> CpGrid::entity<3>( const cpgrid::Entity<3>&) const;
+
+
+/// \brief Size of the overlap on the leaf level
+unsigned int CpGrid::overlapSize(int) const {
+    return 1;
+}
+
+
+/// \brief Size of the ghost cell layer on the leaf level
+unsigned int CpGrid::ghostSize(int) const {
+    return 0;
+}
+
+
+/// \brief Size of the overlap on a given level
+unsigned int CpGrid::overlapSize(int, int) const {
+    return 1;
+}
+
+
+/// \brief Size of the ghost cell layer on a given level
+unsigned int CpGrid::ghostSize(int, int) const {
+    return 0;
+}
+
+unsigned int CpGrid::numBoundarySegments() const
+{
+    if( uniqueBoundaryIds() )
+    {
+        return current_view_data_->unique_boundary_ids_.size();
+    }
+    else
+    {
+        unsigned int numBndSegs = 0;
+        const int num_faces = numFaces();
+        for (int i = 0; i < num_faces; ++i) {
+            cpgrid::EntityRep<1> face(i, true);
+            if (current_view_data_->face_to_cell_[face].size() == 1) {
+                ++numBndSegs;
+            }
+        }
+        return numBndSegs;
+    }
+}
+
+void CpGrid::setZoltanParams(const std::map<std::string,std::string>& params)
+{
+    zoltanParams = params;
+}
+
+const typename CpGridTraits::Communication& Dune::CpGrid::comm () const
+{
+    return current_view_data_->ccobj_;
+}
+
+//
+
+const std::vector<double>& CpGrid::zcornData() const {
+    return current_view_data_->zcornData();
+}
+
+int CpGrid::numCells() const
+{
+    return current_view_data_->cell_to_face_.size();
+}
+/// \brief Get the number of faces.
+int CpGrid::numFaces() const
+{
+    return current_view_data_->face_to_cell_.size();
+}
+/// \brief Get The number of vertices.
+int CpGrid::numVertices() const
+{
+    return current_view_data_->geomVector<3>().size();
+}
+
+int CpGrid::numCellFaces(int cell) const
+{
+    return current_view_data_->cell_to_face_[cpgrid::EntityRep<0>(cell, true)].size();
+}
+
+int CpGrid::cellFace(int cell, int local_index) const
+{
+    return current_view_data_->cell_to_face_[cpgrid::EntityRep<0>(cell, true)][local_index].index();
+}
+
+const cpgrid::OrientedEntityTable<0,1>::row_type CpGrid::cellFaceRow(int cell) const
+{
+    return current_view_data_->cell_to_face_[cpgrid::EntityRep<0>(cell, true)];
+}
+
+int CpGrid::faceCell(int face, int local_index) const
+{
+    // In the parallel case we store non-existent cells for faces along
+    // the front region. Theses marked with index std::numeric_limits<int>::max(),
+    // orientation might be arbitrary, though.
+    cpgrid::OrientedEntityTable<1,0>::row_type r
+        = current_view_data_->face_to_cell_[cpgrid::EntityRep<1>(face, true)];
+    bool a = (local_index == 0);
+    bool b = r[0].orientation();
+    bool use_first = a ? b : !b;
+    // The number of valid cells.
+    int r_size = r.size();
+    // In the case of only one valid cell, this is the index of it.
+    int index = 0;
+    if(r[0].index()==std::numeric_limits<int>::max()){
+        assert(r_size==2);
+        --r_size;
+        index=1;
+    }
+    if(r.size()>1 && r[1].index()==std::numeric_limits<int>::max())
+    {
+        assert(r_size==2);
+        --r_size;
+    }
+    if (r_size == 2) {
+        return use_first ? r[0].index() : r[1].index();
+    } else {
+        return use_first ? r[index].index() : -1;
+    }
+}
+
+int CpGrid::numCellFaces() const
+{
+    return current_view_data_->cell_to_face_.dataSize();
+}
+
+int CpGrid::numFaceVertices(int face) const
+{
+    return current_view_data_->face_to_point_[face].size();
+}
+
+int CpGrid::faceVertex(int face, int local_index) const
+{
+    return current_view_data_->face_to_point_[face][local_index];
+}
+
+double CpGrid::cellCenterDepth(int cell_index) const
+{
+    // Here cell center depth is computed as a raw average of cell corner depths.
+    // This generally gives slightly different results than using the cell centroid.
+    double zz = 0.0;
+    const int nv = current_view_data_->cell_to_point_[cell_index].size();
+    const int nd = 3;
+    for (int i=0; i<nv; ++i) {
+        zz += vertexPosition(current_view_data_->cell_to_point_[cell_index][i])[nd-1];
+    }
+    return zz/nv;
+}
+
+const Dune::FieldVector<double,3> CpGrid::faceCenterEcl(int cell_index, int face) const
+{
+    // This method is an alternative to the method faceCentroid(...).
+    // The face center is computed as a raw average of cell corners.
+    // For faulted cells this gives different results then average of face nodes
+    // that seems to agree more with eclipse.
+    // This assumes the cell nodes are ordered
+    // 6---7
+    // | T |
+    // 4---5
+    //   2---3
+    //   | B |
+    //   0---1
+
+    // this follows the DUNE reference cube
+    static const int faceVxMap[ 6 ][ 4 ] = { {0, 2, 4, 6}, // face 0
+                                             {1, 3, 5, 7}, // face 1
+                                             {0, 1, 4, 5}, // face 2
+                                             {2, 3, 6, 7}, // face 3
+                                             {0, 1, 2, 3}, // face 4
+                                             {4, 5, 6, 7}  // face 5
+    };
+
+
+    assert (current_view_data_->cell_to_point_[cell_index].size() == 8);
+    Dune::FieldVector<double,3> center(0.0);
+    for( int i=0; i<4; ++i )
+    {
+        center += vertexPosition(current_view_data_->cell_to_point_[cell_index][ faceVxMap[ face ][ i ] ]);
+    }
+
+    for (int i=0; i<3; ++i) {
+        center[i] /= 4;
+    }
+    return center;
+
+}
+
+const Dune::FieldVector<double,3> CpGrid::faceAreaNormalEcl(int face) const
+{
+    // same implementation as ResInsight
+    const int nd = Dune::FieldVector<double,3>::dimension;
+    const int nv =  numFaceVertices(face);
+    switch (nv)
+    {
+    case 0:
+    case 1:
+    case 2:
+        {
+            return Dune::FieldVector<double,3>(0.0);
+        }
+        break;
+    case 3:
+        {
+            Dune::FieldVector<double,3> a = vertexPosition(current_view_data_->face_to_point_[face][0])
+                - vertexPosition(current_view_data_->face_to_point_[face][2]);
+            Dune::FieldVector<double,3> b = vertexPosition(current_view_data_->face_to_point_[face][1])
+                - vertexPosition(current_view_data_->face_to_point_[face][2]);
+            Dune::FieldVector<double,3> areaNormal = cross(a,b);
+            for (int i=0; i<nd; ++i) {
+                areaNormal[i] /= 2;
+            }
+            return areaNormal;
+        }
+        break;
+    case 4:
+        {
+            Dune::FieldVector<double,3> a = vertexPosition(current_view_data_->face_to_point_[face][0])
+                - vertexPosition(current_view_data_->face_to_point_[face][2]);
+            Dune::FieldVector<double,3> b = vertexPosition(current_view_data_->face_to_point_[face][1])
+                - vertexPosition(current_view_data_->face_to_point_[face][3]);
+            Dune::FieldVector<double,3> areaNormal = cross(a,b);
+            areaNormal *= 0.5;
+            return areaNormal;
+        }
+        break;
+    default:
+        {
+            int h = (nv - 1)/2;
+            int k = (nv % 2) ? 0 : nv - 1;
+
+            Dune::FieldVector<double,3> areaNormal(0.0);
+            // First quads
+            for (int i = 1; i < h; ++i)
+            {
+                Dune::FieldVector<double,3> a = vertexPosition(current_view_data_->face_to_point_[face][2*i])
+                    - vertexPosition(current_view_data_->face_to_point_[face][0]);
+                Dune::FieldVector<double,3> b = vertexPosition(current_view_data_->face_to_point_[face][2*i+1])
+                    - vertexPosition(current_view_data_->face_to_point_[face][2*i-1]);
+                areaNormal += cross(a,b);
+            }
+
+            // Last triangle or quad
+            Dune::FieldVector<double,3> a = vertexPosition(current_view_data_->face_to_point_[face][2*h])
+                - vertexPosition(current_view_data_->face_to_point_[face][0]);
+            Dune::FieldVector<double,3> b = vertexPosition(current_view_data_->face_to_point_[face][k])
+                - vertexPosition(current_view_data_->face_to_point_[face][2*h-1]);
+            areaNormal += cross(a,b);
+
+            areaNormal *= 0.5;
+
+            return areaNormal;
+        }
+
+    }
+}
+
+const Dune::FieldVector<double,3>& CpGrid::vertexPosition(int vertex) const
+{
+    return current_view_data_->geomVector<3>()[cpgrid::EntityRep<3>(vertex, true)].center();
+}
+
+double CpGrid::faceArea(int face) const
+{
+    return current_view_data_->geomVector<1>()[cpgrid::EntityRep<1>(face, true)].volume();
+}
+
+const Dune::FieldVector<double,3>& CpGrid::faceCentroid(int face) const
+{
+    return current_view_data_->geomVector<1>()[cpgrid::EntityRep<1>(face, true)].center();
+}
+
+const Dune::FieldVector<double,3>& CpGrid::faceNormal(int face) const
+{
+    return current_view_data_->face_normals_.get(face);
+}
+
+double CpGrid::cellVolume(int cell) const
+{
+    return current_view_data_->geomVector<0>()[cpgrid::EntityRep<0>(cell, true)].volume();
+}
+
+const Dune::FieldVector<double,3>& CpGrid::cellCentroid(int cell) const
+{
+    return current_view_data_->geomVector<0>()[cpgrid::EntityRep<0>(cell, true)].center();
+}
+
+CpGrid::CentroidIterator<0> CpGrid::beginCellCentroids() const
+{
+    return CentroidIterator<0>(current_view_data_->geomVector<0>().begin());
+}
+
+CpGrid::CentroidIterator<1> CpGrid::beginFaceCentroids() const
+{
+    return CentroidIterator<1>(current_view_data_->geomVector<1>().begin());
+}
+
+const std::vector<int>& CpGrid::sortedNumAquiferCells() const{
+           return current_view_data_->sortedNumAquiferCells();
+}
+
+int CpGrid::boundaryId(int face) const
+{
+    // Note that this relies on the following implementation detail:
+    // The grid is always construct such that the faces where
+    // orientation() returns true are oriented along the positive IJK
+    // direction. Oriented means that the first cell attached to face
+    // has the lower index.
+    int ret = 0;
+    cpgrid::EntityRep<1> f(face, true);
+    if (current_view_data_->face_to_cell_[f].size() == 1) {
+        if (current_view_data_->uniqueBoundaryIds()) {
+            // Use the unique boundary ids.
+            ret = current_view_data_->unique_boundary_ids_[f];
+        } else {
+            // Use the face tag based ids, i.e. 1-6 for i-, i+, j-, j+, k-, k+.
+            const bool normal_is_in =
+                !(current_view_data_->face_to_cell_[f][0].orientation());
+            enum face_tag tag = current_view_data_->face_tag_[f];
+            switch (tag) {
+            case I_FACE:
+                //                   LEFT : RIGHT
+                ret = normal_is_in ? 1    : 2; // min(I) : max(I)
+                break;
+            case J_FACE:
+                //                   BACK : FRONT
+                ret = normal_is_in ? 3    : 4; // min(J) : max(J)
+                break;
+            case K_FACE:
+                // Note: TOP at min(K) as 'z' measures *depth*.
+                //                   TOP  : BOTTOM
+                ret = normal_is_in ? 5    : 6; // min(K) : max(K)
+                break;
+            case NNC_FACE:
+                // This should not be possible, as NNC "faces" always
+                // have two cell neighbours.
+                OPM_THROW(std::logic_error, "NNC face at boundary. This should never happen!");
+            }
+        }
+    }
+    return ret;
+}
+
+const CpGrid::InterfaceMap& CpGrid::cellScatterGatherInterface() const
+{
+    return *cell_scatter_gather_interfaces_;
+}
+
+const CpGrid::InterfaceMap& CpGrid::pointScatterGatherInterface() const
+{
+    return *point_scatter_gather_interfaces_;
+}
+
+void CpGrid::switchToGlobalView()
+{
+    current_view_data_=data_[0].get();
+}
+
+void CpGrid::switchToDistributedView()
+{
+    if (distributed_data_.empty())
+        OPM_THROW(std::logic_error, "No distributed view available in grid");
+    current_view_data_=distributed_data_[0].get();
+}
+
+const cpgrid::CpGridData::CommunicationType& CpGrid::cellCommunication() const
+{
+    return current_view_data_->cellCommunication();
+}
+
+cpgrid::CpGridData::ParallelIndexSet& CpGrid::getCellIndexSet()
+{
+    return current_view_data_->cellIndexSet();
+}
+
+cpgrid::CpGridData::RemoteIndices& CpGrid::getCellRemoteIndices()
+{
+    return current_view_data_->cellRemoteIndices();
+}
+
+const cpgrid::CpGridData::ParallelIndexSet& CpGrid::getCellIndexSet() const
+{
+    return current_view_data_->cellIndexSet();
+}
+
+const cpgrid::CpGridData::RemoteIndices& CpGrid::getCellRemoteIndices() const
+{
+    return current_view_data_->cellRemoteIndices();
+}
+
+/*const std::vector<int>& CpGrid::sortedNumAquiferCells() const
+  {
+  return current_view_data_->sortedNumAquiferCells();
+  }*/
+
+
+//
+void CpGrid::readSintefLegacyFormat(const std::string& grid_prefix)
+{
+    if ( current_view_data_->ccobj_.rank() == 0 )
+    {
+        current_view_data_->readSintefLegacyFormat(grid_prefix);
+    }
+    current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
+                                         current_view_data_->logical_cartesian_size_.size(),
+                                         0);
+}
+void CpGrid::writeSintefLegacyFormat(const std::string& grid_prefix) const
+{
+    // Only rank 0 has the full data. Use that for writing.
+    if ( current_view_data_->ccobj_.rank() == 0 )
+    {
+        data_[0]->writeSintefLegacyFormat(grid_prefix);
+    }
+}
 
 
 #if HAVE_ECL_INPUT
-    std::vector<std::size_t> CpGrid::processEclipseFormat(const Opm::EclipseGrid* ecl_grid,
-                                                          Opm::EclipseState* ecl_state,
-                                                          bool periodic_extension,
-                                                          bool turn_normals, bool clip_z,
-                                                          bool pinchActive)
-    {
-        auto removed_cells = current_view_data_->processEclipseFormat(ecl_grid, ecl_state, periodic_extension,
-                                                                      turn_normals, clip_z, pinchActive);
-        current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
-                                             current_view_data_->logical_cartesian_size_.size(),
-                                             0);
-        return removed_cells;
-    }
+std::vector<std::size_t> CpGrid::processEclipseFormat(const Opm::EclipseGrid* ecl_grid,
+                                                      Opm::EclipseState* ecl_state,
+                                                      bool periodic_extension,
+                                                      bool turn_normals, bool clip_z,
+                                                      bool pinchActive)
+{
+    auto removed_cells = current_view_data_->processEclipseFormat(ecl_grid, ecl_state, periodic_extension,
+                                                                  turn_normals, clip_z, pinchActive);
+    current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
+                                         current_view_data_->logical_cartesian_size_.size(),
+                                         0);
+    return removed_cells;
+}
 
-    std::vector<std::size_t> CpGrid::processEclipseFormat(const Opm::EclipseGrid* ecl_grid_ptr,
-                                                              Opm::EclipseState* ecl_state,
-                                                              bool periodic_extension, bool turn_normals, bool clip_z)
-    {
-        return processEclipseFormat(ecl_grid_ptr, ecl_state, periodic_extension, turn_normals, clip_z,
-                             !ecl_grid_ptr || ecl_grid_ptr->isPinchActive());
-    }
+std::vector<std::size_t> CpGrid::processEclipseFormat(const Opm::EclipseGrid* ecl_grid_ptr,
+                                                      Opm::EclipseState* ecl_state,
+                                                      bool periodic_extension, bool turn_normals, bool clip_z)
+{
+    return processEclipseFormat(ecl_grid_ptr, ecl_state, periodic_extension, turn_normals, clip_z,
+                                !ecl_grid_ptr || ecl_grid_ptr->isPinchActive());
+}
 
 #endif
 
-    void CpGrid::processEclipseFormat(const grdecl& input_data,
-                                      bool remove_ij_boundary, bool turn_normals)
-    {
-        using NNCMap = std::set<std::pair<int, int>>;
-        using NNCMaps = std::array<NNCMap, 2>;
-        NNCMaps nnc;
-        current_view_data_->processEclipseFormat(input_data,
+void CpGrid::processEclipseFormat(const grdecl& input_data,
+                                  bool remove_ij_boundary, bool turn_normals)
+{
+    using NNCMap = std::set<std::pair<int, int>>;
+    using NNCMaps = std::array<NNCMap, 2>;
+    NNCMaps nnc;
+    current_view_data_->processEclipseFormat(input_data,
 #if HAVE_ECL_INPUT
-                                                 nullptr,
+                                             nullptr,
 #endif
-                                                 nnc,
-                                                 remove_ij_boundary, turn_normals, false);
-        current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
-                                             current_view_data_->logical_cartesian_size_.size(),
-                                             0);
+                                             nnc,
+                                             remove_ij_boundary, turn_normals, false);
+    current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
+                                         current_view_data_->logical_cartesian_size_.size(),
+                                         0);
+}
+
+template<int dim>
+cpgrid::Entity<dim> Dune::createEntity(const CpGrid& grid,int index,bool orientation)
+{
+    return cpgrid::Entity<dim>(*grid.current_view_data_, index, orientation);
+}
+template cpgrid::Entity<0> Dune::createEntity(const CpGrid&, int, bool);
+template cpgrid::Entity<3> Dune::createEntity(const CpGrid&, int, bool);
+template cpgrid::Entity<1> Dune::createEntity(const CpGrid&, int, bool); // needed in distribution_test.cpp 
+
+/// @brief Create a grid out of a coarse one and a refinement(LGR) of a selected block-shaped patch of cells from that coarse grid.
+///
+/// Level0 refers to the coarse grid, assumed to be this-> data_[0]. Level1 refers to the LGR (stored in this->data_[1]).
+/// LeafView (stored in this-> data_[2]) is built with the level0-entities which weren't involded in the
+/// refinenment, together with the new born entities created in level1.
+/// Old-corners and old-faces (from coarse grid) lying on the boundary of the patch, get replaced by new-born-equivalent corners
+/// and new-born-faces.
+///
+/// @param [in] cells_per_dim            Number of (refined) cells in each direction that each parent cell should be refined to.
+/// @param [in] startIJK                 Cartesian triplet index where the patch starts.
+/// @param [in] endIJK                   Cartesian triplet index where the patch ends.
+void CpGrid::createGridWithLgr(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK, const std::array<int,3>& endIJK)
+{
+    if (!distributed_data_.empty()){
+        OPM_THROW(std::logic_error, "Grid has been distributed. Cannot created LGR.");
     }
+    // Get patch corner, face, and cell indices.
+    const auto& [patch_corners, patch_faces, patch_cells] = (*(this->data_[0])).getPatchGeomIndices(startIJK, endIJK);
+    //
+    // Build the LGR/level1 from the selected patch of cells from level0 (level0 = this->data_[0]).
+    const auto& [level1_ptr, boundary_old_to_new_corners, boundary_old_to_new_faces, parent_to_children_faces,
+                 parent_to_children_cells, child_to_parent_faces, child_to_parent_cells]
+        = (*(this-> data_[0])).refinePatch(cells_per_dim, startIJK, endIJK);
+    // Add level 1 to "data".
+    (this-> data_).push_back(level1_ptr);
+    //
+    // LEVEL 0, definition/declaration of some members:
+    // std::vector<std::shared_ptr<CpGridData>> l0_data;
+    (*data_[0]).data_copy_ = &(this -> data_);
+    (*data_[0]).level_ = 0;
+    // Relation between level and leafview cell indices.
+    std::map<int,int>& l0_to_leaf_cells = (*data_[0]).level_to_leaf_cells_;
+    // For level0, attach children to each parent cell. EMPTY entry for no parents.
+    auto& l0_parent_to_children_cells = (*data_[0]).parent_to_children_cells_;
+    const std::vector<int>& no_child = {-1};
+    const int& no_level = -1;
+    const std::tuple<int, std::vector<int>>& no_children = std::make_tuple(no_level, no_child);
+    // For cells with no children, we set {-1,{-1}}. Entries of actual parents will be rewritten.
+    l0_parent_to_children_cells.resize(data_[0]-> size(0));
+    for (int cell = 0; cell < data_[0] -> size(0); ++cell){
+        l0_parent_to_children_cells[cell] = no_children;
+    }
+    // For level1/LGR, attach to each child-cell its parent.
+    std::vector<std::array<int,2>>& l1_child_to_parent_cells = (*data_[1]).child_to_parent_cells_;
+    // For cells with no parent, we set {-1,-1}. Entries with actual parents will be rewritten.
+    const std::array<int,2>& no_parent = {-1,-1};
+    l1_child_to_parent_cells.resize(data_[1]-> size(0));
+    for (int cell = 0; cell < data_[1]->size(0); ++cell){
+        l1_child_to_parent_cells[cell] = no_parent;
+    }
+    // Rewrite entries for actual parents in level0 and actual children in level1.
+    for (const auto& [parent, children] : parent_to_children_cells) {
+        l0_parent_to_children_cells[parent] = {1, children}; // {level LGR, {child0, child1, ...}}
+        for (const auto& child : children){
+            l1_child_to_parent_cells[child] = {0, parent}; // {level of parent cell, parent cell index in that level}
+        }
+    }
+    // LEVEL 1, definition/declaration of some members:
+    (*data_[1]).data_copy_ = &(this -> data_);
+    //std::vector<std::shared_ptr<Dune::cpgrid::CpGridData>> l1_data = this -> data_;
+    (*data_[1]).level_ = 1;
+    // Relation between level and leafview cell indices.
+    std::map<int,int>& l1_to_leaf_cells = (*data_[1]).level_to_leaf_cells_;
+    //
+    // To store the leaf view (mixed grid: with (non parents) coarse and (children) refined entities).
+    typedef Dune::FieldVector<double,3> PointType;
+    std::vector<std::shared_ptr<Dune::cpgrid::CpGridData>>& leaf_data = this -> data_;
+#if HAVE_MPI
+    std::shared_ptr<Dune::cpgrid::CpGridData> leaf_view_ptr =
+        std::make_shared<Dune::cpgrid::CpGridData>((*(this-> data_[0])).ccobj_, leaf_data);
+#else
+    // DUNE 2.7 is missing convertion to NO_COMM
+    std::shared_ptr<CpGridData> refined_grid_ptr = std::make_shared<CpGridData>(leaf_data);
+#endif
+    auto& leaf_view = *leaf_view_ptr;
+    Dune::cpgrid::DefaultGeometryPolicy& leaf_geometries = leaf_view.geometry_;
+    std::vector<std::array<int,8>>& leaf_cell_to_point = leaf_view.cell_to_point_;
+    cpgrid::OrientedEntityTable<0,1>& leaf_cell_to_face = leaf_view.cell_to_face_;
+    Opm::SparseTable<int>& leaf_face_to_point = leaf_view.face_to_point_;
+    cpgrid::OrientedEntityTable<1,0>& leaf_face_to_cell = leaf_view.face_to_cell_;
+    cpgrid::EntityVariable<enum face_tag,1>& leaf_face_tags = leaf_view.face_tag_;
+    cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>,1>& leaf_face_normals = leaf_view.face_normals_;
+    //
+    //leaf_view.grid_ = this;
+    std::vector<std::array<int,2>>& leaf_to_level_cells = leaf_view.leaf_to_level_cells_; // {level, cell index in that level}
+    // leaf_child_to_parent_cells[ cell index ] must be {-1,-1} when the cell has no father.
+    std::vector<std::array<int,2>>& leaf_child_to_parent_cells = leaf_view.child_to_parent_cells_;
+    //
+    // Mutable containers for leaf view corners, faces, cells, face tags, and face normals.
+    Dune::cpgrid::EntityVariableBase<cpgrid::Geometry<0,3>>& leaf_corners =
+        leaf_geometries.geomVector(std::integral_constant<int,3>());
+    Dune::cpgrid::EntityVariableBase<cpgrid::Geometry<2,3>>& leaf_faces =
+        leaf_geometries.geomVector(std::integral_constant<int,1>());
+    Dune::cpgrid::EntityVariableBase<cpgrid::Geometry<3,3>>& leaf_cells =
+        leaf_geometries.geomVector(std::integral_constant<int,0>());
+    Dune::cpgrid::EntityVariableBase<enum face_tag>& mutable_face_tags = leaf_face_tags;
+    Dune::cpgrid::EntityVariableBase<PointType>& mutable_face_normals = leaf_face_normals;
+    //
+    // Integer to count leaf view corners (mixed between corners from level0 not involved in LGR, and new-born-corners).
+    int corner_count = 0;
+    // Map between {level0/level1, old-corner-index/new-born-corner-index}  and its corresponding leafview-corner-index.
+    std::map<std::array<int,2>, int> level_to_leaf_corners;
+    // Corners coming from the level0, excluding patch_corners, i.e., the old-corners involved in the LGR.
+    for (int corner = 0; corner < this-> data_[0]->size(3); ++corner) {
+        // Auxiliary bool to discard patch corners.
+        bool is_there_corn = false;
+        for(const auto& patch_corn : patch_corners) {
+            is_there_corn = is_there_corn || (corner == patch_corn); //true->corn coincides with one patch corner
+            if (is_there_corn)
+                break;
+        }
+        if(!is_there_corn) { // corner is not involved in refinement, so we store it.
+            level_to_leaf_corners[{0, corner}] = corner_count;
+            corner_count +=1;
+        }
+    }
+    // Corners coming from level1, i.e. refined (new-born) corners.
+    for (int corner = 0; corner < this -> data_[1]->size(3); ++corner) {
+        level_to_leaf_corners[{1, corner}] = corner_count;
+        corner_count +=1;
+    }
+    // Resize the container of the leaf view corners.
+    leaf_corners.resize(corner_count);
+    for (const auto& [level_cornIdx, leafCornIdx] : level_to_leaf_corners) { // level_cornIdx = {level, corner index}
+        const auto& level_data = *(this->data_[level_cornIdx[0]]);
+        leaf_corners[leafCornIdx] = level_data.geometry_.geomVector(std::integral_constant<int,3>()).get(level_cornIdx[1]);
+    }
+    // Map to relate boundary patch corners with their equivalent refined/new-born ones. {0,oldCornerIdx} -> {1,newCornerIdx}
+    std::map<std::array<int,2>, std::array<int,2>> old_to_new_boundaryPatchCorners;
+    // To store (indices of) boundary patch corners.
+    std::vector<int> boundary_patch_corners;
+    boundary_patch_corners.reserve(boundary_old_to_new_corners.size());
+    for (long unsigned int corner = 0; corner < boundary_old_to_new_corners.size(); ++corner) {
+        old_to_new_boundaryPatchCorners[{0, boundary_old_to_new_corners[corner][0]}] = {1, boundary_old_to_new_corners[corner][1]};
+        boundary_patch_corners.push_back(boundary_old_to_new_corners[corner][0]);
+    }
+    // Integer to count leaf view faces (mixed between faces from level0 not involved in LGR, and new-born-faces).
+    int face_count = 0;
+    // Map between {level0/level1, old-face-index/new-born-face-index}  and its corresponding leafview-face-index.
+    std::map<std::array<int,2>, int> level_to_leaf_faces;
+    // Faces coming from the level0, that do not belong to the patch.
+    for (int face = 0; face < this->data_[0]->face_to_cell_.size(); ++face) {
+        // Auxiliary bool to discard patch faces.
+        bool is_there_face = false;
+        for(const auto& patch_face : patch_faces) {
+            is_there_face = is_there_face || (face == patch_face); //true->face coincides with one patch faces
+            if (is_there_face)
+                break;
+        }
+        if(!is_there_face) { // false-> face was not involved in the LGR, so we store it.
+            level_to_leaf_faces[{0, face}] = face_count;
+            face_count +=1;
+        }
+    }
+    // Faces coming from level1, i.e. refined faces.
+    for (int face = 0; face < this->data_[1]-> face_to_cell_.size(); ++face) {
+        level_to_leaf_faces[{1, face}] = face_count;
+        face_count +=1;
+    }
+    // Resize leaf_faces, mutable_face_tags, and mutable_face_normals.
+    leaf_faces.resize(face_count);
+    mutable_face_tags.resize(face_count);
+    mutable_face_normals.resize(face_count);
+    // Auxiliary integer to count all the points in leaf_face_to_point.
+    int num_points = 0;
+    // Auxiliary vector to store face_to_point with non consecutive indices.
+    std::vector<std::vector<int>> aux_face_to_point;
+    aux_face_to_point.resize(face_count);
+    for (const auto& [level_faceIdx, leafFaceIdx] : level_to_leaf_faces) { // level_faceIdx = {level0/1, face index }
+        // Get the level data.
+        const auto& level_data = *(this->data_[level_faceIdx[0]]);
+        // Get the (face) entity (from level data).
+        const auto& entity = Dune::cpgrid::EntityRep<1>(level_faceIdx[1], true);
+        // Get the face geometry.
+        leaf_faces[leafFaceIdx] = level_data.geometry_.geomVector(std::integral_constant<int,1>())[entity];
+        // Get the face tag.
+        mutable_face_tags[leafFaceIdx] = level_data.face_tag_[entity];
+        // Get the face normal.
+        mutable_face_normals[leafFaceIdx] = level_data.face_normals_[entity];
+        // Get old_face_to_point.
+        auto old_face_to_point = level_data.face_to_point_[level_faceIdx[1]];
+        aux_face_to_point[leafFaceIdx].reserve(old_face_to_point.size());
+        // Add the amount of points to the count num_points.
+        num_points += old_face_to_point.size();
+        if (level_faceIdx[0] == 0) { // Face comes from level0, check if some of its corners got refined.
+            for (int corn = 0; corn < 4; ++corn) {
+                // Auxiliary bool to identify boundary patch corners.
+                bool is_there_bound_corn = false;
+                for(const auto& bound_corn : boundary_patch_corners) {
+                    is_there_bound_corn = is_there_bound_corn || (corn == bound_corn); //true-> boundary patch corner
+                    if (is_there_bound_corn)
+                        break;
+                }
+                if(!is_there_bound_corn) {  // If it does not belong to the boundary of the patch:
+                    aux_face_to_point[leafFaceIdx].push_back(level_to_leaf_corners[{0, old_face_to_point[corn]}]);
+                }
+                else { // If the corner was involved in the refinement (corner on the boundary of the patch):
+                    aux_face_to_point[leafFaceIdx].push_back(level_to_leaf_corners
+                                                             [old_to_new_boundaryPatchCorners[{0, old_face_to_point[corn]}]]);
+                }
+            }
+        }
+        else { // Face comes from level1/LGR
+            for (long unsigned int corn = 0; corn < old_face_to_point.size(); ++corn) {
+                aux_face_to_point[leafFaceIdx].push_back(level_to_leaf_corners[{1, old_face_to_point[corn]}]);
+            }
+        }
+    }
+    // Leaf view face_to_point.
+    leaf_face_to_point.reserve(face_count, num_points);
+    for (int face = 0; face < face_count; ++face) {
+        leaf_face_to_point.appendRow(aux_face_to_point[face].begin(), aux_face_to_point[face].end());
+    }
+    // Map to relate boundary patch faces with their children refined/new-born ones. {0,oldFaceIdx} -> {1,newFaceIdx}
+    std::map<std::array<int,2>,std::vector<std::array<int,2>>> old_to_new_boundaryPatchFaces;
+    // To store (indices of) boundary patch faces.
+    std::vector<int> boundary_patch_faces;
+    boundary_patch_faces.reserve(boundary_old_to_new_faces.size());
+    for (long unsigned int face = 0; face < boundary_old_to_new_faces.size(); ++face) {
+        for (const auto& child : std::get<1>(boundary_old_to_new_faces[face])) {
+            old_to_new_boundaryPatchFaces[{0, std::get<0>(boundary_old_to_new_faces[face])}].push_back({1, child});
+        }
+        boundary_patch_faces.push_back(std::get<0>(boundary_old_to_new_faces[face]));
+    }
+    // Integer to count leaf view cells (mixed between cells from level0 not involved in LGR, and new-born-cells).
+    int cell_count = 0;
+    // Map between {level0/level1, old-cell-index/new-born-cell-index}  and its corresponding leafview-cell-index.
+    std::map<std::array<int,2>, int> level_to_leaf_cells;
+    // Cells coming from the level0, that do not belong to the patch.
+    for (int cell = 0; cell < this->data_[0]-> size(0); ++cell) {
+        // Auxiliary bool to identify cells of the patch.
+        bool is_there_cell = false;
+        for(const auto& patch_cell : patch_cells) {
+            is_there_cell = is_there_cell || (cell == patch_cell); //true-> coincides with one patch cell
+            if (is_there_cell)
+                break;
+        }
+        if(!is_there_cell) {// Cell does not belong to the patch, so we store it.
+            level_to_leaf_cells[{0, cell}] = cell_count;
+            l0_to_leaf_cells[cell] = cell_count;
+            cell_count +=1;
+        }
+    }
+    // Cells coming from level1, i.e. refined cells.
+    for (int cell = 0; cell < this->data_[1]-> size(0); ++cell) {
+        level_to_leaf_cells[{1, cell}] = cell_count;
+        l1_to_leaf_cells[cell] = cell_count;
+        cell_count +=1;
+    }
+    leaf_cells.resize(cell_count);
+    leaf_cell_to_point.resize(cell_count);
+    leaf_to_level_cells.resize(cell_count);
+    leaf_child_to_parent_cells.resize(cell_count);
+    // For cells that do not have a parent, we set {-1,-1} by defualt and rewrite later for actual children.
+    for (int cell = 0; cell < cell_count; ++cell){
+        leaf_child_to_parent_cells[cell] = no_parent;
+    }
+    // Auxiliary vector to store cell_to_face with non consecutive indices.
+    std::map<int,std::vector<cpgrid::EntityRep<1>>> aux_cell_to_face;
+    for (const auto& [level_cellIdx, leafCellIdx] : level_to_leaf_cells) {// level_cellIdx = {level0/1, cell index}
+        leaf_to_level_cells[leafCellIdx] = level_cellIdx;
+        const auto& level_data =  *(this->data_[level_cellIdx[0]]);
+        const auto& entity =  Dune::cpgrid::EntityRep<0>(level_cellIdx[1], true);
+        // Get the cell geometry.
+        leaf_cells[leafCellIdx] = level_data.geometry_.geomVector(std::integral_constant<int,0>())[entity];
+        // Get old corners of the cell that will be replaced with leaf view ones.
+        auto old_cell_to_point = level_data.cell_to_point_[level_cellIdx[1]];
+        // Get old faces of the cell that will be replaced with leaf view ones.
+        auto old_cell_to_face = level_data.cell_to_face_[entity];
+        if (level_cellIdx[0] == 0) { // Cell comes from level0
+            // Cell to point.
+            for (int corn = 0; corn < 8; ++corn) {
+                // Auxiliary bool to identity boundary patch corners
+                bool is_there_corn = false;
+                for(const auto& patch_corn : patch_corners) {
+                    is_there_corn = is_there_corn || (old_cell_to_point[corn] == patch_corn);
+                    if (is_there_corn)//true-> coincides with one boundary patch corner
+                        break;
+                }
+                if(is_there_corn) { // Corner belongs to the patch boundary.
+                    leaf_cell_to_point[leafCellIdx][corn] =
+                        level_to_leaf_corners[old_to_new_boundaryPatchCorners[{0, old_cell_to_point[corn]}]];
+                }
+                else { // Corner does not belong to the patch boundary.
+                    leaf_cell_to_point[leafCellIdx][corn] = level_to_leaf_corners[{0, old_cell_to_point[corn]}];
+                }
+            }
+            // Cell to face.
+            for (const auto& face : old_cell_to_face)
+            {   // Auxiliary bool to identity boundary patch faces
+                bool is_there_face = false;
+                for(const auto& bound_face : boundary_patch_faces) {
+                    is_there_face = is_there_face || (face.index() == bound_face); //true-> coincides with one boundary patch face
+                    if (is_there_face)
+                        break;
+                }
+                if(is_there_face) { // Face belongs to the patch boundary.
+                    for (const auto& level_newFace : old_to_new_boundaryPatchFaces[{0, face.index()}]) {
+                        aux_cell_to_face[leafCellIdx].push_back({level_to_leaf_faces[level_newFace], face.orientation()});
+                    }
+                }
+                else { // Face does not belong to the patch boundary.
+                    aux_cell_to_face[leafCellIdx].push_back({level_to_leaf_faces[{0, face.index()}], face.orientation()});
+                }
+            }
+        }
+        else { // Refined cells. (Cell comes from level1)
+            // Get level where cell was created and its local index, to later deduce its parent.
+            auto& [l1, l1Idx]  = leaf_to_level_cells[leafCellIdx]; // {1, cell index in level 1}
+            leaf_child_to_parent_cells[leafCellIdx] = l1_child_to_parent_cells[l1Idx]; //(*data_[l1]).child_to_parent_[l1Idx];
+            // Cell to point.
+            for (int corn = 0; corn < 8; ++corn) {
+                leaf_cell_to_point[leafCellIdx][corn] = level_to_leaf_corners[{1, old_cell_to_point[corn]}];
+            }
+            // Cell to face.
+            for (auto& face : old_cell_to_face) {
+                aux_cell_to_face[leafCellIdx].push_back({level_to_leaf_faces[{1, face.index()}], face.orientation()});
+            }
+        }
+    }
+    // Leaf view cell to face.
+    for (int cell = 0; cell < cell_count; ++cell) {
+        leaf_cell_to_face.appendRow(aux_cell_to_face[cell].begin(), aux_cell_to_face[cell].end());
+    }
+    // Leaf view face to cell.
+    leaf_cell_to_face.makeInverseRelation(leaf_face_to_cell);
+    //  Add Leaf View to data_.
+    (this-> data_).push_back(leaf_view_ptr);
+    current_view_data_ = data_[2].get();
+    (*data_[2]).level_ = 2;
+    // Define grid_ for leaf_view level 
+    // (*data_[2]).data_copy_ = &(this-> data_);
+}
+
 
 } // namespace Dune
+
+#define OPM_INSTANTIATE_PARTITION_ITERATE(method, Method)               \
+    template CpGridTraits::template Codim<0>:: Method CpGrid:: method<0>() const; \
+    template CpGridTraits::template Codim<1>:: Method CpGrid:: method<1>() const; \
+    template CpGridTraits::template Codim<3>:: Method CpGrid:: method<3>() const; \
+    OPM_INSTANTIATE_PARTITION_ITERATE(lbegin, LevelIterator);           \
+    OPM_INSTANTIATE_PARTITION_ITERATE(lend, LevelIterator);

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1688,10 +1688,3 @@ void CpGrid::addLgrUpdateLeafView(const std::array<int,3>& cells_per_dim, const 
 
 
 } // namespace Dune
-
-#define OPM_INSTANTIATE_PARTITION_ITERATE(method, Method)               \
-    template CpGridTraits::template Codim<0>:: Method CpGrid:: method<0>() const; \
-    template CpGridTraits::template Codim<1>:: Method CpGrid:: method<1>() const; \
-    template CpGridTraits::template Codim<3>:: Method CpGrid:: method<3>() const; \
-    OPM_INSTANTIATE_PARTITION_ITERATE(lbegin, LevelIterator);           \
-    OPM_INSTANTIATE_PARTITION_ITERATE(lend, LevelIterator);

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -190,6 +190,18 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
         return std::make_pair(false, std::vector<std::pair<std::string,bool> >());
     }
 
+    if (data_.size() > 1)
+    {
+        if (comm().rank() == 0)
+        {
+            OPM_THROW(std::logic_error, "Loadbalancing a grid with local grid refinement is not supported, yet.");
+        }
+        else
+        {
+            OPM_THROW_NOLOG(std::logic_error, "Loadbalancing a grid with local grid refinement is not supported, yet.");
+        }
+    }
+
 #if HAVE_MPI
     auto& cc = data_[0]->ccobj_;
 
@@ -1347,7 +1359,14 @@ template cpgrid::Entity<1> Dune::createEntity(const CpGrid&, int, bool); // need
 void CpGrid::createGridWithLgr(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK, const std::array<int,3>& endIJK)
 {
     if (!distributed_data_.empty()){
-        OPM_THROW(std::logic_error, "Grid has been distributed. Cannot created LGR.");
+        if (comm().rank()==0)
+        {
+            OPM_THROW(std::logic_error, "Adding LGRs to a distributed grid is not supported, yet.");
+        }
+        else
+        {
+            OPM_THROW_NOLOG(std::logic_error, "Adding LGRs to a distributed grid is not supported, yet.");
+        }
     }
     // Get patch corner, face, and cell indices.
     const auto& [patch_corners, patch_faces, patch_cells] = (*(this->data_[0])).getPatchGeomIndices(startIJK, endIJK);

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -579,9 +579,12 @@ int CpGrid::maxLevel() const
     if (!distributed_data_.empty()){
         return 0;
     }
-    else { // add assert to check data_.size() =  1 or 3 ? If 1, maxLevel =0, if 3, maxLevel =1. 
-        return double(this -> data_.size() - 1)/2; // last entry is leafView, and it starts in level 0 
-    } // Assuming last entry of data_ is the LeafView, recall it starts with level 0
+    if (data_.size() == 1){
+        return 0; // "GLOBAL" grid is the unique one
+    }
+    else {  // There are multiple LGRs
+        return double(this -> data_.size() - 2); // last entry is leafView, and it starts in level 0 = GLOBAL grid.
+    }
 }
 
 template<int codim>
@@ -1656,7 +1659,6 @@ void CpGrid::createGridWithLgr(const std::array<int,3>& cells_per_dim, const std
     //  Add Leaf View to data_.
     (this-> data_).push_back(leaf_view_ptr);
     current_view_data_ = data_[2].get();
-    (*data_[2]).level_ = 2; // LeafView 'does not have an actual "level"'. "Temporary" assignment.TO BE MODIFIED.
 }
 
 

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -43,7 +43,7 @@ CpGridData::CpGridData(const CpGridData& g)
 CpGridData::CpGridData(std::vector<std::shared_ptr<CpGridData>>& data)
     : index_set_(new IndexSet()), local_id_set_(new IdSet(*this)),
       global_id_set_(new LevelGlobalIdSet(local_id_set_, this)), partition_type_indicator_(new PartitionTypeIndicator(*this)),
-      data_copy_(),
+      level_data_ptr_(),
       ccobj_(Dune::MPIHelper::getCommunicator()), use_unique_boundary_ids_(false)
 #if HAVE_MPI
     , cell_comm_(Dune::MPIHelper::getCommunicator())
@@ -52,13 +52,13 @@ CpGridData::CpGridData(std::vector<std::shared_ptr<CpGridData>>& data)
 #if HAVE_MPI
     cell_interfaces_=std::make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
 #endif
-     data_copy_ = &data;
+     level_data_ptr_ = &data;
 }
 
 CpGridData::CpGridData(MPIHelper::MPICommunicator comm,  std::vector<std::shared_ptr<CpGridData>>& data)
     : index_set_(new IndexSet()), local_id_set_(new IdSet(*this)),
       global_id_set_(new LevelGlobalIdSet(local_id_set_, this)), partition_type_indicator_(new PartitionTypeIndicator(*this)),
-      data_copy_(),
+      level_data_ptr_(),
       ccobj_(comm), use_unique_boundary_ids_(false)
 #if HAVE_MPI
     , cell_comm_(comm)
@@ -67,7 +67,7 @@ CpGridData::CpGridData(MPIHelper::MPICommunicator comm,  std::vector<std::shared
 #if HAVE_MPI
     cell_interfaces_=std::make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
 #endif
-    data_copy_ = &data;
+    level_data_ptr_ = &data;
 }
 
 #if HAVE_MPI

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -102,10 +102,6 @@ CpGridData::~CpGridData()
     //freeInterfaces(face_interfaces_);
     freeInterfaces(point_interfaces_);
 #endif
-    // delete index_set_;
-    // delete local_id_set_;
-    // delete global_id_set_;
-    // delete partition_type_indicator_;
 }
 
 void CpGridData::populateGlobalCellIndexSet()

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -26,9 +26,9 @@ namespace Dune
 namespace cpgrid
 {
 
-
 CpGridData::CpGridData(const CpGridData& g)
-    : index_set_(new IndexSet(*this)), local_id_set_(new IdSet(*this)),
+    : index_set_(new IndexSet(g.cell_to_face_.size(), g.geomVector<3>().size())),
+      local_id_set_(new IdSet(*this)),
       global_id_set_(new LevelGlobalIdSet(local_id_set_, this)), partition_type_indicator_(new PartitionTypeIndicator(*this)),
       ccobj_(g.ccobj_), use_unique_boundary_ids_(g.use_unique_boundary_ids_)
 #if HAVE_MPI
@@ -40,9 +40,10 @@ CpGridData::CpGridData(const CpGridData& g)
 #endif
 }
 
-CpGridData::CpGridData()
-    : index_set_(new IndexSet(*this)), local_id_set_(new IdSet(*this)),
+CpGridData::CpGridData(std::vector<std::shared_ptr<CpGridData>>& data)
+    : index_set_(new IndexSet()), local_id_set_(new IdSet(*this)),
       global_id_set_(new LevelGlobalIdSet(local_id_set_, this)), partition_type_indicator_(new PartitionTypeIndicator(*this)),
+      data_copy_(),
       ccobj_(Dune::MPIHelper::getCommunicator()), use_unique_boundary_ids_(false)
 #if HAVE_MPI
     , cell_comm_(Dune::MPIHelper::getCommunicator())
@@ -51,11 +52,13 @@ CpGridData::CpGridData()
 #if HAVE_MPI
     cell_interfaces_=std::make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
 #endif
+     data_copy_ = &data;
 }
 
-CpGridData::CpGridData(MPIHelper::MPICommunicator comm)
-    : index_set_(new IndexSet(*this)), local_id_set_(new IdSet(*this)),
+CpGridData::CpGridData(MPIHelper::MPICommunicator comm,  std::vector<std::shared_ptr<CpGridData>>& data)
+    : index_set_(new IndexSet()), local_id_set_(new IdSet(*this)),
       global_id_set_(new LevelGlobalIdSet(local_id_set_, this)), partition_type_indicator_(new PartitionTypeIndicator(*this)),
+      data_copy_(),
       ccobj_(comm), use_unique_boundary_ids_(false)
 #if HAVE_MPI
     , cell_comm_(comm)
@@ -64,6 +67,7 @@ CpGridData::CpGridData(MPIHelper::MPICommunicator comm)
 #if HAVE_MPI
     cell_interfaces_=std::make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
 #endif
+    data_copy_ = &data;
 }
 
 #if HAVE_MPI
@@ -98,10 +102,10 @@ CpGridData::~CpGridData()
     //freeInterfaces(face_interfaces_);
     freeInterfaces(point_interfaces_);
 #endif
-    delete index_set_;
-    delete local_id_set_;
-    delete global_id_set_;
-    delete partition_type_indicator_;
+    // delete index_set_;
+    // delete local_id_set_;
+    // delete global_id_set_;
+    // delete partition_type_indicator_;
 }
 
 void CpGridData::populateGlobalCellIndexSet()
@@ -1724,6 +1728,489 @@ void CpGridData::distributeGlobalGrid(CpGrid& grid,
     static_cast<void>(view_data);
 #endif
 }
+
+const std::array<int,3> CpGridData::getPatchDim(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
+{
+    return {endIJK[0]-startIJK[0], endIJK[1]-startIJK[1], endIJK[2]-startIJK[2]};
+}
+
+const std::array<std::vector<int>,3>
+CpGridData::getPatchGeomIndices(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
+{
+    // Get the patch dimension (total cells in each direction). Used to 'reserve vectors'.
+    const std::array<int,3>& patch_dim = getPatchDim(startIJK, endIJK);
+    // Get grid dimension (total cells in each direction).
+    const std::array<int,3>& grid_dim = this -> logicalCartesianSize();
+    /// PATCH CORNERS
+    std::vector<int> patch_corners;
+    patch_corners.reserve((patch_dim[0]+1)*(patch_dim[1]+1)*(patch_dim[2]+1));
+    for (int j = startIJK[1]; j < endIJK[1]+1; ++j) {
+        for (int i = startIJK[0]; i < endIJK[0]+1; ++i) {
+            for (int k = startIJK[2]; k < endIJK[2]+1; ++k) {
+                patch_corners.push_back((j*(grid_dim[0]+1)*(grid_dim[2]+1)) + (i*(grid_dim[2]+1))+k);
+            } // end i-for-loop
+        } // end j-for-loop
+    } // end k-for-loop
+    /// PATCH FACES
+    std::vector<int> patch_faces;
+    patch_faces.reserve(((patch_dim[0]+1)*patch_dim[1]*patch_dim[2])     // i_patch_faces
+                        + (patch_dim[0]*(patch_dim[1]+1)*patch_dim[2])   // j_patch_faces
+                        + (patch_dim[0]*patch_dim[1]*(patch_dim[2]+1))); // k_patch_faces
+    // I_FACES
+    for (int j = startIJK[1]; j < endIJK[1]; ++j) {
+        for (int i = startIJK[0]; i < endIJK[0]+1; ++i) {
+            for (int k = startIJK[2]; k < endIJK[2]; ++k) {
+                patch_faces.push_back((j*(grid_dim[0]+1)*grid_dim[2]) +(i*grid_dim[2]) + k);
+            } // end k-for-loop
+        } // end i-for-loop
+    } // end j-for-loop
+    // J_FACES
+    for (int j = startIJK[1]; j < endIJK[1]+1; ++j) {
+        for (int i = startIJK[0]; i < endIJK[0]; ++i) {
+            for (int k = startIJK[2]; k < endIJK[2]; ++k) {
+                patch_faces.push_back(((grid_dim[0]+1)*grid_dim[1]*grid_dim[2]) // i_grid_faces
+                                      + (j*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2]) + k);
+            } // end k-for-loop
+        } // end i-for-loop
+    } // end j-for-loop
+    // K_FACES
+    for (int j = startIJK[1]; j < endIJK[1]; ++j) {
+        for (int i = startIJK[0]; i < endIJK[0]; ++i) {
+            for (int k = startIJK[2]; k < endIJK[2]+1; ++k) {
+                patch_faces.push_back((grid_dim[0]*(grid_dim[1]+1)*grid_dim[2]) //j_grid_faces
+                                      + ((grid_dim[0]+1)*grid_dim[1]*grid_dim[2])          // i_grid_faces
+                                      + (j*grid_dim[0]*(grid_dim[2]+1)) + (i*(grid_dim[2]+1))+ k);
+            } // end k-for-loop
+        } // end i-for-loop
+    } // end j-for-loop
+    /// PATCH CELLS
+    std::vector<int> patch_cells;
+    patch_cells.reserve(patch_dim[0]*patch_dim[1]*patch_dim[2]);
+    for (int k = startIJK[2]; k < endIJK[2]; ++k) {
+        for (int j = startIJK[1]; j < endIJK[1]; ++j) {
+            for (int i = startIJK[0]; i < endIJK[0]; ++i) {
+                patch_cells.push_back((k*grid_dim[0]*grid_dim[1]) + (j*grid_dim[0]) +i);
+            } // end i-for-loop
+        } // end j-for-loop
+    } // end k-for-loop
+    return {patch_corners, patch_faces, patch_cells};
+}
+
+const Geometry<3,3> CpGridData::cellifyPatch(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK,
+                                             const std::vector<int>& patch_cells, DefaultGeometryPolicy& cellifiedPatch_geometry,
+                                             std::array<int,8>& cellifiedPatch_to_point,
+                                             std::array<int,8>& allcorners_cellifiedPatch) const
+{
+    if (patch_cells.empty()){
+        OPM_THROW(std::logic_error, "Empty patch. Cannot convert patch into cell.");
+    }
+    else{
+        // Get grid dimension.
+        const std::array<int,3>& grid_dim = this -> logicalCartesianSize();
+        // Select 8 corners of the patch boundary to be the 8 corners of the 'cellified patch'.
+        cellifiedPatch_to_point = { // Corner-index: (J*(grid_dim[0]+1)*(grid_dim[2]+1)) + (I*(grid_dim[2]+1)) +K
+            // Index of corner '0' {startI, startJ, startK}
+            (startIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (startIJK[0]*(grid_dim[2]+1)) + startIJK[2],
+            // Index of corner '1' '{endI, startJ, startK}'
+            (startIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (endIJK[0]*(grid_dim[2]+1)) + startIJK[2],
+            // Index of corner '2' '{startI, endJ, startK}'
+            (endIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (startIJK[0]*(grid_dim[2]+1)) + startIJK[2],
+            // Index of corner '3' '{endI, endJ, startK}'
+            (endIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (endIJK[0]*(grid_dim[2]+1)) + startIJK[2],
+            // Index of corner '4' '{startI, startJ, endK}'
+            (startIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (startIJK[0]*(grid_dim[2]+1))+ endIJK[2],
+            // Index of corner '5' '{endI, startJ, endK}'
+            (startIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (endIJK[0]*(grid_dim[2]+1)) + endIJK[2],
+            // Index of corner '6' '{startI, endJ, endK}'
+            (endIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (startIJK[0]*(grid_dim[2]+1)) + endIJK[2],
+            // Index of corner '7' {endI, endJ, endK}
+            (endIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (endIJK[0]*(grid_dim[2]+1)) + endIJK[2]};
+        EntityVariableBase<cpgrid::Geometry<0,3>>& cellifiedPatch_corners =
+            cellifiedPatch_geometry.geomVector(std::integral_constant<int,3>());
+        cellifiedPatch_corners.resize(8);
+        // Compute the center of the 'cellified patch' and its corners.
+        Geometry<0,3>::GlobalCoordinate cellifiedPatch_center = {0., 0.,0.};
+        for (int corn = 0; corn < 8; ++corn) {
+            // FieldVector in DUNE 2.6 is missing operator/ using a loop
+            for(int i=0; i < 3; ++i){
+                cellifiedPatch_center[i] +=
+                    (this -> geometry_.geomVector(std::integral_constant<int,3>()).get(cellifiedPatch_to_point[corn]).center())[i]/8.;
+            }
+            cellifiedPatch_corners[corn] =
+                this -> geometry_.geomVector(std::integral_constant<int,3>()).get(cellifiedPatch_to_point[corn]);
+        }
+        // Compute the volume of the 'cellified patch'.
+        double cellifiedPatch_volume = 0.;
+        for (const auto& idx : patch_cells) {
+            cellifiedPatch_volume += (this -> geometry_.geomVector(std::integral_constant<int,0>())
+                                      [EntityRep<0>(idx, true)]).volume();
+        }
+        // Indices of 'all the corners', in this case, 0-7 (required to construct a Geometry<3,3> object).
+        allcorners_cellifiedPatch = {0,1,2,3,4,5,6,7};
+        // Create a pointer to the first element of "cellfiedPatch_to_point" (required to construct a Geometry<3,3> object).
+        const int* cellifiedPatch_indices_storage_ptr = &allcorners_cellifiedPatch[0];
+        // Construct (and return) the Geometry<3,3> of the 'cellified patch'.
+        return Geometry<3,3>(cellifiedPatch_center, cellifiedPatch_volume,
+                             cellifiedPatch_geometry.geomVector(std::integral_constant<int,3>()), cellifiedPatch_indices_storage_ptr);
+    }
+}
+
+const std::tuple< const std::shared_ptr<CpGridData>,
+                  const std::vector<std::array<int,2>>,                // parent_to_refined_corners(~boundary_old_to_new_corners)
+                  const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces (~boundary_old_to_new_faces)
+                  const std::tuple<int, std::vector<int>>,             // parent_to_children_cells
+                  const std::vector<std::array<int,2>>,                // child_to_parent_faces
+                  const std::vector<std::array<int,2>>>                // child_to_parent_cells
+CpGridData::refineSingleCell(const std::array<int,3>& cells_per_dim, const int& parent_idx) const
+{
+    // To store the LGR/refined-grid.
+    std::vector<std::shared_ptr<CpGridData>> refined_data;
+    std::shared_ptr<CpGridData> refined_grid_ptr = std::make_shared<CpGridData>(refined_data); // ccobj_
+    auto& refined_grid = *refined_grid_ptr;
+    DefaultGeometryPolicy& refined_geometries = refined_grid.geometry_;
+    std::vector<std::array<int,8>>& refined_cell_to_point = refined_grid.cell_to_point_;
+    cpgrid::OrientedEntityTable<0,1>& refined_cell_to_face = refined_grid.cell_to_face_;
+    Opm::SparseTable<int>& refined_face_to_point = refined_grid.face_to_point_;
+    cpgrid::OrientedEntityTable<1,0>& refined_face_to_cell = refined_grid.face_to_cell_;
+    cpgrid::EntityVariable<enum face_tag,1>& refined_face_tags = refined_grid.face_tag_;
+    cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>,1>& refined_face_normals = refined_grid.face_normals_;
+    // Get parent cell
+    const cpgrid::Geometry<3,3>& parent_cell = geometry_.geomVector(std::integral_constant<int,0>())[EntityRep<0>(parent_idx, true)];
+    // Get parent cell corners.
+    const std::array<int,8>& parent_to_point = this->cell_to_point_[parent_idx];
+    if (parent_to_point.size() != 8){
+        OPM_THROW(std::logic_error, "Cell is not a hexahedron. Cannot be refined (yet).");
+    }
+    // Refine parent cell
+    parent_cell.refine(cells_per_dim, refined_geometries, refined_cell_to_point, refined_cell_to_face,
+                       refined_face_to_point, refined_face_to_cell, refined_face_tags, refined_face_normals);
+    const std::vector<std::array<int,2>>& parent_to_refined_corners{
+        // corIdx (J*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (I*(cells_per_dim[2]+1)) +K
+        // replacing parent-cell corner '0' {0,0,0}
+        {parent_to_point[0], 0},
+            // replacing parent-cell corner '1' {cells_per_dim[0], 0, 0}
+        {parent_to_point[1], cells_per_dim[0]*(cells_per_dim[2]+1)},
+            // replacing parent-cell corner '2' {0, cells_perd_dim[1], 0}
+        {parent_to_point[2], cells_per_dim[1]*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)},
+            // replacing parent-cell corner '3' {cells_per_dim[0], cells_per_dim[1], 0}
+        {parent_to_point[3], (cells_per_dim[1]*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (cells_per_dim[0]*(cells_per_dim[2]+1))},
+            // replacing parent-cell corner '4' {0, 0, cells_per_dim[2]}
+        {parent_to_point[4], cells_per_dim[2]},
+            // replacing parent-cell corner '5' {cells_per_dim[0], 0, cells_per_dim[2]}
+        {parent_to_point[5], (cells_per_dim[0]*(cells_per_dim[2]+1)) + cells_per_dim[2]},
+            // replacing parent-cell corner '6' {0, cells_per_dim[1], cells_per_dim[2]}
+        {parent_to_point[6], (cells_per_dim[1]*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + cells_per_dim[2]},
+            // replacing parent-cell corner '7' {cells_per_dim[0], cells_per_dim[1], cells_per_dim[2]}
+        {parent_to_point[7], (cells_per_dim[1]*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (cells_per_dim[0]*(cells_per_dim[2]+1))
+                + cells_per_dim[2]}};
+    // Get parent_cell_to_face = { {face, orientation}, {another face, its orientation}, ...}.
+    const auto& parent_cell_to_face = (this-> cell_to_face_[EntityRep<0>(parent_idx, true)]);
+    // To store relation old-face to new-born-faces (children faces).
+    std::vector<std::tuple<int,std::vector<int>>>  parent_to_children_faces;
+    parent_to_children_faces.reserve(6);
+    // To store child-to-parent-face relation. Child-faces ordered with the criteria introduced in refine()(Geometry.hpp)K,I,Jfaces.
+    std::vector<std::array<int,2>> child_to_parent_faces;
+    child_to_parent_faces.reserve(refined_face_to_cell.size());
+    // Auxiliary integers to simplify new-born-face-index notation.
+    const int& k_faces = cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1);
+    const int& i_faces = (cells_per_dim[0]+1)*cells_per_dim[1]*cells_per_dim[2];
+    // Populate parent_to_children_faces and child_to_parent_faces.
+    for (const auto& face : parent_cell_to_face) {
+        // Check face tag to identify the type of face (bottom, top, left, right, front, or back).
+        auto& parent_face_tag = (this-> face_tag_[Dune::cpgrid::EntityRep<1>(face.index(), true)]);
+        // To store the new born faces for each face.
+        std::vector<int> children_faces; // Cannot reserve/resize "now", it depends of the type of face.
+        // K_FACES
+        if (parent_face_tag == face_tag::K_FACE) {
+            children_faces.reserve(cells_per_dim[0]*cells_per_dim[1]);
+            for (int j = 0; j < cells_per_dim[1]; ++j) {
+                for (int i = 0; i < cells_per_dim[0]; ++i) {
+                    int child_face;
+                    if (!face.orientation()) // false -> BOTTOM FACE -> k=0
+                        child_face = (j*cells_per_dim[0]) + i;
+                    else // true -> TOP FACE -> k=cells_per_dim[2]
+                        child_face = (cells_per_dim[2]*cells_per_dim[0]*cells_per_dim[1]) +(j*cells_per_dim[0]) + i;
+                    children_faces.push_back(child_face);
+                    child_to_parent_faces.push_back({child_face, face.index()});
+                } // i-for-lopp
+            } //j-for-loop
+        } // if-K_FACE
+        // I_FACES
+        if (parent_face_tag == face_tag::I_FACE) {
+            children_faces.reserve(cells_per_dim[1]*cells_per_dim[2]);
+            for (int k = 0; k < cells_per_dim[2]; ++k) {
+                for (int j = 0; j < cells_per_dim[1]; ++j) {
+                    int child_face;
+                    if (!face.orientation()) // false -> LEFT FACE -> i=0
+                        child_face = k_faces + (k*cells_per_dim[1]) + j;
+                    else // true -> RIGHT FACE -> i=cells_per_dim[0]
+                        child_face = k_faces + (cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]) + (k*cells_per_dim[1]) + j;
+                    children_faces.push_back(child_face);
+                    child_to_parent_faces.push_back({child_face, face.index()});
+                } // j-for-loop
+            } // k-for-loop
+        } // if-I_FACE
+        // J_FACES
+        if (parent_face_tag == face_tag::J_FACE) {
+            children_faces.reserve(cells_per_dim[0]*cells_per_dim[2]);
+            for (int i = 0; i < cells_per_dim[0]; ++i) {
+                for (int k = 0; k < cells_per_dim[2]; ++k) {
+                    int child_face;
+                    if (!face.orientation()) // false -> FRONT FACE -> j=0
+                        child_face = k_faces + i_faces + (i*cells_per_dim[2]) + k;
+                    else  // true -> BACK FACE -> j=cells_per_dim[1]
+                        child_face = k_faces + i_faces  + (cells_per_dim[1]*cells_per_dim[0]*cells_per_dim[2])
+                            + (i*cells_per_dim[2]) + k;
+                    children_faces.push_back(child_face);
+                    child_to_parent_faces.push_back({child_face, face.index()});
+                } // k-for-loop
+            } // i-for-loop
+        } // if-J_FACE
+        parent_to_children_faces.push_back(std::make_tuple(face.index(), children_faces));
+    }
+    std::tuple<int, std::vector<int>> parent_to_children_cells; // {parent cell index (in level0), {child0,...,childN (in level1)}}
+    auto& [ parent_index, children_cells ] = parent_to_children_cells;
+    children_cells.reserve(cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]);
+    // To store the child to parent cell relation.
+    std::vector<std::array<int,2>> child_to_parent_cell; // {child index (in level1), parent cell index (in level0)}
+    child_to_parent_cell.reserve(cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]);
+    // Populate children_cells and child_to_parent_cell.
+    for (int cell = 0; cell < cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]; ++cell) {
+        children_cells.push_back(cell);
+        child_to_parent_cell.push_back({cell, parent_idx});
+    }
+    return {refined_grid_ptr, parent_to_refined_corners, parent_to_children_faces, parent_to_children_cells,
+        child_to_parent_faces, child_to_parent_cell};
+}
+
+const std::tuple< std::shared_ptr<CpGridData>,
+                  const std::vector<std::array<int,2>>,                // boundary_old_to_new_corners
+                  const std::vector<std::tuple<int,std::vector<int>>>, // boundary_old_to_new_faces
+                  const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces
+                  const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_cell
+                  const std::vector<std::array<int,2>>,                // child_to_parent_faces
+                  const std::vector<std::array<int,2>>>                // child_to_parent_cells
+CpGridData::refinePatch(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK,
+                        const std::array<int,3>& endIJK) const
+{
+    // Coarse grid dimension (amount of cells in each direction).
+    const std::array<int,3>& grid_dim = this -> logicalCartesianSize();
+    // Check that the grid is a Cartesian one.
+    long unsigned int gXYZ = grid_dim[0]*grid_dim[1]*grid_dim[2];
+    if (global_cell_.size() != gXYZ){
+        OPM_THROW(std::logic_error, "Grid is not Cartesian. Patch cannot be refined.");
+    }
+    // To store LGR/refined-grid.
+    std::vector<std::shared_ptr<CpGridData>> refined_data;
+    std::shared_ptr<CpGridData> refined_grid_ptr = std::make_shared<CpGridData>(refined_data); // ccobj_
+    auto& refined_grid = *refined_grid_ptr;
+    DefaultGeometryPolicy& refined_geometries = refined_grid.geometry_;
+    std::vector<std::array<int,8>>& refined_cell_to_point = refined_grid.cell_to_point_;
+    cpgrid::OrientedEntityTable<0,1>& refined_cell_to_face = refined_grid.cell_to_face_;
+    Opm::SparseTable<int>& refined_face_to_point = refined_grid.face_to_point_;
+    cpgrid::OrientedEntityTable<1,0>& refined_face_to_cell = refined_grid.face_to_cell_;
+    cpgrid::EntityVariable<enum face_tag,1>& refined_face_tags = refined_grid.face_tag_;
+    cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>,1>& refined_face_normals = refined_grid.face_normals_;
+    // Patch dimension (amount of cells in each direction).
+    const auto& patch_dim = getPatchDim(startIJK, endIJK);
+    // If the patch contains only one cell, use refineSingleCell() to avoid unnecessary computations.
+    if ((patch_dim[0] == 1) && (patch_dim[1] == 1) && (patch_dim[2] == 1)){
+        auto [refined_grid_ptr0, parent_to_refined_corners, parent_to_children_faces, parent_to_children_cells,
+              child_to_parent_faces, child_to_parent_cell] =
+            this->refineSingleCell(cells_per_dim,(startIJK[2]*grid_dim[0]*grid_dim[1]) + (startIJK[1]*grid_dim[0]) + startIJK[0]);
+        // When the patch contains only one cell:
+        // - boundary_old_to_new_corners == parent_to_refined_corners.
+        // - boundary_old_to_new_faces == parent_to_children_faces.
+        // Fix the type of parent_to_children_cells to return it correctly.
+        const std::vector<std::tuple<int, std::vector<int>>> parent_to_children_cells_vec = {parent_to_children_cells};
+        return {refined_grid_ptr0, parent_to_refined_corners, parent_to_children_faces, parent_to_children_faces,
+            parent_to_children_cells_vec, child_to_parent_faces, child_to_parent_cell};
+    }
+    // When the patch consists in more than one cell:
+    else {
+        const auto& [patch_corners, patch_faces, patch_cells] = getPatchGeomIndices(startIJK, endIJK);
+        // Construct the Geometry of the cellified patch.
+        DefaultGeometryPolicy cellified_patch_geometry;
+        std::array<int,8> cellifiedPatch_to_point;
+        std::array<int,8> allcorners_cellifiedPatch;
+        cpgrid::Geometry<3,3> cellified_patch = this -> cellifyPatch(startIJK, endIJK, patch_cells, cellified_patch_geometry,
+                                                                     cellifiedPatch_to_point, allcorners_cellifiedPatch);
+        // Some integers to reduce notation later.
+        const int& xfactor = cells_per_dim[0]*patch_dim[0];
+        const int& yfactor = cells_per_dim[1]*patch_dim[1];
+        const int& zfactor = cells_per_dim[2]*patch_dim[2];
+        // Refine the "cellified_patch".
+        cellified_patch.refine({xfactor, yfactor, zfactor}, refined_geometries, refined_cell_to_point, refined_cell_to_face,
+                               refined_face_to_point, refined_face_to_cell, refined_face_tags, refined_face_normals);
+        // To store the relation between old-corner-indices and the equivalent new-born ones (laying on the patch boundary).
+        std::vector<std::array<int,2>> boundary_old_to_new_corners;
+        boundary_old_to_new_corners.reserve((2*(cells_per_dim[0]+1)*(cells_per_dim[2]+1))
+                                            + (2*(cells_per_dim[1]-1)*(cells_per_dim[2]+1))
+                                            + (2*(cells_per_dim[0]-1)*(cells_per_dim[1]-1)));
+        for (int j = startIJK[1]; j < endIJK[1]+1; ++j) {
+            for (int i = startIJK[0]; i < endIJK[0]+1; ++i) {
+                for (int k = startIJK[2]; k < endIJK[2]+1; ++k) {
+                    if ( (j == startIJK[1]) || (j == endIJK[1]) ){ // Corners in the front/back of the patch.
+                        boundary_old_to_new_corners.push_back({
+                                // Old corner index
+                                (j*(grid_dim[2]+1)*(grid_dim[0]+1)) + (i*(grid_dim[2]+1)) + k,
+                                // New-born corner index (equivalent corner).
+                                (cells_per_dim[1]*(j-startIJK[1])*(xfactor +1)*(zfactor +1))
+                                + (cells_per_dim[0]*(i-startIJK[0])*(zfactor +1))
+                                + (cells_per_dim[2]*(k-startIJK[2])) });
+                    }
+                    if ( (i == startIJK[0]) || (i == endIJK[0]) ) { // Corners in the left/right of the patch.
+                        boundary_old_to_new_corners.push_back({
+                                // Old corner index.
+                                (j*(grid_dim[2]+1)*(grid_dim[0]+1)) + (i*(grid_dim[2]+1)) + k,
+                                // New-born corner index (equivalent corner).
+                                (cells_per_dim[1]*(j-startIJK[1])*(xfactor +1)*(zfactor +1))
+                                + (cells_per_dim[0]*(i-startIJK[0])*(zfactor +1))
+                                + (cells_per_dim[2]*(k-startIJK[2]))});
+                    }
+                    if ( (k == startIJK[2]) || (k == endIJK[2]) ) { // Corners in the bottom/top of the patch.
+                        boundary_old_to_new_corners.push_back({
+                                // Old corner index.
+                                (j*(grid_dim[2]+1)*(grid_dim[0]+1)) + (i*(grid_dim[2]+1)) + k,
+                                // New-born corner index (equivalent corner)
+                                (cells_per_dim[1]*(j-startIJK[1])*(xfactor +1)*(zfactor +1))
+                                + (cells_per_dim[0]*(i-startIJK[0])*(zfactor +1))
+                                + (cells_per_dim[2]*(k-startIJK[2]))});
+                    }
+                } // end k-for-loop
+            } // end i-for-loop
+        } // end j-for-loop
+        // To store face-indices of faces on the boundary of the patch.
+        std::vector<int> boundary_patch_faces;
+        // Auxiliary integers to simplify notation.
+        const int& bound_patch_faces = (2*patch_dim[1]*patch_dim[2]) + (patch_dim[0]*2*patch_dim[2]) + (patch_dim[0]*patch_dim[1]*2);
+        boundary_patch_faces.reserve(bound_patch_faces);
+        // To store relation between old-face-index and its new-born-face indices.
+        std::vector<std::tuple<int, std::vector<int>>> boundary_old_to_new_faces; // {face index, its children-indices}
+        boundary_old_to_new_faces.reserve(bound_patch_faces);
+        // Auxiliary integers to simplify notation.
+        const int& i_grid_faces =  (grid_dim[0]+1)*grid_dim[1]*grid_dim[2];
+        const int& j_grid_faces =  grid_dim[0]*(grid_dim[1]+1)*grid_dim[2];
+        // To store relation bewteen parent face and its children (all faces of the patch, not only the ones on the boundary).
+        std::vector<std::tuple<int,std::vector<int>>> parent_to_children_faces;
+        parent_to_children_faces.reserve(patch_faces.size());
+        // To store relation child-face-index and its parent-face-index.
+        std::vector<std::array<int,2>> child_to_parent_faces; // {child index (in 'level 1'), parent index (in 'level 0')}
+        child_to_parent_faces.reserve(refined_face_to_cell.size());
+        // Populate child_to_parent_faces, parent_to_children_faces, boundary_old_to_new_faces, boundary_faces.
+        // I_FACES
+        for (int j = startIJK[1]; j < endIJK[1]; ++j) {
+            for (int i = startIJK[0]; i < endIJK[0]+1; ++i) {
+                for (int k = startIJK[2]; k < endIJK[2]; ++k) {
+                    int face_idx = (j*grid_dim[1]*grid_dim[2]) + (i*grid_dim[2])+ k;
+                    // To store new born faces, per face. CHILDREN-FACES ARE ORDERED AS IN refine(), Geometry.hpp
+                    std::vector<int> children_list;  // I_FACE ikj (xzy-direction)
+                    // l,m,n play the role of 'x,y,z-direction', lnm = fake ikj (how I_FACES are 'ordered' in refine())
+                    for (int l = (i-startIJK[0])*cells_per_dim[0]; l < (i-startIJK[0]+1)*cells_per_dim[0]; ++l) {
+                        for (int n = (k-startIJK[2])*cells_per_dim[2];n < (k-startIJK[2]+1)*cells_per_dim[2]; ++n) {
+                            for (int m = (j-startIJK[1])*cells_per_dim[1]; m < (j-startIJK[1]+1)*cells_per_dim[1]; ++m) {
+                                children_list.push_back((xfactor*yfactor*(zfactor+1)) +(l*yfactor*zfactor) + (n*yfactor) + m);
+                                child_to_parent_faces.push_back({(xfactor*yfactor*(zfactor+1)) +(l*yfactor*zfactor)
+                                        + (n*yfactor) + m, face_idx});
+                            } // end m-for-loop
+                        } // end n-for-loop
+                    } // end l-for-loop
+                    // Add parent information of each face to "parent_to_children_faces".
+                    parent_to_children_faces.push_back(std::make_tuple(face_idx, children_list));
+                    if ((i == startIJK[0]) || (i == endIJK[0])) { // Detecting if the face is on the patch boundary.
+                        boundary_patch_faces.push_back(face_idx);
+                        // Associate each old face on the boundary of the patch with the new born ones.
+                        boundary_old_to_new_faces.push_back(std::make_tuple(face_idx, children_list));
+                    }
+                } // end k-for-loop
+            } // end i-for-loop
+        } // end j-for-loop
+        // J_FACES
+        for (int j = startIJK[1]; j < endIJK[1]+1; ++j) {
+            for (int i = startIJK[0]; i < endIJK[0]; ++i) {
+                for (int k = startIJK[2]; k < endIJK[2]; ++k) {
+                    int face_idx = i_grid_faces + (j*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2])+ k;
+                    // To store new born faces, per face. CHILDREN FACES ARE ORDERED AS IN refine(), Geometry.hpp
+                    std::vector<int> children_list;  // J_FACE jik (yxz-direction)
+                    // l,m,n play the role of 'x,y,z-direction', mln = fake jik (how J_FACES are 'ordered' in refine())
+                    for (int m = (j-startIJK[1])*cells_per_dim[1]; m < (j-startIJK[1]+1)*cells_per_dim[1]; ++m) {
+                        for (int l = (i-startIJK[0])*cells_per_dim[0]; l < (i-startIJK[0]+1)*cells_per_dim[0]; ++l) {
+                            for (int n = (k-startIJK[2])*cells_per_dim[2]; n < (k-startIJK[2]+1)*cells_per_dim[2]; ++n) {
+                                children_list.push_back((xfactor*yfactor*(zfactor+1)) + ((xfactor+1)*yfactor*zfactor)
+                                                        + (m*xfactor*zfactor) + (l*zfactor)+n);
+                                child_to_parent_faces.push_back({(xfactor*yfactor*(zfactor+1)) + ((xfactor+1)*yfactor*zfactor)
+                                        + (m*xfactor*zfactor) + (l*zfactor)+n, face_idx});
+                            } // end n-for-loop
+                        } // end l-for-loop
+                    } // end m-for-loop
+                    // Add parent information of each face to "parent_to_children_faces".
+                    parent_to_children_faces.push_back(std::make_tuple(face_idx, children_list));
+                    if ((j == startIJK[1]) || (j == endIJK[1])) { // Detecting if face is on the patch boundary.
+                        boundary_patch_faces.push_back(face_idx);
+                        // Associate each old face on the boundary of the patch with the new born ones.
+                        boundary_old_to_new_faces.push_back(std::make_tuple(face_idx, children_list));
+                    }
+                } // end k-for-loop
+            } // end i-for-loop
+        } // end j-for-loop
+        // K_FACES
+        for (int j = startIJK[1]; j < endIJK[1]; ++j) {
+            for (int i = startIJK[0]; i < endIJK[0]; ++i) {
+                for (int k = startIJK[2]; k < endIJK[2]+1; ++k) {
+                    int face_idx = i_grid_faces + j_grid_faces + (j*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2])+ k;
+                    // To store new born faces, per face. CHILDREN FACES ARE ORDERED AS IN refine(), Geometry.hpp
+                    std::vector<int> children_list;  // K_FACE kji (zyx-direction)
+                    // l,m,n play the role of 'x,y,z-direction', nml = fake kji (how K_FACES are 'ordered' in refine())
+                    for (int n = (k-startIJK[2])*cells_per_dim[2]; n < (k-startIJK[2]+1)*cells_per_dim[2]; ++n) {
+                        for (int m = (j-startIJK[1])*cells_per_dim[1]; m < (j-startIJK[1]+1)*cells_per_dim[1]; ++m) {
+                            for (int l = (i-startIJK[0])*cells_per_dim[0]; l < (i-startIJK[0]+1)*cells_per_dim[0]; ++l) {
+                                children_list.push_back((n*xfactor*yfactor) + (m*xfactor)+ l);
+                                child_to_parent_faces.push_back({(n*xfactor*yfactor) + (m*xfactor)+ l, face_idx});
+                            } // end m-for-loop
+                        } // end n-for-loop
+                    } // end l-for-loop
+                    // Add parent information of each face to "parent_to_children_faces".
+                    parent_to_children_faces.push_back(std::make_tuple(face_idx, children_list));
+                    if ((k == startIJK[2]) || (k == endIJK[2])) { // Detecting if the face is on the patch boundary.
+                        boundary_patch_faces.push_back(face_idx);
+                        // Associate each old face on the boundary of the patch with the new born ones.
+                        boundary_old_to_new_faces.push_back(std::make_tuple(face_idx, children_list));
+                    }
+                } // end k-for-loop
+            } // end i-for-loop
+        } // end j-for-loop
+        // To store the relation between parent cell and its new-born-cells.
+        // {parent index (coarse grid), {child 0 index, child 1 index, ... (refined grid)}}
+        std::vector<std::tuple<int,std::vector<int>>> parent_to_children_cells;
+        parent_to_children_cells.reserve(patch_dim[0]*patch_dim[1]*patch_dim[2]);
+        // To store the relation between a new-born-cell and its parent cell.
+        std::vector<std::array<int,2>> child_to_parent_cells; // {child index (refined grid), parent cell index (coarse grid)}
+        child_to_parent_cells.reserve(xfactor*yfactor*zfactor);
+        for (int k = 0; k < grid_dim[2]; ++k) {
+            for (int j = 0; j < grid_dim[1]; ++j) {
+                for (int i = 0; i < grid_dim[0]; ++i) {
+                    int cell_idx = (k*grid_dim[0]*grid_dim[1]) + (j*grid_dim[0]) +i;
+                    std::vector<int> children_list;
+                    if ( (i > startIJK[0]-1) && (i < endIJK[0]) && (j > startIJK[1]-1) && (j < endIJK[1])
+                         && (k > startIJK[2]-1) && (k < endIJK[2])) {
+                        for (int n = (k-startIJK[2])*cells_per_dim[2]; n < (k-startIJK[2]+1)*cells_per_dim[2]; ++n) {
+                            for (int m = (j-startIJK[1])*cells_per_dim[1]; m < (j-startIJK[1]+1)*cells_per_dim[1]; ++m) {
+                                for (int l = (i-startIJK[0])*cells_per_dim[0]; l < (i-startIJK[0]+1)*cells_per_dim[0]; ++l) {
+                                    children_list.push_back((n*xfactor*yfactor) + (m*xfactor) + l);
+                                    child_to_parent_cells.push_back({(n*xfactor*yfactor) + (m*xfactor) + l, cell_idx});
+                                }// end l-for-loop
+                            } // end m-for-loop
+                        } // end n-for-loop
+                        parent_to_children_cells.push_back(std::make_tuple(cell_idx, children_list));
+                    }// end if 'patch cells'
+                } // end i-for-loop
+            } // end j-for-loop
+        } // end k-for-loop
+        return {refined_grid_ptr, boundary_old_to_new_corners, boundary_old_to_new_faces, parent_to_children_faces,
+            parent_to_children_cells, child_to_parent_faces, child_to_parent_cells};
+    }
+}
+   
 
 } // end namespace cpgrid
 } // end namespace Dune

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -47,8 +47,6 @@
 #ifndef OPM_CPGRIDDATA_HEADER
 #define OPM_CPGRIDDATA_HEADER
 
-// Warning suppression for Dune includes.
-#include <opm/grid/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
 #include <dune/common/parallel/mpihelper.hh>
@@ -61,35 +59,22 @@
 #else
 #include <dune/common/parallel/collectivecommunication.hh>
 #endif
-#include <dune/common/parallel/indexset.hh>
-#include <dune/common/parallel/interface.hh>
-#include <dune/common/parallel/plocalindex.hh>
 #if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
 #include <dune/common/parallel/variablesizecommunicator.hh>
 #else
 #include <opm/grid/utility/VariableSizeCommunicator.hpp>
 #endif
 #include <dune/grid/common/gridenums.hh>
-#include <dune/geometry/type.hh>
-
-#include <opm/grid/utility/platform_dependent/reenable_warnings.h>
 
 #if HAVE_ECL_INPUT
 #include <opm/input/eclipse/EclipseState/Grid/NNC.hpp>
 #endif
 
-#include <array>
-#include <tuple>
-#include <algorithm>
-#include <set>
-
-#include "OrientedEntityTable.hpp"
-#include "DefaultGeometryPolicy.hpp"
 #include <opm/grid/cpgpreprocess/preprocess.h>
 
 #include "Entity2IndexDataHandle.hpp"
-#include "DataHandleWrappers.hpp"
-#include "GlobalIdMapping.hpp"
+//#include "DataHandleWrappers.hpp"
+//#include "GlobalIdMapping.hpp"
 #include "Geometry.hpp"
 
 namespace Opm
@@ -146,6 +131,8 @@ class CpGridData
     template<class T, int i> friend struct mover::Mover;
 
     friend class GlobalIdSet;
+    friend class HierarchicIterator;
+    friend class Dune::cpgrid::IndexSet;
     
     friend
     void ::refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,
@@ -167,8 +154,8 @@ class CpGridData
                                const Dune::CpGrid&);
 
 private:
-    CpGridData(const CpGridData& g);
-
+    CpGridData(const CpGridData& g); 
+    
 public:
     enum{
 #ifndef MAX_DATA_COMMUNICATED_PER_ENTITY
@@ -191,12 +178,20 @@ public:
     /// Constructor for parallel grid data.
     /// \param comm The MPI communicator
     /// Default constructor.
-    explicit CpGridData(MPIHelper::MPICommunicator comm);
+    // explicit CpGridData(MPIHelper::MPICommunicator comm);
+    explicit CpGridData(MPIHelper::MPICommunicator comm,  std::vector<std::shared_ptr<CpGridData>>& data);
 
+ 
+    
     /// Constructor
-    CpGridData();
+    CpGridData(std::vector<std::shared_ptr<CpGridData>>& data);
+    //CpGridData();
     /// Destructor
     ~CpGridData();
+    /// Another constructor
+   
+    
+    
     /// number of leaf entities per codim in this process
     int size(int codim) const;
 
@@ -250,7 +245,8 @@ public:
     /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
     /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
     std::vector<std::size_t> processEclipseFormat(const Opm::EclipseGrid* ecl_grid, Opm::EclipseState* ecl_state,
-                                                  bool periodic_extension, bool turn_normals = false, bool clip_z = false, bool pinchActive = true);
+                                                  bool periodic_extension, bool turn_normals = false, bool clip_z = false,
+                                                  bool pinchActive = true);
 #endif
 
     /// Read the Eclipse grid format ('grdecl').
@@ -291,16 +287,10 @@ private:
     /// @param [in]  startIJK  Cartesian triplet index where the patch starts.
     /// @param [in]  endIJK    Cartesian triplet index where the patch ends.
     ///                        Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
-
-
-
     ///
     /// @return patch_dim Patch dimension {#cells in x-direction, #cells in y-direction, #cells in z-direction}.
-    const std::array<int,3> getPatchDim(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
-    {
-        return {endIJK[0]-startIJK[0], endIJK[1]-startIJK[1], endIJK[2]-startIJK[2]};
-    }
-
+    const std::array<int,3> getPatchDim(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
+    
     /// @brief Compute corner, face, and cell indices of a patch of cells. (Cartesian grid required).
     ///
     /// @param [in]  startIJK  Cartesian triplet index where the patch starts.
@@ -308,66 +298,7 @@ private:
     ///                        Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
     ///
     /// @return {patch_corners, patch_faces, patch_cells} Indices of corners, faces, and cells of the patch of cells.
-    const std::array<std::vector<int>,3> getPatchGeomIndices(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
-    {
-        // Get the patch dimension (total cells in each direction). Used to 'reserve vectors'.
-        const std::array<int,3>& patch_dim = getPatchDim(startIJK, endIJK);
-        // Get grid dimension (total cells in each direction).
-        const std::array<int,3>& grid_dim = this -> logicalCartesianSize();
-        /// PATCH CORNERS
-        std::vector<int> patch_corners;
-        patch_corners.reserve((patch_dim[0]+1)*(patch_dim[1]+1)*(patch_dim[2]+1));
-        for (int j = startIJK[1]; j < endIJK[1]+1; ++j) {
-            for (int i = startIJK[0]; i < endIJK[0]+1; ++i) {
-                for (int k = startIJK[2]; k < endIJK[2]+1; ++k) {
-                    patch_corners.push_back((j*(grid_dim[0]+1)*(grid_dim[2]+1)) + (i*(grid_dim[2]+1))+k);
-                } // end i-for-loop
-            } // end j-for-loop
-        } // end k-for-loop
-        /// PATCH FACES
-        std::vector<int> patch_faces;
-        patch_faces.reserve(((patch_dim[0]+1)*patch_dim[1]*patch_dim[2])     // i_patch_faces
-                            + (patch_dim[0]*(patch_dim[1]+1)*patch_dim[2])   // j_patch_faces
-                            + (patch_dim[0]*patch_dim[1]*(patch_dim[2]+1))); // k_patch_faces
-        // I_FACES
-        for (int j = startIJK[1]; j < endIJK[1]; ++j) {
-            for (int i = startIJK[0]; i < endIJK[0]+1; ++i) {
-                for (int k = startIJK[2]; k < endIJK[2]; ++k) {
-                    patch_faces.push_back((j*(grid_dim[0]+1)*grid_dim[2]) +(i*grid_dim[2]) + k);
-                } // end k-for-loop
-            } // end i-for-loop
-        } // end j-for-loop
-        // J_FACES
-        for (int j = startIJK[1]; j < endIJK[1]+1; ++j) {
-            for (int i = startIJK[0]; i < endIJK[0]; ++i) {
-                for (int k = startIJK[2]; k < endIJK[2]; ++k) {
-                    patch_faces.push_back(((grid_dim[0]+1)*grid_dim[1]*grid_dim[2]) // i_grid_faces
-                                          + (j*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2]) + k);
-                } // end k-for-loop
-            } // end i-for-loop
-        } // end j-for-loop
-        // K_FACES
-        for (int j = startIJK[1]; j < endIJK[1]; ++j) {
-            for (int i = startIJK[0]; i < endIJK[0]; ++i) {
-                for (int k = startIJK[2]; k < endIJK[2]+1; ++k) {
-                    patch_faces.push_back((grid_dim[0]*(grid_dim[1]+1)*grid_dim[2]) //j_grid_faces
-                                          + ((grid_dim[0]+1)*grid_dim[1]*grid_dim[2])          // i_grid_faces
-                                          + (j*grid_dim[0]*(grid_dim[2]+1)) + (i*(grid_dim[2]+1))+ k);
-                } // end k-for-loop
-            } // end i-for-loop
-        } // end j-for-loop
-        /// PATCH CELLS
-        std::vector<int> patch_cells;
-        patch_cells.reserve(patch_dim[0]*patch_dim[1]*patch_dim[2]);
-        for (int k = startIJK[2]; k < endIJK[2]; ++k) {
-            for (int j = startIJK[1]; j < endIJK[1]; ++j) {
-                for (int i = startIJK[0]; i < endIJK[0]; ++i) {
-                    patch_cells.push_back((k*grid_dim[0]*grid_dim[1]) + (j*grid_dim[0]) +i);
-                } // end i-for-loop
-            } // end j-for-loop
-        } // end k-for-loop
-        return {patch_corners, patch_faces, patch_cells};
-    }
+    const std::array<std::vector<int>,3> getPatchGeomIndices(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
 
     /// @brief Construct a 'fake cell (Geometry<3,3> object)' out of a patch of cells.(Cartesian grid required).
     ///
@@ -386,62 +317,7 @@ private:
     const Geometry<3,3> cellifyPatch(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK,
                                      const std::vector<int>& patch_cells, DefaultGeometryPolicy& cellifiedPatch_geometry,
                                      std::array<int,8>& cellifiedPatch_to_point,
-                                     std::array<int,8>& allcorners_cellifiedPatch) const
-    {
-        if (patch_cells.empty()){
-            OPM_THROW(std::logic_error, "Empty patch. Cannot convert patch into cell.");
-        }
-        else{
-            // Get grid dimension.
-            const std::array<int,3>& grid_dim = this -> logicalCartesianSize();
-            // Select 8 corners of the patch boundary to be the 8 corners of the 'cellified patch'.
-            cellifiedPatch_to_point = { // Corner-index: (J*(grid_dim[0]+1)*(grid_dim[2]+1)) + (I*(grid_dim[2]+1)) +K
-                // Index of corner '0' {startI, startJ, startK}
-                (startIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (startIJK[0]*(grid_dim[2]+1)) + startIJK[2],
-                // Index of corner '1' '{endI, startJ, startK}'
-                (startIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (endIJK[0]*(grid_dim[2]+1)) + startIJK[2],
-                // Index of corner '2' '{startI, endJ, startK}'
-                (endIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (startIJK[0]*(grid_dim[2]+1)) + startIJK[2],
-                // Index of corner '3' '{endI, endJ, startK}'
-                (endIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (endIJK[0]*(grid_dim[2]+1)) + startIJK[2],
-                // Index of corner '4' '{startI, startJ, endK}'
-                (startIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (startIJK[0]*(grid_dim[2]+1))+ endIJK[2],
-                // Index of corner '5' '{endI, startJ, endK}'
-                (startIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (endIJK[0]*(grid_dim[2]+1)) + endIJK[2],
-                // Index of corner '6' '{startI, endJ, endK}'
-                (endIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (startIJK[0]*(grid_dim[2]+1)) + endIJK[2],
-                // Index of corner '7' {endI, endJ, endK}
-                (endIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (endIJK[0]*(grid_dim[2]+1)) + endIJK[2]};
-            EntityVariableBase<cpgrid::Geometry<0,3>>& cellifiedPatch_corners =
-                cellifiedPatch_geometry.geomVector(std::integral_constant<int,3>());
-            cellifiedPatch_corners.resize(8);
-            // Compute the center of the 'cellified patch' and its corners.
-            Geometry<0,3>::GlobalCoordinate cellifiedPatch_center = {0., 0.,0.};
-            for (int corn = 0; corn < 8; ++corn) {
-                // FieldVector in DUNE 2.6 is missing operator/ using a loop
-                for(int i=0; i < 3; ++i)
-                {
-                    cellifiedPatch_center[i] +=
-                        (this -> geometry_.geomVector(std::integral_constant<int,3>()).get(cellifiedPatch_to_point[corn]).center())[i]/8.;
-                }
-                cellifiedPatch_corners[corn] =
-                    this -> geometry_.geomVector(std::integral_constant<int,3>()).get(cellifiedPatch_to_point[corn]);
-            }
-            // Compute the volume of the 'cellified patch'.
-            double cellifiedPatch_volume = 0.;
-            for (const auto& idx : patch_cells) {
-                cellifiedPatch_volume += (this -> geometry_.geomVector(std::integral_constant<int,0>())
-                                          [EntityRep<0>(idx, true)]).volume();
-            }
-            // Indices of 'all the corners', in this case, 0-7 (required to construct a Geometry<3,3> object).
-            allcorners_cellifiedPatch = {0,1,2,3,4,5,6,7};
-            // Create a pointer to the first element of "cellfiedPatch_to_point" (required to construct a Geometry<3,3> object).
-            const int* cellifiedPatch_indices_storage_ptr = &allcorners_cellifiedPatch[0];
-            // Construct (and return) the Geometry<3,3> of the 'cellified patch'.
-            return Geometry<3,3>(cellifiedPatch_center, cellifiedPatch_volume,
-                                 cellifiedPatch_geometry.geomVector(std::integral_constant<int,3>()), cellifiedPatch_indices_storage_ptr);
-        }
-    }
+                                     std::array<int,8>& allcorners_cellifiedPatch) const;
 
 public:
     /// @brief Refine a single cell and return a shared pointer of CpGridData type.
@@ -454,161 +330,24 @@ public:
     /// @param [in] cells_per_dim                 Number of (refined) cells in each direction that each parent cell should be refined to.
     /// @param [in] parent_idx                    Parent cell index, cell to be refined.
     ///
-    /// @return refined_grid_ptr             Shared pointer pointing at refined_grid.
-    /// @return parent_to_refined_corners    For each corner of the parent cell, we store the index of the
+    /// @return refined_grid_ptr                  Shared pointer pointing at refined_grid.
+    /// @return parent_to_refined_corners         For each corner of the parent cell, we store the index of the
     ///                                           refined corner that coincides with the old one.
     ///                                           We assume they are ordered 0,1,..7
     ///                                                              6---7
     ///                                                      2---3   |   | TOP FACE
     ///                                                      |   |   4---5
     ///                                                      0---1 BOTTOM FACE
-    /// @return parent_to_children_faces/cell For each parent face/cell, we store its child-face/cell indices.
-    ///                                            {parent face/cell index in coarse level, {indices of its children in refined level}}
-    /// @return child_to_parent_faces/cells   {child index, parent index}
-    /// @return isParent_faces/cells          Map with all the face/cell indices. True when the face/cell got refined.
+    /// @return parent_to_children_faces/cell     For each parent face/cell, we store its child-face/cell indices.
+    ///                                           {parent face/cell index in coarse level, {indices of its children in refined level}}
+    /// @return child_to_parent_faces/cells       {child index, parent index}
     const std::tuple< const std::shared_ptr<CpGridData>,
                       const std::vector<std::array<int,2>>,                // parent_to_refined_corners(~boundary_old_to_new_corners)
                       const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces (~boundary_old_to_new_faces)
                       const std::tuple<int, std::vector<int>>,             // parent_to_children_cells
                       const std::vector<std::array<int,2>>,                // child_to_parent_faces
-                      const std::vector<std::array<int,2>>,                // child_to_parent_cells
-                      const std::vector<int>,                              // isParent_faces
-                      const std::vector<int>>                               // isParent_cells
-    refineSingleCell(const std::array<int,3>& cells_per_dim, const int& parent_idx) const
-    {
-        // To store the LGR/refined-grid.
-        #if HAVE_MPI
-         std::shared_ptr<CpGridData> refined_grid_ptr = std::make_shared<CpGridData>(ccobj_);
-        #else
-        // DUNE 2.7 is missing convertion to NO_COMM
-         std::shared_ptr<CpGridData> refined_grid_ptr = std::make_shared<CpGridData>();
-        #endif
-        auto& refined_grid = *refined_grid_ptr;
-        DefaultGeometryPolicy& refined_geometries = refined_grid.geometry_;
-        std::vector<std::array<int,8>>& refined_cell_to_point = refined_grid.cell_to_point_;
-        cpgrid::OrientedEntityTable<0,1>& refined_cell_to_face = refined_grid.cell_to_face_;
-        Opm::SparseTable<int>& refined_face_to_point = refined_grid.face_to_point_;
-        cpgrid::OrientedEntityTable<1,0>& refined_face_to_cell = refined_grid.face_to_cell_;
-        cpgrid::EntityVariable<enum face_tag,1>& refined_face_tags = refined_grid.face_tag_;
-        cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>,1>& refined_face_normals = refined_grid.face_normals_;
-        // Get parent cell
-        const cpgrid::Geometry<3,3>& parent_cell = geometry_.geomVector(std::integral_constant<int,0>())[EntityRep<0>(parent_idx, true)];
-        // Get parent cell corners.
-        const std::array<int,8>& parent_to_point = this->cell_to_point_[parent_idx];
-        if (parent_to_point.size() != 8){
-            OPM_THROW(std::logic_error, "Cell is not a hexahedron. Cannot be refined (yet).");
-        }
-        // Refine parent cell
-        parent_cell.refine(cells_per_dim, refined_geometries, refined_cell_to_point, refined_cell_to_face,
-                           refined_face_to_point, refined_face_to_cell, refined_face_tags, refined_face_normals);
-        const std::vector<std::array<int,2>>& parent_to_refined_corners{
-            // corIdx (J*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (I*(cells_per_dim[2]+1)) +K
-            // replacing parent-cell corner '0' {0,0,0}
-            {parent_to_point[0], 0},
-                // replacing parent-cell corner '1' {cells_per_dim[0], 0, 0}
-            {parent_to_point[1], cells_per_dim[0]*(cells_per_dim[2]+1)},
-                // replacing parent-cell corner '2' {0, cells_perd_dim[1], 0}
-            {parent_to_point[2], cells_per_dim[1]*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)},
-                // replacing parent-cell corner '3' {cells_per_dim[0], cells_per_dim[1], 0}
-            {parent_to_point[3], (cells_per_dim[1]*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (cells_per_dim[0]*(cells_per_dim[2]+1))},
-                // replacing parent-cell corner '4' {0, 0, cells_per_dim[2]}
-            {parent_to_point[4], cells_per_dim[2]},
-                // replacing parent-cell corner '5' {cells_per_dim[0], 0, cells_per_dim[2]}
-            {parent_to_point[5], (cells_per_dim[0]*(cells_per_dim[2]+1)) + cells_per_dim[2]},
-                // replacing parent-cell corner '6' {0, cells_per_dim[1], cells_per_dim[2]}
-            {parent_to_point[6], (cells_per_dim[1]*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + cells_per_dim[2]},
-                // replacing parent-cell corner '7' {cells_per_dim[0], cells_per_dim[1], cells_per_dim[2]}
-            {parent_to_point[7], (cells_per_dim[1]*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (cells_per_dim[0]*(cells_per_dim[2]+1))
-                    + cells_per_dim[2]}};
-        // Get parent_cell_to_face = { {face, orientation}, {another face, its orientation}, ...}.
-        const auto& parent_cell_to_face = (this-> cell_to_face_[EntityRep<0>(parent_idx, true)]);
-        // To store relation old-face to new-born-faces (children faces).
-        std::vector<std::tuple<int,std::vector<int>>>  parent_to_children_faces;
-        parent_to_children_faces.reserve(6);
-        // To store child-to-parent-face relation. Child-faces ordered with the criteria introduced in refine()(Geometry.hpp)K,I,Jfaces.
-        std::vector<std::array<int,2>> child_to_parent_faces;
-        child_to_parent_faces.reserve(refined_face_to_cell.size());
-        // Auxiliary integers to simplify new-born-face-index notation.
-        const int& k_faces = cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1);
-        const int& i_faces = (cells_per_dim[0]+1)*cells_per_dim[1]*cells_per_dim[2];
-        // Populate parent_to_children_faces and child_to_parent_faces.
-        for (const auto& face : parent_cell_to_face) {
-            // Check face tag to identify the type of face (bottom, top, left, right, front, or back).
-            auto& parent_face_tag = (this-> face_tag_[Dune::cpgrid::EntityRep<1>(face.index(), true)]);
-            // To store the new born faces for each face.
-            std::vector<int> children_faces; // Cannot reserve/resize "now", it depends of the type of face.
-            // K_FACES
-            if (parent_face_tag == face_tag::K_FACE) {
-                children_faces.reserve(cells_per_dim[0]*cells_per_dim[1]);
-                for (int j = 0; j < cells_per_dim[1]; ++j) {
-                    for (int i = 0; i < cells_per_dim[0]; ++i) {
-                        int child_face;
-                        if (!face.orientation()) // false -> BOTTOM FACE -> k=0
-                            child_face = (j*cells_per_dim[0]) + i;
-                        else // true -> TOP FACE -> k=cells_per_dim[2]
-                            child_face = (cells_per_dim[2]*cells_per_dim[0]*cells_per_dim[1]) +(j*cells_per_dim[0]) + i;
-                        children_faces.push_back(child_face);
-                        child_to_parent_faces.push_back({child_face, face.index()});
-                    } // i-for-lopp
-                } //j-for-loop
-            } // if-K_FACE
-            // I_FACES
-            if (parent_face_tag == face_tag::I_FACE) {
-                children_faces.reserve(cells_per_dim[1]*cells_per_dim[2]);
-                for (int k = 0; k < cells_per_dim[2]; ++k) {
-                    for (int j = 0; j < cells_per_dim[1]; ++j) {
-                        int child_face;
-                        if (!face.orientation()) // false -> LEFT FACE -> i=0
-                            child_face = k_faces + (k*cells_per_dim[1]) + j;
-                        else // true -> RIGHT FACE -> i=cells_per_dim[0]
-                            child_face = k_faces + (cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]) + (k*cells_per_dim[1]) + j;
-                        children_faces.push_back(child_face);
-                        child_to_parent_faces.push_back({child_face, face.index()});
-                    } // j-for-loop
-                } // k-for-loop
-            } // if-I_FACE
-            // J_FACES
-            if (parent_face_tag == face_tag::J_FACE) {
-                children_faces.reserve(cells_per_dim[0]*cells_per_dim[2]);
-                for (int i = 0; i < cells_per_dim[0]; ++i) {
-                    for (int k = 0; k < cells_per_dim[2]; ++k) {
-                        int child_face;
-                        if (!face.orientation()) // false -> FRONT FACE -> j=0
-                            child_face = k_faces + i_faces + (i*cells_per_dim[2]) + k;
-                        else  // true -> BACK FACE -> j=cells_per_dim[1]
-                            child_face = k_faces + i_faces  + (cells_per_dim[1]*cells_per_dim[0]*cells_per_dim[2])
-                                + (i*cells_per_dim[2]) + k;
-                        children_faces.push_back(child_face);
-                        child_to_parent_faces.push_back({child_face, face.index()});
-                    } // k-for-loop
-                } // i-for-loop
-            } // if-J_FACE
-            parent_to_children_faces.push_back(std::make_tuple(face.index(), children_faces));
-        }
-        std::tuple<int, std::vector<int>> parent_to_children_cells;
-        auto& [ parent_index, children_cells ] = parent_to_children_cells;
-        children_cells.reserve(cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]);
-        // To store the child to parent cell relation.
-        std::vector<std::array<int,2>> child_to_parent_cell;
-        child_to_parent_cell.reserve(cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]);
-        // Populate children_cells and child_to_parent_cell.
-        for (int cell = 0; cell < cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]; ++cell) {
-            children_cells.push_back(cell);
-            child_to_parent_cell.push_back({cell, parent_idx});
-        }
-        // To identify a parent face {index face, true/false}. True when it got refined.
-        std::vector<int> isParent_faces(face_to_cell_.size(), false);
-        // Rewrite the entries of the map for those faces that got refined.
-        for (const auto& face : parent_cell_to_face) {
-            isParent_faces[face.index()] = true;
-        }
-        // To identify the parent cell (only one in this case). {index cell, true/false}. True when it got refined.
-        std::vector<int> isParent_cells(this-> size(0), false);
-        // Rewrite the entry of the map for the single parent cell that got refined.
-        isParent_cells[parent_idx] = true;
-        return {refined_grid_ptr, parent_to_refined_corners, parent_to_children_faces, parent_to_children_cells,
-            child_to_parent_faces, child_to_parent_cell, isParent_faces, isParent_cells};
-    }
+                      const std::vector<std::array<int,2>>>                // child_to_parent_cells
+    refineSingleCell(const std::array<int,3>& cells_per_dim, const int& parent_idx) const;
 
     /// @brief Refine a (connected block-shaped) patch of cells. Based on the patch, a Geometry<3,3> object is created and refined.
     ///
@@ -622,253 +361,15 @@ public:
     /// @return parent_to_children_faces/cell      For each parent face/cell, we store its child-face/cell indices.
     ///                                            {parent face/cell index in coarse level, {indices of its children in refined level}}
     /// @return child_to_parent_faces/cells        {child index, parent index}
-    /// @return isParent_faces/cells               Map with all the face/cell indices. True when the face/cell got refined.
-    const std::tuple<std::shared_ptr<CpGridData>,
-                     const std::vector<std::array<int,2>>,                // boundary_old_to_new_corners
-                     const std::vector<std::tuple<int,std::vector<int>>>, // boundary_old_to_new_faces
-                     const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces
-                     const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_cell
-                     const std::vector<std::array<int,2>>,                // child_to_parent_faces
-                     const std::vector<std::array<int,2>>,                // child_to_parent_cells
-                     const std::vector<int>,                            // isParent_faces
-                     const std::vector<int>>                            // isParent_cells
-    refinePatch(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
-    {
-        // Coarse grid dimension (amount of cells in each direction).
-        const std::array<int,3>& grid_dim = this -> logicalCartesianSize();
-        // Check that the grid is a Cartesian one.
-        long unsigned int gXYZ = grid_dim[0]*grid_dim[1]*grid_dim[2];
-        if (global_cell_.size() != gXYZ){
-            OPM_THROW(std::logic_error, "Grid is not Cartesian. Patch cannot be refined.");
-        }
-        // To store LGR/refined-grid.
-        #if HAVE_MPI
-         std::shared_ptr<CpGridData> refined_grid_ptr = std::make_shared<CpGridData>(ccobj_);
-        #else
-        // DUNE 2.7 is missing convertion to NO_COMM
-         std::shared_ptr<CpGridData> refined_grid_ptr = std::make_shared<CpGridData>();
-        #endif
-        auto& refined_grid = *refined_grid_ptr;
-        DefaultGeometryPolicy& refined_geometries = refined_grid.geometry_;
-        std::vector<std::array<int,8>>& refined_cell_to_point = refined_grid.cell_to_point_;
-        cpgrid::OrientedEntityTable<0,1>& refined_cell_to_face = refined_grid.cell_to_face_;
-        Opm::SparseTable<int>& refined_face_to_point = refined_grid.face_to_point_;
-        cpgrid::OrientedEntityTable<1,0>& refined_face_to_cell = refined_grid.face_to_cell_;
-        cpgrid::EntityVariable<enum face_tag,1>& refined_face_tags = refined_grid.face_tag_;
-        cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>,1>& refined_face_normals = refined_grid.face_normals_;
-        // Patch dimension (amount of cells in each direction).
-        const auto& patch_dim = getPatchDim(startIJK, endIJK);
-        // If the patch contains only one cell, use refineSingleCell() to avoid unnecessary computations.
-        if ((patch_dim[0] == 1) && (patch_dim[1] == 1) && (patch_dim[2] == 1)){
-            auto [refined_grid_ptr0, parent_to_refined_corners,
-                  parent_to_children_faces, parent_to_children_cells,child_to_parent_faces, child_to_parent_cell,
-                  isParent_faces, isParent_cells] =
-                this->refineSingleCell(cells_per_dim,(startIJK[2]*grid_dim[0]*grid_dim[1]) + (startIJK[1]*grid_dim[0]) + startIJK[0]);
-            // When the patch contains only one cell:
-            // - boundary_old_to_new_corners == parent_to_refined_corners.
-            // - boundary_old_to_new_faces == parent_to_children_faces.
-            // Fix the type of parent_to_children_cells to return it correctly.
-            const std::vector<std::tuple<int, std::vector<int>>> parent_to_children_cells_vec = {parent_to_children_cells};
-            return {refined_grid_ptr0, parent_to_refined_corners, parent_to_children_faces, parent_to_children_faces,
-                parent_to_children_cells_vec, child_to_parent_faces, child_to_parent_cell, isParent_faces, isParent_cells};
-        }
-        // When the patch consists in more than one cell:
-        else {
-            const auto& [patch_corners, patch_faces, patch_cells] = getPatchGeomIndices(startIJK, endIJK);
-            // Construct the Geometry of the cellified patch.
-            DefaultGeometryPolicy cellified_patch_geometry;
-            std::array<int,8> cellifiedPatch_to_point;
-            std::array<int,8> allcorners_cellifiedPatch;
-            cpgrid::Geometry<3,3> cellified_patch = this -> cellifyPatch(startIJK, endIJK, patch_cells, cellified_patch_geometry,
-                                                                         cellifiedPatch_to_point, allcorners_cellifiedPatch);
-            // Some integers to reduce notation later.
-            const int& xfactor = cells_per_dim[0]*patch_dim[0];
-            const int& yfactor = cells_per_dim[1]*patch_dim[1];
-            const int& zfactor = cells_per_dim[2]*patch_dim[2];
-            // Refine the "cellified_patch".
-            cellified_patch.refine({xfactor, yfactor, zfactor}, refined_geometries, refined_cell_to_point, refined_cell_to_face,
-                                   refined_face_to_point, refined_face_to_cell, refined_face_tags, refined_face_normals);
-            // To store the relation between old-corner-indices and the equivalent new-born ones (laying on the patch boundary).
-            std::vector<std::array<int,2>> boundary_old_to_new_corners;
-            boundary_old_to_new_corners.reserve((2*(cells_per_dim[0]+1)*(cells_per_dim[2]+1))
-                                                + (2*(cells_per_dim[1]-1)*(cells_per_dim[2]+1))
-                                                + (2*(cells_per_dim[0]-1)*(cells_per_dim[1]-1)));
-            for (int j = startIJK[1]; j < endIJK[1]+1; ++j) {
-                for (int i = startIJK[0]; i < endIJK[0]+1; ++i) {
-                    for (int k = startIJK[2]; k < endIJK[2]+1; ++k) {
-                        if ( (j == startIJK[1]) || (j == endIJK[1]) ){ // Corners in the front/back of the patch.
-                            boundary_old_to_new_corners.push_back({
-                                    // Old corner index
-                                    (j*(grid_dim[2]+1)*(grid_dim[0]+1)) + (i*(grid_dim[2]+1)) + k,
-                                    // New-born corner index (equivalent corner).
-                                    (cells_per_dim[1]*(j-startIJK[1])*(xfactor +1)*(zfactor +1))
-                                    + (cells_per_dim[0]*(i-startIJK[0])*(zfactor +1))
-                                    + (cells_per_dim[2]*(k-startIJK[2])) });
-                        }
-                        if ( (i == startIJK[0]) || (i == endIJK[0]) ) { // Corners in the left/right of the patch.
-                            boundary_old_to_new_corners.push_back({
-                                    // Old corner index.
-                                    (j*(grid_dim[2]+1)*(grid_dim[0]+1)) + (i*(grid_dim[2]+1)) + k,
-                                    // New-born corner index (equivalent corner).
-                                    (cells_per_dim[1]*(j-startIJK[1])*(xfactor +1)*(zfactor +1))
-                                    + (cells_per_dim[0]*(i-startIJK[0])*(zfactor +1))
-                                    + (cells_per_dim[2]*(k-startIJK[2]))});
-                        }
-                        if ( (k == startIJK[2]) || (k == endIJK[2]) ) { // Corners in the bottom/top of the patch.
-                            boundary_old_to_new_corners.push_back({
-                                    // Old corner index.
-                                    (j*(grid_dim[2]+1)*(grid_dim[0]+1)) + (i*(grid_dim[2]+1)) + k,
-                                    // New-born corner index (equivalent corner)
-                                    (cells_per_dim[1]*(j-startIJK[1])*(xfactor +1)*(zfactor +1))
-                                    + (cells_per_dim[0]*(i-startIJK[0])*(zfactor +1))
-                                    + (cells_per_dim[2]*(k-startIJK[2]))});
-                        }
-                    } // end k-for-loop
-                } // end i-for-loop
-            } // end j-for-loop
-            // To store face-indices of faces on the boundary of the patch.
-            std::vector<int> boundary_patch_faces;
-            // Auxiliary integers to simplify notation.
-            const int& bound_patch_faces = (2*patch_dim[1]*patch_dim[2]) + (patch_dim[0]*2*patch_dim[2]) + (patch_dim[0]*patch_dim[1]*2);
-            boundary_patch_faces.reserve(bound_patch_faces);
-            // To store relation between old-face-index and its new-born-face indices.
-            std::vector<std::tuple<int, std::vector<int>>> boundary_old_to_new_faces; // {face index, its children-indices}
-            boundary_old_to_new_faces.reserve(bound_patch_faces);
-            // Auxiliary integers to simplify notation.
-            const int& i_grid_faces =  (grid_dim[0]+1)*grid_dim[1]*grid_dim[2];
-            const int& j_grid_faces =  grid_dim[0]*(grid_dim[1]+1)*grid_dim[2];
-            // To store relation bewteen parent face and its children (all faces of the patch, not only the ones on the boundary).
-            std::vector<std::tuple<int,std::vector<int>>> parent_to_children_faces;
-            parent_to_children_faces.reserve(patch_faces.size());
-            // To store relation child-face-index and its parent-face-index.
-            std::vector<std::array<int,2>> child_to_parent_faces; // {child index (in 'level 1'), parent index (in 'level 0')}
-            child_to_parent_faces.reserve(refined_face_to_cell.size());
-            // Populate child_to_parent_faces, parent_to_children_faces, boundary_old_to_new_faces, boundary_faces.
-            // I_FACES
-            for (int j = startIJK[1]; j < endIJK[1]; ++j) {
-                for (int i = startIJK[0]; i < endIJK[0]+1; ++i) {
-                    for (int k = startIJK[2]; k < endIJK[2]; ++k) {
-                        int face_idx = (j*grid_dim[1]*grid_dim[2]) + (i*grid_dim[2])+ k;
-                        // To store new born faces, per face. CHILDREN-FACES ARE ORDERED AS IN refine(), Geometry.hpp
-                        std::vector<int> children_list;  // I_FACE ikj (xzy-direction)
-                        // l,m,n play the role of 'x,y,z-direction', lnm = fake ikj (how I_FACES are 'ordered' in refine())
-                        for (int l = (i-startIJK[0])*cells_per_dim[0]; l < (i-startIJK[0]+1)*cells_per_dim[0]; ++l) {
-                            for (int n = (k-startIJK[2])*cells_per_dim[2];n < (k-startIJK[2]+1)*cells_per_dim[2]; ++n) {
-                                for (int m = (j-startIJK[1])*cells_per_dim[1]; m < (j-startIJK[1]+1)*cells_per_dim[1]; ++m) {
-                                    children_list.push_back((xfactor*yfactor*(zfactor+1)) +(l*yfactor*zfactor) + (n*yfactor) + m);
-                                    child_to_parent_faces.push_back({(xfactor*yfactor*(zfactor+1)) +(l*yfactor*zfactor)
-                                            + (n*yfactor) + m, face_idx});
-                                } // end m-for-loop
-                            } // end n-for-loop
-                        } // end l-for-loop
-                        // Add parent information of each face to "parent_to_children_faces".
-                        parent_to_children_faces.push_back(std::make_tuple(face_idx, children_list));
-                        if ((i == startIJK[0]) || (i == endIJK[0])) { // Detecting if the face is on the patch boundary.
-                            boundary_patch_faces.push_back(face_idx);
-                            // Associate each old face on the boundary of the patch with the new born ones.
-                            boundary_old_to_new_faces.push_back(std::make_tuple(face_idx, children_list));
-                        }
-                    } // end k-for-loop
-                } // end i-for-loop
-            } // end j-for-loop
-            // J_FACES
-            for (int j = startIJK[1]; j < endIJK[1]+1; ++j) {
-                for (int i = startIJK[0]; i < endIJK[0]; ++i) {
-                    for (int k = startIJK[2]; k < endIJK[2]; ++k) {
-                        int face_idx = i_grid_faces + (j*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2])+ k;
-                        // To store new born faces, per face. CHILDREN FACES ARE ORDERED AS IN refine(), Geometry.hpp
-                        std::vector<int> children_list;  // J_FACE jik (yxz-direction)
-                        // l,m,n play the role of 'x,y,z-direction', mln = fake jik (how J_FACES are 'ordered' in refine())
-                        for (int m = (j-startIJK[1])*cells_per_dim[1]; m < (j-startIJK[1]+1)*cells_per_dim[1]; ++m) {
-                            for (int l = (i-startIJK[0])*cells_per_dim[0]; l < (i-startIJK[0]+1)*cells_per_dim[0]; ++l) {
-                                for (int n = (k-startIJK[2])*cells_per_dim[2]; n < (k-startIJK[2]+1)*cells_per_dim[2]; ++n) {
-                                    children_list.push_back((xfactor*yfactor*(zfactor+1)) + ((xfactor+1)*yfactor*zfactor)
-                                                            + (m*xfactor*zfactor) + (l*zfactor)+n);
-                                    child_to_parent_faces.push_back({(xfactor*yfactor*(zfactor+1)) + ((xfactor+1)*yfactor*zfactor)
-                                            + (m*xfactor*zfactor) + (l*zfactor)+n, face_idx});
-                                } // end n-for-loop
-                            } // end l-for-loop
-                        } // end m-for-loop
-                        // Add parent information of each face to "parent_to_children_faces".
-                        parent_to_children_faces.push_back(std::make_tuple(face_idx, children_list));
-                        if ((j == startIJK[1]) || (j == endIJK[1])) { // Detecting if face is on the patch boundary.
-                            boundary_patch_faces.push_back(face_idx);
-                            // Associate each old face on the boundary of the patch with the new born ones.
-                            boundary_old_to_new_faces.push_back(std::make_tuple(face_idx, children_list));
-                        }
-                    } // end k-for-loop
-                } // end i-for-loop
-            } // end j-for-loop
-            // K_FACES
-            for (int j = startIJK[1]; j < endIJK[1]; ++j) {
-                for (int i = startIJK[0]; i < endIJK[0]; ++i) {
-                    for (int k = startIJK[2]; k < endIJK[2]+1; ++k) {
-                        int face_idx = i_grid_faces + j_grid_faces + (j*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2])+ k;
-                        // To store new born faces, per face. CHILDREN FACES ARE ORDERED AS IN refine(), Geometry.hpp
-                        std::vector<int> children_list;  // K_FACE kji (zyx-direction)
-                        // l,m,n play the role of 'x,y,z-direction', nml = fake kji (how K_FACES are 'ordered' in refine())
-                        for (int n = (k-startIJK[2])*cells_per_dim[2]; n < (k-startIJK[2]+1)*cells_per_dim[2]; ++n) {
-                            for (int m = (j-startIJK[1])*cells_per_dim[1]; m < (j-startIJK[1]+1)*cells_per_dim[1]; ++m) {
-                                for (int l = (i-startIJK[0])*cells_per_dim[0]; l < (i-startIJK[0]+1)*cells_per_dim[0]; ++l) {
-                                    children_list.push_back((n*xfactor*yfactor) + (m*xfactor)+ l);
-                                    child_to_parent_faces.push_back({(n*xfactor*yfactor) + (m*xfactor)+ l, face_idx});
-                                } // end m-for-loop
-                            } // end n-for-loop
-                        } // end l-for-loop
-                          // Add parent information of each face to "parent_to_children_faces".
-                        parent_to_children_faces.push_back(std::make_tuple(face_idx, children_list));
-                        if ((k == startIJK[2]) || (k == endIJK[2])) { // Detecting if the face is on the patch boundary.
-                            boundary_patch_faces.push_back(face_idx);
-                            // Associate each old face on the boundary of the patch with the new born ones.
-                            boundary_old_to_new_faces.push_back(std::make_tuple(face_idx, children_list));
-                        }
-                    } // end k-for-loop
-                } // end i-for-loop
-            } // end j-for-loop
-            // To store the relation between parent cell and its new-born-cells.
-            // {parent index (coarse grid), {child 0 index, child 1 index, ... (refined grid)}}
-            std::vector<std::tuple<int,std::vector<int>>> parent_to_children_cells;
-            parent_to_children_cells.reserve(patch_dim[0]*patch_dim[1]*patch_dim[2]);
-            // To store the relation between a new-born-cell and its parent cell.
-            std::vector<std::array<int,2>> child_to_parent_cells; // {child index (refined grid), parent cell index (coarse grid)}
-            child_to_parent_cells.reserve(xfactor*yfactor*zfactor);
-            for (int k = 0; k < grid_dim[2]; ++k) {
-                for (int j = 0; j < grid_dim[1]; ++j) {
-                    for (int i = 0; i < grid_dim[0]; ++i) {
-                        int cell_idx = (k*grid_dim[0]*grid_dim[1]) + (j*grid_dim[0]) +i;
-                        std::vector<int> children_list;
-                        if ( (i > startIJK[0]-1) && (i < endIJK[0]) && (j > startIJK[1]-1) && (j < endIJK[1])
-                             && (k > startIJK[2]-1) && (k < endIJK[2])) {
-                            for (int n = (k-startIJK[2])*cells_per_dim[2]; n < (k-startIJK[2]+1)*cells_per_dim[2]; ++n) {
-                                for (int m = (j-startIJK[1])*cells_per_dim[1]; m < (j-startIJK[1]+1)*cells_per_dim[1]; ++m) {
-                                    for (int l = (i-startIJK[0])*cells_per_dim[0]; l < (i-startIJK[0]+1)*cells_per_dim[0]; ++l) {
-                                        children_list.push_back((n*xfactor*yfactor) + (m*xfactor) + l);
-                                        child_to_parent_cells.push_back({(n*xfactor*yfactor) + (m*xfactor) + l, cell_idx});
-                                    }// end l-for-loop
-                                } // end m-for-loop
-                            } // end n-for-loop
-                            parent_to_children_cells.push_back(std::make_tuple(cell_idx, children_list));
-                        }// end if 'patch cells'
-                    } // end i-for-loop
-                } // end j-for-loop
-            } // end k-for-loop
-            // To identify parent faces. {index face, true/false}. True when a face got refined.
-            std::vector<int> isParent_faces(this->face_to_cell_.size(), false);
-            // Rewrite the entries of the map for those faces that got refined.
-            for (const auto& face : patch_faces) {
-                isParent_faces[face] = true;
-            }
-            // To identify parent cells. {index cell, true/false}. True when the cell got refined.
-            std::vector<int> isParent_cells(this->size(0), false);
-            // Rewrite the entries of the map for those cells that got refined.
-            for (const auto& cell : patch_cells) {
-                isParent_cells[cell] = true;
-            }
-            return {refined_grid_ptr, boundary_old_to_new_corners, boundary_old_to_new_faces, parent_to_children_faces,
-                parent_to_children_cells, child_to_parent_faces, child_to_parent_cells, isParent_faces, isParent_cells};
-        }
-    }
-
+    const std::tuple< std::shared_ptr<CpGridData>,
+                      const std::vector<std::array<int,2>>,                // boundary_old_to_new_corners
+                      const std::vector<std::tuple<int,std::vector<int>>>, // boundary_old_to_new_faces
+                      const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces
+                      const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_cell
+                      const std::vector<std::array<int,2>>,                // child_to_parent_faces
+                      const std::vector<std::array<int,2>>>                // child_to_parent_cells
+    refinePatch(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
+    
     // Make unique boundary ids for all intersections.
     void computeUniqueBoundaryIds();
 
@@ -1113,7 +614,7 @@ private:
      */
     std::vector<int>                  global_cell_;
     /** @brief The tag of the faces. */
-    cpgrid::EntityVariable<enum face_tag, 1> face_tag_; // {LEFT, BACK, TOP}
+    cpgrid::EntityVariable<enum face_tag, 1> face_tag_; 
     /** @brief The geometries representing the grid. */
     cpgrid::DefaultGeometryPolicy geometry_;
     /** @brief The type of a point in the grid. */
@@ -1123,14 +624,34 @@ private:
     /** @brief The boundary ids. */
     cpgrid::EntityVariable<int, 1> unique_boundary_ids_;
     /** @brief The index set of the grid (level). */
-    cpgrid::IndexSet* index_set_;
+    std::shared_ptr<cpgrid::IndexSet> index_set_;
     /** @brief The internal local id set (not exported). */
-    const cpgrid::IdSet* local_id_set_;
+    std::shared_ptr<const cpgrid::IdSet> local_id_set_;
     /** @brief The global id set (used also as local id set). */
-    LevelGlobalIdSet* global_id_set_;
+    std::shared_ptr<LevelGlobalIdSet> global_id_set_;
     /** @brief The indicator of the partition type of the entities */
-    PartitionTypeIndicator* partition_type_indicator_;   
-
+    std::shared_ptr<PartitionTypeIndicator> partition_type_indicator_;
+    /** Level of the current CpGridData (0 when it's "GLOBAL", 1 for LGR, 2 for LeafView, created via CpGrid::createGridWithLgr()). */
+    int level_;
+    /** Copy of (CpGrid object).data_ associated with the CpGridData object, via created via CpGrid::createGridWithLgr(). */
+    std::vector<std::shared_ptr<CpGridData>>* data_copy_;
+    // SUITABLE FOR ALL LEVELS EXCEPT FOR LEAFVIEW
+    /** Map between level and leafview (maxLevel) cell indices. Only cells (from that level) that appear in leafview count. */  
+    std::map<int,int> level_to_leaf_cells_; // {level cell index, leafview cell index}
+    /** Parent cells and their children. Entry is {-1, {-1}} when cell has no children.*/ // {level LGR, {child0, child1, ...}}
+    std::vector<std::tuple<int,std::vector<int>>> parent_to_children_cells_;
+    // SUITABLE ONLY FOR LEAFVIEW
+    /** Relation between leafview and (possible different) level(s) cell indices. */ // {level, cell index in that level}
+    std::vector<std::array<int,2>> leaf_to_level_cells_; 
+    // SUITABLE FOR ALL LEVELS INCLUDING LEAFVIEW
+    /** Child cells and their parents. Entry is {-1, -1} when cell has no father. */ // {level parent cell, parent cell index}
+    std::vector<std::array<int,2>> child_to_parent_cells_; 
+     
+    
+    
+   
+    
+    
     /// \brief The type of the collective communication.
     typedef MPIHelper::MPICommunicator MPICommunicator;
     #if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -618,7 +618,7 @@ private:
     /** @brief The boundary ids. */
     cpgrid::EntityVariable<int, 1> unique_boundary_ids_;
     /** @brief The index set of the grid (level). */
-    std::shared_ptr<cpgrid::IndexSet> index_set_;
+    std::unique_ptr<cpgrid::IndexSet> index_set_;
     /** @brief The internal local id set (not exported). */
     std::shared_ptr<const cpgrid::IdSet> local_id_set_;
     /** @brief The global id set (used also as local id set). */

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -628,7 +628,7 @@ private:
     /** Level of the current CpGridData (0 when it's "GLOBAL", 1 for LGR, 2 for LeafView, created via CpGrid::createGridWithLgr()). */
     int level_;
     /** Copy of (CpGrid object).data_ associated with the CpGridData object, via created via CpGrid::createGridWithLgr(). */
-    std::vector<std::shared_ptr<CpGridData>>* data_copy_;
+    std::vector<std::shared_ptr<CpGridData>>* level_data_ptr_;
     // SUITABLE FOR ALL LEVELS EXCEPT FOR LEAFVIEW
     /** Map between level and leafview (maxLevel) cell indices. Only cells (from that level) that appear in leafview count. */  
     std::map<int,int> level_to_leaf_cells_; // {level cell index, leafview cell index}

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -73,6 +73,7 @@
 #include <opm/grid/cpgpreprocess/preprocess.h>
 
 #include "Entity2IndexDataHandle.hpp"
+#include "CpGridDataTraits.hpp"
 //#include "DataHandleWrappers.hpp"
 //#include "GlobalIdMapping.hpp"
 #include "Geometry.hpp"
@@ -178,17 +179,15 @@ public:
     /// Constructor for parallel grid data.
     /// \param comm The MPI communicator
     /// Default constructor.
-    // explicit CpGridData(MPIHelper::MPICommunicator comm);
     explicit CpGridData(MPIHelper::MPICommunicator comm,  std::vector<std::shared_ptr<CpGridData>>& data);
 
  
     
     /// Constructor
     CpGridData(std::vector<std::shared_ptr<CpGridData>>& data);
-    //CpGridData();
     /// Destructor
     ~CpGridData();
-    /// Another constructor
+  
    
     
     
@@ -428,26 +427,29 @@ public:
     template<class DataHandle>
     void communicate(DataHandle& data, InterfaceType iftype, CommunicationDirection dir);
 
+    /// \brief The type of the mpi communicator.
+    using MPICommunicator = CpGridDataTraits::MPICommunicator ;
+    /// \brief The type of the collective communication.
+    using Communication = CpGridDataTraits::Communication;
+    using CollectiveCommunication = CpGridDataTraits::CollectiveCommunication;
 #if HAVE_MPI
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+    /// \brief The type of the set of the attributes
+    using AttributeSet = CpGridDataTraits::AttributeSet;
+
     /// \brief The type of the  Communicator.
-    using Communicator = VariableSizeCommunicator<>;
-#else
-    /// \brief The type of the Communicator.
-    using Communicator = Opm::VariableSizeCommunicator<>;
-#endif
+    using Communicator = CpGridDataTraits::Communicator;
 
     /// \brief The type of the map describing communication interfaces.
-    using InterfaceMap = Communicator::InterfaceMap;
+    using InterfaceMap = CpGridDataTraits::InterfaceMap;
 
     /// \brief type of OwnerOverlap communication for cells
-    using CommunicationType = Dune::OwnerOverlapCopyCommunication<int,int>;
+    using CommunicationType = CpGridDataTraits::CommunicationType;
 
     /// \brief The type of the parallel index set
-    using  ParallelIndexSet = CommunicationType::ParallelIndexSet;
+    using  ParallelIndexSet = CpGridDataTraits::ParallelIndexSet;
 
     /// \brief The type of the remote indices information
-    using RemoteIndices = Dune::RemoteIndices<ParallelIndexSet>;
+    using RemoteIndices = CpGridDataTraits::RemoteIndices;
 
     /// \brief Get the owner-overlap-copy communication for cells
     ///
@@ -484,14 +486,6 @@ public:
     {
             return cellCommunication().remoteIndices();
     }
-#endif
-
-#ifdef HAVE_DUNE_ISTL
-    /// \brief The type of the set of the attributes
-    typedef Dune::OwnerOverlapCopyAttributeSet::AttributeSet AttributeSet;
-#else
-    /// \brief The type of the set of the attributes
-    enum AttributeSet{owner, overlap, copy};
 #endif
 
     /// \brief Get sorted active cell indices of numerical aquifer
@@ -645,21 +639,8 @@ private:
     std::vector<std::array<int,2>> leaf_to_level_cells_; 
     // SUITABLE FOR ALL LEVELS INCLUDING LEAFVIEW
     /** Child cells and their parents. Entry is {-1, -1} when cell has no father. */ // {level parent cell, parent cell index}
-    std::vector<std::array<int,2>> child_to_parent_cells_; 
-     
-    
-    
-   
-    
-    
-    /// \brief The type of the collective communication.
-    typedef MPIHelper::MPICommunicator MPICommunicator;
-    #if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
-    using Communication = Dune::Communication<MPICommunicator>;
-#else
-    using CollectiveCommunication = Dune::CollectiveCommunication<MPICommunicator>;
-    using Communication = Dune::CollectiveCommunication<MPICommunicator>;
-#endif
+    std::vector<std::array<int,2>> child_to_parent_cells_;
+
     /// \brief Object for collective communication operations.
     Communication ccobj_;
 

--- a/opm/grid/cpgrid/CpGridDataTraits.hpp
+++ b/opm/grid/cpgrid/CpGridDataTraits.hpp
@@ -1,0 +1,104 @@
+//===========================================================================
+//
+// File: CpGridDataTraits.hpp
+//
+// Created: Fri Mar 08 2023
+//
+// Author(s): Markus Blatt <markus@dr-blatt.de>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2014-2015 Dr. Blatt - HPC-Simulartion-Software & Services
+  Copyright 2009-2023 Equinor ASA.
+
+  This file is part of The Open Porous Media project  (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_CPGRIDDATATRAITS_HEADER
+#define OPM_CPGRIDDATATRAITS_HEADER
+
+#include <dune/common/parallel/mpihelper.hh>
+#ifdef HAVE_DUNE_ISTL
+#include <dune/istl/owneroverlapcopy.hh>
+#endif
+
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+#include <dune/common/parallel/communication.hh>
+#include <dune/common/parallel/variablesizecommunicator.hh>
+#else
+#include <dune/common/parallel/collectivecommunication.hh>
+#include <opm/grid/utility/VariableSizeCommunicator.hpp>
+#endif
+
+namespace Dune
+{
+namespace cpgrid
+{
+struct CpGridDataTraits
+{
+    /// \brief The type of the collective communication.
+    using MPICommunicator = MPIHelper::MPICommunicator;
+
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+    using Communication = Dune::Communication<MPICommunicator>;
+    using CollectiveCommunication = Dune::Communication<MPICommunicator>;
+#else
+    using CollectiveCommunication = Dune::CollectiveCommunication<MPICommunicator>;
+    using Communication = Dune::CollectiveCommunication<MPICommunicator>;
+#endif
+
+#ifdef HAVE_DUNE_ISTL
+    /// \brief The type of the set of the attributes
+    using AttributeSet = Dune::OwnerOverlapCopyAttributeSet::AttributeSet;
+#else
+    /// \brief The type of the set of the attributes
+    enum AttributeSet{owner, overlap, copy};
+#endif
+
+#if HAVE_MPI
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 7)
+    /// \brief The type of the  Communicator.
+    using Communicator = Dune::VariableSizeCommunicator<>;
+#else
+    /// \brief The type of the Communicator.
+    using Communicator = Opm::VariableSizeCommunicator<>;
+#endif
+
+    /// \brief The type of the map describing communication interfaces.
+    using InterfaceMap = Communicator::InterfaceMap;
+
+    /// \brief type of OwnerOverlap communication for cells
+    using CommunicationType = Dune::OwnerOverlapCopyCommunication<int,int>;
+
+    /// \brief The type of the parallel index set
+    using  ParallelIndexSet = typename CommunicationType::ParallelIndexSet;
+
+    /// \brief The type of the remote indices information
+    using RemoteIndices = Dune::RemoteIndices<ParallelIndexSet>;
+#else
+    using InterfaceMap = std::map<int, std::list<int> >;
+#endif // HAVE_MPI
+};
+
+} // end namespace cpgrid
+} // end space Opm
+
+#endif // OPM_CPGRIDDATATRAITS_HEADER

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -392,11 +392,11 @@ bool Entity<codim>::isValid() const
 template <int codim>
 int Entity<codim>::level() const
 {
-    // if distributed_data_ is not empty, data_copy_ has size 1.
-    if ((*(pgrid_ -> data_copy_)).size() == 1){
+    // if distributed_data_ is not empty, level_data_ptr_ has size 1.
+    if ((*(pgrid_ -> level_data_ptr_)).size() == 1){
         return 0; // when there is no refinenment, level_ is not automatically instantiated 
     }
-    if (pgrid_ == (*(pgrid_->data_copy_)).back().get()) { // entity on the leafview -> get the level where it was born:
+    if (pgrid_ == (*(pgrid_->level_data_ptr_)).back().get()) { // entity on the leafview -> get the level where it was born:
         return pgrid_ -> leaf_to_level_cells_[this-> index()][0]; // leaf_to_level_cells_ leafIdx -> {level/LGR, cell index in LGR}
     }
     else {
@@ -443,7 +443,7 @@ Entity<0> Entity<codim>::father() const
     }
     const int& coarse_level = pgrid_ -> child_to_parent_cells_[this->index()][0];
     const int& parent_index = pgrid_ -> child_to_parent_cells_[this->index()][1];
-    const auto& coarse_grid = (*(pgrid_ -> data_copy_))[coarse_level].get(); 
+    const auto& coarse_grid = (*(pgrid_ -> level_data_ptr_))[coarse_level].get(); 
     return Entity<0>( *coarse_grid, parent_index, true); 
 }
 

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -321,7 +321,7 @@ namespace Dune
     } // namespace cpgrid
 } // namespace Dune
 
-#include <opm/grid/CpGrid.hpp>
+
 #include <opm/grid/cpgrid/CpGridData.hpp>
 
 namespace Dune {

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -41,7 +41,7 @@
 #include <dune/grid/common/gridenums.hh>
 
 #include "PartitionTypeIndicator.hpp"
-#include "EntityRep.hpp"
+
 
 namespace Dune
 {
@@ -64,6 +64,8 @@ namespace Dune
         {
             friend class LevelGlobalIdSet;
             friend class GlobalIdSet;
+            friend class HierarchicIterator;
+            friend class CpGridData;
 
         public:
         /// @brief
@@ -116,7 +118,7 @@ namespace Dune
             {
             }
 
-            /// Constructor taking a grid, entity index and orientation.
+            /// Constructor taking a grid, entity index, and orientation.
             Entity(const CpGridData& grid, int index_arg, bool orientation_arg)
                 : EntityRep<codim>(index_arg, orientation_arg), pgrid_(&grid)
             {
@@ -134,67 +136,70 @@ namespace Dune
                 return !operator==(other);
             }
 
-            /// Return an entity seed.
-            /// For CpGrid, EntitySeed and EntityPtr are the same class.
+            /// @brief Return an entity seed (light-weight entity).
+            ///        EntitySeed objects are used to obtain an Entity back when combined with the corresponding grid.
+            ///        For CpGrid, EntitySeed and EntityPtr are the same class.
             EntitySeed seed() const
             {
                 return EntitySeed( impl() );
             }
 
-            /// Returns the geometry of the entity (does not depend on its orientation).
+            /// @brief Return the geometry of the entity (does not depend on its orientation).
             const Geometry& geometry() const;
 
-            /// We do not support refinement, so level() is always 0.
-            int level() const
-            {
-                return 0;
-            }
+            /// @brief Return the level of the entity in the grid hierarchy. Level = 0 represents the coarsest grid.
+            int level() const;
 
-            /// The entity is always on the leaf grid, since we have no refinement.
-            bool isLeaf() const
-            {
-                return true;
-            }
-
+            /// @brief Check if the entity is in the leafview.
+            ///
+            ///        @TODO: Modify the definition to cover serial and parallel cases.
+            ///        Serial: an element is a leaf <-> hbegin and hend return the same iterator
+            ///        Parallel: true <-> the element is a leaf entity of the global refinement hierarchy.
+            bool isLeaf() const;
+            
             /// Refinement is not defined for CpGrid.
             bool isRegular() const
             {
                 return true;
             }
 
-            /// For now, the grid is serial and the only partitionType() is InteriorEntity.
+            /// @brief For now, the grid is serial and the only partitionType() is InteriorEntity.
+            ///        Only needed when distributed_data_ is not empty.
             PartitionType partitionType() const;
-
-            /// Using the cube type for all entities now (cells and vertices).
+            
+            /// @brief Return marker object (GeometryType object) representing the reference element of the entity.
+            ///        Currently, cube type for all entities (cells and vertices).
             GeometryType type() const
             {
                 return Dune::GeometryTypes::cube(3 - codim);
             }
-
-            /// The count of subentities of codimension cc
+            
+            /// @brief Return the number of all subentities of the entity of a given codimension cc.
             unsigned int subEntities ( const unsigned int cc ) const;
             
-            /// Obtain subentity.
+            /// @brief Obtain subentity.
+            ///        Example: If cc = 3 and i = 5, it returns the 5th corner/vertex of the entity.
             template <int cc>
             typename Codim<cc>::Entity subEntity(int i) const;
 
-            /// Start iterator for the cell-cell intersections of this entity.
+            /// Start level-iterator for the cell-cell intersections of this entity.
             inline LevelIntersectionIterator ilevelbegin() const;
 
-            /// End iterator for the cell-cell intersections of this entity.
+            /// End level-iterator for the cell-cell intersections of this entity.
             inline LevelIntersectionIterator ilevelend() const;
 
-            /// Start iterator for the cell-cell intersections of this entity.
+            /// Start leaf-iterator for the cell-cell intersections of this entity.
             inline LeafIntersectionIterator ileafbegin() const;
 
-            /// End iterator for the cell-cell intersections of this entity.
+            /// End leaf-iterator for the cell-cell intersections of this entity.
             inline LeafIntersectionIterator ileafend() const;
 
-            /// Dummy first child iterator.
+            
+            /// @brief Iterator begin over the children. [If requested, also over descendants more than one generation away.]
             HierarchicIterator hbegin(int) const;
-
-            /// Dummy beyond last child iterator.
-            HierarchicIterator hend(int) const;
+            
+            /// @brief Iterator end over the children/beyond last child iterator.
+            HierarchicIterator hend(int) const; 
 
             /// \brief Returns true, if the entity has been created during the last call to adapt(). Dummy.
             bool isNew() const
@@ -208,26 +213,25 @@ namespace Dune
                 return false;
             }
 
-            /// No hierarchy in this grid.
-            bool hasFather() const
-            {
-                return false;
-            }
+            /// @brief ONLY FOR CELLS (Entity<0>)
+            ///        Check if the entity comes from an LGR, i.e., it has been created via refinement from coarser level.
+            ///
+            ///        @TODO: When distributed_data_ is not empty, check whether the father element exists on the
+            ///        local process, which can be used to test whether it is safe to call father.
+            bool hasFather() const;
 
+            /// @brief  ONLY FOR CELLS (Entity<0>). Get the father Entity, in case entity.hasFather() is true.
+            ///
+            /// @return father-entity
+            Entity<0> father() const; 
 
-            /// Dummy, returning this.
-            Entity father() const
-            {
-                return *this;
-            }
-
-
-            /// Dummy, returning default geometry.
-            LocalGeometry geometryInFather() const
-            {
-                return LocalGeometry();
-            }
-
+            /// @brief Return LocalGeometry representing the embedding of the entity inti its father (when hasFather() is true).
+            ///        Map from the entity's reference element into the reference element of its father.
+            ///        Currently, LGR is built via refinement of a block-shaped patch from the coarse grid. So the LocalGeometry
+            ///        of an entity coming from the LGR is one of the refined cells of the unit cube, with suitable amount of cells
+            ///        in each direction.
+            Dune::cpgrid::Geometry<3,3> geometryInFather();
+            
             /// Returns true if any of my intersections are on the boundary.
             /// Implementation note:
             /// This is a slow, computed, function. Could be speeded
@@ -235,7 +239,7 @@ namespace Dune
             bool hasBoundaryIntersections() const;
 
             // Mimic Dune entity wrapper
-
+            /// @brief Access the actual implementation class behind Entity interface class. 
             const Entity& impl() const
             {
                 return *this;
@@ -260,7 +264,6 @@ namespace Dune
 // now we include the Iterators.hh We need to do this here because for hbegin/hend the compiler
 // needs to know the size of hierarchicIterator
 #include "Iterators.hpp"
-#include "Entity.hpp"
 #include "Intersection.hpp"
 namespace Dune
 {
@@ -295,18 +298,20 @@ namespace Dune
   }
 
 
-    template<int codim>
-    HierarchicIterator Entity<codim>::hbegin(int) const
-    {
-        return HierarchicIterator(*pgrid_);
-    }
+  template<int codim>
+  HierarchicIterator Entity<codim>::hbegin(int maxLevel) const 
+  {
+      // Creates iterator with first child as target if there is one. Otherwise empty stack and target.
+      return HierarchicIterator(*pgrid_, *this, maxLevel);
+  }
 
-    /// Dummy beyond last child iterator.
-    template<int codim>
-    HierarchicIterator Entity<codim>::hend(int) const
-    {
-        return HierarchicIterator(*pgrid_);
-    }
+  /// Dummy beyond last child iterator.
+  template<int codim>
+  HierarchicIterator Entity<codim>::hend(int maxLevel) const
+  {
+      // Creates iterator with empty stack and target.
+      return HierarchicIterator(maxLevel);
+  }
 
     template <int codim>
     PartitionType Entity<codim>::partitionType() const
@@ -316,8 +321,8 @@ namespace Dune
     } // namespace cpgrid
 } // namespace Dune
 
+#include <opm/grid/CpGrid.hpp>
 #include <opm/grid/cpgrid/CpGridData.hpp>
-#include <opm/grid/cpgrid/Intersection.hpp>
 
 namespace Dune {
 namespace cpgrid {
@@ -326,9 +331,10 @@ template<int codim>
 unsigned int Entity<codim>::subEntities ( const unsigned int cc ) const
 {
     if (cc == codim) {
-        return 1;
-    } else if ( codim == 0 ){
-        if ( cc == 3 ) {
+            return 1;
+    }
+    else if ( codim == 0 ){ // Cell/element/Entity<0>
+        if ( cc == 3 ) { // Get number of corners of the element.
             return 8;
         }
     }
@@ -336,7 +342,7 @@ unsigned int Entity<codim>::subEntities ( const unsigned int cc ) const
 }
 
 template <int codim>
-const typename Entity<codim>::Geometry& Entity<codim>::geometry() const
+const typename Entity<codim>::Geometry& Entity<codim>::geometry() const 
 {
     return pgrid_->geomVector<codim>()[*this];
 }
@@ -346,16 +352,17 @@ template <int cc>
 typename Entity<codim>::template Codim<cc>::Entity Entity<codim>::subEntity(int i) const
 {
     static_assert(codim == 0, "");
-    if (cc == 0) {
+    if (cc == 0) { // Cell/element/Entity<0>
         assert(i == 0);
-        typename Codim<cc>::Entity se(*pgrid_, EntityRep<codim>::index(), EntityRep<codim>::orientation());
+        typename Codim<cc>::Entity se(*pgrid_, this->index(), this->orientation());
         return se;
-    } else if (cc == 3) {
+    } else if (cc == 3) { // Corner/Entity<3>
         assert(i >= 0 && i < 8);
-        int corner_index = pgrid_->cell_to_point_[EntityRep<codim>::index()][i];
+        int corner_index = pgrid_->cell_to_point_[this->index()][i];
         typename Codim<cc>::Entity se(*pgrid_, corner_index, true);
         return se;
-    } else {
+    }
+    else {
         OPM_THROW(std::runtime_error,
                   "No subentity exists of codimension " + std::to_string(cc));
     }
@@ -380,7 +387,105 @@ bool Entity<codim>::isValid() const
     return pgrid_ ? EntityRep<codim>::index() < pgrid_->size(codim) : false;
 }
 
-}}
+template <int codim>
+int Entity<codim>::level() const
+{
+    if (this -> isLeaf()){
+        return std::size_t((*(pgrid_ -> data_copy_)).size() -1);
+    }
+    else {
+        return pgrid_-> level_;
+    }
+}
+
+template<int codim>
+bool Entity<codim>::isLeaf() const
+{
+    if ((*(pgrid_ -> data_copy_)).size() == 1){
+       return true;
+        }
+    return (pgrid_ == (*(pgrid_->data_copy_)).back().get());
+}
+
+template<int codim>
+bool Entity<codim>::hasFather() const
+{
+    if (pgrid_ -> child_to_parent_cells_.empty()){
+        return false;
+    }
+    else{
+        const auto& [level, parent] = pgrid_-> child_to_parent_cells_[this->index()]; // {-1,-1};
+        return  (parent != -1);
+    }
+}
+
+template<int codim>
+Entity<0> Entity<codim>::father() const
+{
+    if (!(this->hasFather())){
+        OPM_THROW(std::logic_error, "Entity has no father.");
+    }
+    const int& coarse_level = pgrid_ -> child_to_parent_cells_[this->index()][0];
+    const int& parent_index = pgrid_ -> child_to_parent_cells_[this->index()][1];
+    const auto& coarse_grid = (*(pgrid_ -> data_copy_))[coarse_level].get(); 
+    return Entity<0>( *coarse_grid, parent_index, true); 
+}
+
+template<int codim>
+Dune::cpgrid::Geometry<3,3> Dune::cpgrid::Entity<codim>::geometryInFather() 
+{
+    if (!(this->hasFather())){
+        OPM_THROW(std::logic_error, "Entity has no father.");
+    }
+    else{
+        //
+        DefaultGeometryPolicy local_geometry;
+        std::array<int,8> localEntity_to_point;
+        std::array<int,8> allcorners_localEntity;
+        EntityVariableBase<cpgrid::Geometry<0,3>>& local_corners = local_geometry.geomVector(std::integral_constant<int,3>());
+        local_corners.resize(8);
+        // Get IJK index of the entity.
+        std::array<int,3> eIJK;
+        pgrid_ -> getIJK(this->index(), eIJK);
+        // Get dimension of the grid.
+        const auto& grid_dim = pgrid_ -> logicalCartesianSize(); // {cells_per_dim[0]*patch_dim[0] ...[1], ...[2]}
+        // Get the local coordinates of the entity (in the reference unit cube).
+        local_corners = {
+            // corner '0'
+            { double(eIJK[0])/grid_dim[0], double(eIJK[1])/grid_dim[1], double(eIJK[2])/grid_dim[2] },
+            // corner '1'
+            { (double(eIJK[0])+1)/grid_dim[0], double(eIJK[1])/grid_dim[1], double(eIJK[2])/grid_dim[2] },
+            // corner '2'
+            { double(eIJK[0])/grid_dim[0], (double(eIJK[1])+1)/grid_dim[1], double(eIJK[2])/grid_dim[2] },
+            // corner '3'
+            { (double(eIJK[0])+1)/grid_dim[0], (double(eIJK[1])+1)/grid_dim[1], double(eIJK[2])/grid_dim[2] },
+            // corner '4'
+            { double(eIJK[0])/grid_dim[0], double(eIJK[1])/grid_dim[1], (double(eIJK[2])+1)/grid_dim[2] },
+            // corner '5'
+            { (double(eIJK[0])+1)/grid_dim[0], double(eIJK[1])/grid_dim[1], (double(eIJK[2])+1)/grid_dim[2] },
+            // corner '6'
+            { double(eIJK[0])/grid_dim[0], (double(eIJK[1])+1)/grid_dim[1], (double(eIJK[2])+1)/grid_dim[2] },
+            // corner '7'
+            { (double(eIJK[0])+1)/grid_dim[0], (double(eIJK[1])+1)/grid_dim[1], (double(eIJK[2])+1)/grid_dim[2] }};
+        // Compute the center of the 'local-entity'.
+        Dune::FieldVector<double, 3> local_center = {0., 0.,0.};
+        for (int corn = 0; corn < 8; ++corn) {
+            local_center += local_corners[corn].center()/8.;
+        }
+        // Compute the volume of the 'local-entity'.
+        double local_volume = double(1)/(grid_dim[0]*grid_dim[1]*grid_dim[2]);
+        // Indices of 'all the corners', in this case, 0-7 (required to construct a Geometry<3,3> object).
+        allcorners_localEntity= {0,1,2,3,4,5,6,7};
+        // Create a pointer to the first element of "cellfiedPatch_to_point" (required to construct a Geometry<3,3> object).
+        const int* localEntity_indices_storage_ptr = &allcorners_localEntity[0];
+        // Construct (and return) the Geometry<3,3> of the 'cellified patch'.
+        return Dune::cpgrid::Geometry<3,3>(local_center, local_volume,
+                                           local_geometry.geomVector(std::integral_constant<int,3>()), localEntity_indices_storage_ptr);
+    }
+}
+
+} // namespace cpgrid
+} // namespace Dune
 
 
 #endif // OPM_ENTITY_HEADER

--- a/opm/grid/cpgrid/Indexsets.cpp
+++ b/opm/grid/cpgrid/Indexsets.cpp
@@ -1,0 +1,101 @@
+//===========================================================================
+//
+// File: Indexsets.hpp
+//
+// Created: Fri May 29 23:30:01 2009
+//
+// Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
+//            Bård Skaflestad     <bard.skaflestad@sintef.no>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
+Copyright 2009, 2010, 2022 Equinor ASA.
+
+This file is part of The Open Porous Media project  (OPM).
+
+OPM is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+OPM is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "Entity.hpp"
+#include "Indexsets.hpp"
+#include "CpGridData.hpp"
+
+namespace Dune
+{
+namespace cpgrid
+{
+IndexSet::IndexType IndexSet::subIndex(const cpgrid::Entity<0>& e, int i, unsigned int cc) const
+{
+    switch(cc) {
+    case 0: return index(e.subEntity<0>(i));
+    case 1: return index(e.subEntity<1>(i));
+    case 2: return index(e.subEntity<2>(i));
+    case 3: return index(e.subEntity<3>(i));
+    default: OPM_THROW(std::runtime_error,
+                       "Codimension " + std::to_string(cc) + " not supported.");
+    }
+}
+
+IdSet::IdType IdSet::subId(const cpgrid::Entity<0>& e, int i, int cc) const
+{
+    switch (cc) {
+    case 0: return id(e.subEntity<0>(i));
+    case 1: return id(e.subEntity<1>(i));
+    case 2: return id(e.subEntity<2>(i));
+    case 3: return id(e.subEntity<3>(i));
+    default: OPM_THROW(std::runtime_error,
+                       "Cannot get subId of codimension " + std::to_string(cc));
+    }
+    return -1;
+}
+
+LevelGlobalIdSet::IdType LevelGlobalIdSet::subId(const cpgrid::Entity<0>& e, int i, int cc) const
+{
+    assert(view_ == e.pgrid_);
+
+    switch (cc) {
+    case 0: return id(e.subEntity<0>(i));
+        //case 1: return id(*e.subEntity<1>(i));
+        //case 2: return id(*e.subEntity<2>(i));
+    case 3: return id(e.subEntity<3>(i));
+    default: OPM_THROW(std::runtime_error,
+                       "Cannot get subId of codimension " + std::to_string(cc));
+    }
+    return -1;
+}
+
+GlobalIdSet::IdType GlobalIdSet::subId(const cpgrid::Entity<0>& e, int i, int cc) const
+{
+    return levelIdSet(e.pgrid_).subId(e, i, cc);
+}
+
+void GlobalIdSet::insertIdSet(const CpGridData& view)
+{
+    idSets_.insert(std::make_pair(&view,view.global_id_set_));
+}
+GlobalIdSet::GlobalIdSet(const CpGridData& view)
+{
+    idSets_.insert(std::make_pair(&view,view.global_id_set_));
+}
+} // end namespace cpgrid
+} // end namespace Dune

--- a/opm/grid/cpgrid/Indexsets.hpp
+++ b/opm/grid/cpgrid/Indexsets.hpp
@@ -167,18 +167,7 @@ namespace Dune
             /// @tparam
             /// @return
             /// @param
-            IndexType subIndex(const cpgrid::Entity<0>& e, int i, unsigned int cc) const
-            {
-                switch(cc) {
-                case 0: return index(e.subEntity<0>(i));
-                case 1: return index(e.subEntity<1>(i));
-                case 2: return index(e.subEntity<2>(i));
-                case 3: return index(e.subEntity<3>(i));
-                default: OPM_THROW(std::runtime_error,
-                              "Codimension " + std::to_string(cc) + " not supported.");
-                }
-
-            }
+            IndexType subIndex(const cpgrid::Entity<0>& e, int i, unsigned int cc) const;
 
 
             template<int codim>
@@ -241,18 +230,7 @@ namespace Dune
                 return id(e.template subEntity<cc>(i));
             }
 
-            IdType subId(const cpgrid::Entity<0>& e, int i, int cc) const
-            {
-                switch (cc) {
-                case 0: return id(e.subEntity<0>(i));
-                case 1: return id(e.subEntity<1>(i));
-                case 2: return id(e.subEntity<2>(i));
-                case 3: return id(e.subEntity<3>(i));
-                default: OPM_THROW(std::runtime_error,
-                                  "Cannot get subId of codimension " + std::to_string(cc));
-                }
-                return -1;
-            }
+            IdType subId(const cpgrid::Entity<0>& e, int i, int cc) const;
         private:
             template<class EntityType>
             IdType computeId(const EntityType& e) const
@@ -310,20 +288,7 @@ namespace Dune
                 return id(e.template subEntity<cc>(i));
             }
 
-            IdType subId(const cpgrid::Entity<0>& e, int i, int cc) const
-            {
-                assert(view_ == e.pgrid_);
-
-                switch (cc) {
-                case 0: return id(e.subEntity<0>(i));
-                //case 1: return id(*e.subEntity<1>(i));
-                //case 2: return id(*e.subEntity<2>(i));
-                case 3: return id(e.subEntity<3>(i));
-                default: OPM_THROW(std::runtime_error,
-                                   "Cannot get subId of codimension " + std::to_string(cc));
-                }
-                return -1;
-            }
+            IdType subId(const cpgrid::Entity<0>& e, int i, int cc) const;
         private:
             std::shared_ptr<const IdSet> idSet_;
             const CpGridData* view_;
@@ -341,10 +306,7 @@ namespace Dune
         /// \brief The type of the id.
         using IdType = typename LevelGlobalIdSet::IdType;
 
-        GlobalIdSet(const CpGridData& view)
-        {
-            idSets_.insert(std::make_pair(&view,view.global_id_set_));
-        }
+        GlobalIdSet(const CpGridData& view);
 
         template<int codim>
         IdType id(const Entity<codim>& e) const
@@ -358,15 +320,9 @@ namespace Dune
             return levelIdSet(e.pgrid_).template subId<cc>(e, i);
         }
 
-        IdType subId(const cpgrid::Entity<0>& e, int i, int cc) const
-        {
-            return levelIdSet(e.pgrid_).subId(e, i, cc);
-        }
+        IdType subId(const cpgrid::Entity<0>& e, int i, int cc) const;
 
-        void insertIdSet(const CpGridData& view)
-        {
-            idSets_.insert(std::make_pair(&view,view.global_id_set_));
-        }
+        void insertIdSet(const CpGridData& view);
     private:
         /// \brief Get the correct id set of a level (global or distributed)
         const LevelGlobalIdSet& levelIdSet(const CpGridData* const data) const

--- a/opm/grid/cpgrid/Iterators.cpp
+++ b/opm/grid/cpgrid/Iterators.cpp
@@ -1,0 +1,60 @@
+//===========================================================================
+//
+// File: Iterators.cpp
+//
+// Created: Mon February 20  14:02:00 2023
+//
+// Author(s): Antonella Ritorto <antonella.ritortoopm-op.com>  ??? TO BE DOUBLE-CHECKED 
+//            
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+Copyright 2023 Equinor ASA.
+
+This file is part of The Open Porous Media project  (OPM).
+
+OPM is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+OPM is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include "config.h"
+#include "Entity.hpp"
+#include "Iterators.hpp"
+
+#include <stack>
+
+
+void Dune::cpgrid::HierarchicIterator::stackChildren_(const Entity<0>& target)
+{
+    // Load sons of target onto the iterator stack
+    if (target.level() < maxLevel_ && !target.isLeaf()){
+        const auto& children_list_indices = std::get<1>(target.pgrid_ -> parent_to_children_cells_[target.index()]);
+        // GET CHILD GRID
+        for (const auto& child : children_list_indices){
+            this->elemStack_.push(Entity<0>(*(target.pgrid_), child, true)); // CORRECT THE CPGRIDDATA, GET THE CHILD-GRID
+        }
+    }
+}
+void Dune::cpgrid::HierarchicIterator::resetEntity_()
+{
+    // Create an invalid entity, to set in case elemStack_ is empty.
+    // Otherwise, a pointer pointing at the to element of elemStack_.
+    virtualEntity_ = elemStack_.empty() ? Entity<0>() : elemStack_.top();
+}
+

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -362,7 +362,7 @@ namespace cpgrid
         if(ccobj_.size()>1)
             populateGlobalCellIndexSet();
 
-        index_set_.reset(new IndexSet(cell_to_face_.size(), geomVector<3>().size()));
+        index_set_ = std::make_unique<IndexSet>(cell_to_face_.size(), geomVector<3>().size());
 
 #ifdef VERBOSE
         std::cout << "Done with grid processing." << std::endl;

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -361,6 +361,7 @@ namespace cpgrid
         if(ccobj_.size()>1)
             populateGlobalCellIndexSet();
 
+        index_set_.reset(new IndexSet(cell_to_face_.size(), geomVector<3>().size()));
 #ifdef VERBOSE
         std::cout << "Done with grid processing." << std::endl;
 #endif

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -44,7 +44,8 @@
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 
 #include <opm/grid/common/GeometryHelpers.hpp>
-#include <opm/grid/cpgrid/EntityRep.hpp>
+#include <opm/grid/cpgrid/Entity.hpp>
+#include  <opm/grid/cpgrid/Indexsets.hpp>
 
 #include <opm/grid/cpgpreprocess/preprocess.h>
 #include <opm/grid/MinpvProcessor.hpp>

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -363,6 +363,7 @@ namespace cpgrid
             populateGlobalCellIndexSet();
 
         index_set_.reset(new IndexSet(cell_to_face_.size(), geomVector<3>().size()));
+
 #ifdef VERBOSE
         std::cout << "Done with grid processing." << std::endl;
 #endif

--- a/tests/cpgrid/entity_test.cpp
+++ b/tests/cpgrid/entity_test.cpp
@@ -5,7 +5,7 @@
 // Created: Fri May 29 14:04:50 2009
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
-//            Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            BÃ¥rd Skaflestad     <bard.skaflestad@sintef.no>
 //
 // $Date$
 //
@@ -56,7 +56,10 @@ BOOST_AUTO_TEST_CASE(entity)
     int m_argc = boost::unit_test::framework::master_test_suite().argc;
     char** m_argv = boost::unit_test::framework::master_test_suite().argv;
     Dune::MPIHelper::instance(m_argc, m_argv);
-    cpgrid::CpGridData g;
+    std::vector<std::shared_ptr<cpgrid::CpGridData>> data;
+    data.reserve(1);
+    data.push_back(std::make_shared<cpgrid::CpGridData>(data));
+    const auto& g = *data[0];
     cpgrid::Entity<0> e1(g, 0, true);
     cpgrid::Entity<0> e2(g, 0, false);
     cpgrid::Entity<0> e3(g, 1, true);

--- a/tests/cpgrid/grid_lgr_test.cpp
+++ b/tests/cpgrid/grid_lgr_test.cpp
@@ -29,8 +29,10 @@
 #include <opm/grid/CpGrid.hpp>
 #include <opm/grid/cpgrid/CpGridData.hpp>
 #include <opm/grid/cpgrid/DefaultGeometryPolicy.hpp>
+#include <opm/grid/cpgrid/Entity.hpp>
 #include <opm/grid/cpgrid/EntityRep.hpp>
 #include <opm/grid/cpgrid/Geometry.hpp>
+
 
 #include <sstream>
 #include <iostream>
@@ -76,6 +78,8 @@ void check_refinedPatch_grid(const std::array<int,3> cells_per_dim,
 
     int count_cells = cells_per_dim[0]*patch_dim[0]*cells_per_dim[1]*patch_dim[1]*cells_per_dim[2]*patch_dim[2];
     BOOST_CHECK_EQUAL(refined_cells.size(), count_cells);
+
+   
 }
 
 
@@ -94,10 +98,74 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
                             (*coarse_grid.data_[1]).geometry_.template geomVector<1>(),
                             (*coarse_grid.data_[1]).geometry_.template geomVector<3>());
     
-    /*cpgrid::OrientedEntityTable<1,0> face_to_cell_computed;
-    cpgrid::OrientedEntityTable<0,1> cell_to_face_computed;
-    cell_to_face_computed.makeInverseRelation(face_to_cell_computed);
-    BOOST_CHECK(face_to_cell_computed == ((*coarse_grid.data_[1]).face_to_cell_)); */
+    const auto& [patch_corners, patch_faces, patch_cells] = (*coarse_grid.data_[0]).getPatchGeomIndices(start_ijk, end_ijk);
+    for (int cell = 0; cell<  data[0]-> size(0); ++cell)
+    {
+        Dune::cpgrid::Entity<0> entity = Dune::cpgrid::Entity<0>((*coarse_grid.data_[0]), cell, true);
+        BOOST_CHECK( entity.hasFather() == false);
+        BOOST_CHECK_THROW(entity.father(), std::logic_error);
+        const auto& parent_to_children = (*coarse_grid.data_[0]).parent_to_children_cells_[cell];
+        const std::vector<int> no_children = {-1};  
+        if (std::find(patch_cells.begin(), patch_cells.end(), cell) == patch_cells.end()){
+            BOOST_CHECK_EQUAL(std::get<0>(parent_to_children), -1);
+        }
+        else{
+            BOOST_CHECK(!(std::get<1>(parent_to_children) == no_children));
+        }
+        BOOST_CHECK( entity.level() == 0);
+        BOOST_CHECK( entity.isLeaf() == false);
+    }
+
+    
+    for (int cell = 0; cell<  data[1]-> size(0); ++cell)
+    {
+        Dune::cpgrid::Entity<0> entity = Dune::cpgrid::Entity<0>((*coarse_grid.data_[1]), cell, true);
+        BOOST_CHECK( entity.hasFather() == true);
+        BOOST_CHECK(entity.father().level() == 0);
+        BOOST_CHECK_EQUAL( (std::find(patch_cells.begin(), patch_cells.end(), entity.father().index()) == patch_cells.end()), false);
+        const auto& child_to_parent = (*coarse_grid.data_[1]).child_to_parent_cells_[cell];
+        BOOST_CHECK_EQUAL( child_to_parent[0] == -1, false);
+        BOOST_CHECK( entity.level() == 1);
+        BOOST_CHECK( entity.level() == coarse_grid.maxLevel());
+        BOOST_CHECK( entity.isLeaf() == false);
+    }
+
+    for (int cell = 0; cell<  data[2]-> size(0); ++cell)
+    {
+        Dune::cpgrid::Entity<0> entity = Dune::cpgrid::Entity<0>((*coarse_grid.data_[2]), cell, true);
+        const auto& child_to_parent = (*coarse_grid.data_[2]).child_to_parent_cells_[cell];
+        if (entity.hasFather()){
+             BOOST_CHECK(entity.father().level() == 0);
+             BOOST_CHECK_EQUAL( (std::find(patch_cells.begin(), patch_cells.end(), entity.father().index()) == patch_cells.end()), false);
+             BOOST_CHECK(!(child_to_parent[0] == -1));
+             BOOST_CHECK_EQUAL( child_to_parent[1], entity.father().index()); 
+        }
+        else{
+            BOOST_CHECK_THROW(entity.father(), std::logic_error);
+            BOOST_CHECK_EQUAL( child_to_parent[0], -1);
+        }
+        BOOST_CHECK( entity.level() == 2);
+        BOOST_CHECK( entity.isLeaf() == true);
+    }
+
+    for (int l = 0; l < 2; ++l)
+    {
+        const auto& view = coarse_grid.levelGridView(l);
+        for (const auto& element: elements(view)){
+            BOOST_CHECK_EQUAL(element.level(), l);
+        }
+    }
+    
+    /* const auto& view = coarse_grid.levelGridView(1);
+    for (const auto& element: elements(view)){
+        BOOST_CHECK_EQUAL(element.level(), 1);
+        }*/
+
+    const auto& leaf_view = coarse_grid.leafGridView();
+    for (const auto& element: elements(leaf_view)){
+        BOOST_CHECK_EQUAL(element.level(), 2);
+    }
+
 } 
 
 BOOST_AUTO_TEST_CASE(refine_patch)

--- a/tests/cpgrid/grid_lgr_test.cpp
+++ b/tests/cpgrid/grid_lgr_test.cpp
@@ -91,7 +91,7 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
     
     // Call createGridWithLgr()
     auto& data = coarse_grid.data_;
-    coarse_grid.createGridWithLgr(cells_per_dim, start_ijk, end_ijk);
+    coarse_grid.addLgrUpdateLeafView(cells_per_dim, start_ijk, end_ijk);
     BOOST_CHECK(data.size()==3);
     check_refinedPatch_grid(cells_per_dim, start_ijk, end_ijk,
                             (*coarse_grid.data_[1]).geometry_.template geomVector<0>(),
@@ -298,7 +298,7 @@ BOOST_AUTO_TEST_CASE(global_refine)
     std::array<int, 3> start_ijk = {0,0,0};
     std::array<int, 3> end_ijk = {4,3,3};  
     coarse_grid.createCartesian(grid_dim, cell_sizes);
-    coarse_grid.createGridWithLgr(cells_per_dim_patch, start_ijk, end_ijk);
+    coarse_grid.addLgrUpdateLeafView(cells_per_dim_patch, start_ijk, end_ijk);
 
     // Create a 8x6x6 grid with length 4x3x3
     Dune::CpGrid fine_grid;
@@ -321,7 +321,7 @@ BOOST_AUTO_TEST_CASE(global_norefine)
     std::array<int, 3> start_ijk = {0,0,0};
     std::array<int, 3> end_ijk = {4,3,3};  
     coarse_grid.createCartesian(grid_dim, cell_sizes);
-    coarse_grid.createGridWithLgr(cells_per_dim_patch, start_ijk, end_ijk);
+    coarse_grid.addLgrUpdateLeafView(cells_per_dim_patch, start_ijk, end_ijk);
 
     // Create a 8x6x6 grid with length 4x3x3
     Dune::CpGrid fine_grid;

--- a/tests/cpgrid/grid_lgr_test.cpp
+++ b/tests/cpgrid/grid_lgr_test.cpp
@@ -155,11 +155,6 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
             BOOST_CHECK_EQUAL(element.level(), l);
         }
     }
-    
-    /* const auto& view = coarse_grid.levelGridView(1);
-    for (const auto& element: elements(view)){
-        BOOST_CHECK_EQUAL(element.level(), 1);
-        }*/
 
     const auto& leaf_view = coarse_grid.leafGridView();
     for (const auto& element: elements(leaf_view)){


### PR DESCRIPTION
Refactoring CpGrid code was needed to define inheritance methods for CpGrid objects containing one LGR. 