### PR TITLE
Multiple LGRs and LeafView-update supported  

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -88,9 +88,9 @@ void refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,
                       bool);
 
 void refinePatch_and_check(Dune::CpGrid&,
-                           const std::array<int,3>&,
-                           const std::array<int,3>&,
-                           const std::array<int,3>&);
+                           const std::vector<std::array<int,3>>&,
+                           const std::vector<std::array<int,3>>&,
+                           const std::vector<std::array<int,3>>&);
 
 void refinePatch_and_check(const std::array<int,3>&,
                            const std::array<int,3>&,
@@ -225,9 +225,9 @@ namespace Dune
                                 bool);
         friend
         void ::refinePatch_and_check(Dune::CpGrid&,
-                                     const std::array<int,3>&,
-                                     const std::array<int,3>&,
-                                     const std::array<int,3>&);
+                                     const std::vector<std::array<int,3>>&,
+                                     const std::vector<std::array<int,3>>&,
+                                     const std::vector<std::array<int,3>>&);
         friend
         void ::refinePatch_and_check(const std::array<int,3>&,
                                      const std::array<int,3>&,
@@ -460,7 +460,26 @@ namespace Dune
         /// @param [in] startIJK                 Cartesian triplet index where the patch starts.
         /// @param [in] endIJK                   Cartesian triplet index where the patch ends.
         ///                                      Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
-        void addLgrUpdateLeafView(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK, const std::array<int,3>& endIJK);
+        void addLgrUpdateLeafView(std::array<int,3> cells_per_dim, std::array<int,3> startIJK, std::array<int,3> endIJK);
+
+        /// @brief Create a grid out of a coarse one and (at most) 2 refinements(LGRs) of selected block-shaped disjoint patches
+        ///        of cells from that coarse grid.
+        ///
+        /// Level0 refers to the coarse grid, assumed to be this-> data_[0]. Level1 and level2 refer to the LGRs (stored in this->data_[1]
+        /// data_[2]). LeafView (stored in this-> data_[3]) is built with the level0-entities which weren't involded in the
+        /// refinenment, together with the new born entities created in level1 and level2. 
+        /// Old-corners and old-faces (from coarse grid) lying on the boundary of the patches, get replaced by new-born-equivalent corners
+        /// and new-born-faces.
+        ///
+        /// @param [in] cells_per_dim_vec      Vector of Number of (refined) cells in each direction that each
+        ///                                    parent cell should be refined to.
+        /// @param [in] startIJK_vec           Vector of Cartesian triplet indices where each patch starts.
+        /// @param [in] endIJK_vec             Vector of Cartesian triplet indices where each patch ends.
+        ///                                    Last cell part of each patch(lgr) will be
+        ///                                    {endIJK_vec[<patch-number>][0]-1, ..., endIJK_vec[<patch-number>][2]-1}.
+        void addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                   const std::vector<std::array<int,3>>& startIJK_vec,
+                                   const std::vector<std::array<int,3>>& endIJK_vec);
 
         /*  No refinement implemented. GridDefaultImplementation's methods will be used.
 

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -460,7 +460,8 @@ namespace Dune
         /// @param [in] startIJK                 Cartesian triplet index where the patch starts.
         /// @param [in] endIJK                   Cartesian triplet index where the patch ends.
         ///                                      Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
-        void addLgrUpdateLeafView(std::array<int,3> cells_per_dim, std::array<int,3> startIJK, std::array<int,3> endIJK);
+        void addLgrUpdateLeafView(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK,
+                                  const std::array<int,3>& endIJK);
 
         /// @brief Create a grid out of a coarse one and (at most) 2 refinements(LGRs) of selected block-shaped disjoint patches
         ///        of cells from that coarse grid.

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1362,13 +1362,10 @@ template cpgrid::Entity<3> Dune::createEntity(const CpGrid&, int, bool);
 template cpgrid::Entity<1> Dune::createEntity(const CpGrid&, int, bool); // needed in distribution_test.cpp 
 
 
-void CpGrid::addLgrUpdateLeafView(std::array<int,3> cells_per_dim, std::array<int,3> startIJK, std::array<int,3> endIJK)
+void CpGrid::addLgrUpdateLeafView(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK,
+                                  const std::array<int,3>& endIJK)
 {
-    const std::vector<std::array<int,3>> cells_per_dim_vec{{cells_per_dim}};
-    const std::vector<std::array<int,3>> startIJK_vec{{startIJK}};
-    const std::vector<std::array<int,3>> endIJK_vec{{endIJK}};
-    
-    this -> addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec);
+    this -> addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK});
 }
 
 
@@ -1377,48 +1374,56 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
                                    const std::vector<std::array<int,3>>& endIJK_vec)
 {
     if (!distributed_data_.empty()){
-        OPM_THROW(std::logic_error, "Grid has been distributed. Cannot create LGRs.");
+        if (comm().rank()==0){
+            OPM_THROW(std::logic_error, "Adding LGRs to a distributed grid is not supported, yet.");
+        }
+        else{
+            OPM_THROW_NOLOG(std::logic_error, "Adding LGRs to a distributed grid is not supported, yet.");
+        }
     }
-    if (startIJK_vec.size() > 0){
-        if (!(*data_[0]).disjointPatches(startIJK_vec, endIJK_vec)){
-        OPM_THROW(std::logic_error, "Patches are not disjoint.");
+    if (startIJK_vec.size() > 0 && !(*data_[0]).disjointPatches(startIJK_vec, endIJK_vec)){
+        if (comm().rank()==0){
+            OPM_THROW(std::logic_error, "LGRs are not disjoint.");
+        }
+        else{
+            OPM_THROW_NOLOG(std::logic_error, "LGRs are not disjoint.");
         }
     }
     // Total amount of patches:
     const int& num_patches = startIJK_vec.size();
     assert(cells_per_dim_vec.size() == startIJK_vec.size());
     assert(cells_per_dim_vec.size() == endIJK_vec.size());
-    std::vector<int> all_patch_corners; 
-    std::vector<int> all_patch_faces; 
+    std::vector<int> all_patch_corners;
+    std::vector<int> all_patch_faces;
     std::vector<int> all_patch_cells;
-    std::vector<std::vector<std::array<int,2>>> all_patch_boundary_old_to_new_corners;
-    std::vector<std::vector<std::tuple<int,std::vector<int>>>> all_patch_boundary_old_to_new_faces;
+    
+    // Map to relate boundary patches corners with their equivalent refined/new-born ones. {0,oldCornerIdx} -> {level,newCornerIdx}
+    std::map<std::array<int,2>, std::array<int,2>> old_to_new_boundaryPatchCorners;
+    // Map to relate boundary patch faces with their children refined/new-born ones. {0,oldFaceIdx} -> {level,{newFaceIdx0, ...}}
+    std::map<std::array<int,2>, std::tuple<int, std::vector<int>>> old_to_new_boundaryPatchFaces;
+    
     std::vector<std::vector<std::tuple<int,std::vector<int>>>> all_patch_parent_to_children_cells;
     std::vector<std::vector<std::array<int,2>>> all_patch_child_to_parent_cells;
-    all_patch_boundary_old_to_new_corners.reserve(num_patches);
-    all_patch_boundary_old_to_new_faces.reserve(num_patches);
     all_patch_parent_to_children_cells.resize(num_patches);
     all_patch_child_to_parent_cells.resize(num_patches);
-    // For level0, attach children to each parent cell. For no parents, entry {-1, {-1}} representing {no level, {no children}}
+    
+    // For level0, attach children to each parent cell. For no parents, entry {-1, {}} representing {no level, {no children}}
     auto& l0_parent_to_children_cells = (*data_[0]).parent_to_children_cells_;
-    l0_parent_to_children_cells.resize(data_[0]-> size(0));
-    const std::vector<int> no_children = {-1};    
-    const std::tuple<int,std::vector<int>> has_no_children = std::make_tuple(-1, no_children);
-    for (int cell = 0; cell < data_[0]-> size(0); ++cell){
-        l0_parent_to_children_cells[cell] = has_no_children;
-    }
+    l0_parent_to_children_cells.resize(data_[0]-> size(0), std::make_tuple(-1, std::vector<int>()));
     // Get patches corner, face, and cell indices.
     for (int patch = 0; patch < num_patches; ++patch){
-        const auto& [corners, faces, cells] = (*(this->data_[0])).getPatchGeomIndices(startIJK_vec[patch], endIJK_vec[patch]);
-        all_patch_corners.reserve(corners.size());
+        const auto& corners  = (*(this->data_[0])).getPatchCorners(startIJK_vec[patch], endIJK_vec[patch]);
+        const auto& faces = (*(this->data_[0])).getPatchFaces(startIJK_vec[patch], endIJK_vec[patch]);
+        const auto& cells = (*(this->data_[0])).getPatchCells(startIJK_vec[patch], endIJK_vec[patch]);
+        all_patch_corners.reserve(all_patch_corners.size() + corners.size());
         for (const auto& corner : corners){
             all_patch_corners.push_back(corner);
         }
-        all_patch_faces.reserve(faces.size());
+        all_patch_faces.reserve(all_patch_faces.size() + faces.size());
         for (const auto& face : faces){
             all_patch_faces.push_back(face);
         }
-        all_patch_cells.reserve(cells.size());
+        all_patch_cells.reserve(all_patch_cells.size() + cells.size());
         for (const auto& cell : cells){
             all_patch_cells.push_back(cell);
         }
@@ -1436,12 +1441,12 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
         // Extension of container all_patch_child_to_parent_cells, adding {-1,-1} entries for each NO-CHILD cell, in each level/patch.
         (all_patch_child_to_parent_cells[patch]).resize(child_to_parent_cells.size()); // To consider all cells in the LGR.
         // True parent cells have entries: {level of the LGR the parent cell has its children, {child0, child1, ...}}
-        // False parent cells (NO PARENT CELLS) have {-1,{-1}} entries.
+        // False parent cells (NO PARENT CELLS) have {-1,{}} entries.
         // parent_to_children_cells entries look like {parent cell index (in level 0), {child0, child1,..}}
         // True child cells have entries: {0, parent cell index} (0 represents the "GLOBAL" coarse grid)
         // False child cells (with no parent) have {-1,-1} entries.
-        // child_to_parent_cells entries look like {child index in the LGR, parent cell index} 
-        // Re-write entries of actual parent/Create the ones for child cells in each level (not default value {-1,-1} needed).
+        // child_to_parent_cells entries look like {child index in the LGR, parent cell index}
+        // Re-write entries of actual parent/Create the ones for child cells in each level (not default value {-1,-1} needed for LGRs).
         assert(!parent_to_children_cells.empty());
         for (const auto& [trueParent, children_list] : parent_to_children_cells){
             l0_parent_to_children_cells[trueParent] = std::make_tuple(patch +1, children_list); // {level/LGR, {child0, child1, ...}}
@@ -1455,18 +1460,22 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
         // Add this family information [child_to_parent_cells_] in each CpGridData object representing each LGR
         (*data_[patch +1]).child_to_parent_cells_ =  all_patch_child_to_parent_cells[patch];
         // shifted +1 since "GLOBAL" is level0 (coarse grid). Levels are 1,2,..., num_patches.
-        //
-        all_patch_boundary_old_to_new_corners.push_back(boundary_old_to_new_corners);
-        all_patch_boundary_old_to_new_faces.push_back(boundary_old_to_new_faces);
+        // Populate old_to_new_boundaryPatchCorners
+        for (const auto& [oldCorner, newCorner] : boundary_old_to_new_corners) {
+            old_to_new_boundaryPatchCorners[{0, oldCorner}] = {patch +1, newCorner};
+            // (shifted) [patch +1] since coarse grid is level 0, levels/LGRs are 1,2, ..., num_patches.
+        }
+        // Populate old_to_new_boundaryPatchFaces
+        for (const auto& [face, children_list] : boundary_old_to_new_faces) {
+            old_to_new_boundaryPatchFaces[{0,face}] = {patch+1, children_list};
+        }
     } // end-patch-forloop
-    // LEVEL 0, definition/declaration of some members:
-    (*data_[0]).level_data_ptr_ = &(this -> data_);
-    (*data_[0]).level_ = 0;
     // Relation between level and leafview cell indices.
-    std::map<int,int>& l0_to_leaf_cells = (*data_[0]).level_to_leaf_cells_;
+    std::vector<int>& l0_to_leaf_cells = (*data_[0]).level_to_leaf_cells_;
+    l0_to_leaf_cells.resize(data_[0]->size(0));
     // To store the leaf view (mixed grid: with (non parents) coarse and (children) refined entities).
     typedef Dune::FieldVector<double,3> PointType;
-        std::vector<std::shared_ptr<Dune::cpgrid::CpGridData>>& leaf_data = this -> data_;
+    std::vector<std::shared_ptr<Dune::cpgrid::CpGridData>>& leaf_data = this -> data_;
 #if HAVE_MPI
     auto leaf_view_ptr =
         std::make_shared<Dune::cpgrid::CpGridData>((*(this-> data_[0])).ccobj_, leaf_data);
@@ -1499,8 +1508,10 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
     //
     // Integer to count leaf view corners (mixed between corners from level0 not involved in LGRs, and new-born-corners).
     int corner_count = 0;
-    // Map between {level0/level1, old-corner-index/new-born-corner-index}  and its corresponding leafview-corner-index.
-    std::map<std::array<int,2>, int> level_to_leaf_corners;
+    // Relation between {level0/level1, old-corner-index/new-born-corner-index} and its corresponding leafview-corner-index.
+    std::vector<std::vector<int>> level_to_leaf_corners; // level_to_leaf_corners[level][corner] = leaf_corner_index
+    level_to_leaf_corners.resize(num_patches +1); // level 0 + LGRs
+    level_to_leaf_corners[0].resize(this -> data_[0]-> size(3),-1); // Entry '-1' for corners not appearing in the leafview
     // Corners coming from the level0, excluding patch_corners, i.e., the old-corners involved in the LGR.
     for (int corner = 0; corner < this-> data_[0]->size(3); ++corner) {
         // Auxiliary bool to discard ANY CORNER COMING FROM ANY PATCH
@@ -1511,41 +1522,39 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
                 break;
         }
         if(!is_there_allPatchCorn) { // corner is not involved in any refinement, so we store it.
-            level_to_leaf_corners[{0, corner}] = corner_count;
+            level_to_leaf_corners[0][corner] = corner_count; // Only write entries of corners that appear in the LeafView
             corner_count +=1;
         }
     } // end corner-forloop
     // Corners coming from LGRs, i.e. refined (new-born) corners.
     for (int patch = 0; patch < num_patches; ++patch){
+        level_to_leaf_corners[patch +1].resize(this -> data_[patch +1] -> size(3));
         for (int corner = 0; corner < this -> data_[patch+1]->size(3); ++corner) {
-            level_to_leaf_corners[{patch + 1, corner}] = corner_count;
+            level_to_leaf_corners[patch + 1][corner] = corner_count;
             corner_count +=1;
         }
     }
     // Resize the container of the leaf view corners.
     leaf_corners.resize(corner_count);
-    for (const auto& [level_cornIdx, leafCornIdx] : level_to_leaf_corners) { // level_cornIdx[0] = level, level_cornIdx[1] = corner index
-        const auto& level_data = *(this->data_[level_cornIdx[0]]);
-        leaf_corners[leafCornIdx] = level_data.geometry_.geomVector(std::integral_constant<int,3>()).get(level_cornIdx[1]);
+    for (long unsigned int corner = 0; corner < level_to_leaf_corners[0].size(); ++corner) {
+        if (level_to_leaf_corners[0][corner] != -1){ // ONLY NEEDED FOR LEVEL 0
+            leaf_corners[level_to_leaf_corners[0][corner]]
+                = (*(this->data_[0])).geometry_.geomVector(std::integral_constant<int,3>()).get(corner);
+        }
     }
-    // Map to relate boundary patches corners with their equivalent refined/new-born ones. {0,oldCornerIdx} -> {level,newCornerIdx}
-    std::map<std::array<int,2>, std::array<int,2>> old_to_new_boundaryPatchCorners;
-    // To store (indices of) boundary patch corners.
-    std::vector<std::vector<int>> all_boundary_corners; // CHANGE NAME
-    all_boundary_corners.resize(num_patches);
-    for (int patch = 0; patch < num_patches; ++patch){
-        all_boundary_corners[patch].reserve(all_patch_boundary_old_to_new_corners[patch].size());
-        for (int corner = 0; corner < static_cast<int>(all_patch_boundary_old_to_new_corners[patch].size()); ++corner) {
-            old_to_new_boundaryPatchCorners[{0, all_patch_boundary_old_to_new_corners[patch][corner][0]}]
-                = {patch +1, all_patch_boundary_old_to_new_corners[patch][corner][1]};
-            // shifted +1 since coarse grid is level 0, levels/LGRs are 1,2, ..., num_patches. 
-            all_boundary_corners[patch].push_back(all_patch_boundary_old_to_new_corners[patch][corner][0]);
+    for (int l = 1; l < num_patches +1; ++l) {
+        for (long unsigned int corner = 0; corner < level_to_leaf_corners[l].size(); ++corner) {
+            const auto& level_data = *(this->data_[l]);
+            leaf_corners[level_to_leaf_corners[l][corner]]
+                = level_data.geometry_.geomVector(std::integral_constant<int,3>()).get(corner);
         }
     }
     // Integer to count leaf view faces (mixed between faces from level0 not involved in LGR, and new-born-faces).
     int face_count = 0;
-    // Map between {level0/level1/..., old-face-index/new-born-face-index}  and its corresponding leafview-face-index.
-    std::map<std::array<int,2>, int> level_to_leaf_faces;
+    // Relation between {level0/level1/..., old-face-index/new-born-face-index} and its corresponding leafview-face-index.
+    std::vector<std::vector<int>> level_to_leaf_faces; // level_to_leaf_faces[level][face] = leaf_face_index
+    level_to_leaf_faces.resize(num_patches +1); // Level 0 + LGRs
+    level_to_leaf_faces[0].resize(this -> data_[0]->face_to_cell_.size(), -1); // Entry -1 for faces that do not appear in leafView
     // Faces coming from the level0, that do not belong to any patch.
     for (int face = 0; face < this->data_[0]->face_to_cell_.size(); ++face) {
         // Auxiliary bool to discard patch faces OF ANY PATCH
@@ -1556,14 +1565,15 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
                 break;
         }
         if(!is_there_allPatchFace) { // false-> face was not involved in any LGRs, so we store it.
-            level_to_leaf_faces[{0, face}] = face_count;
+            level_to_leaf_faces[0][face] = face_count;
             face_count +=1;
         }
     } //end-face-forloop
     // Faces coming from LGRs, i.e. refined faces.
     for (int patch = 0; patch < num_patches; ++patch) {
+        level_to_leaf_faces[patch +1].resize(this -> data_[patch +1]->face_to_cell_.size());
         for (int face = 0; face < this->data_[patch +1]-> face_to_cell_.size(); ++face) {
-            level_to_leaf_faces[{patch +1, face}] = face_count;
+            level_to_leaf_faces[patch +1][face] = face_count;
             face_count +=1;
         }
     }
@@ -1576,114 +1586,109 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
     // Auxiliary vector to store face_to_point with non consecutive indices.
     std::vector<std::vector<int>> aux_face_to_point;
     aux_face_to_point.resize(face_count);
-    for (const auto& [level_faceIdx, leafFaceIdx] : level_to_leaf_faces) { // level_faceIdx[0] = level, level_faceIdx[1] = face index 
-        // Get the level data.
-        const auto& level_data = *(this->data_[level_faceIdx[0]]);
-        // Get the (face) entity (from level data).
-        const auto& entity = Dune::cpgrid::EntityRep<1>(level_faceIdx[1], true);
-        // Get the face geometry.
-        leaf_faces[leafFaceIdx] = level_data.geometry_.geomVector(std::integral_constant<int,1>())[entity];
-        // Get the face tag.
-        mutable_face_tags[leafFaceIdx] = level_data.face_tag_[entity];
-        // Get the face normal.
-        mutable_face_normals[leafFaceIdx] = level_data.face_normals_[entity];
-        // Get old_face_to_point.
-        auto old_face_to_point = level_data.face_to_point_[level_faceIdx[1]];
-        aux_face_to_point[leafFaceIdx].reserve(old_face_to_point.size());
-        // Add the amount of points to the count num_points.
-        num_points += old_face_to_point.size();
-        if (level_faceIdx[0] == 0) { // Face comes from level0, check if some of its corners got refined.
+    // FACES COMING FROM LEVEL 0
+    for (int face = 0; face < static_cast<int>(this -> data_[0]->face_to_cell_.size()); ++face){
+        if (level_to_leaf_faces[0][face] != -1){ // ONLY NEEDED FOR LEVEL 0
+            const auto& leafFaceIdx =  level_to_leaf_faces[0][face];
+            // Get the level data.
+            const auto& level_data =  *(this->data_[0]);
+            // Get the (face) entity (from level data).
+            const auto& entity =  Dune::cpgrid::EntityRep<1>(face, true);
+            // Get the face geometry.
+            leaf_faces[leafFaceIdx] = level_data.geometry_.geomVector(std::integral_constant<int,1>())[entity];
+            // Get the face tag.
+            mutable_face_tags[leafFaceIdx] = level_data.face_tag_[entity];
+            // Get the face normal.
+            mutable_face_normals[leafFaceIdx] = level_data.face_normals_[entity];
+            // Get old_face_to_point.
+            auto old_face_to_point = level_data.face_to_point_[face];
+            aux_face_to_point[leafFaceIdx].reserve(old_face_to_point.size());
+            // Add the amount of points to the count num_points.
+            num_points += old_face_to_point.size();
             for (int corn = 0; corn < 4; ++corn) {
                 // Auxiliary bool to identify boundary patch corners.
                 bool is_there_allPatchBoundCorn = false;
-                for (int patch = 0; patch < num_patches; ++patch) {
-                    for(const auto& patchBoundCorn : all_boundary_corners[patch]) {
-                        is_there_allPatchBoundCorn = is_there_allPatchBoundCorn || (corn == patchBoundCorn);
-                        //true-> boundary patch corner
-                        if (is_there_allPatchBoundCorn) {
-                            break;
-                            aux_face_to_point[leafFaceIdx].push_back(level_to_leaf_corners
-                                                                     [old_to_new_boundaryPatchCorners[{0, old_face_to_point[corn]}]]);
-                        }
-                        else { // Corner not involded in any LGR.
-                            aux_face_to_point[leafFaceIdx].push_back(level_to_leaf_corners[{0, old_face_to_point[corn]}]);
-                        }
-                    } // end-patchBoundCorn-forloop
-                } // end-patch-forloop
-            } // end-corner-forloop
-        } // end if-level_facaIdx[0]==0        
-        else { // Face comes from level1/leavel2/....
+                for(const auto& [l0_oldCorner, level_newCorner] : old_to_new_boundaryPatchCorners){
+                    is_there_allPatchBoundCorn = is_there_allPatchBoundCorn || (corn == l0_oldCorner[1]);
+                    //true-> boundary patch corner
+                    if (is_there_allPatchBoundCorn) {
+                        aux_face_to_point[leafFaceIdx].push_back(level_to_leaf_corners[level_newCorner[0]][level_newCorner[1]]);
+                        break; // Go to the next corner (on the boundary of a patch)
+                    }
+                }
+                if (!is_there_allPatchBoundCorn) {// Corner not involded in any LGR.
+                    aux_face_to_point[leafFaceIdx].push_back(level_to_leaf_corners[0][old_face_to_point[corn]]);
+                }
+            } // end-corn-forloop
+        } // end-if
+    } // end-face-for-loop
+    // FACES COMING FROM LGRS
+    for (int level = 1; level < num_patches +1; ++level) {
+        for (int face = 0; face < static_cast<int>(this -> data_[level]->face_to_cell_.size()); ++face){
+            const auto& leafFaceIdx =  level_to_leaf_faces[level][face];
+            // Get the level data.
+            const auto& level_data =  *(this->data_[level]);
+            // Get the (face) entity (from level data).
+            const auto& entity =  Dune::cpgrid::EntityRep<1>(face, true);
+            // Get the face geometry.
+            leaf_faces[leafFaceIdx] = level_data.geometry_.geomVector(std::integral_constant<int,1>())[entity];
+            // Get the face tag.
+            mutable_face_tags[leafFaceIdx] = level_data.face_tag_[entity];
+            // Get the face normal.
+            mutable_face_normals[leafFaceIdx] = level_data.face_normals_[entity];
+            // Get old_face_to_point.
+            auto old_face_to_point = level_data.face_to_point_[face];
+            aux_face_to_point[leafFaceIdx].reserve(old_face_to_point.size());
+            // Add the amount of points to the count num_points.
+            num_points += old_face_to_point.size();
+            // Face comes from level1/leavel2/....
             for (int corn = 0; corn < static_cast<int>(old_face_to_point.size()); ++corn) {
-                aux_face_to_point[leafFaceIdx].push_back(level_to_leaf_corners[{level_faceIdx[0], old_face_to_point[corn]}]);
+                aux_face_to_point[leafFaceIdx].push_back(level_to_leaf_corners[level][old_face_to_point[corn]]);
             }
-        }
-    } // end-level_to_leaf_faces-forloop
+        } // end-face-for-loop
+    } // end-level-forloop
     // Leaf view face_to_point.
     leaf_face_to_point.reserve(face_count, num_points);
     for (int face = 0; face < face_count; ++face) {
         leaf_face_to_point.appendRow(aux_face_to_point[face].begin(), aux_face_to_point[face].end());
     }
-    // Map to relate boundary patch faces with their children refined/new-born ones. {0,oldFaceIdx} -> {level,{newFaceIdx0, ...}}
-    std::map<std::array<int,2>, std::tuple<int, std::vector<int>>> old_to_new_boundaryPatchFaces;
-    // To store (indices of) boundary patch faces.
-    std::vector<std::vector<int>> all_boundary_faces;
-    all_boundary_faces.resize(num_patches);
-    for (int patch = 0; patch < num_patches; ++patch){
-        all_boundary_faces[patch].reserve(all_patch_boundary_old_to_new_faces[patch].size());
-        for (const auto& [face, children_list] : all_patch_boundary_old_to_new_faces[patch]) {
-                old_to_new_boundaryPatchFaces[{0,face}] = {patch+1, children_list};
-            all_boundary_faces[patch].push_back(face);
-        }
-    }
     // Integer to count leaf view cells (mixed between cells from level0 not involved in LGR, and new-born-cells).
     int cell_count = 0;
-    // Map between {level0/level1/.., old-cell-index/new-born-cell-index}  and its corresponding leafview-cell-index.
-    // std::map<std::array<int,2>> level_to_leaf_cells_; // CHANGE NAME NOT TO CONFUSE WITH ATTRIBUTE OF CPGRIDDATA
-     // Map between {level0/level1/.., old-cell-index/new-born-cell-index}  and its corresponding leafview-cell-index.
-    std::map<std::array<int,2>,int> allLevels_to_leaf_cells = leaf_view.allLevels_to_leaf_cells_ ;
+    // Map between leafCellIndices and {level0/level1/.., old-cell-index/new-born-cell-index}.
+    leaf_to_level_cells.reserve((this ->data_[0] ->size(0)) + all_patch_cells.size()); // MORE ENTRIES THAT ACTUALLY NEEDED
     // Cells coming from the level0, that do not belong to the patch.
     for (int cell = 0; cell < this->data_[0]-> size(0); ++cell) {
         // Auxiliary bool to identify cells of the patch1.
         bool is_there_allPatchCell = false;
-        //  for (int patch = 0; patch < num_patches; ++patch) {
-            for(const auto& patch_cell : all_patch_cells) {
-                is_there_allPatchCell = is_there_allPatchCell || (cell == patch_cell); //true-> coincides with one patch-cell
-                if (is_there_allPatchCell)
-                    break;
-            }
-            // }
+        for(const auto& patch_cell : all_patch_cells) {
+            is_there_allPatchCell = is_there_allPatchCell || (cell == patch_cell); //true-> coincides with one patch-cell
+            if (is_there_allPatchCell)
+                break;
+        }
         if(!is_there_allPatchCell) {// Cell does not belong to any patch, so we store it.
-            allLevels_to_leaf_cells[{0, cell}] = cell_count;
             l0_to_leaf_cells[cell] = cell_count;
+            leaf_to_level_cells.push_back({0,cell});
             cell_count +=1;
         }
     }
-    std::vector<std::map<int,int>> lgrs_to_leaf_cells_vec; // Each entry of the vector corresponds to a patch.
-    // cell level idx -> cell leafview index (PER EACH LEVEL) 
-    lgrs_to_leaf_cells_vec.resize(num_patches);
     // Cells coming from LGRs, i.e. refined cells.
     for (int patch = 0; patch < num_patches; ++patch){
+        (*data_[patch +1]).level_to_leaf_cells_.resize(this->data_[patch+1]-> size(0));
+        // shifted +1 since "GLOBAL" is level0 (coarse grid). Levels are 1,2,..., num_patches.
         for (int cell = 0; cell < this->data_[patch+1]-> size(0); ++cell) {
-            lgrs_to_leaf_cells_vec[patch][cell] = cell_count;
-            allLevels_to_leaf_cells[{patch +1, cell}] = cell_count;
+            (*data_[patch +1]).level_to_leaf_cells_[cell] = cell_count;
+            leaf_to_level_cells.push_back({patch +1, cell});
             cell_count +=1;
         }
-        (*data_[patch +1]).level_to_leaf_cells_ =  lgrs_to_leaf_cells_vec[patch]; // {cell index in its level, cell index in leafview}
-        // shifted +1 since "GLOBAL" is level0 (coarse grid). Levels are 1,2,..., num_patches.
     }
     leaf_cells.resize(cell_count);
     leaf_cell_to_point.resize(cell_count);
-    leaf_to_level_cells.resize(cell_count);
-    leaf_child_to_parent_cells.resize(cell_count);
     // For cells that do not have a parent, we set {-1,-1} by defualt and rewrite later for actual children
-     const std::array<int,2>& has_no_parent = {-1,-1}; // To populate by defualt child_to_parent_cells_ for LeafView.
-    for (int cell = 0; cell < cell_count; ++cell){
-        leaf_child_to_parent_cells[cell] = has_no_parent;
-    }
+    leaf_child_to_parent_cells.resize(cell_count, std::array<int,2>({-1,-1}));
     // Auxiliary vector to store cell_to_face with non consecutive indices.
     std::map<int,std::vector<cpgrid::EntityRep<1>>> aux_cell_to_face;
-    for (const auto& [level_cellIdx, leafCellIdx] : allLevels_to_leaf_cells) {// level_cellIdx = {level0/1/.., cell index}
-        leaf_to_level_cells[leafCellIdx] = level_cellIdx;
+    for (int leafCellIdx = 0; leafCellIdx < cell_count; ++leafCellIdx){
+        const auto& level_cellIdx = leaf_to_level_cells[leafCellIdx]; // {level, cellIdx}
         const auto& level_data =  *(this->data_[level_cellIdx[0]]);
         const auto& entity =  Dune::cpgrid::EntityRep<0>(level_cellIdx[1], true);
         // Get the cell geometry.
@@ -1697,55 +1702,48 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
             for (int corn = 0; corn < 8; ++corn) {
                 // Auxiliary bool to identity boundary patch corners
                 bool is_there_allPatchBoundCorn = false;
-                for (int patch = 0; patch < num_patches; ++patch) {
-                for(const auto& patch_corn : all_boundary_corners[patch]) {
-                    is_there_allPatchBoundCorn = is_there_allPatchBoundCorn || (old_cell_to_point[corn] == patch_corn);
+                for(const auto& [l0_oldCorner, level_newCorner] : old_to_new_boundaryPatchCorners) {
+                    is_there_allPatchBoundCorn = is_there_allPatchBoundCorn || (old_cell_to_point[corn] == l0_oldCorner[1]);
                     if (is_there_allPatchBoundCorn) { //true-> coincides with one boundary patch corner
-                        break; // Corner belongs to the patch boundary.
-                     leaf_cell_to_point[leafCellIdx][corn] =
-                        level_to_leaf_corners[old_to_new_boundaryPatchCorners[{0, old_cell_to_point[corn]}]];
+                        leaf_cell_to_point[leafCellIdx][corn] = level_to_leaf_corners[level_newCorner[0]][level_newCorner[1]];
+                        break; // Go to the next corner (of the bondary of a patch)
                     }
                 }
-                }
                 if(!is_there_allPatchBoundCorn) { // Corner does not belong to any patch boundary.
-                    leaf_cell_to_point[leafCellIdx][corn] = level_to_leaf_corners[{0, old_cell_to_point[corn]}];
+                    leaf_cell_to_point[leafCellIdx][corn] = level_to_leaf_corners[0][old_cell_to_point[corn]];
                 }
             } // end-corn-forloop
             // Cell to face.
             for (const auto& face : old_cell_to_face) {   // Auxiliary bool to identity boundary patch faces
                 bool is_there_allPatchBoundFace = false;
-                for (int patch = 0; patch < num_patches; ++patch) {
-                    //   for(const auto& bound_face : all_boundary_faces[patch]) {
-                    for (const auto& [bound_face, children_list] : all_patch_boundary_old_to_new_faces[patch]){
-                        is_there_allPatchBoundFace = is_there_allPatchBoundFace || (face.index() == bound_face);
-                        //true-> coincides with one boundary patch face
-                        if (is_there_allPatchBoundFace) { // Face belongs to one of the patch boundaries.
-                            break;
-                            for (const auto& new_face : children_list) {
-                                aux_cell_to_face[leafCellIdx].
-                                    push_back({level_to_leaf_faces[{patch +1, new_face}], face.orientation()});
-                            }
+                for (const auto& [l0_boundFace, level_childrenList] : old_to_new_boundaryPatchFaces) {
+                    // l0_boundFace = {0,face},  level_childrenList = {patch +1, children_list}
+                    is_there_allPatchBoundFace = is_there_allPatchBoundFace || (face.index() == l0_boundFace[1]);
+                    //true-> coincides with one boundary patch face
+                    if (is_there_allPatchBoundFace) { // Face belongs to one of the patch boundaries.
+                        for (const auto& new_face : std::get<1>(level_childrenList)) {
+                            aux_cell_to_face[leafCellIdx].push_back({new_face, face.orientation()});
                         }
+                        is_there_allPatchBoundFace = true;
+                        break; // Go to the next corner (on the boundary of a patch)
                     }
                 }
                 if (!is_there_allPatchBoundFace) { // Face does not belong to any of the patch boundaries.
-                    aux_cell_to_face[leafCellIdx].push_back({level_to_leaf_faces[{0, face.index()}], face.orientation()});
+                    aux_cell_to_face[leafCellIdx].push_back({level_to_leaf_faces[0][face.index()], face.orientation()});
                 }
             } // end-old_cell_to_face-forloop
         }
-            else { // Refined cells. (Cell comes from LGRs)
+        else { // Refined cells. (Cell comes from LGRs)
             // Get level where cell was created and its local index, to later deduce its parent.
             auto& [level, levelIdx]  = leaf_to_level_cells[leafCellIdx]; // {level, cell index in that level} (level != 0)
-            // int shiftedLevel = level -1;
-            leaf_child_to_parent_cells[leafCellIdx] = //all_patch_child_to_parent_cells[shiftedLevel][levelIdx]; // shifted! 
-                (*data_[level]).child_to_parent_cells_[levelIdx]; //{0, parent cell index}
+            leaf_child_to_parent_cells[leafCellIdx] = (*data_[level]).child_to_parent_cells_[levelIdx]; //{0, parent cell index}
             // Cell to point.
             for (int corn = 0; corn < 8; ++corn) {
-                leaf_cell_to_point[leafCellIdx][corn] = level_to_leaf_corners[{level, old_cell_to_point[corn]}];
+                leaf_cell_to_point[leafCellIdx][corn] = level_to_leaf_corners[level][old_cell_to_point[corn]];
             }
             // Cell to face.
             for (auto& face : old_cell_to_face) {
-                aux_cell_to_face[leafCellIdx].push_back({level_to_leaf_faces[{level, face.index()}], face.orientation()});
+                aux_cell_to_face[leafCellIdx].push_back({level_to_leaf_faces[level][face.index()], face.orientation()});
             }
         }
     }

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -1685,12 +1685,12 @@ void CpGridData::distributeGlobalGrid(CpGrid& grid,
 #endif
 }
 
-const std::array<int,3> CpGridData::getPatchDim(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
+std::array<int,3> CpGridData::getPatchDim(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
 {
     return {endIJK[0]-startIJK[0], endIJK[1]-startIJK[1], endIJK[2]-startIJK[2]};
 }
 
-const std::vector<int> CpGridData::getPatchCorners(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
+std::vector<int> CpGridData::getPatchCorners(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
 {
     // Get the patch dimension (total cells in each direction). Used to 'reserve vectors'.
     const std::array<int,3>& patch_dim = getPatchDim(startIJK, endIJK);
@@ -1709,7 +1709,7 @@ const std::vector<int> CpGridData::getPatchCorners(const std::array<int,3>& star
     return patch_corners;
 }
 
-const std::vector<int> CpGridData::getPatchFaces(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
+std::vector<int> CpGridData::getPatchFaces(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
 {
     // Get the patch dimension (total cells in each direction). Used to 'reserve vectors'.
     const std::array<int,3>& patch_dim = getPatchDim(startIJK, endIJK);
@@ -1754,7 +1754,7 @@ const std::vector<int> CpGridData::getPatchFaces(const std::array<int,3>& startI
     return patch_faces;
 }
 
-const std::vector<int> CpGridData::getPatchCells(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
+std::vector<int> CpGridData::getPatchCells(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
 {
     // Get the patch dimension (total cells in each direction). Used to 'reserve vectors'.
     const std::array<int,3>& patch_dim = getPatchDim(startIJK, endIJK);
@@ -1773,7 +1773,7 @@ const std::vector<int> CpGridData::getPatchCells(const std::array<int,3>& startI
     return patch_cells;
 }
 
-const std::vector<int> CpGridData::getPatchBoundaryCorners(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
+std::vector<int> CpGridData::getPatchBoundaryCorners(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
 {
     // Get the patch dimension (total cells in each direction). Used to 'reserve vectors'.
     const std::array<int,3>& patch_dim = getPatchDim(startIJK, endIJK);
@@ -1809,36 +1809,35 @@ bool CpGridData::disjointPatches(const std::vector<std::array<int,3>>& startIJK_
     for (long unsigned int patch = 0; patch < startIJK_vec.size(); ++patch){
         // Auxiliary bool
         bool patch_disjoint_with_otherPatches = true;
-         for (long unsigned int other_patch = 0; other_patch < startIJK_vec.size(); ++other_patch){
-             if (patch!=other_patch){
-              patch_disjoint_with_otherPatches = patch_disjoint_with_otherPatches &&
-                  ((startIJK_vec[patch] < startIJK_vec[other_patch]) || (startIJK_vec[patch] > endIJK_vec[other_patch]))
-                  &&  ((endIJK_vec[patch] < startIJK_vec[other_patch]) || (endIJK_vec[patch] > endIJK_vec[other_patch]));
-             }
-         }
-         disjoint = disjoint && patch_disjoint_with_otherPatches; // false if one of them is false
+        for (long unsigned int other_patch = 0; other_patch < startIJK_vec.size(); ++other_patch){
+            if (patch!=other_patch){
+                patch_disjoint_with_otherPatches = patch_disjoint_with_otherPatches &&
+                    ((startIJK_vec[patch] < startIJK_vec[other_patch]) || (startIJK_vec[patch] > endIJK_vec[other_patch]))
+                    &&  ((endIJK_vec[patch] < startIJK_vec[other_patch]) || (endIJK_vec[patch] > endIJK_vec[other_patch]));
+            }
+        }
+        disjoint = disjoint && patch_disjoint_with_otherPatches; // false if one of them is false
     }
     return disjoint;
 }
 
-const std::vector<int>
+std::vector<int>
 CpGridData::getPatchesCells(const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const
 {
     std::vector<int> all_cells;
     for (long unsigned int patch = 0; patch < startIJK_vec.size(); ++patch){
         /// PATCH CELLS
-        for (const auto& cell : CpGridData::getPatchCells(startIJK_vec[patch], endIJK_vec[patch])){
-            all_cells.push_back(cell);
-        }
+        const auto& patch_cells = CpGridData::getPatchCells(startIJK_vec[patch], endIJK_vec[patch]);
+        all_cells.insert(all_cells.end(), patch_cells.begin(), patch_cells.end());
     }
     return all_cells;
 }
 
 
-const Geometry<3,3> CpGridData::cellifyPatch(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK,
-                                             const std::vector<int>& patch_cells, DefaultGeometryPolicy& cellifiedPatch_geometry,
-                                             std::array<int,8>& cellifiedPatch_to_point,
-                                             std::array<int,8>& allcorners_cellifiedPatch) const
+Geometry<3,3> CpGridData::cellifyPatch(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK,
+                                       const std::vector<int>& patch_cells, DefaultGeometryPolicy& cellifiedPatch_geometry,
+                                       std::array<int,8>& cellifiedPatch_to_point,
+                                       std::array<int,8>& allcorners_cellifiedPatch) const
 {
     if (patch_cells.empty()){
         OPM_THROW(std::logic_error, "Empty patch. Cannot convert patch into cell.");
@@ -1898,12 +1897,12 @@ const Geometry<3,3> CpGridData::cellifyPatch(const std::array<int,3>& startIJK, 
     }
 }
 
-const std::tuple< const std::shared_ptr<CpGridData>,
-                  const std::vector<std::array<int,2>>,                // parent_to_refined_corners(~boundary_old_to_new_corners)
-                  const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces (~boundary_old_to_new_faces)
-                  const std::tuple<int, std::vector<int>>,             // parent_to_children_cells
-                  const std::vector<std::array<int,2>>,                // child_to_parent_faces
-                  const std::vector<std::array<int,2>>>                // child_to_parent_cells
+std::tuple< const std::shared_ptr<CpGridData>,
+            const std::vector<std::array<int,2>>,                // parent_to_refined_corners(~boundary_old_to_new_corners)
+            const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces (~boundary_old_to_new_faces)
+            const std::tuple<int, std::vector<int>>,             // parent_to_children_cells
+            const std::vector<std::array<int,2>>,                // child_to_parent_faces
+            const std::vector<std::array<int,2>>>                // child_to_parent_cells
 CpGridData::refineSingleCell(const std::array<int,3>& cells_per_dim, const int& parent_idx) const
 {
     // To store the LGR/refined-grid.
@@ -2026,13 +2025,13 @@ CpGridData::refineSingleCell(const std::array<int,3>& cells_per_dim, const int& 
         child_to_parent_faces, child_to_parent_cell};
 }
 
-const std::tuple< std::shared_ptr<CpGridData>,
-                  const std::vector<std::array<int,2>>,                // boundary_old_to_new_corners
-                  const std::vector<std::tuple<int,std::vector<int>>>, // boundary_old_to_new_faces
-                  const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces
-                  const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_cell
-                  const std::vector<std::array<int,2>>,                // child_to_parent_faces
-                  const std::vector<std::array<int,2>>>                // child_to_parent_cells
+std::tuple< std::shared_ptr<CpGridData>,
+            const std::vector<std::array<int,2>>,                // boundary_old_to_new_corners
+            const std::vector<std::tuple<int,std::vector<int>>>, // boundary_old_to_new_faces
+            const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces
+            const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_cell
+            const std::vector<std::array<int,2>>,                // child_to_parent_faces
+            const std::vector<std::array<int,2>>>                // child_to_parent_cells
 CpGridData::refinePatch(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK,
                         const std::array<int,3>& endIJK) const
 {
@@ -2056,7 +2055,6 @@ CpGridData::refinePatch(const std::array<int,3>& cells_per_dim, const std::array
     cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>,1>& refined_face_normals = refined_grid.face_normals_;
     // Patch dimension (amount of cells in each direction).
     const auto& patch_dim = getPatchDim(startIJK, endIJK);
-    const auto& patch_corners = getPatchCorners(startIJK, endIJK);
     const auto& patch_faces = getPatchFaces(startIJK, endIJK);
     const auto& patch_cells = getPatchCells(startIJK, endIJK);
     // Construct the Geometry of the cellified patch.

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -1690,8 +1690,7 @@ const std::array<int,3> CpGridData::getPatchDim(const std::array<int,3>& startIJ
     return {endIJK[0]-startIJK[0], endIJK[1]-startIJK[1], endIJK[2]-startIJK[2]};
 }
 
-const std::array<std::vector<int>,3>
-CpGridData::getPatchGeomIndices(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
+const std::vector<int> CpGridData::getPatchCorners(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
 {
     // Get the patch dimension (total cells in each direction). Used to 'reserve vectors'.
     const std::array<int,3>& patch_dim = getPatchDim(startIJK, endIJK);
@@ -1707,6 +1706,15 @@ CpGridData::getPatchGeomIndices(const std::array<int,3>& startIJK, const std::ar
             } // end i-for-loop
         } // end j-for-loop
     } // end k-for-loop
+    return patch_corners;
+}
+
+const std::vector<int> CpGridData::getPatchFaces(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
+{
+    // Get the patch dimension (total cells in each direction). Used to 'reserve vectors'.
+    const std::array<int,3>& patch_dim = getPatchDim(startIJK, endIJK);
+    // Get grid dimension (total cells in each direction).
+    const std::array<int,3>& grid_dim = this -> logicalCartesianSize();
     /// PATCH FACES
     std::vector<int> patch_faces;
     patch_faces.reserve(((patch_dim[0]+1)*patch_dim[1]*patch_dim[2])     // i_patch_faces
@@ -1743,9 +1751,18 @@ CpGridData::getPatchGeomIndices(const std::array<int,3>& startIJK, const std::ar
             } // end k-for-loop
         } // end i-for-loop
     } // end j-for-loop
-    /// PATCH CELLS
+    return patch_faces;
+}
+
+const std::vector<int> CpGridData::getPatchCells(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
+{
+    // Get the patch dimension (total cells in each direction). Used to 'reserve vectors'.
+    const std::array<int,3>& patch_dim = getPatchDim(startIJK, endIJK);
+    // Get grid dimension (total cells in each direction).
+    const std::array<int,3>& grid_dim = this -> logicalCartesianSize();
     std::vector<int> patch_cells;
     patch_cells.reserve(patch_dim[0]*patch_dim[1]*patch_dim[2]);
+    /// PATCH CELLS
     for (int k = startIJK[2]; k < endIJK[2]; ++k) {
         for (int j = startIJK[1]; j < endIJK[1]; ++j) {
             for (int i = startIJK[0]; i < endIJK[0]; ++i) {
@@ -1753,7 +1770,7 @@ CpGridData::getPatchGeomIndices(const std::array<int,3>& startIJK, const std::ar
             } // end i-for-loop
         } // end j-for-loop
     } // end k-for-loop
-    return {patch_corners, patch_faces, patch_cells};
+    return patch_cells;
 }
 
 const std::vector<int> CpGridData::getPatchBoundaryCorners(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
@@ -1762,7 +1779,7 @@ const std::vector<int> CpGridData::getPatchBoundaryCorners(const std::array<int,
     const std::array<int,3>& patch_dim = getPatchDim(startIJK, endIJK);
     // Get grid dimension (total cells in each direction).
     const std::array<int,3>& grid_dim = this -> logicalCartesianSize();
-    /// PATCH CORNERS
+    /// PATCH BOUNDARY CORNERS
     std::vector<int> patch_boundary_corners;
     patch_boundary_corners.reserve(((patch_dim[0]+1)*(patch_dim[2]+1)*2) + ((patch_dim[1]-1)*(patch_dim[2]+1)*2)
                                    + ((patch_dim[0]-1)*(patch_dim[1]-1)*2));
@@ -1787,28 +1804,30 @@ bool CpGridData::disjointPatches(const std::vector<std::array<int,3>>& startIJK_
     if ((startIJK_vec.size() == 1) && (endIJK_vec.size() == 1)){
         return true;
     }
-    auto all_bound_corners_count = 0u;
-    std::set<int> no_repetition_bound_corners;
+    // Auxiliary bool
+    bool disjoint = true;
     for (long unsigned int patch = 0; patch < startIJK_vec.size(); ++patch){
-        const auto& boundary_corners = getPatchBoundaryCorners(startIJK_vec[patch], endIJK_vec[patch]);
-        all_bound_corners_count += boundary_corners.size();
-        for (const auto& corner : boundary_corners){
-            no_repetition_bound_corners.insert(corner);
-        }
+        // Auxiliary bool
+        bool patch_disjoint_with_otherPatches = true;
+         for (long unsigned int other_patch = 0; other_patch < startIJK_vec.size(); ++other_patch){
+             if (patch!=other_patch){
+              patch_disjoint_with_otherPatches = patch_disjoint_with_otherPatches &&
+                  ((startIJK_vec[patch] < startIJK_vec[other_patch]) || (startIJK_vec[patch] > endIJK_vec[other_patch]))
+                  &&  ((endIJK_vec[patch] < startIJK_vec[other_patch]) || (endIJK_vec[patch] > endIJK_vec[other_patch]));
+             }
+         }
+         disjoint = disjoint && patch_disjoint_with_otherPatches; // false if one of them is false
     }
-    return (all_bound_corners_count == no_repetition_bound_corners.size());
+    return disjoint;
 }
 
 const std::vector<int>
 CpGridData::getPatchesCells(const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const
 {
     std::vector<int> all_cells;
-    //auto all_cells_tmp_size = 0u;
     for (long unsigned int patch = 0; patch < startIJK_vec.size(); ++patch){
-        const auto& [cornes, faces, cells] = getPatchGeomIndices(startIJK_vec[patch], endIJK_vec[patch]);
-        //  all_cells_tmp_size += cells.size();
-        //  all_cells.reserve(all_cells_tmp_size);
-        for (const auto& cell : cells){
+        /// PATCH CELLS
+        for (const auto& cell : CpGridData::getPatchCells(startIJK_vec[patch], endIJK_vec[patch])){
             all_cells.push_back(cell);
         }
     }
@@ -2037,7 +2056,9 @@ CpGridData::refinePatch(const std::array<int,3>& cells_per_dim, const std::array
     cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>,1>& refined_face_normals = refined_grid.face_normals_;
     // Patch dimension (amount of cells in each direction).
     const auto& patch_dim = getPatchDim(startIJK, endIJK);
-    const auto& [patch_corners, patch_faces, patch_cells] = getPatchGeomIndices(startIJK, endIJK);
+    const auto& patch_corners = getPatchCorners(startIJK, endIJK);
+    const auto& patch_faces = getPatchFaces(startIJK, endIJK);
+    const auto& patch_cells = getPatchCells(startIJK, endIJK);
     // Construct the Geometry of the cellified patch.
     DefaultGeometryPolicy cellified_patch_geometry;
     std::array<int,8> cellifiedPatch_to_point;
@@ -2111,19 +2132,18 @@ CpGridData::refinePatch(const std::array<int,3>& cells_per_dim, const std::array
     for (int j = startIJK[1]; j < endIJK[1]; ++j) {
         for (int i = startIJK[0]; i < endIJK[0]+1; ++i) {
             for (int k = startIJK[2]; k < endIJK[2]; ++k) {
-                int face_idx = (j*grid_dim[1]*grid_dim[2]) + (i*grid_dim[2])+ k;
+                int face_idx = (j*(grid_dim[0]+1)*grid_dim[2]) + (i*grid_dim[2])+ k;
+                int l =  (i-startIJK[0])*cells_per_dim[0]; // l playing the role of the corresponding "i index" in the LGR
                 // To store new born faces, per face. CHILDREN-FACES ARE ORDERED AS IN refine(), Geometry.hpp
                 std::vector<int> children_list;  // I_FACE ikj (xzy-direction)
                 // l,m,n play the role of 'x,y,z-direction', lnm = fake ikj (how I_FACES are 'ordered' in refine())
-                for (int l = (i-startIJK[0])*cells_per_dim[0]; l < (i-startIJK[0]+1)*cells_per_dim[0]; ++l) {
-                    for (int n = (k-startIJK[2])*cells_per_dim[2];n < (k-startIJK[2]+1)*cells_per_dim[2]; ++n) {
-                        for (int m = (j-startIJK[1])*cells_per_dim[1]; m < (j-startIJK[1]+1)*cells_per_dim[1]; ++m) {
-                            children_list.push_back((xfactor*yfactor*(zfactor+1)) +(l*yfactor*zfactor) + (n*yfactor) + m);
-                            child_to_parent_faces.push_back({(xfactor*yfactor*(zfactor+1)) +(l*yfactor*zfactor)
-                                    + (n*yfactor) + m, face_idx});
-                        } // end m-for-loop
-                    } // end n-for-loop
-                } // end l-for-loop
+                for (int n = (k-startIJK[2])*cells_per_dim[2];n < (k-startIJK[2]+1)*cells_per_dim[2]; ++n) {
+                    for (int m = (j-startIJK[1])*cells_per_dim[1]; m < (j-startIJK[1]+1)*cells_per_dim[1]; ++m) {
+                        children_list.push_back((xfactor*yfactor*(zfactor+1)) +(l*yfactor*zfactor) + (n*yfactor) + m);
+                        child_to_parent_faces.push_back({(xfactor*yfactor*(zfactor+1)) +(l*yfactor*zfactor)
+                                + (n*yfactor) + m, face_idx});
+                    } // end m-for-loop
+                } // end n-for-loop
                 // Add parent information of each face to "parent_to_children_faces".
                 parent_to_children_faces.push_back(std::make_tuple(face_idx, children_list));
                 if ((i == startIJK[0]) || (i == endIJK[0])) { // Detecting if the face is on the patch boundary.
@@ -2139,19 +2159,18 @@ CpGridData::refinePatch(const std::array<int,3>& cells_per_dim, const std::array
         for (int i = startIJK[0]; i < endIJK[0]; ++i) {
             for (int k = startIJK[2]; k < endIJK[2]; ++k) {
                 int face_idx = i_grid_faces + (j*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2])+ k;
+                int m =  (j-startIJK[1])*cells_per_dim[1]; // m playing the role of the corresponding "j index" in the LGR
                 // To store new born faces, per face. CHILDREN FACES ARE ORDERED AS IN refine(), Geometry.hpp
                 std::vector<int> children_list;  // J_FACE jik (yxz-direction)
                 // l,m,n play the role of 'x,y,z-direction', mln = fake jik (how J_FACES are 'ordered' in refine())
-                for (int m = (j-startIJK[1])*cells_per_dim[1]; m < (j-startIJK[1]+1)*cells_per_dim[1]; ++m) {
-                    for (int l = (i-startIJK[0])*cells_per_dim[0]; l < (i-startIJK[0]+1)*cells_per_dim[0]; ++l) {
-                        for (int n = (k-startIJK[2])*cells_per_dim[2]; n < (k-startIJK[2]+1)*cells_per_dim[2]; ++n) {
-                            children_list.push_back((xfactor*yfactor*(zfactor+1)) + ((xfactor+1)*yfactor*zfactor)
-                                                    + (m*xfactor*zfactor) + (l*zfactor)+n);
-                            child_to_parent_faces.push_back({(xfactor*yfactor*(zfactor+1)) + ((xfactor+1)*yfactor*zfactor)
-                                    + (m*xfactor*zfactor) + (l*zfactor)+n, face_idx});
-                        } // end n-for-loop
-                    } // end l-for-loop
-                } // end m-for-loop
+                for (int l = (i-startIJK[0])*cells_per_dim[0]; l < (i-startIJK[0]+1)*cells_per_dim[0]; ++l) {
+                    for (int n = (k-startIJK[2])*cells_per_dim[2]; n < (k-startIJK[2]+1)*cells_per_dim[2]; ++n) {
+                        children_list.push_back((xfactor*yfactor*(zfactor+1)) + ((xfactor+1)*yfactor*zfactor)
+                                                + (m*xfactor*zfactor) + (l*zfactor)+n);
+                        child_to_parent_faces.push_back({(xfactor*yfactor*(zfactor+1)) + ((xfactor+1)*yfactor*zfactor)
+                                + (m*xfactor*zfactor) + (l*zfactor)+n, face_idx});
+                    } // end n-for-loop
+                } // end l-for-loop
                 // Add parent information of each face to "parent_to_children_faces".
                 parent_to_children_faces.push_back(std::make_tuple(face_idx, children_list));
                 if ((j == startIJK[1]) || (j == endIJK[1])) { // Detecting if face is on the patch boundary.
@@ -2166,18 +2185,17 @@ CpGridData::refinePatch(const std::array<int,3>& cells_per_dim, const std::array
     for (int j = startIJK[1]; j < endIJK[1]; ++j) {
         for (int i = startIJK[0]; i < endIJK[0]; ++i) {
             for (int k = startIJK[2]; k < endIJK[2]+1; ++k) {
-                int face_idx = i_grid_faces + j_grid_faces + (j*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2])+ k;
+                int face_idx = i_grid_faces + j_grid_faces + (j*grid_dim[0]*(grid_dim[2]+1)) + (i*(grid_dim[2]+1))+ k;
+                int n =  (k-startIJK[2])*cells_per_dim[2]; // n playing the role of the corresponding "k index" in the LGR
                 // To store new born faces, per face. CHILDREN FACES ARE ORDERED AS IN refine(), Geometry.hpp
                 std::vector<int> children_list;  // K_FACE kji (zyx-direction)
                 // l,m,n play the role of 'x,y,z-direction', nml = fake kji (how K_FACES are 'ordered' in refine())
-                for (int n = (k-startIJK[2])*cells_per_dim[2]; n < (k-startIJK[2]+1)*cells_per_dim[2]; ++n) {
-                    for (int m = (j-startIJK[1])*cells_per_dim[1]; m < (j-startIJK[1]+1)*cells_per_dim[1]; ++m) {
-                        for (int l = (i-startIJK[0])*cells_per_dim[0]; l < (i-startIJK[0]+1)*cells_per_dim[0]; ++l) {
-                            children_list.push_back((n*xfactor*yfactor) + (m*xfactor)+ l);
-                            child_to_parent_faces.push_back({(n*xfactor*yfactor) + (m*xfactor)+ l, face_idx});
-                        } // end m-for-loop
-                    } // end n-for-loop
-                } // end l-for-loop
+                for (int m = (j-startIJK[1])*cells_per_dim[1]; m < (j-startIJK[1]+1)*cells_per_dim[1]; ++m) {
+                    for (int l = (i-startIJK[0])*cells_per_dim[0]; l < (i-startIJK[0]+1)*cells_per_dim[0]; ++l) {
+                        children_list.push_back((n*xfactor*yfactor) + (m*xfactor)+ l);
+                        child_to_parent_faces.push_back({(n*xfactor*yfactor) + (m*xfactor)+ l, face_idx});
+                    } // end l-for-loop
+                } // end m-for-loop
                 // Add parent information of each face to "parent_to_children_faces".
                 parent_to_children_faces.push_back(std::make_tuple(face_idx, children_list));
                 if ((k == startIJK[2]) || (k == endIJK[2])) { // Detecting if the face is on the patch boundary.

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -7,6 +7,7 @@
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
 //            Bård Skaflestad     <bard.skaflestad@sintef.no>
 //            Markus Blatt        <markus@dr-blatt.de>
+//            Antonella Ritorto   <antonella.ritorto@opm-op.com>
 //
 // Comment: Major parts of this file originated in dune/grid/CpGrid.hpp
 //          and got transfered here during refactoring for the parallelization.
@@ -170,13 +171,12 @@ public:
     /// Constructor for parallel grid data.
     /// \param comm The MPI communicator
     /// Default constructor.
-    // explicit
-    CpGridData(MPIHelper::MPICommunicator comm,  std::vector<std::shared_ptr<CpGridData>>& data);
+    explicit CpGridData(MPIHelper::MPICommunicator comm,  std::vector<std::shared_ptr<CpGridData>>& data);
 
- 
+
     
     /// Constructor
-    explicit CpGridData(std::vector<std::shared_ptr<CpGridData>>& data);  // make it explicit?
+    explicit CpGridData(std::vector<std::shared_ptr<CpGridData>>& data);  
     /// Destructor
     ~CpGridData();
   
@@ -280,18 +280,34 @@ private:
     ///                        Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
     ///
     /// @return patch_dim Patch dimension {#cells in x-direction, #cells in y-direction, #cells in z-direction}.
-    const std::array<int,3> getPatchDim(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
+    std::array<int,3> getPatchDim(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
 
-    /// @brief Compute corner/face/cell indices of a patch of cells (Cartesian grid required).
+    /// @brief Compute corner indices of a patch of cells (Cartesian grid required).
     ///
     /// @param [in]  startIJK  Cartesian triplet index where the patch starts.
     /// @param [in]  endIJK    Cartesian triplet index where the patch ends.
     ///                        Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
     ///
-    /// @return patch_corners/patch_faces/patch_cells
-    const std::vector<int> getPatchCorners(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
-    const std::vector<int> getPatchFaces(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
-    const std::vector<int> getPatchCells(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
+    /// @return patch_corners
+    std::vector<int> getPatchCorners(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
+
+    /// @brief Compute face indices of a patch of cells (Cartesian grid required).
+    ///
+    /// @param [in]  startIJK  Cartesian triplet index where the patch starts.
+    /// @param [in]  endIJK    Cartesian triplet index where the patch ends.
+    ///                        Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
+    ///
+    /// @return patch_faces
+    std::vector<int> getPatchFaces(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
+
+    /// @brief Compute cell indices of a patch of cells (Cartesian grid required).
+    ///
+    /// @param [in]  startIJK  Cartesian triplet index where the patch starts.
+    /// @param [in]  endIJK    Cartesian triplet index where the patch ends.
+    ///                        Last cell part of the lgr will be {endIJK[0]-1, ... endIJK[2]-1}.
+    ///
+    /// @return patch_cells
+    std::vector<int> getPatchCells(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
 
     /// @brief Compute patch boundary corner indices (Cartesian grid required).
     ///
@@ -300,16 +316,23 @@ private:
     ///                        Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
     ///
     /// @return patch_boundary_corners
-    const std::vector<int> getPatchBoundaryCorners(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
-    
-    /// @brief Determine if a finite amount of patches (of cells) are disjoint, namely, they do not share any corner nor face. 
+    std::vector<int> getPatchBoundaryCorners(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
+
+    /// @brief Determine if a finite amount of patches (of cells) are disjoint, namely, they do not share any corner nor face.
     ///
     /// @param [in]  startIJK_vec  Vector of Cartesian triplet indices where each patch starts.
     /// @param [in]  endIJK_vec    Vector of Cartesian triplet indices where each patch ends.
     ///                            Last cell part of the lgr will be {endIJK_vec[<patch>][0]-1, ... ,endIJK_vec[<patch>][2]-1}.
     bool disjointPatches(const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
 
-    const std::vector<int>
+    /// @brief Compute cell indices of selected patches of cells (Cartesian grid required).
+    ///
+    /// @param [in]  startIJK_vec  Vector of Cartesian triplet indices where each patch starts.
+    /// @param [in]  endIJK_vec    Vector of Cartesian triplet indices where each patch ends.
+    ///                            Last cell part of the lgr will be {endIJK_vec[<patch>][0]-1, ... endIJK_vec[<patch>][2]-1}.
+    ///
+    /// @return allPatches_cells
+    std::vector<int>
     getPatchesCells(const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
 
     /// @brief Construct a 'fake cell (Geometry<3,3> object)' out of a patch of cells.(Cartesian grid required).
@@ -326,10 +349,10 @@ private:
     /// @param [out] allcorners_cellifiedPatch Required to build a Geometry<3,3> object.
     ///
     /// @return 'cellifiedPatchCell'         Geometry<3,3> object.
-    const Geometry<3,3> cellifyPatch(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK,
-                                     const std::vector<int>& patch_cells, DefaultGeometryPolicy& cellifiedPatch_geometry,
-                                     std::array<int,8>& cellifiedPatch_to_point,
-                                     std::array<int,8>& allcorners_cellifiedPatch) const;
+    Geometry<3,3> cellifyPatch(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK,
+                               const std::vector<int>& patch_cells, DefaultGeometryPolicy& cellifiedPatch_geometry,
+                               std::array<int,8>& cellifiedPatch_to_point,
+                               std::array<int,8>& allcorners_cellifiedPatch) const;
 
 public:
     /// @brief Refine a single cell and return a shared pointer of CpGridData type.
@@ -353,12 +376,12 @@ public:
     /// @return parent_to_children_faces/cell     For each parent face/cell, we store its child-face/cell indices.
     ///                                           {parent face/cell index in coarse level, {indices of its children in refined level}}
     /// @return child_to_parent_faces/cells       {child index, parent index}
-    const std::tuple< const std::shared_ptr<CpGridData>,
-                      const std::vector<std::array<int,2>>,                // parent_to_refined_corners(~boundary_old_to_new_corners)
-                      const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces (~boundary_old_to_new_faces)
-                      const std::tuple<int, std::vector<int>>,             // parent_to_children_cells
-                      const std::vector<std::array<int,2>>,                // child_to_parent_faces
-                      const std::vector<std::array<int,2>>>                // child_to_parent_cells
+    std::tuple< const std::shared_ptr<CpGridData>,
+                const std::vector<std::array<int,2>>,                // parent_to_refined_corners(~boundary_old_to_new_corners)
+                const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces (~boundary_old_to_new_faces)
+                const std::tuple<int, std::vector<int>>,             // parent_to_children_cells
+                const std::vector<std::array<int,2>>,                // child_to_parent_faces
+                const std::vector<std::array<int,2>>>                // child_to_parent_cells
     refineSingleCell(const std::array<int,3>& cells_per_dim, const int& parent_idx) const;
 
     /// @brief Refine a (connected block-shaped) patch of cells. Based on the patch, a Geometry<3,3> object is created and refined.
@@ -373,15 +396,15 @@ public:
     /// @return parent_to_children_faces/cell      For each parent face/cell, we store its child-face/cell indices.
     ///                                            {parent face/cell index in coarse level, {indices of its children in refined level}}
     /// @return child_to_parent_faces/cells        {child index, parent index}
-    const std::tuple< std::shared_ptr<CpGridData>,
-                      const std::vector<std::array<int,2>>,                // boundary_old_to_new_corners
-                      const std::vector<std::tuple<int,std::vector<int>>>, // boundary_old_to_new_faces
-                      const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces
-                      const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_cell
-                      const std::vector<std::array<int,2>>,                // child_to_parent_faces
-                      const std::vector<std::array<int,2>>>                // child_to_parent_cells
+    std::tuple< std::shared_ptr<CpGridData>,
+                const std::vector<std::array<int,2>>,                // boundary_old_to_new_corners
+                const std::vector<std::tuple<int,std::vector<int>>>, // boundary_old_to_new_faces
+                const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces
+                const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_cell
+                const std::vector<std::array<int,2>>,                // child_to_parent_faces
+                const std::vector<std::array<int,2>>>                // child_to_parent_cells
     refinePatch(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
-    
+
     // Make unique boundary ids for all intersections.
     void computeUniqueBoundaryIds();
 
@@ -621,7 +644,7 @@ private:
      */
     std::vector<int>                  global_cell_;
     /** @brief The tag of the faces. */
