### PR TITLE
Support skipping NNCs when PINCH option 4 is ALL.

### DIFF
--- a/opm/grid/GridManager.cpp
+++ b/opm/grid/GridManager.cpp
@@ -149,6 +149,8 @@ namespace Opm
         g.zcorn = zcorn.data();
         g.actnum = actnum.data();
 
+        const double z_tolerance = inputGrid.isPinchActive() ? inputGrid.getPinchThresholdThickness() : 0.0;
+
         if (!poreVolumes.empty() && (inputGrid.getMinpvMode() != MinpvMode::Inactive)) {
             MinpvProcessor mp(g.dims[0], g.dims[1], g.dims[2]);
             const std::vector<double>& minpvv  = inputGrid.getMinpvVector();
@@ -160,11 +162,10 @@ namespace Opm
 
             // The legacy code only supports the opmfil option
             bool opmfil = true; //inputGrid.getMinpvMode() == MinpvMode::OpmFIL;
-            const double z_tolerance = inputGrid.isPinchActive() ? inputGrid.getPinchThresholdThickness() : 0.0;
-            mp.process(thickness, z_tolerance, poreVolumes, minpvv, actnum, opmfil, zcorn.data());
+            mp.process(thickness, z_tolerance, inputGrid.getPinchMaxEmptyGap(), poreVolumes, minpvv,
+                       actnum, opmfil, zcorn.data());
         }
 
