### PR TITLE
Second try to support  item 3 of PINCH (MAX_EMPTY_GAP)

### DIFF
--- a/opm/grid/MinpvProcessor.hpp
+++ b/opm/grid/MinpvProcessor.hpp
@@ -375,7 +375,7 @@ namespace Opm
                                 bool vertically_connected = true; // If true a connection will be there anyway -> Skip NNC
 
                                 for(int i = 0; i < 4; ++i) {
-                                    vertically_connected = vertically_connected && std::abs(cz_below[i] - cz[4+1])
+                                    vertically_connected = vertically_connected && std::abs(cz_below[i] - cz[4+i])
                                         <= tolerance_unique_points;
                                 }
 

--- a/opm/grid/MinpvProcessor.hpp
+++ b/opm/grid/MinpvProcessor.hpp
@@ -27,6 +27,7 @@
 #include <functional>
 #include <map>
 #include <vector>
+#include <numeric>
 
 namespace Opm
 {
@@ -75,6 +76,7 @@ namespace Opm
         /// will have the zcorn numbers changed so they are zero-thickness. Any
         /// cell below will be changed to include the deleted volume if mergeMinPCCells is true
         /// els the volume will be lost
+        /// \param[in]       tolerance_unique_points Tolerance used to identify points based on their cooridinates.
         Result process(const std::vector<double>& thickness,
                        const double z_tolerance,
                        const double max_gap,
@@ -83,11 +85,13 @@ namespace Opm
                        const std::vector<int>& actnum,
                        const bool mergeMinPVCells,
                        double* zcorn,
-                       bool pinchNOGAP = false,
-                       bool pinchOption4ALL = false,
+                       const bool pinchNOGAP = false,
+                       const bool pinchOption4ALL = false,
                        const std::vector<double>& permz = {},
-                       const std::function<double(int)>& multZ = [](int){ return 0;}) const;
+                       const std::function<double(int)>& multZ = [](int){ return 0;},
+                       const double tolerance_unique_points = 0) const;
     private:
+        double computeGap(const std::array<double,8>& coord_above, const std::array<double,8>& coord_below) const;
         std::array<int,8> cornerIndices(const int i, const int j, const int k) const;
         std::array<double, 8> getCellZcorn(const int i, const int j, const int k, const double* z) const;
         void setCellZcorn(const int i, const int j, const int k, const std::array<double, 8>& cellz, double* z) const;
@@ -101,6 +105,21 @@ namespace Opm
     { }
 
 
+    inline double MinpvProcessor::computeGap(const std::array<double,8>& coord_above,
+                                             const std::array<double,8>& coord_below) const
+    {
+        std::array<double, 4> vertical_gap;
+        for (std::size_t i = 0; i < 4; ++i) {
+            vertical_gap[i] = coord_below[i] - coord_above[4 + i];
+            assert(vertical_gap[i] >= 0);
+        }
+        double min_val = *std::min_element(vertical_gap.begin(), vertical_gap.end());
+        if (min_val < 1e-6){
+            return 0;
+        }
+
+        return min_val;
+    }
 
     inline MinpvProcessor::Result MinpvProcessor::process(const std::vector<double>& thickness,
                                                           const double z_tolerance,
@@ -110,10 +129,11 @@ namespace Opm
                                                           const std::vector<int>& actnum,
                                                           const bool mergeMinPVCells,
                                                           double* zcorn,
-                                                          bool pinchNOGAP,
-                                                          bool pinchOption4ALL,
+                                                          const bool pinchNOGAP,
+                                                          const bool pinchOption4ALL,
                                                           const std::vector<double>& permz,
-                                                          const std::function<double(int)>& multz) const
+                                                          const std::function<double(int)>& multz,
+                                                          const double tolerance_unique_points) const
     {
         // Algorithm:
         // 1. Process each column of cells (with same i and j
@@ -136,6 +156,9 @@ namespace Opm
         // 6. If pinchNOGAP (only has an effect if mergeMinPVcells==false holds):
         //    is true active cells with porevolume less than minpvv will only be disregarded
         //    if their thickness is below z_tolerance and nncs will be created in this case.
+        // 7. Default maximum gap allowed if option 3 in PINCH is omitted is 1e20 in any unit
+        //    If pinch is not specified it is 1e20 in SI units, which should still behave similar
+        //    to infinity.
 
 
         Result result;
@@ -179,11 +202,6 @@ namespace Opm
                             // no neighbor below for an NNC.
                             continue;
                         }
-
-                        // \todo revisit. Maybe instead of keeping track based on cell thickness
-                        // we should rather calculate that based on the appropriate corners of the
-                        // upper and lower cell
-                        double total_gap = thickness[c];
 
                         // Find the next cell
                         int kk_iter = kk + 1;
@@ -246,7 +264,7 @@ namespace Opm
                             if (pinchOption4ALL) {
                                 option4ALLSupported = option4ALLSupported || permz[c] == 0 || multz(c) == 0;
                             }
-                            total_gap += thickness[c_below];
+
                             // move to next lower cell
                             kk_iter = kk_iter + 1;
                             if (kk_iter == dims_[2])
