### PR TITLE
[fix] Entity::geometryInFather() lifetime issue solved

### DIFF
--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1512,11 +1512,11 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
     //
     // Mutable containers for leaf view corners, faces, cells, face tags, and face normals.
     Dune::cpgrid::EntityVariableBase<cpgrid::Geometry<0,3>>& leaf_corners =
-        leaf_geometries.geomVector(std::integral_constant<int,3>());
+        *(leaf_geometries.geomVector(std::integral_constant<int,3>()));
     Dune::cpgrid::EntityVariableBase<cpgrid::Geometry<2,3>>& leaf_faces =
-        leaf_geometries.geomVector(std::integral_constant<int,1>());
+        *(leaf_geometries.geomVector(std::integral_constant<int,1>()));
     Dune::cpgrid::EntityVariableBase<cpgrid::Geometry<3,3>>& leaf_cells =
-        leaf_geometries.geomVector(std::integral_constant<int,0>());
+        *(leaf_geometries.geomVector(std::integral_constant<int,0>()));
     Dune::cpgrid::EntityVariableBase<enum face_tag>& mutable_face_tags = leaf_face_tags;
     Dune::cpgrid::EntityVariableBase<PointType>& mutable_face_normals = leaf_face_normals;
     //
@@ -1553,14 +1553,14 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
     for (long unsigned int corner = 0; corner < level_to_leaf_corners[0].size(); ++corner) {
         if (level_to_leaf_corners[0][corner] != -1){ // ONLY NEEDED FOR LEVEL 0
             leaf_corners[level_to_leaf_corners[0][corner]]
-                = (*(this->data_[0])).geometry_.geomVector(std::integral_constant<int,3>()).get(corner);
+                = (*(this->data_[0])).geometry_.geomVector(std::integral_constant<int,3>()) -> get(corner);
         }
     }
     for (int l = 1; l < num_patches +1; ++l) {
         for (long unsigned int corner = 0; corner < level_to_leaf_corners[l].size(); ++corner) {
             const auto& level_data = *(this->data_[l]);
             leaf_corners[level_to_leaf_corners[l][corner]]
-                = level_data.geometry_.geomVector(std::integral_constant<int,3>()).get(corner);
+                = level_data.geometry_.geomVector(std::integral_constant<int,3>()) -> get(corner);
         }
     }
     // Integer to count leaf view faces (mixed between faces from level0 not involved in LGR, and new-born-faces).
@@ -1609,7 +1609,7 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
             // Get the (face) entity (from level data).
             const auto& entity =  Dune::cpgrid::EntityRep<1>(face, true);
             // Get the face geometry.
-            leaf_faces[leafFaceIdx] = level_data.geometry_.geomVector(std::integral_constant<int,1>())[entity];
+            leaf_faces[leafFaceIdx] = (*(level_data.geometry_.geomVector(std::integral_constant<int,1>())))[entity];
             // Get the face tag.
             mutable_face_tags[leafFaceIdx] = level_data.face_tag_[entity];
             // Get the face normal.
@@ -1645,7 +1645,7 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
             // Get the (face) entity (from level data).
             const auto& entity =  Dune::cpgrid::EntityRep<1>(face, true);
             // Get the face geometry.
-            leaf_faces[leafFaceIdx] = level_data.geometry_.geomVector(std::integral_constant<int,1>())[entity];
+            leaf_faces[leafFaceIdx] = (*(level_data.geometry_.geomVector(std::integral_constant<int,1>())))[entity];
             // Get the face tag.
             mutable_face_tags[leafFaceIdx] = level_data.face_tag_[entity];
             // Get the face normal.
@@ -1704,7 +1704,7 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
         const auto& level_data =  *(this->data_[level_cellIdx[0]]);
         const auto& entity =  Dune::cpgrid::EntityRep<0>(level_cellIdx[1], true);
         // Get the cell geometry.
-        leaf_cells[leafCellIdx] = level_data.geometry_.geomVector(std::integral_constant<int,0>())[entity];
+        leaf_cells[leafCellIdx] = (*(level_data.geometry_.geomVector(std::integral_constant<int,0>())))[entity];
         // Get old corners of the cell that will be replaced with leaf view ones.
         auto old_cell_to_point = level_data.cell_to_point_[level_cellIdx[1]];
         // Get old faces of the cell that will be replaced with leaf view ones.

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -33,7 +33,7 @@ CpGridData::CpGridData(const CpGridData& g)
       ccobj_(g.ccobj_), use_unique_boundary_ids_(g.use_unique_boundary_ids_)
 #if HAVE_MPI
     , cell_comm_(g.ccobj_)
-#endif    
+#endif
 {
 #if HAVE_MPI
     cell_interfaces_=std::make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
@@ -47,12 +47,12 @@ CpGridData::CpGridData(std::vector<std::shared_ptr<CpGridData>>& data)
       ccobj_(Dune::MPIHelper::getCommunicator()), use_unique_boundary_ids_(false)
 #if HAVE_MPI
     , cell_comm_(Dune::MPIHelper::getCommunicator())
-#endif 
+#endif
 {
 #if HAVE_MPI
     cell_interfaces_=std::make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
 #endif
-     level_data_ptr_ = &data;
+    level_data_ptr_ = &data;
 }
 
 CpGridData::CpGridData(MPIHelper::MPICommunicator comm,  std::vector<std::shared_ptr<CpGridData>>& data)
@@ -62,7 +62,7 @@ CpGridData::CpGridData(MPIHelper::MPICommunicator comm,  std::vector<std::shared
       ccobj_(comm), use_unique_boundary_ids_(false)
 #if HAVE_MPI
     , cell_comm_(comm)
-#endif       
+#endif
 {
 #if HAVE_MPI
     cell_interfaces_=std::make_tuple(Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_),Interface(ccobj_));
@@ -111,7 +111,7 @@ void CpGridData::populateGlobalCellIndexSet()
     cell_indexset.beginResize();
     for (int index = 0, end = size(0); index != end ; ++index){
         cell_indexset.add(global_id_set_->id(Entity<0>(*this, EntityRep<0>(index, true))),
-                           ParallelIndexSet::LocalIndex(index, AttributeSet::owner, true));
+                          ParallelIndexSet::LocalIndex(index, AttributeSet::owner, true));
     }
     cell_indexset.endResize();
 #endif
@@ -154,7 +154,7 @@ int CpGridData::size(int codim) const
 
 #if HAVE_MPI
 
- // A functor that counts existent entries and renumbers them.
+// A functor that counts existent entries and renumbers them.
 struct CountExistent
 {
     CountExistent() : count() {}
@@ -496,11 +496,11 @@ struct CellGeometryHandle
     CellGeometryHandle(const Container& gatherCont, Container& scatterCont,
                        const std::vector<int>& gatherAquiferCells,
                        std::vector<int>& scatterAquiferCells,
-                       const EntityVariable<cpgrid::Geometry<0, 3>, 3>& pointGeom,
+                       std::shared_ptr<const EntityVariable<cpgrid::Geometry<0, 3>, 3>> pointGeom,
                        const std::vector< std::array<int,8> >& cell2Points)
         : gatherCont_(gatherCont), scatterCont_(scatterCont),
-        gatherAquiferCells_(gatherAquiferCells),scatterAquiferCells_(scatterAquiferCells),
-        pointGeom_(pointGeom), cell2Points_(cell2Points)
+          gatherAquiferCells_(gatherAquiferCells),scatterAquiferCells_(scatterAquiferCells),
+          pointGeom_(pointGeom), cell2Points_(cell2Points)
     {}
 
     ~CellGeometryHandle()
@@ -569,7 +569,7 @@ private:
     Container& scatterCont_;
     const std::vector<int>& gatherAquiferCells_;
     std::vector<int>& scatterAquiferCells_;
-    const EntityVariable<cpgrid::Geometry<0, 3>, 3>& pointGeom_;
+    std::shared_ptr<const EntityVariable<cpgrid::Geometry<0, 3>, 3>> pointGeom_;
     const std::vector< std::array<int,8> >& cell2Points_;
 };
 
@@ -744,7 +744,7 @@ struct SparseTableDataHandle
             point = candidate->second;
         }
     }
