### PR TITLE
Add method to compute Eclipse Centroid for CpGrid

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -112,6 +112,7 @@ list (APPEND TEST_SOURCE_FILES
 if(Boost_VERSION_STRING VERSION_GREATER 1.53)
 	list(APPEND TEST_SOURCE_FILES
 	  tests/cpgrid/disjointPatches_test.cpp
+	  tests/cpgrid/eclCentroid_test.cpp
 	  tests/cpgrid/geometry_test.cpp
 	  tests/cpgrid/grid_lgr_test.cpp
 	  tests/cpgrid/lookupdata_test.cpp

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -6,7 +6,7 @@
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
 //            B�rd Skaflestad     <bard.skaflestad@sintef.no>
-//            Antonella Ritorto   <antonella.ritorto>
+//            Antonella Ritorto   <antonella.ritorto@opm-op.com>
 //
 // $Date$
 //
@@ -500,6 +500,24 @@ namespace Dune
 
 
         const std::map<std::string,int>& getLgrNameToLevel() const;
+
+        // @breif Compute center of an entity/element/cell in the Eclipse way:
+        //        - Average of the 4 corners of the bottom face.
+        //        - Average of the 4 corners of the top face.
+        //        Return average of the previous computations.
+        // @param [in]   int   Index of a cell.
+        // @return            'eclipse centroid'
+        std::array<double,3> getEclCentroid(const int& idx) const;
+
+        // @breif Compute center of an entity/element/cell in the Eclipse way:
+        //        - Average of the 4 corners of the bottom face.
+        //        - Average of the 4 corners of the top face.
+        //        Return average of the previous computations.
+        // @param [in]   Entity<0>   Entity
+        // @return                   'eclipse centroid'
+        std::array<double,3> getEclCentroid(const cpgrid::Entity<0>& elem) const;
+
+
 
         /*  No refinement implemented. GridDefaultImplementation's methods will be used.
 

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -498,7 +498,7 @@ namespace Dune
                                    const std::vector<std::array<int,3>>& endIJK_vec,
                                    const std::vector<std::string>& lgr_name_vec);
 
-
+        // @brief TO BE DONE
         const std::map<std::string,int>& getLgrNameToLevel() const;
 
         // @breif Compute center of an entity/element/cell in the Eclipse way:

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1779,5 +1779,14 @@ const std::map<std::string,int>& CpGrid::getLgrNameToLevel() const{
     return lgr_names_;
 }
 
+std::array<double,3> CpGrid::getEclCentroid(const int& elemIdx) const
+{
+    return this-> current_view_data_ -> computeEclCentroid(elemIdx);
+}
+
+std::array<double,3> CpGrid::getEclCentroid(const cpgrid::Entity<0>& elem) const
+{
+    return this-> current_view_data_ -> computeEclCentroid(elem.index());
+}
 
 } // namespace Dune

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -2267,40 +2267,33 @@ std::array<double,3> CpGridData::getAverageArr(const std::vector<std::array<doub
 {
     assert(!vec.empty());
     std::array<double,3> result = {0., 0., 0.};
-    for (int coord = 0; coord < 3; ++coord) {
-        for (const auto& arr : vec) {
-            result[coord] += (arr.at(coord))/static_cast<double>(vec.size());
+    for (const auto& arr : vec) {
+        for (int coord = 0; coord < 3; ++coord) {
+            result[coord] += (arr[coord])/static_cast<double>(vec.size());
         }
     }
     return result;
 }
 
-std::array<double,3> CpGridData::computeEclCentroid(const int& idx) const
+std::array<double,3> CpGridData::computeEclCentroid(const int idx) const
 {
     const auto& cell_to_point_indices = this -> cell_to_point_[idx];
-    std::array<Dune::FieldVector<double, 3>, 8>
-        // std::array<std::array<double,3>, 8>
-        cell_to_point;
+    std::array<Dune::FieldVector<double, 3>,8> cell_to_point;
     for (int cornIdx = 0; cornIdx < 8; ++cornIdx) {
         cell_to_point[cornIdx] = (this-> geometry_.geomVector(std::integral_constant<int,3>())
                                   -> get(cell_to_point_indices[cornIdx])).center();
     }
-
     assert(!cell_to_point.empty());
-    // Recall corners order: cell_to_point ~ {0,1,2,3,4,5,6,7}
-    //  Top face      6---7      Bottom face     2---3
-    //               /   /                      /   /
-    //              4---5                      0---1
-    std::vector<std::array<double,3>> topCorns; //(cell_to_point.begin()+4, cell_to_point.end());
-    std::vector<std::array<double,3>>  bottomCorns; //(cell_to_point.begin(), cell_to_point.begin()+3);
+    // Recall corners order: cell_to_point ~ { [top face 0,1,2,3], [bottom face 4,5,6,7]}
+    std::vector<std::array<double,3>> topCorns;
+    std::vector<std::array<double,3>>  bottomCorns;
     topCorns.resize(4);
     bottomCorns.resize(4);
     for (int i = 0; i < 4; ++i){
         for (int coord = 0; coord < 3; ++coord){
-            topCorns[i][coord] = cell_to_point[i+4][coord];
-            bottomCorns[i][coord] = cell_to_point[i][coord];
+            topCorns[i][coord] = cell_to_point[i][coord];
+            bottomCorns[i][coord] = cell_to_point[i+4][coord];
         }
-
     }
     std::array<double,3> averageTop = this-> getAverageArr(topCorns);
     std::array<double,3> averageBottom = this -> getAverageArr(bottomCorns);

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -2263,5 +2263,56 @@ CpGridData::refinePatch(const std::array<int,3>& cells_per_dim, const std::array
 }
 
 
+std::array<double,3> CpGridData::getAverageArr(const std::vector<std::array<double,3>>& vec) const
+{
+    assert(!vec.empty());
+    std::array<double,3> result = {0., 0., 0.};
+    for (int coord = 0; coord < 3; ++coord) {
+        for (const auto& arr : vec) {
+            result[coord] += (arr.at(coord))/static_cast<double>(vec.size());
+        }
+    }
+    return result;
+}
+
+std::array<double,3> CpGridData::computeEclCentroid(const int& idx) const
+{
+    const auto& cell_to_point_indices = this -> cell_to_point_[idx];
+    std::array<Dune::FieldVector<double, 3>, 8>
+        // std::array<std::array<double,3>, 8>
+        cell_to_point;
+    for (int cornIdx = 0; cornIdx < 8; ++cornIdx) {
+        cell_to_point[cornIdx] = (this-> geometry_.geomVector(std::integral_constant<int,3>())
+                                  -> get(cell_to_point_indices[cornIdx])).center();
+    }
+
+    assert(!cell_to_point.empty());
+    // Recall corners order: cell_to_point ~ {0,1,2,3,4,5,6,7}
+    //  Top face      6---7      Bottom face     2---3
+    //               /   /                      /   /
+    //              4---5                      0---1
+    std::vector<std::array<double,3>> topCorns; //(cell_to_point.begin()+4, cell_to_point.end());
+    std::vector<std::array<double,3>>  bottomCorns; //(cell_to_point.begin(), cell_to_point.begin()+3);
+    topCorns.resize(4);
+    bottomCorns.resize(4);
+    for (int i = 0; i < 4; ++i){
+        for (int coord = 0; coord < 3; ++coord){
+            topCorns[i][coord] = cell_to_point[i+4][coord];
+            bottomCorns[i][coord] = cell_to_point[i][coord];
+        }
+
+    }
+    std::array<double,3> averageTop = this-> getAverageArr(topCorns);
+    std::array<double,3> averageBottom = this -> getAverageArr(bottomCorns);
+
+    std::vector<std::array<double,3>> topAndBottomAverage = {averageTop, averageBottom};
+    return this -> getAverageArr(topAndBottomAverage);
+}
+
+std::array<double,3> CpGridData::computeEclCentroid(const Entity<0>& elem) const
+{
+    return this->computeEclCentroid(elem.index());
+}
+
 } // end namespace cpgrid
 } // end namespace Dune

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -441,7 +441,7 @@ public:
     //        Return average of the previous computations.
     // @param [in]   int   Index of a cell.
     // @return            'eclipse centroid'
-    std::array<double,3> computeEclCentroid(const int& idx) const;
+    std::array<double,3> computeEclCentroid(const int idx) const;
 
     // @breif Compute center of an entity/element/cell in the Eclipse way:
     //        - Average of the 4 corners of the bottom face.

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -723,7 +723,8 @@ private:
     std::vector<std::array<int,2>> leaf_to_level_cells_;
     // SUITABLE FOR ALL LEVELS INCLUDING LEAFVIEW
     /** Child cells and their parents. Entry is {-1,-1} when cell has no father. */ // {level parent cell, parent cell index}
-    std::vector<std::array<int,2>> child_to_parent_cells_; 
+    std::vector<std::array<int,2>> child_to_parent_cells_;
+
 
     /// \brief Object for collective communication operations.
     Communication ccobj_;

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -378,6 +378,12 @@ private:
                                std::array<int,8>& cellifiedPatch_to_point,
                                std::array<int,8>& allcorners_cellifiedPatch) const;
 
+    // @brief Compute the average of array<double,3>.
+    //
+    // @param [in] vector of array<double,3>
+    // @return     array<double,3> (average of the entries of the given vector).
+    std::array<double,3> getAverageArr(const std::vector<std::array<double,3>>& vec) const;
+
 public:
     /// @brief Refine a single cell and return a shared pointer of CpGridData type.
     ///
@@ -428,6 +434,22 @@ public:
                 const std::vector<std::array<int,2>>,                // child_to_parent_faces
                 const std::vector<std::array<int,2>>>                // child_to_parent_cells
     refinePatch(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
+
+    // @breif Compute center of an entity/element/cell in the Eclipse way:
+    //        - Average of the 4 corners of the bottom face.
+    //        - Average of the 4 corners of the top face.
+    //        Return average of the previous computations.
+    // @param [in]   int   Index of a cell.
+    // @return            'eclipse centroid'
+    std::array<double,3> computeEclCentroid(const int& idx) const;
+
+    // @breif Compute center of an entity/element/cell in the Eclipse way:
+    //        - Average of the 4 corners of the bottom face.
+    //        - Average of the 4 corners of the top face.
+    //        Return average of the previous computations.
+    // @param [in]   Entity<0>   Entity
+    // @return                   'eclipse centroid'
+    std::array<double,3> computeEclCentroid(const Entity<0>& elem) const;
 
     // Make unique boundary ids for all intersections.
     void computeUniqueBoundaryIds();

--- a/tests/cpgrid/eclCentroid_test.cpp
+++ b/tests/cpgrid/eclCentroid_test.cpp
@@ -1,0 +1,339 @@
+//===========================================================================
+//
+// File: eclCentroid_test.cpp
+//
+// Created: Friday 07.07.2023 11:00:00
+//
+// Author(s): Antonella Ritorto   <antonella.ritorto@opm-op.com>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2023 Equinor ASA. 
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#define BOOST_TEST_MODULE EclipseCentroidTest
+#include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
+
+
+#include <opm/grid/CpGrid.hpp>
+#include <dune/common/version.hh>
+#include <dune/grid/common/mcmgmapper.hh>
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/input/eclipse/Parser/Parser.hpp>
+#include <opm/grid/CpGrid.hpp>
+
+
+
+#include <sstream>
+#include <iostream>
+
+struct Fixture
+{
+    Fixture()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        Dune::MPIHelper::instance(m_argc, m_argv);
+        Opm::OpmLog::setupSimpleDefaultLogging();
+    }
+
+    static int rank()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        return Dune::MPIHelper::instance(m_argc, m_argv).rank();
+    }
+};
+
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+void createEclGridCpGrid_and_checkEclCentroid(const std::string& deckString)
+{
+    Opm::Parser parser;
+    const auto deck = parser.parseString(deckString);
+
+    Dune::CpGrid grid;
+    Opm::EclipseGrid ecl_grid(deck);
+
+    grid.processEclipseFormat(&ecl_grid, nullptr, false, false, false);
+    
+    const auto& gridLeafView = grid.leafGridView();
+    Dune::CartesianIndexMapper<Dune::CpGrid> gridCartMapper =  Dune::CartesianIndexMapper<Dune::CpGrid>(grid);
+    for (const auto& element: Dune::elements(gridLeafView)){
+        const auto& elemEclCentroid = ecl_grid.getCellCenter(gridCartMapper.cartesianIndex(element.index()));
+        const auto& elemCpGridEclCentroid_Entity = grid.getEclCentroid(element);
+        const auto& elemCpGridEclCentroid_Index = grid.getEclCentroid(element.index());
+        for (int coord = 0; coord < 3; ++coord)
+        {
+            BOOST_CHECK_CLOSE(elemEclCentroid[coord],elemCpGridEclCentroid_Entity[coord] , 1e-6);
+            assert(elemCpGridEclCentroid_Entity[coord] == elemCpGridEclCentroid_Index[coord]);
+            std::cout << " From Eclipse: " << elemEclCentroid[coord]
+                      << " From CpGrid (Entity): " << elemCpGridEclCentroid_Entity[coord]
+                      << " From CpGrid (Index): " << elemCpGridEclCentroid_Index[coord]<< '\n';
+        }
+        std::cout << " CpGrid center: " << element.geometry().center() << '\n';
+        std::cout << " " << '\n';
+    }
+   
+}
+
+
+
+BOOST_AUTO_TEST_CASE(stringA)
+{
+    const std::string deckString =
+        R"( RUNSPEC
+        DIMENS
+        1  1  5 /
+        GRID
+        COORD
+        0 0 0
+        0 0 1
+        1 0 0
+        1 0 1
+        0 1 0
+        0 1 1
+        1 1 0
+        1 1 1
+        /
+        ZCORN
+        4*0
+        8*1
+        8*2
+        8*3
+        8*4
+        4*5
+        /
+        ACTNUM
+        5*1
+        /
+        PORO
+        5*0.15
+        /)";
+
+    createEclGridCpGrid_and_checkEclCentroid(deckString);
+
+}
+
+BOOST_AUTO_TEST_CASE(stringB)
+{
+    const std::string deckString =
+        R"(RUNSPEC
+        DIMENS
+        1  1  3 /
+        GRID
+        COORD
+        0 0 0  0 0 3
+        1 0 0  1 0 3
+        0 1 0  0 1 3
+        1 1 0  1 1 3
+        /
+        ZCORN
+        4*0
+        8*1
+        8*1.1
+        4*2.1
+        /
+       ACTNUM
+       3*1
+       /
+       PORO
+       3*0.15
+       /)";
+
+    createEclGridCpGrid_and_checkEclCentroid(deckString);
+    
+}
+
+
+BOOST_AUTO_TEST_CASE(stringC)
+{
+    const std::string deckString =
+        R"(RUNSPEC
+        DIMENS
+        1  1  3 /
+        GRID
+        COORD
+        0 0 0  0 0 3
+        1 0 0  1 0 3
+        0 1 0  0 1 3
+        1 1 0  1 1 3
+        /
+        ZCORN
+        4*0
+        8*1
+        8*1.1
+        4*2.1
+        /
+        ACTNUM
+        3*1
+        /
+        PINCH
+        0.02   NOGAP   1*   1*
+        /
+        )";
+    
+    createEclGridCpGrid_and_checkEclCentroid(deckString);
+    
+}
+
+BOOST_AUTO_TEST_CASE(stringD)
+{
+    /*
+Cell corners:
+0 {0, 0, 2}
+1 {4, 1, 1}
+2 {2, 5, 1}
+3 {5, 4, 1}
+4 {1, 1, 5}
+5 {4, 0, 4}
+6 {0, 4, 5}
+7 {4, 3, 4}
+
+COORD 
+line 1: corners 0 and 4
+line 2: corners 1 and 5
+line 3: corners 2 and 6
+line 4: corners 3 and 7
+
+     */
+    const std::string deckString =
+        R"(RUNSPEC
+        DIMENS
+        1  1  1 /
+        GRID
+        COORD
+        0 0 2  1 1 5
+        4 1 1  4 0 4
+        2 5 1  0 4 5
+        5 4 1  4 3 4
+        /
+        ZCORN
+        4*0
+        4*1
+        /
+        ACTNUM
+        1*1
+        /
+        )";
+
+    createEclGridCpGrid_and_checkEclCentroid(deckString);
+    
+}
+
+BOOST_AUTO_TEST_CASE(stringE)
+{
+    /*
+Cell corners:
+0 {0, 0, 0}
+1 {1, 0, 0}
+2 {0, 1, 0}
+3 {1, 1, 0}
+4 {0, 0, 1}
+5 {1, 0, 0}  coincides with 1
+6 {0, 1, 1}
+7 {1, 1, 0}  coincides with 3
+
+COORD 
+line 1: corners 0 and 4
+line 2: corners 1 and 5
+line 3: corners 2 and 6
+line 4: corners 3 and 7
+
+     */
+    const std::string deckString =
+        R"(RUNSPEC
+        DIMENS
+        1  1  1 /
+        GRID
+        COORD
+        0 0 0  0 0 1
+        1 0 0  1 0 0
+        0 1 0  0 1 1
+        1 1 0  1 1 0
+        /
+        ZCORN
+        4*0
+        4*1
+        /
+        ACTNUM
+        1*1
+        /
+        )";
+
+    createEclGridCpGrid_and_checkEclCentroid(deckString);
+    
+}
+
+BOOST_AUTO_TEST_CASE(stringF)
+{
+    /*
+Cell corners:
+0  {0, 0, 0}
+1  {2, 0, 0}
+2  {0, 1, 0}
+3  {2, 1, 0}
+4  {1, 0, 1}
+5  {3, 0, 1}
+6  {1, 1, 1}
+7  {3, 1, 1}
+
+COORD 
+line 1: corners 0 and 4
+line 2: corners 1 and 5
+line 3: corners 2 and 6
+line 4: corners 3 and 7
+
+     */
+    const std::string deckString =
+        R"(RUNSPEC
+        DIMENS
+        1  1  1 /
+        GRID
+        COORD
+        0 0 0  1 0 1
+        2 0 0  3 0 1
+        0 1 0  1 1 1
+        2 1 0  3 1 1
+        /
+        ZCORN
+        4*0.5
+        4*1
+        /
+        ACTNUM
+        1*1
+        /
+        )";
+
+    createEclGridCpGrid_and_checkEclCentroid(deckString);
+    
+}
+