-    cpgrid::EntityVariable<enum face_tag, 1> face_tag_; 
+    cpgrid::EntityVariable<enum face_tag, 1> face_tag_;
     /** @brief The geometries representing the grid. */
     cpgrid::DefaultGeometryPolicy geometry_;
     /** @brief The type of a point in the grid. */
@@ -647,6 +670,8 @@ private:
     std::vector<int> level_to_leaf_cells_; // In entry 'level cell index', we store 'leafview cell index'
     /** Parent cells and their children. Entry is {-1, {}} when cell has no children.*/ // {level LGR, {child0, child1, ...}}
     std::vector<std::tuple<int,std::vector<int>>> parent_to_children_cells_; 
+    /** Amount of children cells per parent cell in each direction. */ // {# children in x-direction, ... y-, ... z-}
+    std::array<int,3> cells_per_dim_;
     // SUITABLE ONLY FOR LEAFVIEW
     /** Relation between leafview and (possible different) level(s) cell indices. */ // {level, cell index in that level}
     std::vector<std::array<int,2>> leaf_to_level_cells_;

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -282,15 +282,16 @@ private:
     /// @return patch_dim Patch dimension {#cells in x-direction, #cells in y-direction, #cells in z-direction}.
     const std::array<int,3> getPatchDim(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
 
-    /// @brief Compute corner, face, and cell indices of a patch of cells, as well as patch boundary face indices
-    ///        (Cartesian grid required).
+    /// @brief Compute corner/face/cell indices of a patch of cells (Cartesian grid required).
     ///
     /// @param [in]  startIJK  Cartesian triplet index where the patch starts.
     /// @param [in]  endIJK    Cartesian triplet index where the patch ends.
     ///                        Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
     ///
-    /// @return {patch_corners, patch_faces, patch_cells, patch_boundary_Ifaces, patch_boundary_Jfaces, patch_boundary_Kfaces}
-    const std::array<std::vector<int>,3> getPatchGeomIndices(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
+    /// @return patch_corners/patch_faces/patch_cells
+    const std::vector<int> getPatchCorners(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
+    const std::vector<int> getPatchFaces(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
+    const std::vector<int> getPatchCells(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
 
     /// @brief Compute patch boundary corner indices (Cartesian grid required).
     ///
@@ -638,19 +639,17 @@ private:
     /** @brief The indicator of the partition type of the entities */
     std::shared_ptr<PartitionTypeIndicator> partition_type_indicator_;
     /** Level of the current CpGridData (0 when it's "GLOBAL", 1,2,.. for LGRs, created via CpGrid::createGridWithLgrs()). */
-    int level_;
+    int level_{0};
     /** Copy of (CpGrid object).data_ associated with the CpGridData object, via created via CpGrid::createGridWithLgrs(). */
     std::vector<std::shared_ptr<CpGridData>>* level_data_ptr_;
     // SUITABLE FOR ALL LEVELS EXCEPT FOR LEAFVIEW
-    /** Map between level and leafview (maxLevel) cell indices. Only cells (from that level) that appear in leafview count. */  
-    std::map<int,int> level_to_leaf_cells_; // {level cell index, leafview cell index}
-    /** Parent cells and their children. Entry is {-1, {-1}} when cell has no children.*/ // {level LGR, {child0, child1, ...}}
+    /** Map between level and leafview cell indices. Only cells (from that level) that appear in leafview count. */  
+    std::vector<int> level_to_leaf_cells_; // In entry 'level cell index', we store 'leafview cell index'
+    /** Parent cells and their children. Entry is {-1, {}} when cell has no children.*/ // {level LGR, {child0, child1, ...}}
     std::vector<std::tuple<int,std::vector<int>>> parent_to_children_cells_; 
     // SUITABLE ONLY FOR LEAFVIEW
     /** Relation between leafview and (possible different) level(s) cell indices. */ // {level, cell index in that level}
     std::vector<std::array<int,2>> leaf_to_level_cells_;
-     /** Relation between all level cells and leafview cell indices. */ // {level, cell index in that level} -> leafview index
-    std::map<std::array<int,2>,int> allLevels_to_leaf_cells_; 
     // SUITABLE FOR ALL LEVELS INCLUDING LEAFVIEW
     /** Child cells and their parents. Entry is {-1,-1} when cell has no father. */ // {level parent cell, parent cell index}
     std::vector<std::array<int,2>> child_to_parent_cells_; 

--- a/opm/grid/cpgrid/DefaultGeometryPolicy.hpp
+++ b/opm/grid/cpgrid/DefaultGeometryPolicy.hpp
@@ -83,8 +83,7 @@ namespace Dune
                 static_assert(codim != 2, "");
                 return geomVector(std::integral_constant<int,codim>());
             }
-
-        private:
+            
             /// \brief Get cell geometry
             const EntityVariable<cpgrid::Geometry<3, 3>, 0>& geomVector(const std::integral_constant<int, 0>&) const
             {
@@ -119,6 +118,8 @@ namespace Dune
                 static_assert(codim==3, "Codim has to be 3");
                 return point_geom_;
             }
+            
+        private:
             EntityVariable<cpgrid::Geometry<3, 3>, 0> cell_geom_;
             EntityVariable<cpgrid::Geometry<2, 3>, 1> face_geom_;
             EntityVariable<cpgrid::Geometry<0, 3>, 3> point_geom_;

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -229,7 +229,7 @@ namespace Dune
             ///        Currently, LGR is built via refinement of a block-shaped patch from the coarse grid. So the LocalGeometry
             ///        of an entity coming from the LGR is one of the refined cells of the unit cube, with suitable amount of cells
             ///        in each direction.
-            Dune::cpgrid::Geometry<3,3> geometryInFather() const;
+            Dune::cpgrid::Geometry<3,3> geometryInFather();
             
             /// Returns true if any of my intersections are on the boundary.
             /// Implementation note:
@@ -301,7 +301,7 @@ namespace Dune
   HierarchicIterator Entity<codim>::hbegin(int maxLevel) const 
   {
       // Creates iterator with first child as target if there is one. Otherwise empty stack and target.
-      return HierarchicIterator(*this, maxLevel);
+      return HierarchicIterator(*pgrid_, *this, maxLevel);
   }
 
   /// Dummy beyond last child iterator.
@@ -449,13 +449,12 @@ Entity<0> Entity<codim>::father() const
 }
 
 template<int codim>
-Dune::cpgrid::Geometry<3,3> Dune::cpgrid::Entity<codim>::geometryInFather() const
+Dune::cpgrid::Geometry<3,3> Dune::cpgrid::Entity<codim>::geometryInFather() 
 {
     if (!(this->hasFather())){
         OPM_THROW(std::logic_error, "Entity has no father.");
     }
     else{
-#if 0
         //
         DefaultGeometryPolicy local_geometry;
         std::array<int,8> localEntity_to_point;
@@ -500,9 +499,6 @@ Dune::cpgrid::Geometry<3,3> Dune::cpgrid::Entity<codim>::geometryInFather() cons
         // Construct (and return) the Geometry<3,3> of the 'cellified patch'.
         return Dune::cpgrid::Geometry<3,3>(local_center, local_volume,
                                            local_geometry.geomVector<codim>(), localEntity_indices_storage_ptr);
-#endif
-        OPM_THROW(std::logic_error, "geometryInFather() not implemented");
-        return {};
     }
 }
 

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -6,6 +6,7 @@
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
 //            Brd Skaflestad     <bard.skaflestad@sintef.no>
+//            Antonella Ritorto   <antonella.ritorto@opm-op.com>
 //
 // $Date$
 //
@@ -41,6 +42,7 @@
 #include <dune/grid/common/gridenums.hh>
 
 #include "PartitionTypeIndicator.hpp"
+#include <opm/grid/cpgrid/DefaultGeometryPolicy.hpp>
 
 
 namespace Dune
@@ -113,13 +115,19 @@ namespace Dune
 
             /// Constructor taking a grid and an entity representation.
             Entity(const CpGridData& grid, EntityRep<codim> entityrep)
-                : EntityRep<codim>(entityrep), pgrid_(&grid)
+                : EntityRep<codim>(entityrep), pgrid_(&grid), local_geometry_indices_storage_ptr(0)
             {
             }
 
             /// Constructor taking a grid, entity index, and orientation.
             Entity(const CpGridData& grid, int index_arg, bool orientation_arg)
-                : EntityRep<codim>(index_arg, orientation_arg), pgrid_(&grid)
+                : EntityRep<codim>(index_arg, orientation_arg), pgrid_(&grid), local_geometry_indices_storage_ptr(0)
+            {
+            }
+
+            /// Constructor taking a entity index, and orientation.
+            Entity(int index_arg, bool orientation_arg)
+                : EntityRep<codim>(index_arg, orientation_arg), pgrid_(), local_geometry_indices_storage_ptr(0)
             {
             }
 
@@ -224,12 +232,12 @@ namespace Dune
             /// @return father-entity
             Entity<0> father() const; 
 
-            /// @brief Return LocalGeometry representing the embedding of the entity inti its father (when hasFather() is true).
+            /// @brief Return LocalGeometry representing the embedding of the entity into its father (when hasFather() is true).
             ///        Map from the entity's reference element into the reference element of its father.
             ///        Currently, LGR is built via refinement of a block-shaped patch from the coarse grid. So the LocalGeometry
             ///        of an entity coming from the LGR is one of the refined cells of the unit cube, with suitable amount of cells
             ///        in each direction.
-            Dune::cpgrid::Geometry<3,3> geometryInFather();
+            Dune::cpgrid::Geometry<3,3> geometryInFather() const;
             
             /// Returns true if any of my intersections are on the boundary.
             /// Implementation note:
@@ -255,6 +263,8 @@ namespace Dune
 
         protected:
             const CpGridData* pgrid_;
+            DefaultGeometryPolicy local_geometry_;
+            const int* local_geometry_indices_storage_ptr;
         };
 
     } // namespace cpgrid
@@ -301,7 +311,7 @@ namespace Dune
   HierarchicIterator Entity<codim>::hbegin(int maxLevel) const 
   {
       // Creates iterator with first child as target if there is one. Otherwise empty stack and target.
-      return HierarchicIterator(*pgrid_, *this, maxLevel);
+      return HierarchicIterator(*this, maxLevel);
   }
 
   /// Dummy beyond last child iterator.
@@ -383,7 +393,7 @@ bool Entity<codim>::hasBoundaryIntersections() const
 template <int codim>
 bool Entity<codim>::isValid() const
 {
-    return pgrid_ ? EntityRep<codim>::index() < pgrid_->size(codim) : false;
+    return pgrid_ ?  EntityRep<codim>::index() < pgrid_->size(codim) : false;
 }
 
 
@@ -440,7 +450,7 @@ Entity<0> Entity<codim>::father() const
     if (this->hasFather()){
         const int& coarse_level = pgrid_ -> child_to_parent_cells_[this->index()][0]; // currently, always 0
         const int& parent_index = pgrid_ -> child_to_parent_cells_[this->index()][1];
-        const auto& coarse_grid = (*(pgrid_ -> level_data_ptr_))[coarse_level].get(); 
+        const auto& coarse_grid = (*(pgrid_ -> level_data_ptr_))[coarse_level].get();
         return Entity<0>( *coarse_grid, parent_index, true);
     }
     else{
@@ -449,41 +459,70 @@ Entity<0> Entity<codim>::father() const
 }
 
 template<int codim>
-Dune::cpgrid::Geometry<3,3> Dune::cpgrid::Entity<codim>::geometryInFather() 
+Dune::cpgrid::Geometry<3,3> Dune::cpgrid::Entity<codim>::geometryInFather() const
 {
     if (!(this->hasFather())){
         OPM_THROW(std::logic_error, "Entity has no father.");
     }
     else{
         //
-        DefaultGeometryPolicy local_geometry;
-        std::array<int,8> localEntity_to_point;
+        DefaultGeometryPolicy local_geometry = this -> local_geometry_;
         std::array<int,8> allcorners_localEntity;
-        EntityVariableBase<cpgrid::Geometry<0,3>>& local_corners = local_geometry.geomVector<codim>();
+        Dune::cpgrid::EntityVariableBase<cpgrid::Geometry<0,3>>& local_corners
+            = local_geometry.geomVector(std::integral_constant<int,3>());
         local_corners.resize(8);
         // Get IJK index of the entity.
         std::array<int,3> eIJK;
-        pgrid_ -> getIJK(this->index(), eIJK);
-        // Get dimension of the grid.
-        const auto& grid_dim = pgrid_ -> logicalCartesianSize(); // {cells_per_dim[0]*patch_dim[0] ...[1], ...[2]}
+        // Get the amount of children cell in each direction of the parent cell of the entity (same for all parents of each LGR)
+        std::array<int,3> cells_per_dim;
+        // Get "child0" IJK in the LGR
+        std::array<int,3> child0_IJK;
+        const auto& level0_grid =  (*(pgrid_->level_data_ptr_))[0];
+        const auto& child0_Idx = std::get<1>((*level0_grid).parent_to_children_cells_[this->father().index()])[0];
+        // If pgrid_ is the leafview, go to the LGR where the entity was born to get its IJK index in the LGR and the LGR dimension.
+        if (pgrid_ == (*(pgrid_->level_data_ptr_)).back().get()) // checking if pgrid_ is the LeafView 
+        {
+           const auto& lgr_grid = (*(pgrid_->level_data_ptr_))[this -> level()];
+           cells_per_dim = (*lgr_grid).cells_per_dim_;
+           
+           const auto& entity_lgrIdx = pgrid_ -> leaf_to_level_cells_[this->index()][1]; // leaf_to_level_cells_[cell] = {level, index} 
+           (*lgr_grid).getIJK(entity_lgrIdx, eIJK);
+           (*lgr_grid).getIJK(child0_Idx, child0_IJK);
+        }
+        else // Getting grid dimension and IJK entity index when pgrid_ is an LGR
+        {
+            pgrid_ -> getIJK(this->index(), eIJK);
+            cells_per_dim = pgrid_ -> cells_per_dim_;
+            pgrid_ -> getIJK(child0_Idx, child0_IJK);
+        }
+        // Transform the local coordinates that comes from the refinemnet in such a way that the
+        // reference element of each parent cell is the unit cube. Here, eIJK[*]/cells_per_dim[*]
         // Get the local coordinates of the entity (in the reference unit cube).
         const std::vector<FieldVector<double, 3>>& local_corners_temp = {
             // corner '0'
-            { double(eIJK[0])/grid_dim[0], double(eIJK[1])/grid_dim[1], double(eIJK[2])/grid_dim[2] },
+            { double(eIJK[0]-child0_IJK[0])/cells_per_dim[0], double(eIJK[1]-child0_IJK[1])/cells_per_dim[1],
+              double(eIJK[2]-child0_IJK[2])/cells_per_dim[2] },
             // corner '1'
-            { (double(eIJK[0])+1)/grid_dim[0], double(eIJK[1])/grid_dim[1], double(eIJK[2])/grid_dim[2] },
+            { double(eIJK[0]-child0_IJK[0]+1)/cells_per_dim[0], double(eIJK[1]-child0_IJK[1])/cells_per_dim[1],
+              double(eIJK[2]-child0_IJK[2])/cells_per_dim[2] },
             // corner '2'
-            { double(eIJK[0])/grid_dim[0], (double(eIJK[1])+1)/grid_dim[1], double(eIJK[2])/grid_dim[2] },
+            { double(eIJK[0]-child0_IJK[0])/cells_per_dim[0], double(eIJK[1]-child0_IJK[1]+1)/cells_per_dim[1],
+              double(eIJK[2]-child0_IJK[2])/cells_per_dim[2] },
             // corner '3'
-            { (double(eIJK[0])+1)/grid_dim[0], (double(eIJK[1])+1)/grid_dim[1], double(eIJK[2])/grid_dim[2] },
+            { double(eIJK[0]-child0_IJK[0]+1)/cells_per_dim[0], double(eIJK[1]-child0_IJK[1]+1)/cells_per_dim[1],
+              double(eIJK[2]-child0_IJK[2])/cells_per_dim[2] },
             // corner '4'
-            { double(eIJK[0])/grid_dim[0], double(eIJK[1])/grid_dim[1], (double(eIJK[2])+1)/grid_dim[2] },
+            { double(eIJK[0]-child0_IJK[0])/cells_per_dim[0], double(eIJK[1]-child0_IJK[1])/cells_per_dim[1],
+              double(eIJK[2]-child0_IJK[2]+1)/cells_per_dim[2] },
             // corner '5'
-            { (double(eIJK[0])+1)/grid_dim[0], double(eIJK[1])/grid_dim[1], (double(eIJK[2])+1)/grid_dim[2] },
+            { double(eIJK[0]-child0_IJK[0]+1)/cells_per_dim[0], double(eIJK[1]-child0_IJK[1])/cells_per_dim[1],
+              double(eIJK[2]-child0_IJK[2]+1)/cells_per_dim[2] },
             // corner '6'
-            { double(eIJK[0])/grid_dim[0], (double(eIJK[1])+1)/grid_dim[1], (double(eIJK[2])+1)/grid_dim[2] },
+            { double(eIJK[0]-child0_IJK[0])/cells_per_dim[0], double(eIJK[1]-child0_IJK[1]+1)/cells_per_dim[1],
+              double(eIJK[2]-child0_IJK[2]+1)/cells_per_dim[2] },
             // corner '7'
-            { (double(eIJK[0])+1)/grid_dim[0], (double(eIJK[1])+1)/grid_dim[1], (double(eIJK[2])+1)/grid_dim[2] }};
+            { double(eIJK[0]-child0_IJK[0]+1)/cells_per_dim[0], double(eIJK[1]-child0_IJK[1]+1)/cells_per_dim[1],
+              double(eIJK[2]-child0_IJK[2]+1)/cells_per_dim[2] }};
         // Compute the center of the 'local-entity'.
         Dune::FieldVector<double, 3> local_center = {0., 0.,0.};
         for (int corn = 0; corn < 8; ++corn) {
@@ -491,15 +530,17 @@ Dune::cpgrid::Geometry<3,3> Dune::cpgrid::Entity<codim>::geometryInFather()
             local_center += local_corners[corn].center()/8.;
         }
         // Compute the volume of the 'local-entity'.
-        double local_volume = double(1)/(grid_dim[0]*grid_dim[1]*grid_dim[2]);
+        double local_volume = double(1)/(cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]);
         // Indices of 'all the corners', in this case, 0-7 (required to construct a Geometry<3,3> object).
-        allcorners_localEntity= {0,1,2,3,4,5,6,7};
+        allcorners_localEntity = {0,1,2,3,4,5,6,7};
         // Create a pointer to the first element of "cellfiedPatch_to_point" (required to construct a Geometry<3,3> object).
-        const int* localEntity_indices_storage_ptr = &allcorners_localEntity[0];
+        const int* localEntity_indices_storage_ptr = this -> local_geometry_indices_storage_ptr;
+        localEntity_indices_storage_ptr = &allcorners_localEntity[0];
         // Construct (and return) the Geometry<3,3> of the 'cellified patch'.
-        return Dune::cpgrid::Geometry<3,3>(local_center, local_volume,
-                                           local_geometry.geomVector<codim>(), localEntity_indices_storage_ptr);
+        return Dune::cpgrid::Geometry<3,3>(local_center, local_volume, local_geometry.geomVector(std::integral_constant<int,3>()),
+                                           localEntity_indices_storage_ptr);
     }
