### PR TITLE
Correctly process inactive thin cell not next to pinched out cells.

### DIFF
--- a/opm/grid/MinpvProcessor.cpp
+++ b/opm/grid/MinpvProcessor.cpp
@@ -243,8 +243,8 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                             kk = kk_iter;
                             continue;
                         }
-                        // top or bottom cell not active, hence no ncc is created
-                        if (!actnum.empty() && (!actnum[c] ||  !actnum[c_below])) {
+                        // bottom cell not active, hence no ncc is created
+                        if (!actnum.empty() && !actnum[c_below]) {
                             kk = kk_iter;
                             continue;
                         }

--- a/opm/grid/MinpvProcessor.cpp
+++ b/opm/grid/MinpvProcessor.cpp
@@ -243,13 +243,14 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                             kk = kk_iter;
                             continue;
                         }
-                        // bottom cell not active, hence no ncc is created
+                        // bottom cell not active, hence no nnc is created
                         if (!actnum.empty() && !actnum[c_below]) {
                             kk = kk_iter;
                             continue;
                         }
 
-                        // Bypass inactive cells with thickness below tolerance and active cells with volume below minpv
+                        // Bypass inactive cells with thickness below tolerance and
+                        // active cells with volume below minpv
                         int k_above = kk-1;
                         int c_above = ii + dims_[0] * (jj + dims_[1] * (kk-1));
                         auto above_active = actnum.empty() || actnum[c_above];

--- a/opm/grid/MinpvProcessor.cpp
+++ b/opm/grid/MinpvProcessor.cpp
@@ -118,16 +118,26 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                 // a case
                 bool option4ALLSupported = false;
                 const int c = ii + dims_[0] * (jj + dims_[1] * kk);