--- a/tests/cpgrid/eclCentroid_test.cpp
+++ b/tests/cpgrid/eclCentroid_test.cpp
@@ -94,15 +94,9 @@ void createEclGridCpGrid_and_checkEclCentroid(const std::string& deckString)
         for (int coord = 0; coord < 3; ++coord)
         {
             BOOST_CHECK_CLOSE(elemEclCentroid[coord],elemCpGridEclCentroid_Entity[coord] , 1e-6);
-            assert(elemCpGridEclCentroid_Entity[coord] == elemCpGridEclCentroid_Index[coord]);
-            std::cout << " From Eclipse: " << elemEclCentroid[coord]
-                      << " From CpGrid (Entity): " << elemCpGridEclCentroid_Entity[coord]
-                      << " From CpGrid (Index): " << elemCpGridEclCentroid_Index[coord]<< '\n';
+            BOOST_CHECK_CLOSE(elemEclCentroid[coord],elemCpGridEclCentroid_Index[coord] , 1e-6);
         }
-        std::cout << " CpGrid center: " << element.geometry().center() << '\n';
-        std::cout << " " << '\n';
-    }
-   
+    } 
 }
 
 

--- a/tests/cpgrid/eclCentroid_test.cpp
+++ b/tests/cpgrid/eclCentroid_test.cpp
@@ -134,41 +134,10 @@ BOOST_AUTO_TEST_CASE(stringA)
         /)";
 
     createEclGridCpGrid_and_checkEclCentroid(deckString);
