### PR TITLE
removing the duplicated AlignAfterOpenBracket entries in .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,5 @@
 {
         BasedOnStyle: WebKit,
-        AlignAfterOpenBracket: AlwaysBreak,
         AlignConsecutiveAssignments: false,
         AlignConsecutiveDeclarations: false,
         AlignAfterOpenBracket: Align,


### PR DESCRIPTION
removing a warning when using an IDE. 

same with https://github.com/OPM/opm-common/pull/3616 and will self-merge. 

