### PR TITLE
Levels/LeafGridView global_cell_ defined for CpGrid with LGRs

### DIFF
--- a/opm/grid/LookUpData.hh
+++ b/opm/grid/LookUpData.hh
@@ -182,7 +182,7 @@ public:
     FeatureType operator()(const EntityType& elem,const std::vector<FeatureType>& feature_vec) const;
 
     /// \brief: Call operator taking an Index and a FeatureVector.
-    /// 
+    ///
     ///         Return feature of the entity, via CARTESIAN INDEX
     ///         For general grids, the feature vector is given for the gridView_.
     ///         For CpGrid, the feature vector is given for level 0.
@@ -312,7 +312,7 @@ FeatureType Opm::LookUpCartesianData<Grid,GridView>::operator()
     assert(cartMapper_);
     assert( (0 <= this->getOriginIndexFromEntity<EntityType,Grid>(elem)) &&
             (static_cast<int>(feature_vec.size()) > this-> getOriginIndexFromEntity<EntityType,Grid>(elem)) );
-    return feature_vec[cartMapper_-> cartesianIndex(this->getOriginIndexFromEntity<EntityType,Grid>(elem))];
+    return feature_vec[cartMapper_-> cartesianIndex(this->elemMapper_.index(elem))]; 
 }
 
 template<typename Grid, typename GridView>
@@ -322,7 +322,7 @@ FeatureType Opm::LookUpCartesianData<Grid,GridView>::operator()(const int& elemI
     assert(cartMapper_);
     assert(0 <= this->getOriginIndex<Grid>(elemIdx) &&
            static_cast<int>(feature_vec.size()) > this-> getOriginIndex<Grid>(elemIdx));
-    return feature_vec[cartMapper_-> cartesianIndex(this->getOriginIndex<Grid>(elemIdx))];
+    return feature_vec[cartMapper_-> cartesianIndex(elemIdx)];
 }
 
 template<typename Grid, typename GridView>

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -598,12 +598,7 @@ const std::array<int, 3>& CpGrid::logicalCartesianSize() const
 {
     // Temporary. For a grid with LGRs, we set the logical cartesian size of the LeafGridView as the one for level 0.
     //            Goal: CartesianIndexMapper well-defined for CpGrid LeafView with LGRs.
-    if (current_view_data_ == this-> data_.back().get()){
-        return this -> data_[0] -> logical_cartesian_size_;
-    }
-    else{
-        return this -> distributed_data_[0] ->logical_cartesian_size_;
-    }
+    return current_view_data_ -> logical_cartesian_size_;
 }
 
 const std::vector<int>& CpGrid::globalCell() const
@@ -611,7 +606,9 @@ const std::vector<int>& CpGrid::globalCell() const
     // Temporary. For a grid with LGRs, we set the globalCell() of the as the one for level 0.
     //            Goal: CartesianIndexMapper well-defined for CpGrid LeafView with LGRs.
     if (current_view_data_ == this-> data_.back().get()){
-        return this -> data_[0] -> global_cell_;
+        return current_view_data_
+            //this -> data_[0]
+            -> global_cell_;
     }
     else{
         return this -> distributed_data_[0] ->global_cell_;

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -554,9 +554,9 @@ Dune::cpgrid::Entity<0> Dune::cpgrid::Entity<codim>::getOrigin() const
     {
         return this->father(); // currently, always a level 0 entity. 
     }
-    if (!(pgrid_ -> leaf_to_level_cells_.empty()))//(pgrid_ == (*(pgrid_->level_data_ptr_)).back().get() ) // entity on the LeafView
+    if (!(pgrid_ -> leaf_to_level_cells_.empty())) // entity on the LeafGridView
     {
-        const int& entityIdxInLevel0 = pgrid_->leaf_to_level_cells_[this->index()][1];
+        const int& entityIdxInLevel0 = pgrid_->leaf_to_level_cells_[this->index()][1]; // leaf_to_level_cells_ [leaf idx] = {0, cell idx}
         const auto& coarse_grid = (*(pgrid_ -> level_data_ptr_))[0].get();
         return Dune::cpgrid::Entity<0>( *coarse_grid, entityIdxInLevel0, true);
     }

--- a/tests/cpgrid/grid_lgr_test.cpp
+++ b/tests/cpgrid/grid_lgr_test.cpp
@@ -134,7 +134,7 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
             const auto& patch_cells = (*data[0]).getPatchCells(startIJK_vec[level-1], endIJK_vec[level-1]);
 
             // GLOBAL grid
-            for (int cell = 0; cell<  data[0]-> size(0); ++cell)
+            for (int cell = 0; cell <  data[0]-> size(0); ++cell)
             {
                 Dune::cpgrid::Entity<0> entity = Dune::cpgrid::Entity<0>((*coarse_grid.data_[0]), cell, true);
                 BOOST_CHECK( entity.hasFather() == false);
@@ -192,11 +192,12 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
             }
 
             // LGRs
-            for (int cell = 0; cell<  data[level]-> size(0); ++cell)
+            for (int cell = 0; cell <  data[level]-> size(0); ++cell)
             {
                 Dune::cpgrid::Entity<0> entity = Dune::cpgrid::Entity<0>((*coarse_grid.data_[level]), cell, true);
                 BOOST_CHECK( entity.hasFather() == true);
                 BOOST_CHECK( entity.getOrigin() ==  entity.father());
+                BOOST_CHECK( entity.index() == (data[level] -> global_cell_[entity.index()])); // global_cell_ = {0,1,..., total cells -1}
                 BOOST_CHECK( entity.getOrigin().level() == 0);
                 BOOST_CHECK_CLOSE(entity.geometryInFather().volume(),
                                   1./(cells_per_dim_vec[level-1][0]*cells_per_dim_vec[level-1][1]*cells_per_dim_vec[level-1][2]), 1e-6);
@@ -245,6 +246,8 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
                     BOOST_CHECK_EQUAL( child_to_parent[0] == 0, true);
                     BOOST_CHECK_EQUAL( child_to_parent[1], entity.father().index());
                     BOOST_CHECK( entity.father() == entity.getOrigin());
+                    BOOST_CHECK(  (data[startIJK_vec.size() +1] -> global_cell_[entity.index()]) ==
+                                  (data[0] -> global_cell_[entity.getOrigin().index()]) );
                     BOOST_CHECK( entity.getOrigin().level() == 0);
                     BOOST_CHECK( std::get<0>((*data[0]).parent_to_children_cells_[child_to_parent[1]]) == entity.level());
                     BOOST_CHECK_EQUAL((std::find(std::get<1>((*data[0]).parent_to_children_cells_[child_to_parent[1]]).begin(),


### PR DESCRIPTION
For a CpGrid with LGRs, the leaf grid view global_cell_ has size the total amount of cells in the leaf grid view and stores in each entry 'leaf cell index', the value of the level zero global_cell_ in the corresponding origin cell (parent/equivalent cell in level zero). For each LRG, global_cell_ is a vector {0,1,...., total amount of cells in the LGR -1}.

A modification in LookUpCartesianData was necessary. Its call operator uses cartesianIndex() which relies on globalCell() so tracking the origin cell is now done implicitly in LookUpCartesianData::operator() definition.    