-
 }
+
 
 BOOST_AUTO_TEST_CASE(stringB)
-{
-    const std::string deckString =
-        R"(RUNSPEC
-        DIMENS
-        1  1  3 /
-        GRID
-        COORD
-        0 0 0  0 0 3
-        1 0 0  1 0 3
-        0 1 0  0 1 3
-        1 1 0  1 1 3
-        /
-        ZCORN
-        4*0
-        8*1
-        8*1.1
-        4*2.1
-        /
-       ACTNUM
-       3*1
-       /
-       PORO
-       3*0.15
-       /)";
-
-    createEclGridCpGrid_and_checkEclCentroid(deckString);
-    
-}
-
-
-BOOST_AUTO_TEST_CASE(stringC)
 {
     const std::string deckString =
         R"(RUNSPEC
@@ -195,30 +164,20 @@ BOOST_AUTO_TEST_CASE(stringC)
         /
         )";
     
-    createEclGridCpGrid_and_checkEclCentroid(deckString);
-    
+    createEclGridCpGrid_and_checkEclCentroid(deckString);   
 }
 
-BOOST_AUTO_TEST_CASE(stringD)
-{
-    /*
-Cell corners:
-0 {0, 0, 2}
-1 {4, 1, 1}
-2 {2, 5, 1}
-3 {5, 4, 1}
+BOOST_AUTO_TEST_CASE(stringC)
+{/*
+Cell corners:      COORD
+0 {0, 0, 2}        line 1: corners 0 and 4
+1 {4, 1, 1}        line 2: corners 1 and 5
+2 {2, 5, 1}        line 3: corners 2 and 6
+3 {5, 4, 1}        line 4: corners 3 and 7
 4 {1, 1, 5}
 5 {4, 0, 4}
 6 {0, 4, 5}
-7 {4, 3, 4}
-
-COORD 
-line 1: corners 0 and 4
-line 2: corners 1 and 5
-line 3: corners 2 and 6
-line 4: corners 3 and 7
-
-     */
+7 {4, 3, 4} */
     const std::string deckString =
         R"(RUNSPEC
         DIMENS
@@ -239,30 +198,20 @@ line 4: corners 3 and 7
         /
         )";
 