-                if (pv[c] < minpvv[c] && (actnum.empty() || actnum[c])) {
-                    // Cell is made inactive due to MINPV
+                bool c_active = actnum.empty() || actnum[c];
+                bool c_thin = (thickness[c] <= z_tolerance);
+                bool c_thin_inactive = !c_active && c_thin;
+                bool c_low_pv_active = pv[c] < minpvv[c] && c_active;
+
+                if (c_low_pv_active || c_thin_inactive) {
+                    std::array<double, 8> cz = getCellZcorn(ii, jj, kk, zcorn);
+                    // Cell is either inactive or made inactive due to MINPV
+
                     // Move deeper (higher k) coordinates to lower k coordinates.
                     // i.e remove the cell
-                    std::array<double, 8> cz = getCellZcorn(ii, jj, kk, zcorn);
                     for (int count = 0; count < 4; ++count) {
                         cz[count + 4] = cz[count];
                     }
                     setCellZcorn(ii, jj, kk, cz, zcorn);
-                    result.removed_cells.push_back(c);
+
+                    if (c_low_pv_active) {
+                        // Inactive due to MINPV mark it as removed
+                        result.removed_cells.push_back(c);
+                    }
 
                     if (kk == dims_[2] - 1) {
                         // this is cell at the bottom of the grid
@@ -135,7 +145,19 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                         continue;
                     }
 
-                    // Find the next cell
+                    // In the case of PinchNOGAP this cell must be thin to allow NNCs, if it was deactivated
+                    // via PINCH, too.
+                    // In addition skip NNC if PINCH option 4 is ALL and we know that Z transmissibilty will
+                    // be zero because of multz or permz
+                    bool nnc_allowed = (!c_low_pv_active || (!pinchNOGAP || thickness[c] <= z_tolerance))
+                        && (!pinchOption4ALL || (permz[c] != 0.0 && multz(c) != 0.0) );
+
+                    if (pinchOption4ALL)
+                    {
+                        option4ALLSupported = option4ALLSupported || permz[c] == 0 || multz(c) == 0;
+                    }
+
+                    // Find the next cell below
                     int kk_iter = kk + 1;
 
                     int c_below = ii + dims_[0] * (jj + dims_[1] * (kk_iter));
@@ -143,16 +165,7 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                     bool thin = (thickness[c_below] <= z_tolerance);
                     bool thin_inactive = !active && thin;
                     bool low_pv_active = pv[c_below] < minpvv[c_below] && active;
-                    // In the case of PichNOGAP this cell must be thin to allow NNCs, too.
-                    // In addition skip NNC if PINCH option 4 is ALL and we know that Z transmissibilty will
-                    // be zero because of multz or permz
-                    bool nnc_allowed = (!pinchNOGAP || thickness[c] <= z_tolerance)
-                        && (!pinchOption4ALL || (permz[c] != 0.0 && multz(c) != 0.0) );
 
-                    if (pinchOption4ALL)
-                    {
-                        option4ALLSupported = option4ALLSupported || permz[c] == 0 || multz(c) == 0;
-                    }
 
                     while ( (thin_inactive || low_pv_active) && kk_iter < dims_[2] )
                     {
@@ -212,7 +225,7 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                     }
 
                     // create nnc if false or merge the cells if true
-                    if (mergeMinPVCells) {
+                    if (mergeMinPVCells && c_low_pv_active) {
                         // Set lower k coordinates of cell below to upper cells's coordinates.
                         // i.e fill the void using the cell below
                         std::array<double, 8> cz_below = getCellZcorn(ii, jj, kk_iter, zcorn);

--- a/tests/test_minpvprocessor.cpp
+++ b/tests/test_minpvprocessor.cpp
@@ -217,9 +217,25 @@ BOOST_AUTO_TEST_CASE(Processing)
                                   2, 2, 2, 2,
                                   3, 3, 3, 3,
                                   3, 3, 3, 3,
-                                  3, 3, 3, 3,
-                                  3, 3, 3, 3,
+                                  3.1, 3.1, 3.1, 3.1,
+                                  3.1, 3.1, 3.1, 3.1,
                                   6, 6, 6, 6 };
+    std::vector<double> zcorn1after = { 0, 0, 0, 0,
+                                        2, 2, 2, 2,
+                                        2, 2, 2, 2,
+                                        3, 3, 3, 3,
+                                        3, 3, 3, 3,
+                                        3, 3, 3, 3, // thin inactive cell collapsed
+                                        3.1, 3.1, 3.1, 3.1,
+                                        6, 6, 6, 6 };
+    std::vector<double> zcorn1bafter = { 0, 0, 0, 0,
+                                        2, 2, 2, 2,
+                                        2, 2, 2, 2,
+                                        3, 3, 3, 3,
+                                        3, 3, 3, 3,
+                                        3, 3, 3, 3, // collapsed thin active cell with small pv
+                                        3, 3, 3, 3, // pv filled,
+                                        6, 6, 6, 6 };
     std::vector<double> zcorn2after = { 0, 0, 0, 0,
                                         2, 2, 2, 2,
                                         2, 2, 2, 2,
@@ -242,7 +258,7 @@ BOOST_AUTO_TEST_CASE(Processing)
                                         2, 2, 2, 2,
                                         2, 2, 2, 2,
                                         2, 2, 2, 2,
-                                        3, 3, 3, 3,
+                                        3.1, 3.1, 3.1, 3.1,
                                         6, 6, 6, 6 };
     std::vector<double> zcorn5after = { 0, 0, 0, 0,
                                         0, 0, 0, 0,
@@ -250,7 +266,15 @@ BOOST_AUTO_TEST_CASE(Processing)
                                         2, 2, 2, 2,
                                         2, 2, 2, 2,
                                         2, 2, 2, 2,
+                                        3.1, 3.1, 3.1, 3.1,
+                                        6, 6, 6, 6 };
+    std::vector<double> zcorn7after = { 0, 0, 0, 0,
+                                        2, 2, 2, 2,
+                                        2, 2, 2, 2,
                                         3, 3, 3, 3,
+                                        3, 3, 3, 3,
+                                        3, 3, 3, 3,
+                                        3.1, 3.1, 3.1, 3.1,
                                         6, 6, 6, 6 };
 
     std::vector<double> pv = { 2, 1, 0, 3};
@@ -264,13 +288,13 @@ BOOST_AUTO_TEST_CASE(Processing)
     std::vector<double> minpvv1(4, 0.5);
     bool fill_removed_cells = true;
     mp1.process(thicknes, z_threshold, 1e20, pv, minpvv1, actnum, fill_removed_cells, z1.data());
-    BOOST_CHECK_EQUAL_COLLECTIONS(z1.begin(), z1.end(), zcorn.begin(), zcorn.end());
+    BOOST_CHECK_EQUAL_COLLECTIONS(z1.begin(), z1.end(), zcorn1after.begin(), zcorn1after.end());
 
     // check that it is possible to pass empty actnum
     Opm::MinpvProcessor mp1b(1, 1, 4);
     auto z1b = zcorn;
     mp1b.process(thicknes, z_threshold, 1e20, pv, minpvv1, actnum_empty, fill_removed_cells, z1b.data());
-    BOOST_CHECK_EQUAL_COLLECTIONS(z1b.begin(), z1b.end(), zcorn.begin(), zcorn.end());
+    BOOST_CHECK_EQUAL_COLLECTIONS(z1b.begin(), z1b.end(), zcorn1bafter.begin(), zcorn1bafter.end());
 
     Opm::MinpvProcessor mp2(1, 1, 4);
     auto z2 = zcorn;
@@ -305,4 +329,13 @@ BOOST_AUTO_TEST_CASE(Processing)
     auto minpv_result6 = mp6.process(thicknes, z_threshold, 1e20, pv, minpvv6, actnum, !fill_removed_cells, z6.data());
     BOOST_CHECK_EQUAL(minpv_result6.nnc.size(), 1);
     BOOST_CHECK_EQUAL_COLLECTIONS(z6.begin(), z6.end(), zcorn4after.begin(), zcorn4after.end());
+
+    Opm::MinpvProcessor mp7(1, 1, 4);
+    auto z7 = zcorn;
+    std::vector<double> minpvv7(4, 0); // don't deactivate any cells
+    thicknes = {2, 1, 0.1, 3};
+    z_threshold = 0.2; // create NNC over it
+    auto minpv_result7 = mp7.process(thicknes, z_threshold, 1e20, pv, minpvv7, actnum, !fill_removed_cells, z7.data());
+    BOOST_CHECK_EQUAL(minpv_result7.nnc.size(), 1);
+    BOOST_CHECK_EQUAL_COLLECTIONS(z7.begin(), z7.end(), zcorn7after.begin(), zcorn7after.end());
 }


### PR DESCRIPTION
Pinch processing only started when active cells were pinched out due  to pore volume being below the threshold. Over Thin inactive cells, that were processed in the same iteration might, NNCs might be created. The problem was that we never created an NNC over thin inactive cells without a pinched out neighbor.
    
With this patch we do that now and collapse these inactive cells, too.

Fixes test cases T4A1_GAP and T4A1_NOGAP.

This will conflict with #658 and needs to be rebased once that is merged.
