### PR TITLE
changed: use Boost_VERSION_STRING

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -104,7 +104,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_compressed_cartesian_mapping.cpp
 	)
 
-if(BOOST_VERSION VERSION_GREATER 1.53 OR Boost_VERSION VERSION_GREATER 1.53)
+if(Boost_VERSION_STRING VERSION_GREATER 1.53)
 	list(APPEND TEST_SOURCE_FILES
 	  tests/cpgrid/geometry_test.cpp
 	  tests/cpgrid/grid_lgr_test.cpp


### PR DESCRIPTION
Boost_VERSION is the version string x.y.z in some versions of cmake, and the boost xxyyzz-number in some cmake versions. Boost_VERSION_STRING is always the expected x.y.z format

sorry to  have to revisit this yet again. the cmake in epel seems to be a bit of a moving target.
it now sets the Boost_XXX variables as expected from modern FindBoost. That's good. However,
while it claims to be cmake 3.17 and the find module documentation says that Boost_VERSION is the same as Boost_VERSION_STRING starting in cmake 3.15, it is not on epel. it is still the Boost_VERSION_MACRO (ie internal boost version number). So I have to change it again.