### PR TITLE
Looking up data of leaf cells from level 0 grid supported

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -110,8 +110,11 @@ list (APPEND TEST_SOURCE_FILES
 
 if(Boost_VERSION_STRING VERSION_GREATER 1.53)
 	list(APPEND TEST_SOURCE_FILES
+	  tests/cpgrid/disjointPatches_test.cpp
 	  tests/cpgrid/geometry_test.cpp
 	  tests/cpgrid/grid_lgr_test.cpp
+	  tests/cpgrid/lookupdata_test.cpp
+	  tests/cpgrid/lookupdataCpGrid_test.cpp
 	  tests/cpgrid/shifted_cart_test.cpp
   )
 endif()
@@ -182,6 +185,8 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/grid/cpgrid/Indexsets.hpp
   opm/grid/cpgrid/Intersection.hpp
   opm/grid/cpgrid/Iterators.hpp
+  opm/grid/LookUpData.hh
+  opm/grid/LookUpDataCpGrid.hh
   opm/grid/cpgrid/OrientedEntityTable.hpp
   opm/grid/cpgrid/PartitionIteratorRule.hpp
   opm/grid/cpgrid/PartitionTypeIndicator.hpp

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -84,6 +84,9 @@ namespace Dune
     }
 }
 
+void disjointPatches_check(Dune::CpGrid&,
+                           const std::vector<std::array<int,3>>&,
+                           const std::vector<std::array<int,3>>&);
 
 void lookup_check(const Dune::CpGrid&);
 
@@ -224,6 +227,9 @@ namespace Dune
         friend class cpgrid::Entity<3>;
         template<int dim>
         friend cpgrid::Entity<dim> createEntity(const CpGrid&,int,bool);