-    private:
+private:
     const Table& global_;
     const LevelGlobalIdSet& globalIds_;
     Table& local_;
@@ -910,10 +910,10 @@ public:
             }
             using IndexPair = typename IndexSet::IndexPair;
             auto candidate = std::lower_bound(global2Local_.begin(), global2Local_.end(),
-                                          IndexPair(i),
-                                          [](const IndexPair& p1,
-                                             const IndexPair& p2){
-                                              return p1.global() < p2.global();});
+                                              IndexPair(i),
+                                              [](const IndexPair& p1,
+                                                 const IndexPair& p2){
+                                                  return p1.global() < p2.global();});
             if (candidate == global2Local_.end() || i != candidate->global())
             {
                 // mark cell as being stored elsewhere
@@ -940,13 +940,13 @@ struct AttributeDataHandle
                         const T& cell_to_entity,
                         const CpGridData& grid)
         : rank_(rank), indicator_(indicator), vals_(vals),
-        c2e_(cell_to_entity), grid_(grid)
+          c2e_(cell_to_entity), grid_(grid)
     {}
 
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 8)
     bool fixedSize()
 #else
-    bool fixedsize()
+        bool fixedsize()
 #endif
     {
         return true;
@@ -1027,7 +1027,7 @@ template<class Tuple>
 struct InterfaceTupleFunctor
 {
     InterfaceTupleFunctor(Tuple& t)
-    : t_(t)
+        : t_(t)
     {}
 
     void operator()(int rank, std::size_t index, PartitionType mine, PartitionType other)
@@ -1102,9 +1102,9 @@ void reserve(const std::vector<std::map<int,std::pair<std::size_t,std::size_t> >
  */
 template<std::size_t i>
 struct SizeFunctor :
-    public InterfaceFunctor<std::size_t, InterfaceIncrementor,
-                            typename std::tuple_element<i,typename Converter::SourceTuple>::type,
-                            typename std::tuple_element<i,typename Converter::DestinationTuple>::type>
+        public InterfaceFunctor<std::size_t, InterfaceIncrementor,
+                                typename std::tuple_element<i,typename Converter::SourceTuple>::type,
+                                typename std::tuple_element<i,typename Converter::DestinationTuple>::type>
 {
     typedef InterfaceFunctor<std::size_t, InterfaceIncrementor,
                              typename std::tuple_element<i,typename Converter::SourceTuple>::type,
@@ -1121,9 +1121,9 @@ struct SizeFunctor :
  */
 template<std::size_t i>
 struct AddFunctor :
-    public InterfaceFunctor<InterfaceInformation, InterfaceAdder,
-                             typename std::tuple_element<i,typename Converter::SourceTuple>::type,
-                             typename std::tuple_element<i,typename Converter::DestinationTuple>::type>
+        public InterfaceFunctor<InterfaceInformation, InterfaceAdder,
+                                typename std::tuple_element<i,typename Converter::SourceTuple>::type,
+                                typename std::tuple_element<i,typename Converter::DestinationTuple>::type>
 {
     typedef InterfaceFunctor<InterfaceInformation, InterfaceAdder,
                              typename std::tuple_element<i,typename Converter::SourceTuple>::type,
@@ -1138,7 +1138,7 @@ class FacePartitionTypeIterator
 {
 public:
     FacePartitionTypeIterator(const PartitionTypeIndicator* part)
-    : indicator_(part), index_()
+        : indicator_(part), index_()
     {}
     void operator++()
     {
@@ -1198,11 +1198,11 @@ void createInterfaces(std::vector<std::map<int,char> >& attributes,
                        SizeFunctor<4> > SizeTuple;
 
     SizeTuple
-    size_functor_tuple = std::make_tuple(SizeFunctor<0>(sizes[0]),
-                                         SizeFunctor<1>(sizes[1]),
-                                         SizeFunctor<2>(sizes[2]),
-                                         SizeFunctor<3>(sizes[3]),
-                                         SizeFunctor<4>(sizes[4]));
+        size_functor_tuple = std::make_tuple(SizeFunctor<0>(sizes[0]),
+                                             SizeFunctor<1>(sizes[1]),
+                                             SizeFunctor<2>(sizes[2]),
+                                             SizeFunctor<3>(sizes[3]),
+                                             SizeFunctor<4>(sizes[4]));
     InterfaceTupleFunctor<SizeTuple> size_functor(size_functor_tuple);
     iterate_over_attributes(attributes, partition_type_iterator, size_functor);
     // reserve space
@@ -1230,18 +1230,18 @@ void CpGridData::computeGeometry(CpGrid& grid,
                                  const OrientedEntityTable<0, 1>& cell2Faces,
                                  const std::vector< std::array<int,8> >& cell2Points)
 {
-    FaceGeometryHandle faceGeomHandle(globalGeometry.geomVector(std::integral_constant<int,1>()),
-                                      geometry.geomVector(std::integral_constant<int,1>()));
+    FaceGeometryHandle faceGeomHandle(*globalGeometry.geomVector(std::integral_constant<int,1>()),
+                                      *geometry.geomVector(std::integral_constant<int,1>()));
     FaceViaCellHandleWrapper<FaceGeometryHandle>
         wrappedFaceGeomHandle(faceGeomHandle, globalCell2Faces, cell2Faces);
     grid.scatterData(wrappedFaceGeomHandle);
 
-    PointGeometryHandle pointGeomHandle(globalGeometry.geomVector(std::integral_constant<int,3>()),
-                                             geometry.geomVector(std::integral_constant<int,3>()));
+    PointGeometryHandle pointGeomHandle(*globalGeometry.geomVector(std::integral_constant<int,3>()),
+                                        *geometry.geomVector(std::integral_constant<int,3>()));
     grid.scatterData(pointGeomHandle);
 
-    CellGeometryHandle cellGeomHandle(globalGeometry.geomVector(std::integral_constant<int,0>()),
-                                      geometry.geomVector(std::integral_constant<int,0>()),
+    CellGeometryHandle cellGeomHandle(*globalGeometry.geomVector(std::integral_constant<int,0>()),
+                                      *geometry.geomVector(std::integral_constant<int,0>()),
                                       globalAquiferCells, aquiferCells,
                                       geometry.geomVector(std::integral_constant<int,3>()),
                                       cell2Points);
@@ -1294,7 +1294,7 @@ void computeFace2Cell(CpGrid& grid,
     using Table = OrientedEntityTable<1,0>;
     RowSizeDataHandle<Table,1> rowSizeHandle(globalFace2Cells, rowSizes);
     FaceViaCellHandleWrapper<RowSizeDataHandle<Table,1> > wrappedSizeHandle(rowSizeHandle,
-                                                                        globalCell2Faces, cell2Faces);
+                                                                            globalCell2Faces, cell2Faces);
     grid.scatterData(wrappedSizeHandle);
     face2Cells.allocate(rowSizes.begin(), rowSizes.end());
     // Use entity with index INT_MAX to mark unprocessed row entries
@@ -1325,11 +1325,11 @@ void computeFace2Cell(CpGrid& grid,
 
 
 std::map<int,int> computeCell2Face(CpGrid& grid,
-                                    const OrientedEntityTable<0, 1>& globalCell2Faces,
-                                    const LevelGlobalIdSet& globalIds,
-                                    OrientedEntityTable<0, 1>& cell2Faces,
-                                    std::vector<int>& map2Global,
-                                    std::size_t noCells)
+                                   const OrientedEntityTable<0, 1>& globalCell2Faces,
+                                   const LevelGlobalIdSet& globalIds,
+                                   OrientedEntityTable<0, 1>& cell2Faces,
+                                   std::vector<int>& map2Global,
+                                   std::size_t noCells)
 {
     std::vector<int> rowSizes(noCells);
     using Table = OrientedEntityTable<0,1>;
@@ -1400,7 +1400,7 @@ void createInterfaceList(const typename CpGridData::InterfaceMap::value_type& pr
                          const Map2Global& local2Global,
                          Map2Local& map2Local,
                          typename CpGridData::InterfaceMap::mapped_type& pointLists
-)
+                         )
 {
     const auto& cellList = send? procCellLists.second.first : procCellLists.second.second;
 
@@ -1560,9 +1560,9 @@ void CpGridData::distributeGlobalGrid(CpGrid& grid,
     logical_cartesian_size_=view_data.logical_cartesian_size_;
 
     // Set up the new topology arrays
-    geometry_.geomVector(std::integral_constant<int,1>()).resize(noExistingFaces);
-    geometry_.geomVector(std::integral_constant<int,0>()).resize(cell_to_face_.size());
-    geometry_.geomVector(std::integral_constant<int,3>()).resize(noExistingPoints);
+    geometry_.geomVector(std::integral_constant<int,1>()) -> resize(noExistingFaces);
+    geometry_.geomVector(std::integral_constant<int,0>()) -> resize(cell_to_face_.size());
+    geometry_.geomVector(std::integral_constant<int,3>()) -> resize(noExistingPoints);
 
     computeGeometry(grid, view_data.geometry_, view_data.aquifer_cells_, view_data.cell_to_face_,
                     geometry_, aquifer_cells_, cell_to_face_, cell_to_point_);
@@ -1585,7 +1585,7 @@ void CpGridData::distributeGlobalGrid(CpGrid& grid,
         FaceTagNormalBIdHandle faceHandle(view_data.face_tag_, view_data.face_normals_, view_data.unique_boundary_ids_,
                                           face_tag_, face_normals_, unique_boundary_ids_);
         FaceViaCellHandleWrapper<FaceTagNormalBIdHandle>
-        wrappedFaceHandle(faceHandle, view_data.cell_to_face_, cell_to_face_);
+            wrappedFaceHandle(faceHandle, view_data.cell_to_face_, cell_to_face_);
         grid.scatterData(wrappedFaceHandle);
     }
     else
@@ -1593,7 +1593,7 @@ void CpGridData::distributeGlobalGrid(CpGrid& grid,
         FaceTagNormalHandle faceHandle(view_data.face_tag_, view_data.face_normals_,
                                        face_tag_, face_normals_);
         FaceViaCellHandleWrapper<FaceTagNormalHandle>
-        wrappedFaceHandle(faceHandle, view_data.cell_to_face_, cell_to_face_);
+            wrappedFaceHandle(faceHandle, view_data.cell_to_face_, cell_to_face_);
         grid.scatterData(wrappedFaceHandle);
     }
 
@@ -1641,7 +1641,7 @@ void CpGridData::distributeGlobalGrid(CpGrid& grid,
                EnumItem<AttributeSet, AttributeSet::copy>());
     std::get<Overlap_All_Interface>(cell_interfaces_)
         .build(cell_remote_indices, EnumItem<AttributeSet, AttributeSet::copy>(),
-                                 AllSet<AttributeSet>());
+               AllSet<AttributeSet>());
     std::get<All_All_Interface>(cell_interfaces_)
         .build(cell_remote_indices, AllSet<AttributeSet>(), AllSet<AttributeSet>());
 
@@ -1650,22 +1650,22 @@ void CpGridData::distributeGlobalGrid(CpGrid& grid,
     const auto& all_all_cell_interface = std::get<All_All_Interface>(cell_interfaces_);
 
     Communicator comm(all_all_cell_interface.communicator(),
-                     all_all_cell_interface.interfaces());
+                      all_all_cell_interface.interfaces());
 
     /*
-      // code deactivated, because users cannot access face indices and therefore
-      // communication on faces makes no sense!
+    // code deactivated, because users cannot access face indices and therefore
+    // communication on faces makes no sense!
     std::vector<std::map<int,char> > face_attributes(noExistingFaces);
     AttributeDataHandle<Opm::SparseTable<EntityRep<1> > >
-        face_handle(ccobj_.rank(), *partition_type_indicator_,
-                    face_attributes, static_cast<Opm::SparseTable<EntityRep<1> >&>(cell_to_face_),
-                    *this);
+    face_handle(ccobj_.rank(), *partition_type_indicator_,
+    face_attributes, static_cast<Opm::SparseTable<EntityRep<1> >&>(cell_to_face_),
+    *this);
     if( std::get<All_All_Interface>(cell_interfaces_).interfaces().size() )
     {
-        comm.forward(face_handle);
+    comm.forward(face_handle);
     }
     createInterfaces(face_attributes, FacePartitionTypeIterator(partition_type_indicator_),
-                     face_interfaces_);
+    face_interfaces_);
     std::vector<std::map<int,char> >().swap(face_attributes);
     */
     std::vector<std::map<int,char> > point_attributes(noExistingPoints);
@@ -1835,7 +1835,8 @@ CpGridData::getPatchesCells(const std::vector<std::array<int,3>>& startIJK_vec, 
 
 
 Geometry<3,3> CpGridData::cellifyPatch(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK,
-                                       const std::vector<int>& patch_cells, DefaultGeometryPolicy& cellifiedPatch_geometry,
+                                       const std::vector<int>& patch_cells,
+                                       DefaultGeometryPolicy& cellifiedPatch_geometry,
                                        std::array<int,8>& cellifiedPatch_to_point,
                                        std::array<int,8>& allcorners_cellifiedPatch) const
 {
@@ -1843,8 +1844,7 @@ Geometry<3,3> CpGridData::cellifyPatch(const std::array<int,3>& startIJK, const 
         OPM_THROW(std::logic_error, "Empty patch. Cannot convert patch into cell.");
     }
     if (patch_cells.size() == 1){
-        return (this -> geometry_.geomVector(std::integral_constant<int,0>())
-                [EntityRep<0>(patch_cells[0], true)]);
+        return (*(this -> geometry_.geomVector(std::integral_constant<int,0>())))[EntityRep<0>(patch_cells[0], true)];
     }
     else{
         // Get grid dimension.
@@ -1868,7 +1868,7 @@ Geometry<3,3> CpGridData::cellifyPatch(const std::array<int,3>& startIJK, const 
             // Index of corner '7' {endI, endJ, endK}
             (endIJK[1]*(grid_dim[0]+1)*(grid_dim[2]+1)) + (endIJK[0]*(grid_dim[2]+1)) + endIJK[2]};
         EntityVariableBase<cpgrid::Geometry<0,3>>& cellifiedPatch_corners =
-            cellifiedPatch_geometry.geomVector(std::integral_constant<int,3>());
+            *(cellifiedPatch_geometry.geomVector(std::integral_constant<int,3>()));
         cellifiedPatch_corners.resize(8);
         // Compute the center of the 'cellified patch' and its corners.
         Geometry<0,3>::GlobalCoordinate cellifiedPatch_center = {0., 0.,0.};
@@ -1876,16 +1876,16 @@ Geometry<3,3> CpGridData::cellifyPatch(const std::array<int,3>& startIJK, const 
             // FieldVector in DUNE 2.6 is missing operator/ using a loop
             for(int i=0; i < 3; ++i){
                 cellifiedPatch_center[i] +=
-                    (this -> geometry_.geomVector(std::integral_constant<int,3>()).get(cellifiedPatch_to_point[corn]).center())[i]/8.;
+                    (*(this -> geometry_.geomVector(std::integral_constant<int,3>()))).get(cellifiedPatch_to_point[corn]).center()[i]/8.;
             }
             cellifiedPatch_corners[corn] =
-                this -> geometry_.geomVector(std::integral_constant<int,3>()).get(cellifiedPatch_to_point[corn]);
+                (*(this -> geometry_.geomVector(std::integral_constant<int,3>()))).get(cellifiedPatch_to_point[corn]);
         }
         // Compute the volume of the 'cellified patch'.
         double cellifiedPatch_volume = 0.;
         for (const auto& idx : patch_cells) {
-            cellifiedPatch_volume += (this -> geometry_.geomVector(std::integral_constant<int,0>())
-                                      [EntityRep<0>(idx, true)]).volume();
+            cellifiedPatch_volume +=
+                (*(this -> geometry_.geomVector(std::integral_constant<int,0>())))[EntityRep<0>(idx, true)].volume();
         }
         // Indices of 'all the corners', in this case, 0-7 (required to construct a Geometry<3,3> object).
         allcorners_cellifiedPatch = {0,1,2,3,4,5,6,7};
@@ -1893,7 +1893,8 @@ Geometry<3,3> CpGridData::cellifyPatch(const std::array<int,3>& startIJK, const 
         const int* cellifiedPatch_indices_storage_ptr = &allcorners_cellifiedPatch[0];
         // Construct (and return) the Geometry<3,3> of the 'cellified patch'.
         return Geometry<3,3>(cellifiedPatch_center, cellifiedPatch_volume,
-                             cellifiedPatch_geometry.geomVector(std::integral_constant<int,3>()), cellifiedPatch_indices_storage_ptr);
+                             cellifiedPatch_geometry.geomVector(std::integral_constant<int,3>()),
+                             cellifiedPatch_indices_storage_ptr);
     }
 }
 
@@ -1917,7 +1918,7 @@ CpGridData::refineSingleCell(const std::array<int,3>& cells_per_dim, const int& 
     cpgrid::EntityVariable<enum face_tag,1>& refined_face_tags = refined_grid.face_tag_;
     cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>,1>& refined_face_normals = refined_grid.face_normals_;
     // Get parent cell
-    const cpgrid::Geometry<3,3>& parent_cell = geometry_.geomVector(std::integral_constant<int,0>())[EntityRep<0>(parent_idx, true)];
+    const cpgrid::Geometry<3,3>& parent_cell = (*(geometry_.geomVector(std::integral_constant<int,0>())))[EntityRep<0>(parent_idx, true)];
     // Get parent cell corners.
     const std::array<int,8>& parent_to_point = this->cell_to_point_[parent_idx];
     if (parent_to_point.size() != 8){
@@ -2234,7 +2235,7 @@ CpGridData::refinePatch(const std::array<int,3>& cells_per_dim, const std::array
     return {refined_grid_ptr, boundary_old_to_new_corners, boundary_old_to_new_faces, parent_to_children_faces,
         parent_to_children_cells, child_to_parent_faces, child_to_parent_cells};
 }
-   
+
 
 } // end namespace cpgrid
 } // end namespace Dune

--- a/opm/grid/cpgrid/DefaultGeometryPolicy.hpp
+++ b/opm/grid/cpgrid/DefaultGeometryPolicy.hpp
@@ -41,93 +41,98 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 namespace Dune
 {
 
-    class CpGrid;
+class CpGrid;
 
-    namespace cpgrid
-    {
-        template<int mydim, int dim>
-        class Geometry;
-        /// @brief
-        /// @todo Doc me!
-        class DefaultGeometryPolicy
-        {
-            friend class CpGridData;
-            template<int mydim, int dim>
-            friend class Geometry;
-            friend class ::Dune::CpGrid;
-        public:
-            /// @brief
-            /// @todo Doc me
-            DefaultGeometryPolicy()
-            {
-            }
+namespace cpgrid
+{
+template<int mydim, int dim>
+class Geometry;
+/// @brief
+/// @todo Doc me!
+class DefaultGeometryPolicy
+{
+friend class CpGridData;
+template<int mydim, int dim>
+friend class Geometry;
+friend class ::Dune::CpGrid;
+public:
+/// @brief
+/// @todo Doc me
+DefaultGeometryPolicy()
+:cell_geom_ptr_(std::make_shared<EntityVariable<cpgrid::Geometry<3, 3>, 0>>()),
+face_geom_ptr_(std::make_shared<EntityVariable<cpgrid::Geometry<2, 3>, 1>>()),
+point_geom_ptr_(std::make_shared<EntityVariable<cpgrid::Geometry<0, 3>, 3>>())
+{
+}
 
-            /// @brief
-            /// @todo Doc me
-            /// @param
-            DefaultGeometryPolicy(const EntityVariable<cpgrid::Geometry<3, 3>, 0>& cell_geom,
-                                  const EntityVariable<cpgrid::Geometry<2, 3>, 1>& face_geom,
-                                  const EntityVariable<cpgrid::Geometry<0, 3>, 3>& point_geom)
-                : cell_geom_(cell_geom), face_geom_(face_geom), point_geom_(point_geom)
-            {
-            }
+/// @brief
+/// @todo Doc me
+/// @param
+DefaultGeometryPolicy(const EntityVariable<cpgrid::Geometry<3, 3>, 0>& cell_geom,
+const EntityVariable<cpgrid::Geometry<2, 3>, 1>& face_geom,
+const EntityVariable<cpgrid::Geometry<0, 3>, 3>& point_geom)
+: cell_geom_ptr_(std::make_shared<EntityVariable<cpgrid::Geometry<3, 3>, 0>>(cell_geom)),
+face_geom_ptr_(std::make_shared<EntityVariable<cpgrid::Geometry<2, 3>, 1>>(face_geom)),
+point_geom_ptr_(std::make_shared<EntityVariable<cpgrid::Geometry<0, 3>, 3>>(point_geom))
+{
+}
 
-            /// @brief
-            /// @todo Doc me!
-            /// @tparam
-            /// @param
-            /// @return
-            template <int codim>
-            const EntityVariable<cpgrid::Geometry<3 - codim, 3>, codim>& geomVector() const
-            {
-                static_assert(codim != 2, "");
-                return geomVector(std::integral_constant<int,codim>());
-            }
-            
-            /// \brief Get cell geometry
-            const EntityVariable<cpgrid::Geometry<3, 3>, 0>& geomVector(const std::integral_constant<int, 0>&) const
-            {
-                return cell_geom_;
-            }
-            /// \brief Get cell geometry
-            EntityVariable<cpgrid::Geometry<3, 3>, 0>& geomVector(const std::integral_constant<int, 0>&)
-            {
-                return cell_geom_;
-            }
-            /// \brief Get face geometry
-            const EntityVariable<cpgrid::Geometry<2, 3>, 1>& geomVector(const std::integral_constant<int, 1>&) const
-            {
-                return face_geom_;
-            }
-            /// \brief Get face geometry
-            EntityVariable<cpgrid::Geometry<2, 3>, 1>& geomVector(const std::integral_constant<int, 1>&)
-            {
-                return face_geom_;
-            }
+/// @brief
+/// @todo Doc me!
+/// @tparam
+/// @param
+/// @return
+template <int codim>
+const EntityVariable<cpgrid::Geometry<3 - codim, 3>, codim>& geomVector() const
+{
+static_assert(codim != 2, "");
+return *geomVector(std::integral_constant<int,codim>());
+}
 
-            /// \brief Get point geometry
-            template<int codim>
-            const EntityVariable<cpgrid::Geometry<0, 3>, 3>& geomVector(const std::integral_constant<int, codim>&) const
-            {
-                static_assert(codim==3, "Codim has to be 3");
-                return point_geom_;
-            }/// \brief Get point geometry
-            template<int codim>
-            EntityVariable<cpgrid::Geometry<0, 3>, 3>& geomVector(const std::integral_constant<int, codim>&)
-            {
-                static_assert(codim==3, "Codim has to be 3");
-                return point_geom_;
-            }
-            
-        private:
-            EntityVariable<cpgrid::Geometry<3, 3>, 0> cell_geom_;
-            EntityVariable<cpgrid::Geometry<2, 3>, 1> face_geom_;
-            EntityVariable<cpgrid::Geometry<0, 3>, 3> point_geom_;
-        };
+/// \brief Get cell geometry
+std::shared_ptr<const EntityVariable<cpgrid::Geometry<3, 3>, 0>> geomVector(const std::integral_constant<int, 0>&) const
+{
+return cell_geom_ptr_;
+}
+/// \brief Get cell geometry
+std::shared_ptr<EntityVariable<cpgrid::Geometry<3, 3>, 0>> geomVector(const std::integral_constant<int, 0>&)
+{
+return cell_geom_ptr_;
+}
+/// \brief Get face geometry
+std::shared_ptr<const EntityVariable<cpgrid::Geometry<2, 3>, 1>> geomVector(const std::integral_constant<int, 1>&) const
+{
+return face_geom_ptr_;
+}
+/// \brief Get face geometry
+std::shared_ptr<EntityVariable<cpgrid::Geometry<2, 3>, 1>> geomVector(const std::integral_constant<int, 1>&)
+{
+return face_geom_ptr_;
+}
+
+/// \brief Get point geometry
+template<int codim>
+std::shared_ptr<const EntityVariable<cpgrid::Geometry<0, 3>, 3>> geomVector(const std::integral_constant<int, codim>&) const
+{
+static_assert(codim==3, "Codim has to be 3");
+return point_geom_ptr_;
+}/// \brief Get point geometry
+template<int codim>
+std::shared_ptr<EntityVariable<cpgrid::Geometry<0, 3>, 3>> geomVector(const std::integral_constant<int, codim>&)
+{
+static_assert(codim==3, "Codim has to be 3");
+return point_geom_ptr_;
+}
+
+private:
+std::shared_ptr<EntityVariable<cpgrid::Geometry<3, 3>, 0>> cell_geom_ptr_;
+std::shared_ptr<EntityVariable<cpgrid::Geometry<2, 3>, 1>> face_geom_ptr_;
+std::shared_ptr<EntityVariable<cpgrid::Geometry<0, 3>, 3>> point_geom_ptr_;
+};
 
 
 
-    } // namespace cpgrid
+} // namespace cpgrid
 } // namespace Dune
 
 

--- a/opm/grid/cpgrid/DefaultGeometryPolicy.hpp
+++ b/opm/grid/cpgrid/DefaultGeometryPolicy.hpp
@@ -51,83 +51,84 @@ class Geometry;
 /// @todo Doc me!
 class DefaultGeometryPolicy
 {
-friend class CpGridData;
-template<int mydim, int dim>
-friend class Geometry;
-friend class ::Dune::CpGrid;
+    friend class CpGridData;
+    template<int mydim, int dim>
+    friend class Geometry;
+    friend class ::Dune::CpGrid;
 public:
-/// @brief
-/// @todo Doc me
-DefaultGeometryPolicy()
-:cell_geom_ptr_(std::make_shared<EntityVariable<cpgrid::Geometry<3, 3>, 0>>()),
-face_geom_ptr_(std::make_shared<EntityVariable<cpgrid::Geometry<2, 3>, 1>>()),
-point_geom_ptr_(std::make_shared<EntityVariable<cpgrid::Geometry<0, 3>, 3>>())
-{
-}
+    /// @brief
+    /// @todo Doc me
+    DefaultGeometryPolicy()
+        : cell_geom_ptr_(std::make_shared<EntityVariable<cpgrid::Geometry<3, 3>, 0>>()),
+          face_geom_ptr_(std::make_shared<EntityVariable<cpgrid::Geometry<2, 3>, 1>>()),
+          point_geom_ptr_(std::make_shared<EntityVariable<cpgrid::Geometry<0, 3>, 3>>())
+    {
+    }
 
-/// @brief
-/// @todo Doc me
-/// @param
-DefaultGeometryPolicy(const EntityVariable<cpgrid::Geometry<3, 3>, 0>& cell_geom,
-const EntityVariable<cpgrid::Geometry<2, 3>, 1>& face_geom,
-const EntityVariable<cpgrid::Geometry<0, 3>, 3>& point_geom)
-: cell_geom_ptr_(std::make_shared<EntityVariable<cpgrid::Geometry<3, 3>, 0>>(cell_geom)),
-face_geom_ptr_(std::make_shared<EntityVariable<cpgrid::Geometry<2, 3>, 1>>(face_geom)),
-point_geom_ptr_(std::make_shared<EntityVariable<cpgrid::Geometry<0, 3>, 3>>(point_geom))
-{
-}
+    /// @brief
+    /// @todo Doc me
+    /// @param
+    DefaultGeometryPolicy(const EntityVariable<cpgrid::Geometry<3, 3>, 0>& cell_geom,
+                          const EntityVariable<cpgrid::Geometry<2, 3>, 1>& face_geom,
+                          const EntityVariable<cpgrid::Geometry<0, 3>, 3>& point_geom)
+        : cell_geom_ptr_(std::make_shared<EntityVariable<cpgrid::Geometry<3, 3>, 0>>(cell_geom)),
+          face_geom_ptr_(std::make_shared<EntityVariable<cpgrid::Geometry<2, 3>, 1>>(face_geom)),
+          point_geom_ptr_(std::make_shared<EntityVariable<cpgrid::Geometry<0, 3>, 3>>(point_geom))
+    {
+    }
 
-/// @brief
-/// @todo Doc me!
-/// @tparam
-/// @param
-/// @return
-template <int codim>
-const EntityVariable<cpgrid::Geometry<3 - codim, 3>, codim>& geomVector() const
-{
-static_assert(codim != 2, "");
-return *geomVector(std::integral_constant<int,codim>());
-}
+    /// @brief
+    /// @todo Doc me!
+    /// @tparam
+    /// @param
+    /// @return
+    template <int codim>
+    const EntityVariable<cpgrid::Geometry<3 - codim, 3>, codim>& geomVector() const
+    {
+        static_assert(codim != 2, "");
+        return *geomVector(std::integral_constant<int,codim>());
+    }
 
-/// \brief Get cell geometry
-std::shared_ptr<const EntityVariable<cpgrid::Geometry<3, 3>, 0>> geomVector(const std::integral_constant<int, 0>&) const
-{
-return cell_geom_ptr_;
-}
-/// \brief Get cell geometry
-std::shared_ptr<EntityVariable<cpgrid::Geometry<3, 3>, 0>> geomVector(const std::integral_constant<int, 0>&)
-{
-return cell_geom_ptr_;
-}
-/// \brief Get face geometry
-std::shared_ptr<const EntityVariable<cpgrid::Geometry<2, 3>, 1>> geomVector(const std::integral_constant<int, 1>&) const
-{
-return face_geom_ptr_;
-}
-/// \brief Get face geometry
-std::shared_ptr<EntityVariable<cpgrid::Geometry<2, 3>, 1>> geomVector(const std::integral_constant<int, 1>&)
-{
-return face_geom_ptr_;
-}
+    /// \brief Get cell geometry
+    std::shared_ptr<const EntityVariable<cpgrid::Geometry<3, 3>, 0>> geomVector(const std::integral_constant<int, 0>&) const
+    {
+        return cell_geom_ptr_;
+    }
+    /// \brief Get cell geometry
+    std::shared_ptr<EntityVariable<cpgrid::Geometry<3, 3>, 0>> geomVector(const std::integral_constant<int, 0>&)
+    {
+        return cell_geom_ptr_;
+    }
+    /// \brief Get face geometry
+    std::shared_ptr<const EntityVariable<cpgrid::Geometry<2, 3>, 1>> geomVector(const std::integral_constant<int, 1>&) const
+    {
+        return face_geom_ptr_;
+    }
+    /// \brief Get face geometry
+    std::shared_ptr<EntityVariable<cpgrid::Geometry<2, 3>, 1>> geomVector(const std::integral_constant<int, 1>&)
+    {
+        return face_geom_ptr_;
+    }
 
-/// \brief Get point geometry
-template<int codim>
-std::shared_ptr<const EntityVariable<cpgrid::Geometry<0, 3>, 3>> geomVector(const std::integral_constant<int, codim>&) const
-{
-static_assert(codim==3, "Codim has to be 3");
-return point_geom_ptr_;
-}/// \brief Get point geometry
-template<int codim>
-std::shared_ptr<EntityVariable<cpgrid::Geometry<0, 3>, 3>> geomVector(const std::integral_constant<int, codim>&)
-{
-static_assert(codim==3, "Codim has to be 3");
-return point_geom_ptr_;
-}
+    /// \brief Get point geometry
+    template<int codim>
+    std::shared_ptr<const EntityVariable<cpgrid::Geometry<0, 3>, 3>> geomVector(const std::integral_constant<int, codim>&) const
+    {
+        static_assert(codim==3, "Codim has to be 3");
+        return point_geom_ptr_;
+    }
+    /// \brief Get point geometry
+    template<int codim>
+    std::shared_ptr<EntityVariable<cpgrid::Geometry<0, 3>, 3>> geomVector(const std::integral_constant<int, codim>&)
+    {
+        static_assert(codim==3, "Codim has to be 3");
+        return point_geom_ptr_;
+    }
 
 private:
-std::shared_ptr<EntityVariable<cpgrid::Geometry<3, 3>, 0>> cell_geom_ptr_;
-std::shared_ptr<EntityVariable<cpgrid::Geometry<2, 3>, 1>> face_geom_ptr_;
-std::shared_ptr<EntityVariable<cpgrid::Geometry<0, 3>, 3>> point_geom_ptr_;
+    std::shared_ptr<EntityVariable<cpgrid::Geometry<3, 3>, 0>> cell_geom_ptr_;
+    std::shared_ptr<EntityVariable<cpgrid::Geometry<2, 3>, 1>> face_geom_ptr_;
+    std::shared_ptr<EntityVariable<cpgrid::Geometry<0, 3>, 3>> point_geom_ptr_;
 };
 
 

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -47,234 +47,230 @@
 
 namespace Dune
 {
-    namespace cpgrid
+namespace cpgrid
+{
+
+template<int,int> class Geometry;
+template<int,PartitionIteratorType> class Iterator;
+class IntersectionIterator;
+class HierarchicIterator;
+class CpGridData;
+class LevelGlobalIdSet;
+
+/// @brief
+/// @todo Doc me!
+/// @tparam
+template <int codim>
+class Entity : public EntityRep<codim>
+{
+    friend class LevelGlobalIdSet;
+    friend class GlobalIdSet;
+    friend class HierarchicIterator;
+    friend class CpGridData;
+
+public:
+    /// @brief
+    /// @todo Doc me!
+    enum { codimension = codim };
+    enum { dimension = 3 };
+    enum { mydimension = dimension - codimension };
+    enum { dimensionworld = 3 };
+
+    // the official DUNE names
+    typedef Entity    EntitySeed;
+
+    /// @brief
+    /// @todo Doc me!
+    /// @tparam
+    template <int cd>
+    struct Codim
     {
-
-       template<int,int> class Geometry;
-       template<int,PartitionIteratorType> class Iterator;
-       class IntersectionIterator;
-       class HierarchicIterator;
-       class CpGridData;
-       class LevelGlobalIdSet;
-
-        /// @brief
-        /// @todo Doc me!
-        /// @tparam
-        template <int codim>
-        class Entity : public EntityRep<codim>
-        {
-            friend class LevelGlobalIdSet;
-            friend class GlobalIdSet;
-            friend class HierarchicIterator;
-            friend class CpGridData;
-
-        public:
-        /// @brief
-        /// @todo Doc me!
-            enum { codimension = codim };
-            enum { dimension = 3 };
-            enum { mydimension = dimension - codimension };
-            enum { dimensionworld = 3 };
-
-            // the official DUNE names
-            typedef Entity    EntitySeed;
-
-            /// @brief
-            /// @todo Doc me!
-            /// @tparam
-            template <int cd>
-            struct Codim
-            {
-                typedef cpgrid::Entity<cd> Entity;
-            };
+        typedef cpgrid::Entity<cd> Entity;
+    };
 
 
-            typedef cpgrid::Geometry<3-codim,3> Geometry;
-            typedef Geometry LocalGeometry;
+    typedef cpgrid::Geometry<3-codim,3> Geometry;
+    typedef Geometry LocalGeometry;
 
-            typedef cpgrid::IntersectionIterator LeafIntersectionIterator;
-            typedef cpgrid::IntersectionIterator LevelIntersectionIterator;
-            typedef cpgrid::HierarchicIterator HierarchicIterator;
+    typedef cpgrid::IntersectionIterator LeafIntersectionIterator;
+    typedef cpgrid::IntersectionIterator LevelIntersectionIterator;
+    typedef cpgrid::HierarchicIterator HierarchicIterator;
 
-            typedef double ctype;
+    typedef double ctype;
 
-            /// Constructor taking a grid and an integer entity representation.
-            /// This constructor should probably be removed, since it exposes
-            /// details of the implementation of \see EntityRep, see comment in
-            /// EntityRep<>::EntityRep(int).
-//             Entity(const CpGridData& grid, int entityrep)
-//              : EntityRep<codim>(entityrep), pgrid_(&grid)
-//          {
-//          }
+    /// Constructor taking a grid and an integer entity representation.
+    /// This constructor should probably be removed, since it exposes
+    /// details of the implementation of \see EntityRep, see comment in
+    /// EntityRep<>::EntityRep(int).
+    //             Entity(const CpGridData& grid, int entityrep)
+    //              : EntityRep<codim>(entityrep), pgrid_(&grid)
+    //          {
+    //          }
 
-            /// Constructor creating empty entity
-            Entity()
-                : EntityRep<codim>(), pgrid_( 0 )
-            {
-            }
+    /// Constructor creating empty entity
+    Entity()
+        : EntityRep<codim>(), pgrid_( 0 )
+    {
+    }
 
-            /// Constructor taking a grid and an entity representation.
-            Entity(const CpGridData& grid, EntityRep<codim> entityrep)
-                : EntityRep<codim>(entityrep), pgrid_(&grid)
-            {
-            }
+    /// Constructor taking a grid and an entity representation.
+    Entity(const CpGridData& grid, EntityRep<codim> entityrep)
+        : EntityRep<codim>(entityrep), pgrid_(&grid)
+    {
+    }
 
-            /// Constructor taking a grid, entity index, and orientation.
-            Entity(const CpGridData& grid, int index_arg, bool orientation_arg)
-                : EntityRep<codim>(index_arg, orientation_arg), pgrid_(&grid)
-            {
-            }
+    /// Constructor taking a grid, entity index, and orientation.
+    Entity(const CpGridData& grid, int index_arg, bool orientation_arg)
+        : EntityRep<codim>(index_arg, orientation_arg), pgrid_(&grid)
+    {
+    }
 
-            /// Constructor taking a entity index, and orientation.
-            Entity(int index_arg, bool orientation_arg)
-                : EntityRep<codim>(index_arg, orientation_arg), pgrid_()
-            {
-            }
+    /// Constructor taking a entity index, and orientation.
+    Entity(int index_arg, bool orientation_arg)
+        : EntityRep<codim>(index_arg, orientation_arg), pgrid_()
+    {
+    }
 
-            /// Equality.
-            bool operator==(const Entity& other) const
-            {
-                return EntityRep<codim>::operator==(other)  &&  pgrid_ == other.pgrid_;
-            }
+    /// Equality.
+    bool operator==(const Entity& other) const
+    {
+        return EntityRep<codim>::operator==(other)  &&  pgrid_ == other.pgrid_;
+    }
 
-            /// Inequality.
-            bool operator!=(const Entity& other) const
-            {
-                return !operator==(other);
-            }
+    /// Inequality.
+    bool operator!=(const Entity& other) const
+    {
+        return !operator==(other);
+    }
 
-            /// @brief Return an entity seed (light-weight entity).
-            ///        EntitySeed objects are used to obtain an Entity back when combined with the corresponding grid.
-            ///        For CpGrid, EntitySeed and EntityPtr are the same class.
-            EntitySeed seed() const
-            {
-                return EntitySeed( impl() );
-            }
+    /// @brief Return an entity seed (light-weight entity).
+    ///        EntitySeed objects are used to obtain an Entity back when combined with the corresponding grid.
+    ///        For CpGrid, EntitySeed and EntityPtr are the same class.
+    EntitySeed seed() const
+    {
+        return EntitySeed( impl() );
+    }
 
-            /// @brief Return the geometry of the entity (does not depend on its orientation).
-            const Geometry& geometry() const;
+    /// @brief Return the geometry of the entity (does not depend on its orientation).
+    const Geometry& geometry() const;
 
-            /// @brief Return the level of the entity in the grid hierarchy. Level = 0 represents the coarsest grid.
-            int level() const;
+    /// @brief Return the level of the entity in the grid hierarchy. Level = 0 represents the coarsest grid.
+    int level() const;
 
-            /// @brief Check if the entity is in the leafview.
-            ///
-            ///        @TODO: Modify the definition to cover serial and parallel cases.
-            ///        Serial: an element is a leaf <-> hbegin and hend return the same iterator
-            ///        Parallel: true <-> the element is a leaf entity of the global refinement hierarchy.
-            bool isLeaf() const;
+    /// @brief Check if the entity is in the leafview.
+    ///
+    ///        @TODO: Modify the definition to cover serial and parallel cases.
+    ///        Serial: an element is a leaf <-> hbegin and hend return the same iterator
+    ///        Parallel: true <-> the element is a leaf entity of the global refinement hierarchy.
+    bool isLeaf() const;
 
-            /// Refinement is not defined for CpGrid.
-            bool isRegular() const
-            {
-                return true;
-            }
+    /// Refinement is not defined for CpGrid.
+    bool isRegular() const
+    {
+        return true;
+    }
 
-            /// @brief For now, the grid is serial and the only partitionType() is InteriorEntity.
-            ///        Only needed when distributed_data_ is not empty.
-            PartitionType partitionType() const;
+    /// @brief For now, the grid is serial and the only partitionType() is InteriorEntity.
+    ///        Only needed when distributed_data_ is not empty.
+    PartitionType partitionType() const;
 
-            /// @brief Return marker object (GeometryType object) representing the reference element of the entity.
-            ///        Currently, cube type for all entities (cells and vertices).
-            GeometryType type() const
-            {
-                return Dune::GeometryTypes::cube(3 - codim);
-            }
+    /// @brief Return marker object (GeometryType object) representing the reference element of the entity.
+    ///        Currently, cube type for all entities (cells and vertices).
+    GeometryType type() const
+    {
+        return Dune::GeometryTypes::cube(3 - codim);
+    }
 
-            /// @brief Return the number of all subentities of the entity of a given codimension cc.
-            unsigned int subEntities ( const unsigned int cc ) const;
+    /// @brief Return the number of all subentities of the entity of a given codimension cc.
+    unsigned int subEntities ( const unsigned int cc ) const;
 
-            /// @brief Obtain subentity.
-            ///        Example: If cc = 3 and i = 5, it returns the 5th corner/vertex of the entity.
-            template <int cc>
-            typename Codim<cc>::Entity subEntity(int i) const;
+    /// @brief Obtain subentity.
+    ///        Example: If cc = 3 and i = 5, it returns the 5th corner/vertex of the entity.
+    template <int cc>
+    typename Codim<cc>::Entity subEntity(int i) const;
 
-            /// Start level-iterator for the cell-cell intersections of this entity.
-            inline LevelIntersectionIterator ilevelbegin() const;
+    /// Start level-iterator for the cell-cell intersections of this entity.
+    inline LevelIntersectionIterator ilevelbegin() const;
 
-            /// End level-iterator for the cell-cell intersections of this entity.
-            inline LevelIntersectionIterator ilevelend() const;
+    /// End level-iterator for the cell-cell intersections of this entity.
+    inline LevelIntersectionIterator ilevelend() const;
 
-            /// Start leaf-iterator for the cell-cell intersections of this entity.
-            inline LeafIntersectionIterator ileafbegin() const;
+    /// Start leaf-iterator for the cell-cell intersections of this entity.
+    inline LeafIntersectionIterator ileafbegin() const;
 
-            /// End leaf-iterator for the cell-cell intersections of this entity.
-            inline LeafIntersectionIterator ileafend() const;
+    /// End leaf-iterator for the cell-cell intersections of this entity.
+    inline LeafIntersectionIterator ileafend() const;
 
 
-            /// @brief Iterator begin over the children. [If requested, also over descendants more than one generation away.]
-            HierarchicIterator hbegin(int) const;
+    /// @brief Iterator begin over the children. [If requested, also over descendants more than one generation away.]
+    HierarchicIterator hbegin(int) const;
 
-            /// @brief Iterator end over the children/beyond last child iterator.
-            HierarchicIterator hend(int) const;
+    /// @brief Iterator end over the children/beyond last child iterator.
+    HierarchicIterator hend(int) const;
 
-            /// \brief Returns true, if the entity has been created during the last call to adapt(). Dummy.
-            bool isNew() const
-            {
-                return false;
-            }
+    /// \brief Returns true, if the entity has been created during the last call to adapt(). Dummy.
+    bool isNew() const
+    {
+        return false;
+    }
 
-            /// \brief Returns true, if entity might disappear during the next call to adapt(). Dummy.
-            bool mightVanish() const
-            {
-                return false;
-            }
+    /// \brief Returns true, if entity might disappear during the next call to adapt(). Dummy.
+    bool mightVanish() const
+    {
+        return false;
+    }
 
-            /// @brief ONLY FOR CELLS (Entity<0>)
-            ///        Check if the entity comes from an LGR, i.e., it has been created via refinement from coarser level.
-            ///
-            ///        @TODO: When distributed_data_ is not empty, check whether the father element exists on the
-            ///        local process, which can be used to test whether it is safe to call father.
-            bool hasFather() const;
+    /// @brief ONLY FOR CELLS (Entity<0>)
+    ///        Check if the entity comes from an LGR, i.e., it has been created via refinement from coarser level.
+    ///
+    ///        @TODO: When distributed_data_ is not empty, check whether the father element exists on the
+    ///        local process, which can be used to test whether it is safe to call father.
+    bool hasFather() const;
 
-            /// @brief  ONLY FOR CELLS (Entity<0>). Get the father Entity, in case entity.hasFather() is true.
-            ///
-            /// @return father-entity
-            Entity<0> father() const;
+    /// @brief  ONLY FOR CELLS (Entity<0>). Get the father Entity, in case entity.hasFather() is true.
+    ///
+    /// @return father-entity
+    Entity<0> father() const;
 
-            /// @brief Return LocalGeometry representing the embedding of the entity into its father (when hasFather() is true).
-            ///        Map from the entity's reference element into the reference element of its father.
-            ///        Currently, LGR is built via refinement of a block-shaped patch from the coarse grid. So the LocalGeometry
-            ///        of an entity coming from the LGR is one of the refined cells of the unit cube, with suitable amount of cells
-            ///        in each direction.
-            Dune::cpgrid::Geometry<3,3> geometryInFather() const;
+    /// @brief Return LocalGeometry representing the embedding of the entity into its father (when hasFather() is true).
+    ///        Map from the entity's reference element into the reference element of its father.
+    ///        Currently, LGR is built via refinement of a block-shaped patch from the coarse grid. So the LocalGeometry
+    ///        of an entity coming from the LGR is one of the refined cells of the unit cube, with suitable amount of cells
+    ///        in each direction.
+    Dune::cpgrid::Geometry<3,3> geometryInFather() const;
 
-            /// Returns true if any of my intersections are on the boundary.
-            /// Implementation note:
-            /// This is a slow, computed, function. Could be speeded
-            /// up by putting boundary info in the CpGrid class.
-            bool hasBoundaryIntersections() const;
+    /// Returns true if any of my intersections are on the boundary.
+    /// Implementation note:
+    /// This is a slow, computed, function. Could be speeded
+    /// up by putting boundary info in the CpGrid class.
+    bool hasBoundaryIntersections() const;
 
-            // Mimic Dune entity wrapper
-            /// @brief Access the actual implementation class behind Entity interface class.
-            const Entity& impl() const
-            {
-                return *this;
-            }
+    // Mimic Dune entity wrapper
+    /// @brief Access the actual implementation class behind Entity interface class.
+    const Entity& impl() const
+    {
+        return *this;
+    }
 
-            Entity& impl()
-            {
-                return *this;
-            }
+    Entity& impl()
+    {
+        return *this;
+    }
 
-            /// isValid method for EntitySeed
-            /// \return return true if seed is pointing to a valid entity
-            bool isValid () const;
+    /// isValid method for EntitySeed
+    /// \return return true if seed is pointing to a valid entity
+    bool isValid () const;
 
-        protected:
-            const CpGridData* pgrid_;
-        private:
-            // mutable as it is used in a const function
-            /// \brief stores the corner of the geometry in father if geometryInFather is called.
-            mutable std::shared_ptr<EntityVariable<cpgrid::Geometry<0, 3>, 3>> in_father_reference_elem_corners_;
-            // static to not need any extra storage per Enitity. One object used for all instances
-            // constexpr to allow for in-class instantiation
-            /// \brief Indices of corners in in_father_reference_elem_corners_ for the Geometry returned by geometryInFather
-            static constexpr std::array<int,8> in_father_reference_elem_corner_indices_ =
-                { 0, 1, 2, 3, 4, 5, 6, 7 };
-        };
+protected:
+    const CpGridData* pgrid_;
+private:
+    // static    to not need any extra storage per Enitity. One object used for all instances
+    // constexpr to allow for in-class instantiation
+    /// \brief Indices of corners in entity's geometry in father reference element, for the Geometry returned by geometryInFather
+    static constexpr std::array<int,8> in_father_reference_elem_corner_indices_ = {0,1,2,3,4,5,6,7};
+};
 
-    } // namespace cpgrid
+} // namespace cpgrid
 } // namespace Dune
 
 // now we include the Iterators.hh We need to do this here because for hbegin/hend the compiler
@@ -497,7 +493,7 @@ Dune::cpgrid::Geometry<3,3> Dune::cpgrid::Entity<codim>::geometryInFather() cons
             pgrid_ -> getIJK(child0_Idx, child0_IJK);
         }
         // Transform the local coordinates that comes from the refinemnet in such a way that the
-        // reference element of each parent cell is the unit cube. Here, eIJK[*]/cells_per_dim[*]
+        // reference element of each parent cell is the unit cube. Here, (eIJK[*]-"shift")/cells_per_dim[*]
         // Get the local coordinates of the entity (in the reference unit cube).
         FieldVector<double, 3> corners_in_father_reference_elem_temp[8] = {
             // corner '0'
@@ -524,9 +520,9 @@ Dune::cpgrid::Geometry<3,3> Dune::cpgrid::Entity<codim>::geometryInFather() cons
             // corner '7'
             { double(eIJK[0]-child0_IJK[0]+1)/cells_per_dim[0], double(eIJK[1]-child0_IJK[1]+1)/cells_per_dim[1],
               double(eIJK[2]-child0_IJK[2]+1)/cells_per_dim[2] }};
-        in_father_reference_elem_corners_ = std::make_shared<EntityVariable<cpgrid::Geometry<0, 3>, 3>>();
-        EntityVariableBase<cpgrid::Geometry<0, 3>>& mutable_in_father_reference_elem_corners = *in_father_reference_elem_corners_;
-        // assign the corners. Make use of the fact that pointers behave like iterators.
+        auto in_father_reference_elem_corners = std::make_shared<EntityVariable<cpgrid::Geometry<0, 3>, 3>>();
+        EntityVariableBase<cpgrid::Geometry<0, 3>>& mutable_in_father_reference_elem_corners = *in_father_reference_elem_corners;
+        // Assign the corners. Make use of the fact that pointers behave like iterators.
         mutable_in_father_reference_elem_corners.assign(corners_in_father_reference_elem_temp,
                                                         corners_in_father_reference_elem_temp + 8);
         // Compute the center of the 'local-entity'.
@@ -541,9 +537,8 @@ Dune::cpgrid::Geometry<3,3> Dune::cpgrid::Entity<codim>::geometryInFather() cons
         double volume_in_father_reference_elem = double(1)/(cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]);
         // Construct (and return) the Geometry<3,3> of 'child-cell in the reference element of its father (unit cube)'.
         return Dune::cpgrid::Geometry<3,3>(center_in_father_reference_elem, volume_in_father_reference_elem,
-                                           *in_father_reference_elem_corners_, in_father_reference_elem_corner_indices_.data());
+                                           in_father_reference_elem_corners, in_father_reference_elem_corner_indices_.data());
     }
-
 }
 
 

--- a/opm/grid/cpgrid/Intersection.cpp
+++ b/opm/grid/cpgrid/Intersection.cpp
@@ -185,7 +185,7 @@ Intersection::Entity Intersection::outside() const
 
 Intersection::Geometry Intersection::geometry() const
 {
-    return pgrid_->geometry_.geomVector<1>()[faces_of_cell_[subindex_]];
+    return pgrid_-> geometry_.geomVector<1>()[faces_of_cell_[subindex_]];
 }
 
 

--- a/opm/grid/cpgrid/writeSintefLegacyFormat.cpp
+++ b/opm/grid/cpgrid/writeSintefLegacyFormat.cpp
@@ -102,7 +102,7 @@ namespace Dune
             if (!file) {
                 OPM_THROW(std::runtime_error, "Could not open file " + vtkfilename);
             }
-            writeVtkVolumes(file, geometry_.geomVector(std::integral_constant<int,3>()), cell_to_point_);
+            writeVtkVolumes(file, *(geometry_.geomVector(std::integral_constant<int,3>())), cell_to_point_);
         }
     }
 

--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -153,11 +153,12 @@ BOOST_AUTO_TEST_CASE(cellgeom)
 //     for (int i = 0; i < 8; ++i) {
 //         std::cout << corners[i] << std::endl;
 //     }
-    cpgrid::EntityVariable<cpgrid::Geometry<0, 3>, 3> pg;
-    pg.reserve(8);
+    // call empty constructor initialze an object that we point to.
+    auto pg = std::make_shared<cpgrid::EntityVariable<cpgrid::Geometry<0, 3>, 3>>();
+    (*pg).reserve(8);
     for (const auto& crn : corners)
     {
-        pg.push_back(cpgrid::Geometry<0, 3>(crn));
+        (*pg).push_back(cpgrid::Geometry<0, 3>(crn));
     }
 
     int cor_idx[8] = { 0, 1, 2, 3, 4, 5, 6, 7 };
@@ -208,11 +209,12 @@ BOOST_AUTO_TEST_CASE(cellgeom)
     corners[5][2] = 0.0;
     corners[7][2] = 0.0;
 
-    cpgrid::EntityVariable<cpgrid::Geometry<0, 3>, 3> pg1;
-    pg1.reserve(8);
+    // call empty constructor initialze an object that we point to.
+    auto pg1 = std::make_shared<cpgrid::EntityVariable<cpgrid::Geometry<0, 3>, 3>>();
+    (*pg1).reserve(8);
     for (const auto& crn : corners)
     {
-        pg1.push_back(cpgrid::Geometry<0, 3>(crn));
+        (*pg1).push_back(cpgrid::Geometry<0, 3>(crn));
     }
     g = Geometry(c, v, pg1, cor_idx);
 
@@ -525,9 +527,10 @@ BOOST_AUTO_TEST_CASE(refine_simple_cube)
     const GlobalCoordinate c = {0.5, 0.5, 0.5};
     const Geometry::ctype v = 1.0;
 
-    cpgrid::EntityVariable<cpgrid::Geometry<0, 3>, 3> pg;
+    // call empty constructor initialze an object that we point to.
+    auto pg = std::make_shared<cpgrid::EntityVariable<cpgrid::Geometry<0, 3>, 3>>();
     for (const auto& crn : corners) {
-        pg.push_back(cpgrid::Geometry<0, 3>(crn));
+        (*pg).push_back(cpgrid::Geometry<0, 3>(crn));
     }
 
     int cor_idx[8] = {0, 1, 2, 3, 4, 5, 6, 7};
@@ -566,9 +569,10 @@ BOOST_AUTO_TEST_CASE(refine_distorted_cube)
         }
     }
 
-    cpgrid::EntityVariable<cpgrid::Geometry<0, 3>, 3> pg;
+    // call empty constructor initialze an object that we point to.
+    auto pg = std::make_shared<cpgrid::EntityVariable<cpgrid::Geometry<0, 3>, 3>>();
     for (const auto& crn : corners) {
-        pg.push_back(cpgrid::Geometry<0, 3>(crn));
+        (*pg).push_back(cpgrid::Geometry<0, 3>(crn));
     }
 
     int cor_idx[8] = {0, 1, 2, 3, 4, 5, 6, 7};


### PR DESCRIPTION
Improved solution (to the one given in #656) for the lifetime of the Geometry object returned by `Entity::geometryInFather()`, exploiting the advantages of shared pointers.  With the current approach, the Geometry object (returned by `Entity::geometryInFather()`) might live longer than its corresponding Entity.