### PR TITLE
MinpvProcessor: process cells in a vertical column subsequently.

### DIFF
--- a/opm/grid/MinpvProcessor.hpp
+++ b/opm/grid/MinpvProcessor.hpp
@@ -134,9 +134,9 @@ namespace Opm
         }
 
         // Main loop.
-        for (int kk = 0; kk < dims_[2]; ++kk) {
-            for (int jj = 0; jj < dims_[1]; ++jj) {
-                for (int ii = 0; ii < dims_[0]; ++ii) {
+        for (int jj = 0; jj < dims_[1]; ++jj) {
+            for (int ii = 0; ii < dims_[0]; ++ii) {
+                for (int kk = 0; kk < dims_[2]; ++kk) {
                     const int c = ii + dims_[0] * (jj + dims_[1] * kk);
                     if (pv[c] < minpvv[c] && (actnum.empty() || actnum[c])) {
                         // Move deeper (higher k) coordinates to lower k coordinates.

--- a/opm/grid/MinpvProcessor.hpp
+++ b/opm/grid/MinpvProcessor.hpp
@@ -156,8 +156,8 @@ namespace Opm
 
                         int c_below = ii + dims_[0] * (jj + dims_[1] * (kk_iter));
                         // bypass inactive cells with thickness less then the tolerance
-                        while ( ((actnum.empty() || !actnum[c_below]) && (thickness[c_below] <= z_tolerance))  ){
-                            // move these cell to the posistion of the first cell to make the
+                        while ( ((!actnum.empty() && !actnum[c_below]) && (thickness[c_below] <= z_tolerance))  ){
+                            // move these cell to the position of the first cell to make the
                             // coordinates strictly sorted
                             setCellZcorn(ii, jj, kk_iter, cz, zcorn);
                             kk_iter ++;
@@ -185,7 +185,7 @@ namespace Opm
 
                             // Bypass inactive cells with thickness below tolerance and active cells with volume below minpv
                             auto above_active = actnum.empty() || actnum[c_above];
-                            auto above_inactive = actnum.empty() || !actnum[c_above]; // \todo Kept original, but should be !actnum.empty() && !actnum[c_above]
+                            auto above_inactive = !actnum.empty() && !actnum[c_above];
                             auto above_thin = thickness[c_above] < z_tolerance;
                             auto above_small_pv = pv[c_above] < minpvv[c_above];
                             if ((above_inactive && above_thin) || (above_active && above_small_pv
@@ -193,7 +193,7 @@ namespace Opm
                                 for (int topk = kk - 2; topk > 0; --topk) {
                                     c_above = ii + dims_[0] * (jj + dims_[1] * (topk));
                                     above_active = actnum.empty() || actnum[c_above];
-                                    above_inactive = actnum.empty() || !actnum[c_above];
+                                    above_inactive = !actnum.empty() && !actnum[c_above];
                                     auto above_significant_pv = pv[c_above] > minpvv[c_above];
                                     auto above_broad = thickness[c_above] > z_tolerance;
                                     // \todo if condition seems wrong and should be the negation of above?
@@ -205,7 +205,7 @@ namespace Opm
 
                             // Bypass inactive cells with thickness below tolerance and active cells with volume below minpv
                             auto below_active = actnum.empty() || actnum[c_below];
-                            auto below_inactive = actnum.empty() || !actnum[c_below]; // \todo Kept original, but should be !actnum.empty() && !actnum[c_below]
+                            auto below_inactive = !actnum.empty() && !actnum[c_below];
                             auto below_thin = thickness[c_below] < z_tolerance;
                             auto below_small_pv = pv[c_below] < minpvv[c];
                             if ((below_inactive && below_thin) || (below_active && below_small_pv
@@ -213,7 +213,7 @@ namespace Opm
                                 for (int botk = kk_iter + 1; botk <  dims_[2]; ++botk) {
                                     c_below = ii + dims_[0] * (jj + dims_[1] * (botk));
                                     below_active = actnum.empty() || actnum[c_below];
-                                    below_inactive = actnum.empty() || !actnum[c_below]; // \todo Kept original, but should be !actnum.empty() && !actnum[c_below]
+                                    below_inactive = !actnum.empty() && !actnum[c_below];
                                     auto below_significant_pv = pv[c_below] > minpvv[c_below];
                                     auto below_broad = thickness[c_above] > z_tolerance;
                                     // \todo if condition seems wrong and should be the negation of above?


### PR DESCRIPTION
The current implementation might be wrong for cases with multiple cells in the prospective pinch-out column (e.g. all cells below the thickness theshold, but the sum is not).
Hence we need to be able to process those cells once only and move kk index to the next cell not being piched out directly.

It seems like for multiple neighbouring cells begin pinched out the current algorithm will also add the same NNC multiple times.

For PINCH option 4 will need to be able to compute the harmonic average of the transmissibilities of the cells beween the active ones. As those cells are not represented in he grid we will need to compute the cell centers, face centers, and face areas of the pinched out cells here and make them available. This might also be easier with the new loop.

Playing it careful and creating it in draft mode for now.