### PR TITLE
Reduce grid_equal() implementation verbosity

### DIFF
--- a/opm/grid/UnstructuredGrid.c
+++ b/opm/grid/UnstructuredGrid.c
@@ -17,7 +17,6 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "config.h"
 #include <opm/grid/UnstructuredGrid.h>
 
 #include <assert.h>
@@ -25,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <math.h>
 
 
 void
@@ -558,5 +556,3 @@ read_grid(const char *fname)
 
     return G;
 }
-
-

--- a/opm/grid/UnstructuredGrid.h
+++ b/opm/grid/UnstructuredGrid.h
@@ -320,10 +320,30 @@ struct UnstructuredGrid *
 read_grid(const char *fname);
 
 
-
-
+/**
+ * Determine whether or not two grid structures represent the same
+ * underlying geometry and topology.
+ *
+ * The grids are declared equal if all of the following conditions hold:
+ *
+ *   -# They have the same physical dimensions, the same number of cells,
+ *      the same number of faces, and the same number of nodes.
+ *
+ *   -# All cell, face, and node topology arrays are exactly equal.
+ *
+ *   -# All node coordinate, centroid, face normal, face area and cell
+ *      volume arrays differ by a relative distance of at most @code 1.0e-5
+ *      @endcode in each element.
+ *
+ * @param[in] grid1 First grid.
+ * @param[in] grid2 Second grid.
+ *
+ * @return True (integer one) if the grids are equal and false
+ * (integer zero) otherwise.
+ */
 bool
-grid_equal(const struct UnstructuredGrid * grid1 , const struct UnstructuredGrid * grid2);
+grid_equal(const struct UnstructuredGrid *grid1,
+           const struct UnstructuredGrid *grid2);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
In particular, refactor the explicit calls to comparators out to a separate helper function, equal_vector<>(), that dispatches to std::equal() or Opm::cmp::array_equal<>() depending on the nature of the element type.  Integral types use the former and floating point types use the latter.