### PR TITLE
Modified centroids lookup: separated function members 

### DIFF
--- a/tests/cpgrid/lookUpCellCentroid_cpgrid_test.cpp
+++ b/tests/cpgrid/lookUpCellCentroid_cpgrid_test.cpp
@@ -87,13 +87,13 @@ void createEclGridCpGrid_and_checkCentroid(const std::string& deckString)
     const Dune::CartesianIndexMapper<Dune::CpGrid> gridCartMapper(grid);
 
     const Opm::LookUpCellCentroid<Dune::CpGrid, Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>
-        lookUpCellCentroid(leafGridView, gridCartMapper, &eclGrid);
+        lookUpCellCentroid(leafGridView, gridCartMapper, nullptr);
 
     for (const auto& element: Dune::elements(leafGridView)){
         const auto& elemEclCentroid = eclGrid.getCellCenter(gridCartMapper.cartesianIndex(element.index()));
         const auto& elemCpGridEclCentroid_Entity = grid.getEclCentroid(element);
         const auto& elemCpGridEclCentroid_Index = grid.getEclCentroid(element.index());
-        const auto& centroid = lookUpCellCentroid(element.index());
+        const auto& centroid = lookUpCellCentroid.getCentroidFromCpGrid(element.index());
         for (int coord = 0; coord < 3; ++coord)
         {
             BOOST_CHECK_EQUAL(elemEclCentroid[coord], elemCpGridEclCentroid_Entity[coord]);

--- a/tests/test_cellCentroid_polyhedralGrid.cpp
+++ b/tests/test_cellCentroid_polyhedralGrid.cpp
@@ -99,8 +99,9 @@ void createEclGridPolyhedralGrid_and_checkCentroid(const std::string& deckString
 
     for (const auto& element: Dune::elements(leafGridView)){
         const int idx = mapper.index(element);
-        const auto& elemEclCentroid = eclGrid.getCellCenter(gridCartMapper.cartesianIndex(idx));
-        const auto& centroid = lookUpCellCentroid(idx);
+        const auto& cartIdx = gridCartMapper.cartesianIndex(idx);
+        const auto& elemEclCentroid = eclGrid.getCellCenter(cartIdx);
+        const auto& centroid = lookUpCellCentroid.getCentroidFromEclGrid(idx);
         for (int coord = 0; coord < 3; ++coord)
         {
             BOOST_CHECK_EQUAL(elemEclCentroid[coord], centroid[coord]);


### PR DESCRIPTION
In #672, a new structure to search for cell centroids was added, however  its application generated issues in OPM/opm-simulators#4778. 

The new approach is to have two separated function members to compute centroids: one via Eclipse grid and the other for CpGrid. 

The issue seems to be related to the fact that, even when the Grid template parameter of EclBaseVanguard is a CpGrid, centroids might be computed via its associated EclipseGrid, when rank is zero. This is just my interpretation of several errors messages, which can be wrong. 