### PR TITLE
[cmake] Fix version test for Boost that skip compiling some tests.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -102,7 +102,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_compressed_cartesian_mapping.cpp
 	)
 
-if(BOOST_VERSION VERSION_GREATER 1.53)
+if(BOOST_VERSION VERSION_GREATER 1.53 OR Boost_VERSION VERSION_GREATER 1.53)
 	list(APPEND TEST_SOURCE_FILES
 	  tests/cpgrid/geometry_test.cpp
 	  tests/cpgrid/grid_lgr_test.cpp


### PR DESCRIPTION
On some systems it is Boost_VERSION and not BOOST_VERSION it seems.
Fixes fallout from #634 