+    
 }
 
 

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -55,7 +55,6 @@ namespace Dune
        class CpGridData;
        class LevelGlobalIdSet;
 
-
         /// @brief
         /// @todo Doc me!
         /// @tparam
@@ -412,6 +411,7 @@ int Entity<codim>::level() const
 // - if distrubuted_data_ is NOT empty: there may be children on a different process. Therefore,
 // isLeaf() returns true <-> the element is a leaf entity of the global refinement hierarchy. Equivalently,
 // it can be checked whether parent_to_children_cells_ is empty.
+
 template<int codim>
 bool Entity<codim>::isLeaf() const
 {
@@ -426,25 +426,26 @@ bool Entity<codim>::isLeaf() const
 template<int codim>
 bool Entity<codim>::hasFather() const
 {
-    if (pgrid_ -> child_to_parent_cells_.empty()){
+    if ((pgrid_ -> child_to_parent_cells_.empty()) || (pgrid_ -> child_to_parent_cells_[this->index()][0] == -1)){
         return false;
     }
     else{
-        const auto& [level, parent] = pgrid_-> child_to_parent_cells_[this->index()]; // {-1,-1};
-        return  (parent != -1);
+        return true;
     }
 }
 
 template<int codim>
 Entity<0> Entity<codim>::father() const
 {
-    if (!(this->hasFather())){
-        OPM_THROW(std::logic_error, "Entity has no father.");
+    if (this->hasFather()){
+        const int& coarse_level = pgrid_ -> child_to_parent_cells_[this->index()][0]; // currently, always 0
+        const int& parent_index = pgrid_ -> child_to_parent_cells_[this->index()][1];
+        const auto& coarse_grid = (*(pgrid_ -> level_data_ptr_))[coarse_level].get(); 
+        return Entity<0>( *coarse_grid, parent_index, true);
     }
-    const int& coarse_level = pgrid_ -> child_to_parent_cells_[this->index()][0];
-    const int& parent_index = pgrid_ -> child_to_parent_cells_[this->index()][1];
-    const auto& coarse_grid = (*(pgrid_ -> level_data_ptr_))[coarse_level].get(); 
-    return Entity<0>( *coarse_grid, parent_index, true); 
+    else{
+        OPM_THROW(std::logic_error, "Entity has no father.");
+    }   
 }
 
 template<int codim>
@@ -504,6 +505,7 @@ Dune::cpgrid::Geometry<3,3> Dune::cpgrid::Entity<codim>::geometryInFather() cons
         return {};
     }
 }
+
 
 } // namespace cpgrid
 } // namespace Dune

