### PR TITLE
Search Cartesian Index of origin cell

### DIFF
--- a/opm/grid/LookUpData.hh
+++ b/opm/grid/LookUpData.hh
@@ -233,6 +233,20 @@ public:
     template<typename GridType = Grid>
     typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int> getOriginIndex(const int& elemIdx) const;
 
+    /// \brief: It returns the Cartesian index of origin cell (parent/equivalent cell when elem has no father) in level 0.
+    ///
+    /// \tparam     EntityType
+    /// \param [in] element
+    /// \return     Cartesian Index of the origin cell (parent/equivalent cell when element has no father) in level 0.
+    template<typename EntityType>
+    int getCartesianOriginIdxFromEntity(const EntityType& elem) const;
+
+    /// \brief: It returns the Cartesian index of origin cell (parent/equivalent cell when elem has no father) in level 0.
+    ///
+    /// \param [in] element index
+    /// \return     Cartesian Index of the origin cell (parent/equivalent cell when element has no father) in level 0.
+    int getCartesianOriginIndex(const int& elemIdx) const;
+
 
 protected:
     const GridView& gridView_;
@@ -361,3 +375,17 @@ Opm::LookUpCartesianData<Grid,GridView>::getOriginIndex(const int& elemIdx) cons
     const auto& elem = Dune::cpgrid::Entity<0>(*(gridView_.grid().current_view_data_), elemIdx, true);
     return elem.getOrigin().index(); // getOrign() returns parent Entity or the equivalent Entity in level 0.
 }
+
+template<typename Grid, typename GridView>
+template<typename EntityType>
+int Opm::LookUpCartesianData<Grid,GridView>::getCartesianOriginIdxFromEntity(const EntityType& elem) const
+{
+    return cartMapper_-> cartesianIndex(this->elemMapper_.index(elem));
+}
+
+template<typename Grid, typename GridView>
+int Opm::LookUpCartesianData<Grid,GridView>::getCartesianOriginIndex(const int& elemIdx) const
+{
+    return cartMapper_-> cartesianIndex(elemIdx);
+}
+

--- a/tests/cpgrid/lookupdataCpGrid_test.cpp
+++ b/tests/cpgrid/lookupdataCpGrid_test.cpp
@@ -114,6 +114,10 @@ void lookup_check(const Dune::CpGrid& grid)
         BOOST_CHECK(featureInElemDoubleIDX == featureInElemDouble);
         BOOST_CHECK(featureInElemCartesianIDX == featureInElemCartesian);
         BOOST_CHECK(featureInElemDoubleCartesianIDX == featureInElemDoubleCartesian);
+        // Extra checks related to Cartesian Index
+        const auto cartIdx = cartMapper.cartesianIndex(elem.index());
+        BOOST_CHECK(cartIdx == lookUpCartesianData.getCartesianOriginIdxFromEntity(elem));
+        BOOST_CHECK(cartIdx == lookUpCartesianData.getCartesianOriginIndex(elem.index()));
         // Extra checks related to ElemMapper
         BOOST_CHECK(featureInElem == level0Mapper.index(elem.getOrigin()) +3);
         BOOST_CHECK(featureInElem == fake_feature[lookUpData.getOriginIndexFromEntity(elem)]);

--- a/tests/test_lookupdata_polyhedral.cpp
+++ b/tests/test_lookupdata_polyhedral.cpp
@@ -116,8 +116,11 @@ void lookup_check(const Dune::PolyhedralGrid<3,3>& grid)
         BOOST_CHECK(featureInElemDoubleIDX == featureInElemDouble);
         BOOST_CHECK(featureInElemCartesianIDX == featureInElemCartesian);
         BOOST_CHECK(featureInElemDoubleCartesianIDX == featureInElemDoubleCartesian);
+        // Extra checks related to Cartesian Index
+        const auto cartIdx = cartMapper.cartesianIndex(idx);
+        BOOST_CHECK(cartIdx == lookUpCartesianData.getCartesianOriginIdxFromEntity(elem));
+        BOOST_CHECK(cartIdx == lookUpCartesianData.getCartesianOriginIndex(idx));
     }
-
 }
 
 BOOST_AUTO_TEST_CASE(PolyGridFromEcl)


### PR DESCRIPTION
New methods added (in LookUpCartesianData) to search the Cartesian Index of the origin cell (parent/equivalent cell in level 0) for each cell in the leaf grid view. 
The methods are tested for CpGrid with/without LGRs and for PolyhedralGrid. 

This will play a key role in upcoming modifications in opm-simulators/ebos files, to support LGRs. 