+        friend void ::disjointPatches_check(Dune::CpGrid&,
+                                          const std::vector<std::array<int,3>>&,
+                                          const std::vector<std::array<int,3>>&);
         friend void ::lookup_check(const Dune::CpGrid&);
         friend
         void ::refine_and_check(const Dune::cpgrid::Geometry<3,3>&,

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -6,6 +6,7 @@
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
 //            B�rd Skaflestad     <bard.skaflestad@sintef.no>
+//            Antonella Ritorto   <antonella.ritorto>
 //
 // $Date$
 //
@@ -15,7 +16,7 @@
 
 /*
   Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
-  Copyright 2009, 2010, 2014, 2022 Equinor ASA.
+  Copyright 2009, 2010, 2014, 2022-2023 Equinor ASA.
   Copyright 2014, 2015 Dr. Blatt - HPC-Simulartion-Software & Services
   Copyright 2015       NTNU
 
@@ -79,10 +80,13 @@ namespace Dune
     class IntersectionIterator;
     class IndexSet;
     class IdSet;
-
     
     }
 }
+
+
+void lookup_check(const Dune::CpGrid&);
+
 void refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,
                       const std::array<int, 3>&,
                       bool);
@@ -220,6 +224,7 @@ namespace Dune
         friend class cpgrid::Entity<3>;
         template<int dim>
         friend cpgrid::Entity<dim> createEntity(const CpGrid&,int,bool);
+        friend void ::lookup_check(const Dune::CpGrid&);
         friend
         void ::refine_and_check(const Dune::cpgrid::Geometry<3,3>&,
                                 const std::array<int,3>&,

--- a/opm/grid/LookUpData.hh
+++ b/opm/grid/LookUpData.hh
@@ -1,0 +1,64 @@
+//===========================================================================
+//
+// File: LookUpData.hpp
+//
+// Created: Tue May 23 14:44:00 2023
+//
+// Author(s): Antonella Ritorto <antonella.ritorto@opm-op.com>
+//
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+Copyright 2023 Equinor ASA.
+
+This file is part of The Open Porous Media project  (OPM).
+
+OPM is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+OPM is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <dune/grid/common/mcmgmapper.hh>
+#include <opm/grid/cpgrid/Entity.hpp>
+
+namespace Dune
+{
+template <typename GridType>
+class LookUpData
+{
+public:
+    // Constructor taking a CpGrid object
+    LookUpData(const GridType& grid) :
+        leaf_view_(grid.leafGridView()),
+        leafMapper_(leaf_view_, Dune::mcmgElementLayout())
+    {
+    }
+
+    template<typename feature_type>
+    int operator()(const Dune::cpgrid::Entity<0>& elem, const std::vector<feature_type>& feature_vec)
+    {
+        // Assuming there is no LGR, so level 0 = leafview = "GLOBAL"
+        return feature_vec[leafMapper_.index(elem)];
+    }
+protected:
+    typename GridType::LeafGridView leaf_view_;
+    Dune::MultipleCodimMultipleGeomTypeMapper<typename GridType::LeafGridView> leafMapper_;
+
+
+}; // end LookUpData class
+}
+// end namespace Dune

--- a/opm/grid/LookUpDataCpGrid.hh
+++ b/opm/grid/LookUpDataCpGrid.hh
@@ -1,0 +1,60 @@
+//===========================================================================
+//
+// File: LookUpData.hpp
+//
+// Created: Tue May 25 11:45:00 2023
+//
+// Author(s): Antonella Ritorto <antonella.ritorto@opm-op.com>
+//
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2023 Equinor ASA.
+
+  This file is part of The Open Porous Media project  (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Dune
+{
+template <typename GridType>
+class LookUpData
+{
+};
+/// Specialization for CpGrid
+template<>
+class LookUpData<Dune::CpGrid>
+{
+public:
+    // Constructor taking a CpGrid object
+    LookUpData(const Dune::CpGrid&){
+    }
+
+    template<typename feature_type>
+    int operator()(const Dune::cpgrid::Entity<0>& elem, const std::vector<feature_type>& feature_vec)
+    {
+        // elem.getOrigin() Get entity in level 0 (either parent cell, or equivalent cell, or 'itself' if grid_ = level 0)
+        return feature_vec[elem.getOrigin().index()];
+    }
+
+}; // end LookUpData<CpGrid> class
+}
+// end namespace Dune
+

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -1821,6 +1821,7 @@ bool CpGridData::disjointPatches(const std::vector<std::array<int,3>>& startIJK_
     return disjoint;
 }
 
+
 std::vector<int>
 CpGridData::getPatchesCells(const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const
 {

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -1800,25 +1800,50 @@ std::vector<int> CpGridData::getPatchBoundaryCorners(const std::array<int,3>& st
 bool CpGridData::disjointPatches(const std::vector<std::array<int,3>>& startIJK_vec,
                                  const std::vector<std::array<int,3>>& endIJK_vec) const
 {
-    assert(startIJK_vec.size() == endIJK_vec.size());
+    assert(!startIJK_vec.empty());
+    assert(!endIJK_vec.empty());
     if ((startIJK_vec.size() == 1) && (endIJK_vec.size() == 1)){
         return true;
     }
-    // Auxiliary bool
-    bool disjoint = true;
+    if (startIJK_vec.size() != endIJK_vec.size() ){
+        OPM_THROW(std::logic_error, "Sizes of the arguments differ. Not enough information provided.");
+    }
     for (long unsigned int patch = 0; patch < startIJK_vec.size(); ++patch){
-        // Auxiliary bool
+        bool valid_patch = true;
+        for (int c = 0; c < 3; ++c){
+            valid_patch = valid_patch && (startIJK_vec[patch][c] < endIJK_vec[patch][c]);
+        }
+        if (!valid_patch){
+            OPM_THROW(std::logic_error, "There is at least one invalid patch.");
+        }
+    }
+    bool are_disjoint = true;
+    for (long unsigned int patch = 0; patch < startIJK_vec.size(); ++patch) {
         bool patch_disjoint_with_otherPatches = true;
-        for (long unsigned int other_patch = 0; other_patch < startIJK_vec.size(); ++other_patch){
-            if (patch!=other_patch){
-                patch_disjoint_with_otherPatches = patch_disjoint_with_otherPatches &&
-                    ((startIJK_vec[patch] < startIJK_vec[other_patch]) || (startIJK_vec[patch] > endIJK_vec[other_patch]))
-                    &&  ((endIJK_vec[patch] < startIJK_vec[other_patch]) || (endIJK_vec[patch] > endIJK_vec[other_patch]));
+        for (long unsigned int other_patch = patch+1; other_patch < startIJK_vec.size(); ++other_patch) {
+            bool otherPatch_on_rightOrLeft_of_patch = (startIJK_vec[other_patch][0] > endIJK_vec[patch][0]) ||
+                (endIJK_vec[other_patch][0] < startIJK_vec[patch][0]);
+            if (!otherPatch_on_rightOrLeft_of_patch) {
+                bool otherPatch_on_frontOrBack_of_patch = (startIJK_vec[other_patch][1] > endIJK_vec[patch][1]) ||
+                    (endIJK_vec[other_patch][1] < startIJK_vec[patch][1]);
+                if (!otherPatch_on_frontOrBack_of_patch) {
+                    bool otherPatch_on_topOrBottom_of_patch = (startIJK_vec[other_patch][2] > endIJK_vec[patch][2]) ||
+                        (endIJK_vec[other_patch][2] < startIJK_vec[patch][2]);
+                    patch_disjoint_with_otherPatches = patch_disjoint_with_otherPatches && otherPatch_on_topOrBottom_of_patch;
+                    // true for disjoint patches, false for overlapping ones.
+                }
+            }
+            else{
+                patch_disjoint_with_otherPatches = patch_disjoint_with_otherPatches && otherPatch_on_rightOrLeft_of_patch;
+                // true for disjoint patches
+            }
+            if (!patch_disjoint_with_otherPatches){
+                return patch_disjoint_with_otherPatches; // should be false
             }
         }
-        disjoint = disjoint && patch_disjoint_with_otherPatches; // false if one of them is false
+        are_disjoint = are_disjoint && patch_disjoint_with_otherPatches;
     }
-    return disjoint;
+    return are_disjoint; // should be true
 }
 
 

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -20,7 +20,7 @@
 
 /*
   Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
-  Copyright 2009, 2010, 2013, 2022 Equinor ASA.
+  Copyright 2009, 2010, 2013, 2022-2023 Equinor ASA.
   Copyright 2013 Dr. Blatt - HPC-Simulation-Software & Services
 
   This file is part of The Open Porous Media project  (OPM).
@@ -91,9 +91,13 @@ template<int> class EntityRep;
 }
 }
 
+
+void lookup_check(const Dune::CpGrid&);
+
 void refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,
                       const std::array<int, 3>&,
-                    bool);
+                      bool);
+
 void refinePatch_and_check(const std::array<int,3>&,
                            const std::array<int,3>&,
                            const std::array<int,3>&);
@@ -127,7 +131,11 @@ class CpGridData
     friend class GlobalIdSet;
     friend class HierarchicIterator;
     friend class Dune::cpgrid::IndexSet;
-    
+
+
+    friend
+    void ::lookup_check(const Dune::CpGrid&);
+
     friend
     void ::refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,
                             const std::array<int, 3>&,

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -91,6 +91,9 @@ template<int> class EntityRep;
 }
 }
 
+void disjointPatches_check(Dune::CpGrid&,
+                           const std::vector<std::array<int,3>>&,
+                           const std::vector<std::array<int,3>>&);
 
 void lookup_check(const Dune::CpGrid&);
 
@@ -132,6 +135,10 @@ class CpGridData
     friend class HierarchicIterator;
     friend class Dune::cpgrid::IndexSet;
 
+    friend
+    void ::disjointPatches_check(Dune::CpGrid&,
+                                 const std::vector<std::array<int,3>>&,
+                                 const std::vector<std::array<int,3>>&);
 
     friend
     void ::lookup_check(const Dune::CpGrid&);

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -261,6 +261,11 @@ public:
     /// \return return true if seed is pointing to a valid entity
     bool isValid () const;
 
+    /// getOrigin()
+    /// Returns parent entity in level 0, if the entity was born in any LGR.
+    /// Otherwise, returns itself. 
+    Entity<0> getOrigin() const;
+
 protected:
     const CpGridData* pgrid_;
 private:
@@ -541,6 +546,25 @@ Dune::cpgrid::Geometry<3,3> Dune::cpgrid::Entity<codim>::geometryInFather() cons
     }
 }
 
+
+template<int codim>
+Dune::cpgrid::Entity<0> Dune::cpgrid::Entity<codim>::getOrigin() const
+{
+    if (hasFather())
+    {
+        return this->father(); // currently, always a level 0 entity. 
+    }
+    if (!(pgrid_ -> leaf_to_level_cells_.empty()))//(pgrid_ == (*(pgrid_->level_data_ptr_)).back().get() ) // entity on the LeafView
+    {
+        const int& entityIdxInLevel0 = pgrid_->leaf_to_level_cells_[this->index()][1];
+        const auto& coarse_grid = (*(pgrid_ -> level_data_ptr_))[0].get();
+        return Dune::cpgrid::Entity<0>( *coarse_grid, entityIdxInLevel0, true);
+    }
+    else
+    {
+        return *this; 
+    }
+}
 
 } // namespace cpgrid
 } // namespace Dune

--- a/tests/cpgrid/disjointPatches_test.cpp
+++ b/tests/cpgrid/disjointPatches_test.cpp
@@ -1,0 +1,194 @@
+//===========================================================================
+//
+// File: disjointPatches_test.cpp
+//
+// Created: May 30 2023 16:34:00
+//
+// Author(s): Antonella Ritorto   <antonella.ritorto@opm-op.com>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+/*
+  Copyright 2023 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#define BOOST_TEST_MODULE LGRTests
+#include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
+#include <opm/grid/CpGrid.hpp>
+
+
+#include <sstream>
+#include <iostream>
+
+struct Fixture
+{
+    Fixture()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        Dune::MPIHelper::instance(m_argc, m_argv);
+        Opm::OpmLog::setupSimpleDefaultLogging();
+    }
+
+    static int rank()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        return Dune::MPIHelper::instance(m_argc, m_argv).rank();
+    }
+};
+
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+void disjointPatches_check(Dune::CpGrid& grid,
+                           const std::vector<std::array<int,3>>& startIJK_vec,
+                           const std::vector<std::array<int,3>>& endIJK_vec)
+{
+    const auto& data = grid.data_;
+    try
+    {
+        std::cout << std::boolalpha;
+        std::cout << (*data[0]).disjointPatches(startIJK_vec, endIJK_vec) << '\n';
+
+    }
+    catch(const std::exception& e)
+    {
+        std::cout << e.what() << '\n';
+    }
+}
+
+BOOST_AUTO_TEST_CASE(lgrs_disjointPatches)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    grid.createCartesian(grid_dim, cell_sizes);
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,2}, {3,2,2}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {1,1,3}, {4,3,3}};
+    disjointPatches_check(grid, startIJK_vec, endIJK_vec);
+}
+
+BOOST_AUTO_TEST_CASE(lgrs_disjointPatchesB)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    grid.createCartesian(grid_dim, cell_sizes);
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {3,2,0}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1}, {4,3,3}};
+    disjointPatches_check(grid, startIJK_vec, endIJK_vec);
+}
+
+BOOST_AUTO_TEST_CASE(patches_share_corner)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    grid.createCartesian(grid_dim, cell_sizes);
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {1,1,1}, {3,2,2}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{1,1,1}, {2,2,2}, {4,3,3}};
+    disjointPatches_check(grid, startIJK_vec, endIJK_vec);
+}
+
+BOOST_AUTO_TEST_CASE(patches_share_corners)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    grid.createCartesian(grid_dim, cell_sizes);
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {2,0,1}, {3,2,2}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {3,1,2}, {4,3,3}};
+    disjointPatches_check(grid, startIJK_vec, endIJK_vec);
+}
+
+BOOST_AUTO_TEST_CASE(pathces_share_face)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    grid.createCartesian(grid_dim, cell_sizes);
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {2,2,2}, {2,2,2}};
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {2,0,0}, {3,2,2}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {3,1,1}, {4,3,3}};
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
+    disjointPatches_check(grid, startIJK_vec, endIJK_vec);
+}
+
+BOOST_AUTO_TEST_CASE(pathces_share_faceB)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    grid.createCartesian(grid_dim, cell_sizes);
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,1}, {1,1,2}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1}, {3,2,2}, {4,3,3}};
+    disjointPatches_check(grid, startIJK_vec, endIJK_vec);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_argument_sizes)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    grid.createCartesian(grid_dim, cell_sizes);
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,1}, {1,1,2}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1}, {3,2,1}};
+    disjointPatches_check(grid, startIJK_vec, endIJK_vec);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_argument_sizesB)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    grid.createCartesian(grid_dim, cell_sizes);
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,2}, {3,2,2}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {1,1,3}, {4,3,3}, {2,1,1}};
+    disjointPatches_check(grid, startIJK_vec, endIJK_vec);
+}
+
+
+BOOST_AUTO_TEST_CASE(disjoint_patches_C)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    grid.createCartesian(grid_dim, cell_sizes);
+    const std::vector<std::array<int,3>> startIJK_vec = {{2,2,2}, {0,0,0}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{3,3,3}, {4,1,1}};
+    disjointPatches_check(grid, startIJK_vec, endIJK_vec);
+}

--- a/tests/cpgrid/lookupdataCpGrid_test.cpp
+++ b/tests/cpgrid/lookupdataCpGrid_test.cpp
@@ -1,0 +1,168 @@
+//===========================================================================
+//
+// File: lookupdataCpGrid_test.cpp
+//
+// Created: Thurs 25.05.2023 16:05:00
+//
+// Author(s): Antonella Ritorto   <antonella.ritorto@opm-op.com>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+/*
+  Copyright 2023 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#define BOOST_TEST_MODULE LGRTests
+#include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
+#include <opm/grid/CpGrid.hpp>
+#include <opm/grid/LookUpDataCpGrid.hh>
+
+#include <dune/grid/common/mcmgmapper.hh>
+
+#include <sstream>
+#include <iostream>
+
+struct Fixture
+{
+    Fixture()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        Dune::MPIHelper::instance(m_argc, m_argv);
+        Opm::OpmLog::setupSimpleDefaultLogging();
+    }
+
+    static int rank()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        return Dune::MPIHelper::instance(m_argc, m_argv).rank();
+    }
+};
+
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+void lookup_check(const Dune::CpGrid& grid)
+{
+    const auto& data = grid.data_;
+    std::vector<int> fake_feature(data[0]->size(0), 0);
+    std::iota(fake_feature.begin(), fake_feature.end(), 3);
+    const auto& leaf_view = grid.leafGridView();
+
+    Dune::LookUpData<Dune::CpGrid> lookUpData(grid);
+
+    const auto& level0_view = grid.levelGridView(0);
+    Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LeafGridView> leafMapper(leaf_view, Dune::mcmgElementLayout());
+    Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LevelGridView> level0Mapper(level0_view, Dune::mcmgElementLayout());
+
+    const auto& leaf_idSet = (*data.back()).local_id_set_;
+    const auto& level0_idSet = (*data[0]).local_id_set_;
+
+    for (const auto& elem : elements(leaf_view)) {
+        auto featureInElem = lookUpData(elem, fake_feature);
+        BOOST_CHECK(featureInElem == level0Mapper.index(elem.getOrigin()) +3);
+        if (elem.hasFather()) { // leaf_cell has a father!
+            const auto& id = (*leaf_idSet).id(elem);
+            const auto& parent_id = (*level0_idSet).id(elem.father());
+            BOOST_CHECK(elem.index() == id);
+            BOOST_CHECK(elem.index() == leafMapper.index(elem));
+            BOOST_CHECK(elem.father().index() == featureInElem -3);
+            BOOST_CHECK(elem.father().index() == parent_id);
+            BOOST_CHECK(elem.father().index() == level0Mapper.index(elem.father()));
+        }
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(one_lgr_grid)
+{
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+
+    const std::array<int, 3> cells_per_dim = {2,2,2};
+    const std::array<int, 3> startIJK = {1,0,1};
+    const std::array<int, 3> endIJK = {3,2,3};  // patch_dim = {3-1, 2-0, 3-1} ={2,2,2}
+    const std::string lgr_name = {"LGR1"};
+    coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+
+    lookup_check(coarse_grid);
+}
+
+BOOST_AUTO_TEST_CASE(single_cell_lgr_grid)
+{
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+
+    const std::array<int, 3> cells_per_dim = {2,2,2};
+    const std::array<int, 3> startIJK = {1,0,1};
+    const std::array<int, 3> endIJK = {2,1,2};  // patch_dim = {2-1, 1-0, 2-1} ={1,1,1} -> Single Cell!
+    const std::string lgr_name = {"LGR1"};
+    coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+
+    lookup_check(coarse_grid);
+}
+
+BOOST_AUTO_TEST_CASE(lgrs_grid_A)
+{
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}, {4,4,4}};
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,2}, {3,2,2}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {1,1,3}, {4,3,3}};
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
+    coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+
+    lookup_check(coarse_grid);
+}
+
+BOOST_AUTO_TEST_CASE(lgrs_grid_B)
+{
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}};
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {3,2,0}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1}, {4,3,3}};
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2"};
+    coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+
+    lookup_check(coarse_grid);
+}

--- a/tests/cpgrid/lookupdata_general_test.cpp
+++ b/tests/cpgrid/lookupdata_general_test.cpp
@@ -1,0 +1,91 @@
+//===========================================================================
+//
+// File: lookupdata_test.cpp
+//
+// Created: Thurs 25.05.2023 14:47:00
+//
+// Author(s): Antonella Ritorto   <antonella.ritorto@opm-op.com>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+/*
+  Copyright 2023 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#define BOOST_TEST_MODULE LGRTests
+#include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
+#include <opm/grid/CpGrid.hpp>
+#include <opm/grid/LookUpData.hh>
+
+#include <sstream>
+#include <iostream>
+
+struct Fixture
+{
+    Fixture()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        Dune::MPIHelper::instance(m_argc, m_argv);
+        Opm::OpmLog::setupSimpleDefaultLogging();
+    }
+
+    static int rank()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        return Dune::MPIHelper::instance(m_argc, m_argv).rank();
+    }
+};
+
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+void lookup_check(const Dune::CpGrid& grid)
+{
+    std::vector<int> fake_feature(grid.data_[0]->size(0), 0);
+    std::iota(fake_feature.begin(), fake_feature.end(), 3);
+
+    const auto& leaf_view = grid.leafGridView();
+    Dune::LookUpData<Dune::CpGrid> lookUpData(grid);
+
+    for (const auto& elem : elements(leaf_view)) {
+        auto featureInElem = lookUpData(elem, fake_feature);
+        BOOST_CHECK(featureInElem == elem.index() +3); // Particular case of levle0 = leafview, and fake_feaure definition.
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(no_lgrs_grid)
+{
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+    lookup_check(coarse_grid);
+}

--- a/tests/cpgrid/lookupdata_test.cpp
+++ b/tests/cpgrid/lookupdata_test.cpp
@@ -1,0 +1,91 @@
+//===========================================================================
+//
+// File: lookupdata_test.cpp
+//
+// Created: Thurs 25.05.2023 14:47:00
+//
+// Author(s): Antonella Ritorto   <antonella.ritorto@opm-op.com>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+/*
+  Copyright 2023 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#define BOOST_TEST_MODULE LGRTests
+#include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
+#include <opm/grid/CpGrid.hpp>
+#include <opm/grid/LookUpDataCpGrid.hh>
+
+#include <sstream>
+#include <iostream>
+
+struct Fixture
+{
+    Fixture()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        Dune::MPIHelper::instance(m_argc, m_argv);
+        Opm::OpmLog::setupSimpleDefaultLogging();
+    }
+
+    static int rank()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        return Dune::MPIHelper::instance(m_argc, m_argv).rank();
+    }
+};
+
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+void lookup_check(const Dune::CpGrid& grid)
+{
+    std::vector<int> fake_feature(grid.data_[0]->size(0), 0);
+    std::iota(fake_feature.begin(), fake_feature.end(), 3);
+
+    const auto& leaf_view = grid.leafGridView();
+    Dune::LookUpData<Dune::CpGrid> lookUpData(grid);
+
+    for (const auto& elem : elements(leaf_view)) {
+        auto featureInElem = lookUpData(elem, fake_feature);
+        BOOST_CHECK(featureInElem == elem.index() +3); // Particular case of levle0 = leafview, and fake_feaure definition.
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(no_lgrs_grid)
+{
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+    lookup_check(coarse_grid);
+}


### PR DESCRIPTION
Given an element in the LeafView and a container of properties, the property of its origin-cell (parent cell, if exists) is returned, in the case of (multiple LGRs) CpGrid. For general grids, the given properties are assumed to be on the leafview. 

Fix CpGridData::disjointPatches(), test added. 