-    createEclGridCpGrid_and_checkEclCentroid(deckString);
-    
+    createEclGridCpGrid_and_checkEclCentroid(deckString);   
 }
 
-BOOST_AUTO_TEST_CASE(stringE)
-{
-    /*
-Cell corners:
-0 {0, 0, 0}
-1 {1, 0, 0}
-2 {0, 1, 0}
-3 {1, 1, 0}
+BOOST_AUTO_TEST_CASE(stringD)
+{/*
+Cell corners:                     COORD
+0 {0, 0, 0}                       line 1: corners 0 and 4
+1 {1, 0, 0}                       line 2: corners 1 and 5
+2 {0, 1, 0}                       line 3: corners 2 and 6
+3 {1, 1, 0}                       line 4: corners 3 and 7
 4 {0, 0, 1}
 5 {1, 0, 0}  coincides with 1
 6 {0, 1, 1}
-7 {1, 1, 0}  coincides with 3
-
-COORD 
-line 1: corners 0 and 4
-line 2: corners 1 and 5
-line 3: corners 2 and 6
-line 4: corners 3 and 7
-
-     */
+7 {1, 1, 0}  coincides with 3 */
     const std::string deckString =
         R"(RUNSPEC
         DIMENS
@@ -284,29 +233,19 @@ line 4: corners 3 and 7
         )";
 
     createEclGridCpGrid_and_checkEclCentroid(deckString);