--- a/opm/grid/cpgrid/Geometry.hpp
+++ b/opm/grid/cpgrid/Geometry.hpp
@@ -6,6 +6,7 @@
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
 //            B�rd Skaflestad     <bard.skaflestad@sintef.no>
+//            Antonella Ritorto   <antonella.ritorto@opm-op.com>
 //
 // $Date$
 //

--- a/opm/grid/cpgrid/Indexsets.hpp
+++ b/opm/grid/cpgrid/Indexsets.hpp
@@ -73,7 +73,7 @@ namespace Dune
             /// @brief
             /// @todo Doc me!
             /// @param
-            IndexSet(){}
+            IndexSet() : IndexSet(0,0){}
             
             IndexSet(std::size_t numCells, std::size_t numPoints)
             {

--- a/opm/grid/cpgrid/Iterators.cpp
+++ b/opm/grid/cpgrid/Iterators.cpp
@@ -4,7 +4,7 @@
 //
 // Created: Mon February 20  14:02:00 2023
 //
-// Author(s): Antonella Ritorto <antonella.ritortoopm-op.com>  ??? TO BE DOUBLE-CHECKED 
+// Author(s): Antonella Ritorto <antonella.ritorto@opm-op.com> 
 //            
 //
 // $Date$
@@ -43,11 +43,12 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 void Dune::cpgrid::HierarchicIterator::stackChildren_(const Entity<0>& target)
 {
     // Load sons of target onto the iterator stack
-    if (target.level() < maxLevel_ && !target.isLeaf()){
-        const auto& children_list_indices = std::get<1>(target.pgrid_ -> parent_to_children_cells_[target.index()]);
+    if (!target.isLeaf() && (target.level() < maxLevel_)){
+        const auto& [lgr_level, children_list] = target.pgrid_-> parent_to_children_cells_[target.index()];
         // GET CHILD GRID
-        for (const auto& child : children_list_indices){
-            this->elemStack_.push(Entity<0>(*(target.pgrid_), child, true)); // CORRECT THE CPGRIDDATA, GET THE CHILD-GRID
+        const auto& lgr_grid =  (*(target.pgrid_-> level_data_ptr_))[lgr_level];
+        for (const auto& child : children_list){
+            this->elemStack_.push(Entity<0>(*lgr_grid, child, true));
         }
     }
 }
@@ -55,6 +56,6 @@ void Dune::cpgrid::HierarchicIterator::resetEntity_()
 {
     // Create an invalid entity, to set in case elemStack_ is empty.
     // Otherwise, a pointer pointing at the to element of elemStack_.
-    virtualEntity_ = elemStack_.empty() ? Entity<0>() : elemStack_.top();
+    virtualEntity_ = elemStack_.empty() ? Entity<0>(Entity<0>::InvalidIndex, true) : elemStack_.top();
 }
 

--- a/tests/cpgrid/grid_lgr_test.cpp
+++ b/tests/cpgrid/grid_lgr_test.cpp
@@ -66,7 +66,7 @@ void check_refinedPatch_grid(const std::array<int,3> cells_per_dim,
 {
     const std::array<int,3> patch_dim = {end_ijk[0]-start_ijk[0], end_ijk[1]-start_ijk[1], end_ijk[2]-start_ijk[2]};
     if ((patch_dim[0] == 0) || (patch_dim[1] == 0) || (patch_dim[2] == 0)) {
-                    OPM_THROW(std::logic_error, "Empty patch. Cannot convert patch into cell.");
+        OPM_THROW(std::logic_error, "Empty patch. Cannot convert patch into cell.");
     }
     // Check amount of refined faces.
     int count_faces = (cells_per_dim[0]*patch_dim[0]*cells_per_dim[1]*patch_dim[1]*((cells_per_dim[2]*patch_dim[2])+1)) // 'bottom/top faces'
@@ -80,7 +80,7 @@ void check_refinedPatch_grid(const std::array<int,3> cells_per_dim,
     int count_cells = cells_per_dim[0]*patch_dim[0]*cells_per_dim[1]*patch_dim[1]*cells_per_dim[2]*patch_dim[2];
     BOOST_CHECK_EQUAL(refined_cells.size(), count_cells);
 
-   
+
 }
 
 void refinePatch_and_check(Dune::CpGrid& coarse_grid,
@@ -93,25 +93,21 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
     const bool are_disjoint = (*data[0]).disjointPatches(startIJK_vec, endIJK_vec);
     if (are_disjoint){
         coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec);
-      
-        BOOST_CHECK(data.size() == startIJK_vec.size() + 2);
-        BOOST_CHECK( (*coarse_grid.data_[0]).child_to_parent_cells_.empty());
 
-        const auto& all_parent_cell_indices = (*coarse_grid.data_[0]).getPatchesCells(startIJK_vec, endIJK_vec);
-        // const std::vector<int>& no_children = {-1};
-        // const auto& noLevel_noChildren = std::make_tuple(-1, no_children); // {-1, {-1}} representing no level, no children
-        
-    
+        BOOST_CHECK(data.size() == startIJK_vec.size() + 2);
+        BOOST_CHECK( (*data[0]).child_to_parent_cells_.empty());
+
+        const auto& all_parent_cell_indices = (*data[0]).getPatchesCells(startIJK_vec, endIJK_vec);
+
         for (long unsigned int level = 1; level < startIJK_vec.size() +1; ++level) // only 1 when there is only 1 patch
         {
             check_refinedPatch_grid(cells_per_dim_vec[level-1], startIJK_vec[level-1], endIJK_vec[level-1],
-                                    (*coarse_grid.data_[level]).geometry_.template geomVector<0>(),
-                                    (*coarse_grid.data_[level]).geometry_.template geomVector<1>(),
-                                    (*coarse_grid.data_[level]).geometry_.template geomVector<3>());
-            BOOST_CHECK( (*coarse_grid.data_[level]).parent_to_children_cells_.empty());
+                                    (*data[level]).geometry_.template geomVector<0>(),
+                                    (*data[level]).geometry_.template geomVector<1>(),
+                                    (*data[level]).geometry_.template geomVector<3>());
+            BOOST_CHECK( (*data[level]).parent_to_children_cells_.empty());
 
-            const auto& [patch_corners, patch_faces, patch_cells]
-                = (*coarse_grid.data_[0]).getPatchGeomIndices(startIJK_vec[level-1], endIJK_vec[level-1]);
+            const auto& patch_cells = (*data[0]).getPatchCells(startIJK_vec[level-1], endIJK_vec[level-1]);
 
             // GLOBAL grid
             for (int cell = 0; cell<  data[0]-> size(0); ++cell)
@@ -119,17 +115,19 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
                 Dune::cpgrid::Entity<0> entity = Dune::cpgrid::Entity<0>((*coarse_grid.data_[0]), cell, true);
                 BOOST_CHECK( entity.hasFather() == false);
                 BOOST_CHECK_THROW(entity.father(), std::logic_error);
-                const auto& parent_to_children = (*coarse_grid.data_[0]).parent_to_children_cells_[cell]; 
+                const auto& parent_to_children = (*coarse_grid.data_[0]).parent_to_children_cells_[cell];
                 if (std::find(all_parent_cell_indices.begin(), all_parent_cell_indices.end(), cell) == all_parent_cell_indices.end()){
                     BOOST_CHECK_EQUAL(std::get<0>(parent_to_children), -1);
-                    BOOST_CHECK_EQUAL(std::get<1>(parent_to_children)[0], -1);
+                    BOOST_CHECK(std::get<1>(parent_to_children).empty());
                     BOOST_CHECK( entity.isLeaf() == true);
                 }
                 else{
                     BOOST_CHECK( std::get<0>(parent_to_children) != -1);
-                    BOOST_CHECK( std::get<1>(parent_to_children).size() > 1 ); 
-                    for (long unsigned int child = 0; child < std::get<1>(parent_to_children).size(); ++child){
-                         BOOST_CHECK( std::get<1>(parent_to_children)[child] != -1);
+                    BOOST_CHECK( std::get<1>(parent_to_children).size() > 1);
+                    for (const auto& child : std::get<1>(parent_to_children)){
+                        BOOST_CHECK( child != -1);
+                        BOOST_CHECK( data[std::get<0>(parent_to_children)] -> child_to_parent_cells_[child][0] == 0);
+                        BOOST_CHECK( data[std::get<0>(parent_to_children)] -> child_to_parent_cells_[child][1] == cell);
                     }
                     BOOST_CHECK_EQUAL( entity.isLeaf(), false); // parent cells do not appear in the LeafView
                 }
@@ -143,11 +141,19 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
                 BOOST_CHECK(entity.father().level() == 0);
                 // Check entity.father().index() belongs to the patch_cells (corresponding LGR parents)
                 BOOST_CHECK_EQUAL((std::find(patch_cells.begin(), patch_cells.end(),
-                                            entity.father().index()) == patch_cells.end()) , false);
-                const auto& child_to_parent = (*coarse_grid.data_[level]).child_to_parent_cells_[cell];
+                                             entity.father().index()) == patch_cells.end()) , false);
+                const auto& child_to_parent = (*data[level]).child_to_parent_cells_[cell];
                 BOOST_CHECK_EQUAL( child_to_parent[0] == -1, false);
                 BOOST_CHECK_EQUAL( child_to_parent[0] == 0, true);
                 BOOST_CHECK_EQUAL( child_to_parent[1], entity.father().index());
+                BOOST_CHECK( std::get<0>((*data[0]).parent_to_children_cells_[child_to_parent[1]]) == entity.level());
+                BOOST_CHECK_EQUAL((std::find(std::get<1>((*data[0]).parent_to_children_cells_[child_to_parent[1]]).begin(),
+                                             std::get<1>((*data[0]).parent_to_children_cells_[child_to_parent[1]]).end(),
+                                             entity.index()) ==
+                                   std::get<1>((*data[0]).parent_to_children_cells_[child_to_parent[1]]).end()) , false);
+                // Check amount of children cells of the parent cell
+                BOOST_CHECK_EQUAL(std::get<1>((*data[0]).parent_to_children_cells_[child_to_parent[1]]).size(),
+                                  cells_per_dim_vec[level-1][0]*cells_per_dim_vec[level-1][1]*cells_per_dim_vec[level-1][2]);
                 BOOST_CHECK( entity.level() == static_cast<int>(level));
                 BOOST_CHECK( entity.isLeaf() == true);
             }
@@ -155,7 +161,8 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
             for (int cell = 0; cell <  data[startIJK_vec.size()+1]-> size(0); ++cell)
             {
                 Dune::cpgrid::Entity<0> entity = Dune::cpgrid::Entity<0>((*coarse_grid.data_[startIJK_vec.size()+1]), cell, true);
-                const auto& child_to_parent = (*coarse_grid.data_[startIJK_vec.size()+1]).child_to_parent_cells_[cell];
+                const auto& child_to_parent = (*data[startIJK_vec.size()+1]).child_to_parent_cells_[cell];
+                const auto& level_cellIdx = (*data[startIJK_vec.size()+1]).leaf_to_level_cells_[entity.index()];
                 if (entity.hasFather()){
                     BOOST_CHECK(entity.father().level() == 0);
                     BOOST_CHECK_EQUAL( (std::find(all_parent_cell_indices.begin(), all_parent_cell_indices.end(),
@@ -163,22 +170,151 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
                     BOOST_CHECK(child_to_parent[0] != -1);
                     BOOST_CHECK_EQUAL( child_to_parent[0] == 0, true);
                     BOOST_CHECK_EQUAL( child_to_parent[1], entity.father().index());
+                    BOOST_CHECK( std::get<0>((*data[0]).parent_to_children_cells_[child_to_parent[1]]) == entity.level());
+                    BOOST_CHECK_EQUAL((std::find(std::get<1>((*data[0]).parent_to_children_cells_[child_to_parent[1]]).begin(),
+                                                 std::get<1>((*data[0]).parent_to_children_cells_[child_to_parent[1]]).end(),
+                                                 level_cellIdx[1]) ==
+                                       std::get<1>((*data[0]).parent_to_children_cells_[child_to_parent[1]]).end()) , false);
+                    // Check amount of children cells of the parent cell
+                    BOOST_CHECK_EQUAL(std::get<1>((*data[0]).parent_to_children_cells_[child_to_parent[1]]).size(),
+                                      cells_per_dim_vec[entity.level()-1][0]*
+                                      cells_per_dim_vec[entity.level()-1][1]*cells_per_dim_vec[entity.level()-1][2]);
                     BOOST_CHECK( entity.father().isLeaf() == false);
                     BOOST_CHECK( (entity.level() > 0) || (entity.level() < static_cast<int>(startIJK_vec.size()) +1));
+                    BOOST_CHECK( level_cellIdx[0] == entity.level());
                 }
                 else{
                     BOOST_CHECK_THROW(entity.father(), std::logic_error);
                     BOOST_CHECK_EQUAL(child_to_parent[0], -1);
+                    BOOST_CHECK_EQUAL(child_to_parent[1], -1);
+                    BOOST_CHECK( level_cellIdx[0] == 0);
+                    BOOST_CHECK( std::get<0>((*data[0]).parent_to_children_cells_[level_cellIdx[1]]) == -1);
+                    BOOST_CHECK( std::get<1>((*data[0]).parent_to_children_cells_[level_cellIdx[1]]).empty());
                     BOOST_CHECK( entity.level() == 0);
-                }
+                    // Get index of the cell in level 0
+                    const auto& entityOldIdx =  (*data[startIJK_vec.size()+1]).leaf_to_level_cells_[entity.index()][1];
+                    // Get IJK of the old index
+                    std::array<int,3> entityOldIJK;
+                    (*data[0]).getIJK(entityOldIdx, entityOldIJK); // ijk
+                    // Get the entity cell_to_face_ on the LeafView
+                    const auto& leaf_cell_to_face =
+                        (*data[startIJK_vec.size()+1]).cell_to_face_[Dune::cpgrid::EntityRep<0>(entity.index(), true)];
+                    int face_count = 0;
+                    bool touch_patch_onLeftFace = false; // false -> 0, true -> 1
+                    bool touch_patch_onRightFace = false;
+                    bool touch_patch_onFrontFace = false;
+                    bool touch_patch_onBackFace = false;
+                    bool touch_patch_onBottomFace = false;
+                    bool touch_patch_onTopFace = false;
+                    for (long unsigned int patch = 0; patch < startIJK_vec.size(); ++patch)
+                    {
+                        // LEFT Check if i == endIJK_vec[patch][0] (and j, k in the range) for some patch.
+                        // If true, increase amount of faces by cells_per_dim_vec[patch][1]*cells_per_dim_vec[patch][2]
+                        // RIGHT Check if i+1 == startIJK_vec[patch][0] (and j, k in the range) for some patch.
+                        // If true, increase amount of faces by cells_per_dim_vec[patch][1]*cells_per_dim_vec[patch][2]
+                        // Auxiliary bools
+                        touch_patch_onLeftFace = touch_patch_onLeftFace ||
+                            ((entityOldIJK[0] == endIJK_vec[patch][0]) &&
+                             (entityOldIJK[1] >= startIJK_vec[patch][1]) && (entityOldIJK[1] < endIJK_vec[patch][1]) &&
+                             (entityOldIJK[2] >= startIJK_vec[patch][2]) && (entityOldIJK[2] < endIJK_vec[patch][2]));
+                        touch_patch_onRightFace = touch_patch_onRightFace ||
+                            ((entityOldIJK[0]+1 == startIJK_vec[patch][0]) &&
+                             (entityOldIJK[1] >= startIJK_vec[patch][1]) && (entityOldIJK[1] < endIJK_vec[patch][1]) &&
+                             (entityOldIJK[2] >= startIJK_vec[patch][2]) && (entityOldIJK[2] < endIJK_vec[patch][2]));
+                        if (touch_patch_onLeftFace || touch_patch_onRightFace) // true when at lesat one is true
+                        {
+                            face_count += (touch_patch_onLeftFace + touch_patch_onRightFace)*
+                                (cells_per_dim_vec[patch][1]*cells_per_dim_vec[patch][2]);
+                            // when both are true, we summ twice, otherwise, we sum once.
+                            break;
+                        }
+                    } // end patch-for-loop
+                    for (long unsigned int patch = 0; patch < startIJK_vec.size(); ++patch)
+                    {
+                        // FRONT Check if j == endIJK_vec[patch][1] (and i, k in the range) for some patch.
+                        // If true, increase amount of faces by cells_per_dim_vec[patch][0]*cells_per_dim_vec[patch][2]
+                        // BACK Check if j+1 == statIJK_vec[patch][1] (and i, k in the range) for some patch.
+                        // If true, increase amount of faces by cells_per_dim_vec[patch][0]*cells_per_dim_vec[patch][2]
+                        // Auxiliary bools
+                        touch_patch_onFrontFace = touch_patch_onFrontFace ||
+                            ((entityOldIJK[1] == endIJK_vec[patch][1]) &&
+                             (entityOldIJK[0] >= startIJK_vec[patch][0]) && (entityOldIJK[0] < endIJK_vec[patch][0]) &&
+                             (entityOldIJK[2] >= startIJK_vec[patch][2]) && (entityOldIJK[2] < endIJK_vec[patch][2]));
+                        touch_patch_onBackFace = touch_patch_onBackFace ||
+                            ((entityOldIJK[1]+1 == startIJK_vec[patch][1]) &&
+                             (entityOldIJK[0] >= startIJK_vec[patch][0]) && (entityOldIJK[0] < endIJK_vec[patch][0]) &&
+                             (entityOldIJK[2] >= startIJK_vec[patch][2]) && (entityOldIJK[2] < endIJK_vec[patch][2]));
+                        if (touch_patch_onFrontFace || touch_patch_onBackFace)
+                        {
+                            face_count +=  (touch_patch_onFrontFace + touch_patch_onBackFace)*
+                                (cells_per_dim_vec[patch][0]*cells_per_dim_vec[patch][2]);
+                            break;
+                        }
+                    } // end patch-for-loop
+                    for (long unsigned int patch = 0; patch < startIJK_vec.size(); ++patch)
+                    {
+                        // BOTTOM Check if k == endIJK_vec[patch][2] (and i, j in the range) for some patch.
+                        // If true, increase amount of faces by cells_per_dim_vec[patch][0]*cells_per_dim_vec[patch][1]
+                        // TOP Check if k+1 == startIJK_vec[patch][2] (and i, j in the range) for some patch.
+                        // If true, increase amount of faces by cells_per_dim_vec[patch][0]*cells_per_dim_vec[patch][2]
+                        // Auxiliary bools
+                        touch_patch_onBottomFace = touch_patch_onBottomFace ||
+                            ((entityOldIJK[2] == endIJK_vec[patch][2]) &&
+                             (entityOldIJK[0] >= startIJK_vec[patch][0]) && (entityOldIJK[0] < endIJK_vec[patch][0]) &&
+                             (entityOldIJK[1] >= startIJK_vec[patch][1]) && (entityOldIJK[1] < endIJK_vec[patch][1]));
+                        touch_patch_onTopFace = touch_patch_onTopFace ||
+                            ((entityOldIJK[2]+1 == startIJK_vec[patch][2]) &&
+                             (entityOldIJK[0] >= startIJK_vec[patch][0]) && (entityOldIJK[0] < endIJK_vec[patch][0]) &&
+                             (entityOldIJK[1] >= startIJK_vec[patch][1]) && (entityOldIJK[1] < endIJK_vec[patch][1]));
+                        if (touch_patch_onBottomFace || touch_patch_onTopFace)
+                        {
+                            face_count +=  (touch_patch_onBottomFace + touch_patch_onTopFace)*
+                                (cells_per_dim_vec[patch][0]*cells_per_dim_vec[patch][1]);
+                            break;
+                        }
+                    } // end patch-for-loop
+                    if (!touch_patch_onLeftFace)
+                    {
+                        face_count +=1;
+                    }
+                    if (!touch_patch_onRightFace)
+                    {
+                        face_count +=1;
+                    }
+                    if (!touch_patch_onFrontFace)
+                    {
+                        face_count +=1;
+                    }
+                    if (!touch_patch_onBackFace)
+                    {
+                        face_count +=1;
+                    }
+                    if (!touch_patch_onBottomFace)
+                    {
+                        face_count +=1;
+                    }
+                    if (!touch_patch_onTopFace)
+                    {
+                        face_count +=1;
+                    }
+                    std::cout << "Entity old index: " << entityOldIdx << "Entity leaf idx: " << entity.index() << '\n';
+                    std::cout << "Leaf cell_to_face_.size(): " << leaf_cell_to_face.size() << '\n';
+                    std::cout << "Face count: " << face_count << '\n';
+                    std::cout << "touch_patch_onLeftFace: " << touch_patch_onLeftFace << '\n';
+                    std::cout << "touch_patch_onRightFace: " << touch_patch_onRightFace << '\n';
+                    std::cout << "touch_patch_onFrontFace: " << touch_patch_onFrontFace << '\n';
+                    std::cout << "touch_patch_onBackFace: " << touch_patch_onBackFace << '\n';
+                    std::cout << "touch_patch_onBottomFace: " << touch_patch_onBottomFace << '\n';
+                    std::cout << "touch_patch_onTopFace: " << touch_patch_onTopFace << '\n';
+                    BOOST_CHECK( leaf_cell_to_face.size() == face_count);
+                } // end else
                 BOOST_CHECK( entity.isLeaf() == true);
-       
             }
         }
 
         BOOST_CHECK( static_cast<int>(startIJK_vec.size()) == coarse_grid.maxLevel());
-        BOOST_CHECK( (*coarse_grid.data_[data.size()-1]).parent_to_children_cells_.empty());
-   
+        BOOST_CHECK( (*data[data.size()-1]).parent_to_children_cells_.empty());
+
         for (long unsigned int l = 0; l < startIJK_vec.size() +1; ++l) // level 0,1,2,... , last patch
         {
             const auto& view = coarse_grid.levelGridView(l);
@@ -192,7 +328,7 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
             BOOST_CHECK( ((element.level() >= 0) || (element.level() < static_cast<int>(startIJK_vec.size()) +1)));
         }
     }
-    
+
 }
 
 
@@ -202,13 +338,11 @@ BOOST_AUTO_TEST_CASE(refine_patch)
     Dune::CpGrid coarse_grid;
     std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
     std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim_patch = {2,2,2};   
+    const std::array<int, 3> cells_per_dim_patch = {2,2,2};
     std::array<int, 3> start_ijk = {1,0,1};
     std::array<int, 3> end_ijk = {3,2,3};  // patch_dim = {3-1, 2-0, 3-1} ={2,2,2}
     coarse_grid.createCartesian(grid_dim, cell_sizes);
-    refinePatch_and_check(coarse_grid,
-                          {cells_per_dim_patch},
-                          {start_ijk}, {end_ijk});
+    refinePatch_and_check(coarse_grid, {cells_per_dim_patch}, {start_ijk}, {end_ijk});
 }
 
 BOOST_AUTO_TEST_CASE(refine_patch_one_cell)
@@ -217,13 +351,12 @@ BOOST_AUTO_TEST_CASE(refine_patch_one_cell)
     Dune::CpGrid coarse_grid;
     std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
     std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim_patch = {2,2,2};   
+    const std::array<int, 3> cells_per_dim_patch = {2,2,2};
     std::array<int, 3> start_ijk = {1,0,1};
     std::array<int, 3> end_ijk = {2,1,2};  // patch_dim = {2-1, 1-0, 2-1} ={1,1,1} -> Single Cell!
     coarse_grid.createCartesian(grid_dim, cell_sizes);
-    refinePatch_and_check(coarse_grid,
-                          {cells_per_dim_patch},
-                          {start_ijk}, {end_ijk});
+    refinePatch_and_check(coarse_grid, {cells_per_dim_patch}, {start_ijk}, {end_ijk});
+    // Choose a cell touching the boundary of the patch and check amount of faces
 }
 
 BOOST_AUTO_TEST_CASE(lgrs_disjointPatches)
