### PR TITLE
[bugfix] Prevent out-of-bounds indexing during pinch processing.

### DIFF
--- a/opm/grid/MinpvProcessor.hpp
+++ b/opm/grid/MinpvProcessor.hpp
@@ -173,6 +173,12 @@ namespace Opm
                         setCellZcorn(ii, jj, kk, cz, zcorn);
                         result.removed_cells.push_back(c);
 
+                        if (kk == dims_[2] - 1) {
+                            // this is cell at the bottom of the grid
+                            // no neighbor below for an NNC.
+                            continue;
+                        }
+
                         // \todo revisit. Maybe instead of keeping track based on cell thickness
                         // we should rather calculate that based on the appropriate corners of the
                         // upper and lower cell


### PR DESCRIPTION
If we are processing a cell at the bottom of the grid, then there will be no lower neighbor at all and certainly not for an NNC.

Previously we would compute the index of a cell in the next non-existing layer and sometimes would index containers actnum and thickness out of bounds.