-    
 }
 
-BOOST_AUTO_TEST_CASE(stringF)
-{
-    /*
-Cell corners:
-0  {0, 0, 0}
-1  {2, 0, 0}
-2  {0, 1, 0}
-3  {2, 1, 0}
+BOOST_AUTO_TEST_CASE(stringE)
+{/*
+Cell corners:       COORD
+0  {0, 0, 0}        line 1: corners 0 and 4
+1  {2, 0, 0}        line 2: corners 1 and 5
+2  {0, 1, 0}        line 3: corners 2 and 6
+3  {2, 1, 0}        line 4: corners 3 and 7
 4  {1, 0, 1}
 5  {3, 0, 1}
 6  {1, 1, 1}
-7  {3, 1, 1}
-
-COORD 
-line 1: corners 0 and 4
-line 2: corners 1 and 5
-line 3: corners 2 and 6
-line 4: corners 3 and 7
-
-     */
+7  {3, 1, 1} */
     const std::string deckString =
         R"(RUNSPEC
         DIMENS
@@ -328,6 +267,5 @@ line 4: corners 3 and 7
         )";
 
     createEclGridCpGrid_and_checkEclCentroid(deckString);
-    
 }
 

--- a/tests/test_cpgrid.cpp
+++ b/tests/test_cpgrid.cpp
@@ -166,6 +166,25 @@ int main(int argc, char** argv )
 
     grid.processEclipseFormat(&ecl_grid, nullptr, false, false, false);
     testGrid( grid, "CpGrid_ecl", 8, 27 );
