### PR TITLE
Correctly support item 3 of PINCH (MAX_EMPTY_GAP).

### DIFF
--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -550,7 +550,7 @@ void CpGrid::createCartesian(const std::array<int, 3>& dims,
 #if HAVE_ECL_INPUT
                                              nullptr,
 #endif
-                                             nnc, false, false, false);
+                                             nnc, false, false, false, 0.0);
     // global grid only on rank 0
     current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
                                          current_view_data_->logical_cartesian_size_.size(),
@@ -1348,7 +1348,7 @@ void CpGrid::processEclipseFormat(const grdecl& input_data,
                                              nullptr,
 #endif
                                              nnc,
-                                             remove_ij_boundary, turn_normals, false);
+                                             remove_ij_boundary, turn_normals, false, 0.0);
     current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
                                          current_view_data_->logical_cartesian_size_.size(),
                                          0);

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -237,6 +237,7 @@ public:
     ///        side. That is, i- faces will match i+ faces etc.
     /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
     /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
+    /// \param pichActive Whether PINCH keyword was specified
     std::vector<std::size_t> processEclipseFormat(const Opm::EclipseGrid* ecl_grid, Opm::EclipseState* ecl_state,
                                                   bool periodic_extension, bool turn_normals = false, bool clip_z = false,
                                                   bool pinchActive = true);
@@ -252,12 +253,14 @@ public:
     /// \param remove_ij_boundary if true, will remove (i, j) boundaries. Used internally.
     /// \param pinchActive If true, we will add faces between vertical cells that have only inactive cells or cells
     ///            with zero volume between them. If false these cells will not be connected.
+    /// \param tolerance_unique_points Tolerance used to identify points based on their cooridinate
     void processEclipseFormat(const grdecl& input_data,
 #if HAVE_ECL_INPUT
                               Opm::EclipseState* ecl_state,
 #endif
                               std::array<std::set<std::pair<int, int>>, 2>& nnc,
-                              bool remove_ij_boundary, bool turn_normals, bool pinchActive);
+                              bool remove_ij_boundary, bool turn_normals, bool pinchActive,
+                              double tolerance_unique_points);
 
     /// @brief
     ///    Extract Cartesian index triplet (i,j,k) of an active cell.

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -149,10 +149,10 @@ namespace cpgrid
         g.actnum = actnumData.empty() ? nullptr : &actnumData[0];
         Opm::MinpvProcessor::Result minpv_result;
 