@@ -287,24 +305,27 @@ namespace Opm
                             }
 
                             // Bypass inactive cells with thickness below tolerance and active cells with volume below minpv
+                            int k_above = kk-1;
                             int c_above = ii + dims_[0] * (jj + dims_[1] * (kk-1));
                             auto above_active = actnum.empty() || actnum[c_above];
                             auto above_inactive = !actnum.empty() && !actnum[c_above];
                             auto above_thin = thickness[c_above] < z_tolerance;
                             auto above_small_pv = pv[c_above] < minpvv[c_above];
+
                             if ((above_inactive && above_thin) || (above_active && above_small_pv
                                                                    && (!pinchNOGAP || above_thin) ) ) {
-                                for (int topk = kk - 2; topk > 0; --topk) {
-                                    c_above = ii + dims_[0] * (jj + dims_[1] * (topk));
+                                for (k_above = kk - 2; k_above > 0; --k_above) {
+                                    c_above = ii + dims_[0] * (jj + dims_[1] * (k_above));
                                     above_active = actnum.empty() || actnum[c_above];
                                     above_inactive = !actnum.empty() && !actnum[c_above];
                                     auto above_significant_pv = pv[c_above] > minpvv[c_above];
                                     auto above_broad = thickness[c_above] > z_tolerance;
+
                                     // \todo if condition seems wrong and should be the negation of above?
                                     if ( (above_active && (above_significant_pv || (pinchNOGAP && above_broad) ) ) || (above_inactive && above_broad)) {
                                         break;
                                     }
-                                    total_gap += thickness[c_above];
+
                                     nnc_allowed = nnc_allowed &&
                                         (!pinchOption4ALL || (permz[c] != 0.0 && multz(c) != 0.0) );
 
@@ -315,7 +336,10 @@ namespace Opm
                             }
 
                             // Allow nnc only of total thickness of pinched out cells is below threshold.
-                            nnc_allowed = nnc_allowed && (total_gap < max_gap);
+                            // and sum of gaps is below threshold
+                            const std::array<double, 8> cz_below = getCellZcorn(ii, jj, kk_iter, zcorn);
+                            const std::array<double, 8> cz_above = getCellZcorn(ii, jj, k_above, zcorn);
+                            nnc_allowed = nnc_allowed && (computeGap(cz_above, cz_below) < max_gap);
 
                             if ( nnc_allowed &&
                                  (actnum.empty() || (actnum[c_above] && actnum[c_below])) &&
@@ -333,12 +357,41 @@ namespace Opm
                             kk = kk_iter;
                         }
                     }
+                    else
+                    {
+                        if (kk < dims_[2] - 1 && (actnum.empty() || actnum[c]) && pv[c] > minpvv[c] &&
+                            multz(c) != 0.0)
+                        {
+                            // Check whether there is a gap to the neighbor below whose thickness is less
+                            // than MAX_GAP. In that case we need to create an NNC if there is a gap between the two cells.
+                            int kk_below = kk + 1;
+                            int c_below = ii + dims_[0] * (jj + dims_[1] * kk_below);
+
+                            if ((actnum.empty() || actnum[c_below]) && pv[c_below] > minpvv[c_below])
+                            {
+                                // Check MAX_GAP threshold
+                                std::array<double, 8> cz = getCellZcorn(ii, jj, kk, zcorn);
+                                std::array<double, 8> cz_below = getCellZcorn(ii, jj, kk_below, zcorn);
+                                bool vertically_connected = true; // If true a connection will be there anyway -> Skip NNC
+
+                                for(int i = 0; i < 4; ++i) {
+                                    vertically_connected = vertically_connected && std::abs(cz_below[i] - cz[4+1])
+                                        <= tolerance_unique_points;
+                                }
+
+                                if (!vertically_connected && computeGap(cz, cz_below) < max_gap) {
+                                    result.add_nnc(c, c_below);
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
 
         return result;
     }
+
 
 
 

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -550,7 +550,7 @@ void CpGrid::createCartesian(const std::array<int, 3>& dims,
 #if HAVE_ECL_INPUT
                                              nullptr,
 #endif
-                                             nnc, false, false, false);
+                                             nnc, false, false, false, 0.0);
     // global grid only on rank 0
     current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
                                          current_view_data_->logical_cartesian_size_.size(),
@@ -1348,7 +1348,7 @@ void CpGrid::processEclipseFormat(const grdecl& input_data,
                                              nullptr,
 #endif
                                              nnc,
-                                             remove_ij_boundary, turn_normals, false);
+                                             remove_ij_boundary, turn_normals, false, 0.0);
     current_view_data_->ccobj_.broadcast(current_view_data_->logical_cartesian_size_.data(),
                                          current_view_data_->logical_cartesian_size_.size(),
                                          0);

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -237,6 +237,7 @@ public:
     ///        side. That is, i- faces will match i+ faces etc.
     /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
     /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
+    /// \param pichActive Whether PINCH keyword was specified
     std::vector<std::size_t> processEclipseFormat(const Opm::EclipseGrid* ecl_grid, Opm::EclipseState* ecl_state,
                                                   bool periodic_extension, bool turn_normals = false, bool clip_z = false,
                                                   bool pinchActive = true);
@@ -252,12 +253,14 @@ public:
     /// \param remove_ij_boundary if true, will remove (i, j) boundaries. Used internally.
     /// \param pinchActive If true, we will add faces between vertical cells that have only inactive cells or cells
     ///            with zero volume between them. If false these cells will not be connected.
+    /// \param tolerance_unique_points Tolerance used to identify points based on their cooridinate
     void processEclipseFormat(const grdecl& input_data,
 #if HAVE_ECL_INPUT
                               Opm::EclipseState* ecl_state,
 #endif
                               std::array<std::set<std::pair<int, int>>, 2>& nnc,
-                              bool remove_ij_boundary, bool turn_normals, bool pinchActive);
+                              bool remove_ij_boundary, bool turn_normals, bool pinchActive,
+                              double tolerance_unique_points);
 
     /// @brief
     ///    Extract Cartesian index triplet (i,j,k) of an active cell.

--- a/tests/test_minpvprocessor.cpp
+++ b/tests/test_minpvprocessor.cpp
@@ -27,6 +27,39 @@
 
 #include <opm/grid/MinpvProcessor.hpp>
 
+
+BOOST_AUTO_TEST_CASE(GAP_MAXGAP)
+{
+    // Set up a simple example.
+    std::vector<double> zcorn = { 0, 0, 0, 0,
+                                  2, 2, 2, 2,
+                                  2, 2, 2, 2,
+                                  2.5, 2.5, 2.5, 2.5,
+                                  2.8, 2.8, 2.8, 2.8,
+                                  3.5, 3.5, 3.5, 3.5};
+    std::vector<double> pv = { 2, 0.5, 0.7};
+    std::vector<double> minpvv(3, 0.6);
+    std::vector<int> actnum = { 1, 1, 1 };
+    std::vector<double> thickness = {2, 0.5, 0.7};
+    double z_threshold = 0.4;
+
+    Opm::MinpvProcessor mp1(1, 1, 3);
+    auto z1 = zcorn;
+    double max_gap = 1e20;
+    bool fill_removed_cells = false;
+    bool pinch_no_gap = false;
+
+    auto minpv_result = mp1.process(thickness, z_threshold, max_gap, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
+    BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 1);
+    BOOST_CHECK_EQUAL(minpv_result.nnc[0], 2);
+
+    max_gap = .29;
+    zcorn = z1;
+    minpv_result = mp1.process(thickness, z_threshold, max_gap, pv, minpvv, actnum, fill_removed_cells, z1.data(), pinch_no_gap);
+    BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 0);
+}
+
+    
 BOOST_AUTO_TEST_CASE(Pinch)
 {
     // Set up a simple example.

--- a/tests/test_minpvprocessor.cpp
+++ b/tests/test_minpvprocessor.cpp
@@ -59,7 +59,34 @@ BOOST_AUTO_TEST_CASE(GAP_MAXGAP)
     BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 0);
 }
 