@@ -233,7 +366,7 @@ BOOST_AUTO_TEST_CASE(lgrs_disjointPatches)
     std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
     std::array<int, 3> grid_dim = {4,3,3};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
-    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}, {4,4,4}};   
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}, {4,4,4}};
     const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,2}, {3,2,2}};
     const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {1,1,3}, {4,3,3}};
     refinePatch_and_check(coarse_grid, cells_per_dim_vec, startIJK_vec, endIJK_vec);
@@ -241,25 +374,25 @@ BOOST_AUTO_TEST_CASE(lgrs_disjointPatches)
 
 BOOST_AUTO_TEST_CASE(lgrs_disjointPatchesB)
 {
-     // Create a grid
+    // Create a grid
     Dune::CpGrid coarse_grid;
     std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
     std::array<int, 3> grid_dim = {4,3,3};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
-    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}};   
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}};
     const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {3,2,0}};
     const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1}, {4,3,3}};
-    refinePatch_and_check(coarse_grid, cells_per_dim_vec, startIJK_vec, endIJK_vec); 
+    refinePatch_and_check(coarse_grid, cells_per_dim_vec, startIJK_vec, endIJK_vec);
 }
 
 BOOST_AUTO_TEST_CASE(patches_share_corner)
 {
-     // Create a grid
+    // Create a grid
     Dune::CpGrid coarse_grid;
     std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
     std::array<int, 3> grid_dim = {4,3,3};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
-    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}, {4,4,4}};   
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}, {4,4,4}};
     const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {1,1,1}, {3,2,2}};
     const std::vector<std::array<int,3>> endIJK_vec = {{1,1,1}, {2,2,2}, {4,3,3}};
     BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec), std::logic_error);