-        const double z_tolerance = inputGrid.isPinchActive() ? inputGrid.getPinchThresholdThickness() : 0.0;
         ug_ = create_grid_cornerpoint(&g, z_tolerance);
         if (!ug_) {
             OPM_THROW(std::runtime_error, "Failed to construct grid.");

--- a/opm/grid/MinpvProcessor.hpp
+++ b/opm/grid/MinpvProcessor.hpp
@@ -156,6 +156,10 @@ namespace Opm
         for (int jj = 0; jj < dims_[1]; ++jj) {
             for (int ii = 0; ii < dims_[0]; ++ii) {
                 for (int kk = 0; kk < dims_[2]; ++kk) {
+                    // We only support a corner case for option ALL
+                    // (where one of cells in-between has 0 transmissibility)
+                    // This bool is to keep track whether this is such
+                    // a case
                     bool option4ALLSupported = false;
                     const int c = ii + dims_[0] * (jj + dims_[1] * kk);
                     if (pv[c] < minpvv[c] && (actnum.empty() || actnum[c])) {

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -159,7 +159,9 @@ namespace cpgrid
             const double z_tolerance = ecl_grid.isPinchActive() ?  ecl_grid.getPinchThresholdThickness() : 0.0;
             const bool nogap = !pinchActive || ecl_grid.getPinchGapMode() ==  Opm::PinchMode::NOGAP;
             const auto& poreVolume = ecl_state->fieldProps().porv(true);
-            minpv_result = mp.process(thickness, z_tolerance, poreVolume, ecl_grid.getMinpvVector(), actnumData, false, zcornData.data(), nogap);
+            minpv_result = mp.process(thickness, z_tolerance, ecl_grid.getPinchMaxEmptyGap(),
+                                      poreVolume, ecl_grid.getMinpvVector(), actnumData, false,
+                                      zcornData.data(), nogap);
             if (!minpv_result.nnc.empty()) {
                 this->zcorn = zcornData;
             }

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -42,6 +42,7 @@
 #include "Geometry.hpp"
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
 
 #include <opm/grid/common/GeometryHelpers.hpp>
 #include <opm/grid/cpgrid/EntityRep.hpp>
@@ -159,9 +160,21 @@ namespace cpgrid
             const double z_tolerance = ecl_grid.isPinchActive() ?  ecl_grid.getPinchThresholdThickness() : 0.0;
             const bool nogap = !pinchActive || ecl_grid.getPinchGapMode() ==  Opm::PinchMode::NOGAP;
             const auto& poreVolume = ecl_state->fieldProps().porv(true);
+            const auto& fp = ecl_state->fieldProps();
+            const auto& permZ = fp.has_double("PERMX") ? (fp.has_double("PERMZ") ?
+                                                          fp.get_global_double("PERMZ") :
+                                                          fp.get_global_double("PERMX"))
+                : std::vector<double>();
+            const bool pinchOptionALL = ecl_grid.getPinchOption() == Opm::PinchMode::ALL;
+            auto& transMult = ecl_state->getTransMult();
+            auto multZ =[ &transMult] (int cartindex) {
+                return transMult.getMultiplier(cartindex, ::Opm::FaceDir::ZPlus) *
+                    transMult.getMultiplier(cartindex, ::Opm::FaceDir::ZMinus);
+            };
             minpv_result = mp.process(thickness, z_tolerance, ecl_grid.getPinchMaxEmptyGap(),
                                       poreVolume, ecl_grid.getMinpvVector(), actnumData, false,
-                                      zcornData.data(), nogap);
+                                      zcornData.data(), nogap, pinchOptionALL,
+                                      permZ, multZ);
             if (!minpv_result.nnc.empty()) {
                 this->zcorn = zcornData;
             }

--- a/opm/grid/polyhedralgrid/grid.hh
+++ b/opm/grid/polyhedralgrid/grid.hh
@@ -917,6 +917,8 @@ namespace Dune
         g.zcorn = zcorn.data();
         g.actnum = actnum.data();
 
+        const double z_tolerance = inputGrid.isPinchActive() ? inputGrid.getPinchThresholdThickness() : 0.0;
+
         if (!poreVolumes.empty() && (inputGrid.getMinpvMode() != Opm::MinpvMode::Inactive))
         {
           Opm::MinpvProcessor mp(g.dims[0], g.dims[1], g.dims[2]);
@@ -930,8 +932,8 @@ namespace Dune
           for (size_t i = 0; i < cartGridSize; ++i) {
               thickness[i] = inputGrid.getCellThickness(i);
           }
-          const double z_tolerance = inputGrid.isPinchActive() ? inputGrid.getPinchThresholdThickness() : 0.0;
-          mp.process(thickness, z_tolerance, poreVolumes, minpvv, actnum, opmfil, zcorn.data());
+          mp.process(thickness, z_tolerance, inputGrid.getPinchMaxEmptyGap() , poreVolumes,
+                     minpvv, actnum, opmfil, zcorn.data());
         }
 
         /*
@@ -945,8 +947,6 @@ namespace Dune
         }
         */
 
-        const double z_tolerance = inputGrid.isPinchActive() ?
-            inputGrid.getPinchThresholdThickness() : 0.0;
         UnstructuredGridType* cgrid = create_grid_cornerpoint(&g, z_tolerance);
         if (!cgrid) {
             OPM_THROW(std::runtime_error, "Failed to construct grid.");

--- a/tests/test_minpvprocessor.cpp
+++ b/tests/test_minpvprocessor.cpp
@@ -59,13 +59,13 @@ BOOST_AUTO_TEST_CASE(Pinch)
          3.5, 3.5, 3.5, 3.5,
          6, 6, 6, 6
         };
-    auto minpv_result = mp1.process(thickness, z_threshold, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
+    auto minpv_result = mp1.process(thickness, z_threshold, 1e20, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
     BOOST_CHECK_EQUAL_COLLECTIONS(z1.begin(), z1.end(), zcornAfter.begin(), zcornAfter.end());
     BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 1);
 
     z1= zcorn;
     pinch_no_gap = true;
-    minpv_result = mp1.process(thickness, z_threshold, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
+    minpv_result = mp1.process(thickness, z_threshold, 1e20, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
     BOOST_CHECK_EQUAL_COLLECTIONS(z1.begin(), z1.end(), zcornAfter.begin(), zcornAfter.end());
     BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 0); // No nnc because deactivated cell thickness is too high
 
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(Pinch)
     pinch_no_gap = true;
     minpvv = std::vector(4, 0.6);
     z1 = zcorn;
-    minpv_result = mp1.process(thickness, z_threshold, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
+    minpv_result = mp1.process(thickness, z_threshold, 1e20, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
 
     BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 1);
     BOOST_CHECK_EQUAL(minpv_result.nnc[0], 2);
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(Pinch)
     pinch_no_gap = false;
     minpvv = std::vector(4, 0.6);
     z1 = zcorn;
-    minpv_result = mp1.process(thickness, z_threshold, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
+    minpv_result = mp1.process(thickness, z_threshold, 1e20, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
 
     BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 1);
     BOOST_CHECK(minpv_result.removed_cells == std::vector<std::size_t>{1});
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(Pinch)
     pinch_no_gap = true;
     minpvv = std::vector(4, 0.4);
     z1 = zcorn;
-    minpv_result = mp1.process(thickness, z_threshold, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
+    minpv_result = mp1.process(thickness, z_threshold, 1e20, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
 
     BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 0);
     BOOST_CHECK_EQUAL_COLLECTIONS(z1.begin(), z1.end(), zcorn.begin(), zcorn.end());
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(Pinch)
     pinch_no_gap = false;
     minpvv = std::vector(4, 1.1);
     z1 = zcorn;
-    minpv_result = mp1.process(thickness, z_threshold, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
+    minpv_result = mp1.process(thickness, z_threshold, 1e20, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
     zcornAfter =
         {0, 0, 0, 0,
          2, 2, 2, 2,
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(Pinch)
     pinch_no_gap = true;
     minpvv = std::vector(4, 1.1);
     z1 = zcorn;
-    minpv_result = mp1.process(thickness, z_threshold, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
+    minpv_result = mp1.process(thickness, z_threshold, 1e20, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
     zcornAfter =
         {0, 0, 0, 0,
          2, 2, 2, 2,
@@ -193,31 +193,31 @@ BOOST_AUTO_TEST_CASE(Processing)
     auto z1 = zcorn;
     std::vector<double> minpvv1(4, 0.5);
     bool fill_removed_cells = true;
-    mp1.process(thicknes, z_threshold, pv, minpvv1, actnum, fill_removed_cells, z1.data());
+    mp1.process(thicknes, z_threshold, 1e20, pv, minpvv1, actnum, fill_removed_cells, z1.data());
     BOOST_CHECK_EQUAL_COLLECTIONS(z1.begin(), z1.end(), zcorn.begin(), zcorn.end());
 
     // check that it is possible to pass empty actnum
     Opm::MinpvProcessor mp1b(1, 1, 4);
     auto z1b = zcorn;
-    mp1b.process(thicknes, z_threshold, pv, minpvv1, actnum_empty, fill_removed_cells, z1b.data());
+    mp1b.process(thicknes, z_threshold, 1e20, pv, minpvv1, actnum_empty, fill_removed_cells, z1b.data());
     BOOST_CHECK_EQUAL_COLLECTIONS(z1b.begin(), z1b.end(), zcorn.begin(), zcorn.end());
 
     Opm::MinpvProcessor mp2(1, 1, 4);
     auto z2 = zcorn;
     std::vector<double> minpvv2(4, 1.5);
-    mp2.process(thicknes, z_threshold, pv, minpvv2, actnum, fill_removed_cells, z2.data());
+    mp2.process(thicknes, z_threshold, 1e20, pv, minpvv2, actnum, fill_removed_cells, z2.data());
     BOOST_CHECK_EQUAL_COLLECTIONS(z2.begin(), z2.end(), zcorn2after.begin(), zcorn2after.end());
 
     Opm::MinpvProcessor mp3(1, 1, 4);
     auto z3 = zcorn;
     std::vector<double> minpvv3(4, 2.5);
-    auto minpv_result3 = mp3.process(thicknes, z_threshold, pv, minpvv3, actnum, fill_removed_cells, z3.data());
+    auto minpv_result3 = mp3.process(thicknes, z_threshold, 1e20, pv, minpvv3, actnum, fill_removed_cells, z3.data());
     BOOST_CHECK_EQUAL(minpv_result3.nnc.size(), 0);
     BOOST_CHECK_EQUAL_COLLECTIONS(z3.begin(), z3.end(), zcorn3after.begin(), zcorn3after.end());
 
     Opm::MinpvProcessor mp4(1, 1, 4);
     auto z4 = zcorn;
-    auto minpv_result4 = mp4.process(thicknes, z_threshold, pv, minpvv2, actnum, !fill_removed_cells, z4.data());
+    auto minpv_result4 = mp4.process(thicknes, z_threshold, 1e20, pv, minpvv2, actnum, !fill_removed_cells, z4.data());
     BOOST_CHECK_EQUAL(minpv_result4.nnc.size(), 1);
     BOOST_CHECK_EQUAL(minpv_result4.nnc.at(0), 3);
     BOOST_CHECK(minpv_result4.removed_cells == std::vector<std::size_t>{1});
@@ -225,14 +225,14 @@ BOOST_AUTO_TEST_CASE(Processing)
 
     Opm::MinpvProcessor mp5(1, 1, 4);
     auto z5 = zcorn;
-    auto minpv_result5 = mp5.process(thicknes, z_threshold, pv, minpvv3, actnum, !fill_removed_cells, z5.data());
+    auto minpv_result5 = mp5.process(thicknes, z_threshold, 1e20, pv, minpvv3, actnum, !fill_removed_cells, z5.data());
     BOOST_CHECK_EQUAL(minpv_result5.nnc.size(), 0);
     BOOST_CHECK_EQUAL_COLLECTIONS(z5.begin(), z5.end(), zcorn5after.begin(), zcorn5after.end());
 
     Opm::MinpvProcessor mp6(1, 1, 4);
     auto z6 = zcorn;
     std::vector<double> minpvv6 = {1, 2, 2, 1};
-    auto minpv_result6 = mp6.process(thicknes, z_threshold, pv, minpvv6, actnum, !fill_removed_cells, z6.data());
+    auto minpv_result6 = mp6.process(thicknes, z_threshold, 1e20, pv, minpvv6, actnum, !fill_removed_cells, z6.data());
     BOOST_CHECK_EQUAL(minpv_result6.nnc.size(), 1);
     BOOST_CHECK_EQUAL_COLLECTIONS(z6.begin(), z6.end(), zcorn4after.begin(), zcorn4after.end());
 }

--- a/tests/test_minpvprocessor.cpp
+++ b/tests/test_minpvprocessor.cpp
@@ -80,6 +80,16 @@ BOOST_AUTO_TEST_CASE(Pinch)
     BOOST_CHECK(minpv_result.removed_cells == std::vector<std::size_t>{1});
     BOOST_CHECK_EQUAL_COLLECTIONS(z1.begin(), z1.end(), zcornAfter.begin(), zcornAfter.end());
 
+    z_threshold = 1.1;
+    pinch_no_gap = true;
+    minpvv = std::vector(4, 1.1);
+    z1 = zcorn;
+    double max_gap = 1.0;
+    minpv_result = mp1.process(thickness, z_threshold, max_gap, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
+
+    BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 0);
+    BOOST_CHECK((minpv_result.removed_cells == std::vector<std::size_t>{1, 2}));
+
     z_threshold = 0.4;
     pinch_no_gap = false;
     minpvv = std::vector(4, 0.6);


### PR DESCRIPTION
Note that this only supports a special case for option 4 ALL:

If one of the pinched out cells between the two active cells has zero transmissibility in Z-direction then the transimissibility between these cells is assumed to be zero and no NNC will be created.

This is the only case really supported with this. General support will need to calculate the harmonic average of all the transmissibilities of the cells in-between. As those cells are not represented by CpGrid, we will need to export some geometry information from the MinpvProcessor, such as face volume, normal, distance between cell and face center. Then hopefully this can be used by the simulator to calculate these transmissibilities.

This based on and includes #640.
Needs upstream OPM/opm-common#3456

Edit (2023-03-29): In addition we now throw an exception for the yet unsupported cases (option 4 is ALL and an NNC would be created). In that case the transmissibilities would be wrong as we are calculating them from the top and bottom cell and not the harmonic average over all pinched out cells.