-    
+BOOST_AUTO_TEST_CASE(GAP_MAXGAP_no_pinched_cells)
+{
+    // Set up a simple example.
+    std::vector<double> zcorn = { 0, 0, 0, 0,
+                                  2, 2.1, 2, 2,
+                                  2, 2.1, 2, 2,
+                                  2.5, 2.5, 2.5, 2.5,
+                                  2.8, 2.8, 2.8, 2.8,
+                                  3.5, 3.5, 3.5, 3.5};
+    std::vector<double> pv = { 2, 0.5, 0.7};
+    std::vector<double> minpvv(3, 0.0);
+    std::vector<int> actnum = { 1, 1, 1 };
+    std::vector<double> thickness = {2, 0.5, 0.7};
+    double z_threshold = 0.0;
+
+    Opm::MinpvProcessor mp1(1, 1, 3);
+    double max_gap = 1e20;
+    bool fill_removed_cells = false;
+    bool pinch_no_gap = false;
+
+    // Use options that will create NNCs for vertically unconnected cells with small gaps without cells being pinched.
+    auto minpv_result = mp1.process(thickness, z_threshold, max_gap, pv, minpvv, actnum, fill_removed_cells,
+                                    zcorn.data(), pinch_no_gap, false, {}, [](int){ return 1; });
+    BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 1);
+    if (minpv_result.nnc.size() )
+      BOOST_CHECK_EQUAL(minpv_result.nnc[1], 2);
+}
+
 BOOST_AUTO_TEST_CASE(Pinch)
 {
     // Set up a simple example.


### PR DESCRIPTION
This #658 again with a  fix for the embarassing fallout due to a typo. My apologies for the fallout. Also added a test that would have found that issue.

Original text:
"
MAX_EMPTY_GAP specifies the maximum thickness of gap between active cells allowed for creating NNCs. The default value is 1.0e20 in any unit system.

If PINCH is not specified, then the EclipseGrid will specify 1e20 in SI units. This should be big enough to account for infinity in a simulation and hence this implementation should work.

Fixes the following cases in opm-tests: T2A_NOPINCH, T2A_GAP, T2A_NOGAP
"