@@ -268,12 +401,12 @@ BOOST_AUTO_TEST_CASE(patches_share_corner)
 
 BOOST_AUTO_TEST_CASE(patches_share_corners)
 {
-     // Create a grid
+    // Create a grid
     Dune::CpGrid coarse_grid;
     std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
     std::array<int, 3> grid_dim = {4,3,3};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
-    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {2,2,2}, {2,2,2}};   
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {2,2,2}, {2,2,2}};
     const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {2,0,1}, {3,2,2}};
     const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {3,1,1}, {4,3,3}};
     BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec), std::logic_error);
@@ -282,26 +415,26 @@ BOOST_AUTO_TEST_CASE(patches_share_corners)
 
 BOOST_AUTO_TEST_CASE(pathces_share_face)
 {
-     // Create a grid
+    // Create a grid
     Dune::CpGrid coarse_grid;
     std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
     std::array<int, 3> grid_dim = {4,3,3};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
-    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {2,2,2}, {2,2,2}};   
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {2,2,2}, {2,2,2}};
     const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {2,0,0}, {3,2,2}};
     const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {3,1,1}, {4,3,3}};
     BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec), std::logic_error);
-    std::cout << "Patches are NOT disjoint" << "\n";  
+    std::cout << "Patches are NOT disjoint" << "\n";
 }
 
 BOOST_AUTO_TEST_CASE(pathces_share_faceB)
 {
-     // Create a grid
+    // Create a grid
     Dune::CpGrid coarse_grid;
     std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
     std::array<int, 3> grid_dim = {4,3,3};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
-    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {2,2,2}, {2,2,2}};   
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {2,2,2}, {2,2,2}};
     const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,1}, {1,1,2}};
     const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1}, {3,2,1}, {4,3,3}};
     BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec), std::logic_error);