-        // Possibly process MINPV
-        if (ecl_state && (ecl_grid.getMinpvMode() != Opm::MinpvMode::Inactive)) {
+        // Possibly process MINPV and PINCH
+        // This even needs to be done if neither of them is specified.
+        if (ecl_state ) {
             Opm::MinpvProcessor mp(g.dims[0], g.dims[1], g.dims[2]);
-            // Currently PINCH is always assumed to be active
             const size_t cartGridSize = g.dims[0] * g.dims[1] * g.dims[2];
             std::vector<double> thickness(cartGridSize);
             for (size_t i = 0; i < cartGridSize; ++i) {

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -149,6 +149,7 @@ namespace cpgrid
         g.actnum = actnumData.empty() ? nullptr : &actnumData[0];
         Opm::MinpvProcessor::Result minpv_result;
 
+        double tolerance_unique_points = 0;
         // Possibly process MINPV and PINCH
         // This even needs to be done if neither of them is specified.
         if (ecl_state ) {
@@ -175,7 +176,7 @@ namespace cpgrid
             minpv_result = mp.process(thickness, z_tolerance, ecl_grid.getPinchMaxEmptyGap(),
                                       poreVolume, ecl_grid.getMinpvVector(), actnumData, false,
                                       zcornData.data(), nogap, pinchOptionALL,
-                                      permZ, multZ);
+                                      permZ, multZ, tolerance_unique_points);
             if (!minpv_result.nnc.empty()) {
                 this->zcorn = zcornData;
             }
@@ -249,10 +250,10 @@ namespace cpgrid
             grdecl new_g;
             addOuterCellLayer(g, new_coord, new_zcorn, new_actnum, new_g);
             // Make the grid.
-            processEclipseFormat(new_g, ecl_state, nnc_cells, true, turn_normals, pinchActive);
+            processEclipseFormat(new_g, ecl_state, nnc_cells, true, turn_normals, pinchActive, tolerance_unique_points);
         } else {
             // Make the grid.
-            processEclipseFormat(g, ecl_state, nnc_cells, false, turn_normals, pinchActive);
+            processEclipseFormat(g, ecl_state, nnc_cells, false, turn_normals, pinchActive, tolerance_unique_points);
         }
 
         return minpv_result.removed_cells;
@@ -269,7 +270,8 @@ namespace cpgrid
                                           Opm::EclipseState* ecl_state,
 #endif
                                           NNCMaps& nnc, bool remove_ij_boundary, bool turn_normals,
-                                          bool pinchActive)
+                                          bool pinchActive,
+                                          double tolerance_unique_points)
     {
         if( ccobj_.rank() != 0 )
         {
@@ -291,11 +293,11 @@ namespace cpgrid
             for ([[maybe_unused]]const auto&[global_index, volume] : aquifer_cell_volumes) {
                 is_aquifer_cell[global_index] = 1;
             }
-            process_ok = process_grdecl(&input_data, 0, is_aquifer_cell.data(), &output, pinchActive);
+            process_ok = process_grdecl(&input_data, tolerance_unique_points, is_aquifer_cell.data(), &output, pinchActive);
         } else
 #endif
         {
-            process_ok = process_grdecl(&input_data, 0, nullptr, &output, pinchActive);
+            process_ok = process_grdecl(&input_data, tolerance_unique_points, nullptr, &output, pinchActive);
         }
 
         if (process_ok == 0) {

--- a/tests/test_minpvprocessor.cpp
+++ b/tests/test_minpvprocessor.cpp
@@ -27,6 +27,39 @@
 
 #include <opm/grid/MinpvProcessor.hpp>
 
+
+BOOST_AUTO_TEST_CASE(GAP_MAXGAP)
+{
+    // Set up a simple example.
+    std::vector<double> zcorn = { 0, 0, 0, 0,
+                                  2, 2, 2, 2,
+                                  2, 2, 2, 2,
+                                  2.5, 2.5, 2.5, 2.5,
+                                  2.8, 2.8, 2.8, 2.8,
+                                  3.5, 3.5, 3.5, 3.5};
+    std::vector<double> pv = { 2, 0.5, 0.7};
+    std::vector<double> minpvv(3, 0.6);
+    std::vector<int> actnum = { 1, 1, 1 };
+    std::vector<double> thickness = {2, 0.5, 0.7};
+    double z_threshold = 0.4;
+
+    Opm::MinpvProcessor mp1(1, 1, 3);
+    auto z1 = zcorn;
+    double max_gap = 1e20;
+    bool fill_removed_cells = false;
+    bool pinch_no_gap = false;
+
+    auto minpv_result = mp1.process(thickness, z_threshold, max_gap, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
+    BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 1);
+    BOOST_CHECK_EQUAL(minpv_result.nnc[0], 2);
+
+    max_gap = .29;
+    zcorn = z1;
+    minpv_result = mp1.process(thickness, z_threshold, max_gap, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
+    BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 0);
+}
+
+    
 BOOST_AUTO_TEST_CASE(Pinch)
 {
     // Set up a simple example.


### PR DESCRIPTION
MAX_EMPTY_GAP specifies the maximum thickness of gap between active cells allowed for creating NNCs. The default value is 1.0e20 in any unit system.

If PINCH is not specified, then the EclipseGrid will specify 1e20 in SI units. This should be big enough to account for infinity in a simulation and hence this implementation should work.

Fixes the following cases in opm-tests: T2A_NOPINCH, T2A_GAP, T2A_NOGAP