+    
+    const auto& grid_leafView = grid.leafGridView();
+    Dune::CartesianIndexMapper<Grid> grid_cartMapper =  Dune::CartesianIndexMapper<Grid>(grid);
+    for (const auto& element: Dune::elements(grid_leafView)){
+        const auto& elemEclCentroid = ecl_grid.getCellCenter(grid_cartMapper.cartesianIndex(element.index()));
+        const auto& elemCpGridEclCentroid_Entity = grid.getEclCentroid(element);
+        const auto& elemCpGridEclCentroid_Index = grid.getEclCentroid(element.index());
+        for (int coord = 0; coord < 3; ++coord)
+        {
+            assert(elemEclCentroid[coord] == elemCpGridEclCentroid_Entity[coord]);
+            assert(elemEclCentroid[coord] == elemCpGridEclCentroid_Index[coord]);
+            std::cout << "From Eclipse: " << elemEclCentroid[coord]
+                      << " From CpGrid (Entity): " << elemCpGridEclCentroid_Entity[coord]
+                      << " From CpGrid (Index): " << elemCpGridEclCentroid_Index[coord]<< '\n';
+        }
+        std::cout << " " << '\n';
+    }
+    
+    
 #endif
 
     std::stringstream dgfFile;


### PR DESCRIPTION
For CpGrid, a method to compute centers of elements as in an Eclipse Grid is added and tested. 