@@ -309,7 +442,7 @@ BOOST_AUTO_TEST_CASE(pathces_share_faceB)
 }
 
 #define CHECK_COORDINATES(c1, c2)                                       \
-    for (int c = 0; c < 3; c++) {                                        \
+    for (int c = 0; c < 3; c++) {                                       \
         BOOST_TEST(c1[c] == c2[c], boost::test_tools::tolerance(1e-12)); \
     }
 
@@ -342,7 +475,7 @@ void check_global_refine(const Dune::CpGrid& refined_grid, const Dune::CpGrid& e
             std::cout << coord<< " ";
         std::cout <<std::endl;
         for(const auto& coord: point.center())
-            BOOST_TEST(std::isfinite(coord)); 
+            BOOST_TEST(std::isfinite(coord));
         ++equiv_point_iter;
     }
     auto j = 0u;
@@ -355,7 +488,7 @@ void check_global_refine(const Dune::CpGrid& refined_grid, const Dune::CpGrid& e
             std::cout << coord<< " ";
         std::cout <<std::endl;
         for(const auto& coord: cell.center())
-        BOOST_TEST(std::isfinite(coord));
+            BOOST_TEST(std::isfinite(coord));
         BOOST_CHECK_CLOSE(cell.volume(), equiv_cell_iter->volume(), 1e-6);
         ++equiv_cell_iter;
     }
@@ -419,7 +552,7 @@ BOOST_AUTO_TEST_CASE(global_refine)
     std::array<int, 3> grid_dim = {4,3,3};
     std::array<int, 3> cells_per_dim_patch = {2,2,2};
     std::array<int, 3> start_ijk = {0,0,0};
-    std::array<int, 3> end_ijk = {4,3,3};  
+    std::array<int, 3> end_ijk = {4,3,3};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
     coarse_grid.addLgrsUpdateLeafView({cells_per_dim_patch}, {start_ijk}, {end_ijk});
 
@@ -442,7 +575,7 @@ BOOST_AUTO_TEST_CASE(global_norefine)
     std::array<int, 3> grid_dim = {4,3,3};
     std::array<int, 3> cells_per_dim_patch = {1,1,1};
     std::array<int, 3> start_ijk = {0,0,0};
-    std::array<int, 3> end_ijk = {4,3,3};  
+    std::array<int, 3> end_ijk = {4,3,3};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
     coarse_grid.addLgrsUpdateLeafView({cells_per_dim_patch}, {start_ijk}, {end_ijk});
 


### PR DESCRIPTION
Superseding #643 and #653, incorporating #642 (by Arne Morton, @akva2). 

Supporting multiple LGRs and updating LeafView (Cartesian grid required). Entity::geometryInFather() and HierarchicIterators fixed and tested.