### PR TITLE
Backport #651: changed: use Boost_VERSION_STRING

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -104,7 +104,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_compressed_cartesian_mapping.cpp
 	)
 
-if(BOOST_VERSION VERSION_GREATER 1.53 OR Boost_VERSION VERSION_GREATER 1.53)
+if(Boost_VERSION_STRING VERSION_GREATER 1.53)
 	list(APPEND TEST_SOURCE_FILES
 	  tests/cpgrid/geometry_test.cpp
 	  tests/cpgrid/grid_lgr_test.cpp


### PR DESCRIPTION
Boost_VERSION is the version string x.y.z in some versions of cmake, and the boost xxyyzz-number in some cmake versions. Boost_VERSION_STRING is always the expected x.y.z format