### PR TITLE
Lookup of field properties via strings (LGRs data supported)

### DIFF
--- a/opm/grid/LookUpData.hh
+++ b/opm/grid/LookUpData.hh
@@ -72,14 +72,6 @@ public:
     {
     }
 
-    /// \brief: Get field propertry for an element in the leaf grid view, from a vector.
-    ///
-    ///         For general grids, the field property vector is assumed to be given for the gridView_.
-    ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
-    ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
-    template<typename EntityType, typename FieldPropType>
-    FieldPropType operator()(const EntityType& elem, const std::vector<FieldPropType>& fieldProp) const;
-
     /// \brief: Get field propertry for an element in the leaf grid view, from a vector and element index.
     ///
     ///         For general grids, the field property vector is assumed to be given for the gridView_.
@@ -87,6 +79,15 @@ public:
     ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
     template<typename FieldPropType>
     FieldPropType operator()(const int& elemIdx, const std::vector<FieldPropType>& fieldProp) const;
+
+    /// \brief: Get field propertry for an element in the leaf grid view, from a vector.
+    ///
+    ///         For general grids, the field property vector is assumed to be given for the gridView_.
+    ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
+    ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
+    template<typename EntityType, typename FieldPropType>
+    typename std::enable_if_t<!std::is_same_v<EntityType, unsigned int>, FieldPropType>
+    operator()(const EntityType& elem, const std::vector<FieldPropType>& fieldProp) const;
 
     /// \brief: Get property of type double from field properties manager by name, via element or its index.
     template<typename ElemOrIndex>
@@ -100,15 +101,15 @@ public:
                      const std::string& propString,
                      const ElemOrIndex& elemOrIndex) const;
 
-    /// \brief: Retunrs the same element index for all grids different from CpGrid.
+    /// \brief: Return the same element index for all grids different from CpGrid.
     ///
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
     template<typename EntityType, typename GridType = Grid>
-    typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
+    typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid> && !std::is_same_v<EntityType, unsigned int>,int>
     getFieldPropIdx(const EntityType& elem) const;
 
-    /// \brief: Returns index to search for the field propertries, for CpGrids.
+    /// \brief: Return index to search for the field propertries, for CpGrids.
     ///
     ///         When isFieldPropInLgr_ == false : fieldPropIdx == Index of the origin cell (parent/equivalent cell when element
     ///                                           has nofather) in level 0.
@@ -117,10 +118,10 @@ public:
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
     template<typename EntityType, typename GridType = Grid>
-    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
+    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid> && !std::is_same_v<EntityType, unsigned int>,int>
     getFieldPropIdx(const EntityType& elem) const;
 
-    /// \brief: Retunrs the same element index for all grids different from CpGrid.
+    /// \brief: Return the same element index for all grids different from CpGrid.
     ///
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
@@ -128,7 +129,7 @@ public:
     typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
     getFieldPropIdx(const int& elemIdx) const;
 
-    /// \brief: Returns the index to search for the field properties, for CpGrids.
+    /// \brief: Return the index to search for the field properties, for CpGrids.
     ///
     ///         When isFieldPropInLgr_ == false : fieldPropIdx == Index of the origin cell (parent/equivalent cell when element
     ///                                           has nofather) in level 0.
@@ -175,21 +176,22 @@ public:
     {
     }
 
-    /// \brief: Get field propertry for an element in the leaf grid view, from a vector, via Cartesian Index.
-    ///
-    ///         For general grids, the field property vector is assumed to be given for the gridView_.
-    ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
-    ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
-    template<typename EntityType, typename FieldPropType>
-    FieldPropType operator()(const EntityType& elem,const std::vector<FieldPropType>& fieldProp) const;
-
-    /// \brief: Get field propertry for an element in the leaf grid view, from a vector, via Cartesian Index.
+    /// \brief: Get field property for an element in the leaf grid view, from a vector, via Cartesian Index.
     ///
     ///         For general grids, the field property vector is assumed to be given for the gridView_.
     ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
     ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
     template<typename FieldPropType>
     FieldPropType operator()(const int& elemIdx, const std::vector<FieldPropType>& fieldProp) const;
+
+    /// \brief: Get field property for an element in the leaf grid view, from a vector, via Cartesian Index.
+    ///
+    ///         For general grids, the field property vector is assumed to be given for the gridView_.
+    ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
+    ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
+    template<typename EntityType, typename FieldPropType>
+    typename std::enable_if_t<!std::is_same_v<EntityType, unsigned int>, FieldPropType>
+    operator()(const EntityType& elem,const std::vector<FieldPropType>& fieldProp) const;
 
     /// \brief: Get property of type double from field properties manager by name, via element or its index.
     template<typename ElemOrIndex>
@@ -203,15 +205,15 @@ public:
                      const std::string& propString,
                      const ElemOrIndex& elemOrIndex) const;
 
-    /// \brief: Retunrs the same element index for all grids different from CpGrid.
+    /// \brief: Return the same element index for all grids different from CpGrid.
     ///
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
     template<typename EntityType, typename GridType = Grid>
-    typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
+    typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>  && !std::is_same_v<EntityType, unsigned int>,int>
     getFieldPropCartesianIdx(const EntityType& elem) const;
 
-    /// \brief: Returns index to search for the field propertries, for CpGrids.
+    /// \brief: Return index to search for the field propertries, for CpGrids.
     ///
     ///         When isFieldPropInLgr_ == false : fieldPropIdx == Index of the origin cell (parent/equivalent cell when element
     ///                                           has nofather) in level 0.
@@ -219,10 +221,10 @@ public:
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
     template<typename EntityType, typename GridType = Grid>
-    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
+    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid> && !std::is_same_v<EntityType, unsigned int>,int>
     getFieldPropCartesianIdx(const EntityType& elem) const;
 
-    /// \brief: Retunrs the same element index for all grids different from CpGrid.
+    /// \brief: Return the same element index for all grids different from CpGrid.
     ///
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
@@ -230,7 +232,7 @@ public:
     typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
     getFieldPropCartesianIdx(const int& elemIdx) const;
 
-    /// \brief: Returns index to search for the field propertries, for CpGrids.
+    /// \brief: Return index to search for the field propertries, for CpGrids.
     ///
     ///         When isFieldPropInLgr_ == false : fieldPropIdx == Index of the origin cell (parent/equivalent cell when element
     ///                                           has nofather) in level 0.
@@ -255,22 +257,23 @@ protected:
 /// LookUpData
 
 template<typename Grid, typename GridView>
-template<typename EntityType, typename FieldPropType>
-FieldPropType Opm::LookUpData<Grid,GridView>::operator()(const EntityType& elem,
-                                                         const std::vector<FieldPropType>& fieldProp) const
-{
-    const auto& fieldPropIdx = this->getFieldPropIdx<EntityType,Grid>(elem);
-    assert( (0 <= fieldPropIdx) && (static_cast<int>(fieldProp.size()) > fieldPropIdx));
-    return fieldProp[fieldPropIdx];
-}
-
-template<typename Grid, typename GridView>
 template<typename FieldPropType>
 FieldPropType Opm::LookUpData<Grid,GridView>::operator()(const int& elemIdx,
                                                          const std::vector<FieldPropType>& fieldProp) const
 {
     const auto& fieldPropIdx = this->getFieldPropIdx<Grid>(elemIdx);
     assert(0 <= fieldPropIdx && static_cast<int>(fieldProp.size()) > fieldPropIdx);
+    return fieldProp[fieldPropIdx];
+}
+
+template<typename Grid, typename GridView>
+template<typename EntityType, typename FieldPropType>
+typename std::enable_if_t<!std::is_same_v<EntityType, unsigned int>,FieldPropType>
+Opm::LookUpData<Grid,GridView>::operator()(const EntityType& elem,
+                                           const std::vector<FieldPropType>& fieldProp) const
+{
+    const auto& fieldPropIdx = this->getFieldPropIdx<EntityType,Grid>(elem);
+    assert( (0 <= fieldPropIdx) && (static_cast<int>(fieldProp.size()) > fieldPropIdx));
     return fieldProp[fieldPropIdx];
 }
 
@@ -296,7 +299,7 @@ int Opm::LookUpData<Grid,GridView>::fieldPropInt(const FieldPropsManager& fieldP
 
 template<typename Grid, typename GridView>
 template<typename EntityType, typename GridType>
-typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
+typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid> && !std::is_same_v<EntityType, unsigned int>,int>
 Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const EntityType& elem) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
@@ -306,17 +309,17 @@ Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const EntityType& elem) const
 
 template<typename Grid, typename GridView>
 template<typename EntityType,typename GridType>
-typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
+typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid> && !std::is_same_v<EntityType, unsigned int>,int>
 Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const EntityType& elem) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
     static_assert(std::is_same_v<EntityType,Dune::cpgrid::Entity<0>>);
     if (isFieldPropInLgr_ && elem.level()) { // level > 0 == true ; level == 0 == false
         // In case some LGRs do not have refined field properties, the next line need to be modified.
-        return elem.getLevelElem().index(); // getLgrElem() returns equivalent refined Entity in the LGR the leafGridView cell was born.
+        return elem.getLevelElem().index();
     }
     else {
-        return elem.getOrigin().index(); // getOrign() returns parent Entity or the equivalent Entity in level 0.
+        return elem.getOrigin().index();
     }
 }
 
@@ -340,27 +343,16 @@ Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const int& elemIdx) const
     const auto& elem = Dune::cpgrid::Entity<0>(*(gridView_.grid().current_view_data_), elemIdx, true);
     if (isFieldPropInLgr_ && elem.level()) { // level > 0 == true ; level == 0 == false
         // In case some LGRs do not have refined field properties, the next line need to be modified.
-        return elem.getLevelElem().index(); // getLgrElem() returns equivalent refined Entity in the LGR the leafGridView cell was born.
+        return elem.getLevelElem().index();
     }
     else {
-        return elem.getOrigin().index(); // getOrign() returns parent Entity or the equivalent Entity in level 0.
+        return elem.getOrigin().index();
     }
 }
 
 
 
 /// LookUpCartesianData
-
-template<typename Grid, typename GridView>
-template<typename EntityType, typename FieldPropType>
-FieldPropType Opm::LookUpCartesianData<Grid,GridView>::operator()(const EntityType& elem,
-                                                                  const std::vector<FieldPropType>& fieldProp) const
-{
-    assert(cartMapper_);
-    const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<EntityType,Grid>(elem);
-    assert( (0 <= fieldPropCartIdx) && (static_cast<int>(fieldProp.size()) > fieldPropCartIdx) );
-    return fieldProp[fieldPropCartIdx];
-}
 
 template<typename Grid, typename GridView>
 template<typename FieldPropType>
@@ -373,6 +365,17 @@ FieldPropType Opm::LookUpCartesianData<Grid,GridView>::operator()(const int& ele
     return fieldProp[fieldPropCartIdx];
 }
 
+template<typename Grid, typename GridView>
+template<typename EntityType, typename FieldPropType>
+typename std::enable_if_t<!std::is_same_v<EntityType, unsigned int>,FieldPropType>
+Opm::LookUpCartesianData<Grid,GridView>::operator()(const EntityType& elem,
+                                                    const std::vector<FieldPropType>& fieldProp) const
+{
+    assert(cartMapper_);
+    const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<EntityType,Grid>(elem);
+    assert( (0 <= fieldPropCartIdx) && (static_cast<int>(fieldProp.size()) > fieldPropCartIdx) );
+    return fieldProp[fieldPropCartIdx];
+}
 
 
 template<typename Grid, typename GridView>
@@ -397,7 +400,7 @@ int Opm::LookUpCartesianData<Grid,GridView>::fieldPropInt(const FieldPropsManage
 
 template<typename Grid, typename GridView>
 template<typename EntityType, typename GridType>
-typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
+typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid> && !std::is_same_v<EntityType, unsigned int>,int>
 Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const EntityType& elem) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
@@ -408,7 +411,7 @@ Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const EntityTy
 
 template<typename Grid, typename GridView>
 template<typename EntityType, typename GridType>
-typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
+typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid> && !std::is_same_v<EntityType, unsigned int>,int>
 Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const EntityType& elem) const
 {
     static_assert(std::is_same_v<Grid,GridType>);

--- a/opm/grid/LookUpData.hh
+++ b/opm/grid/LookUpData.hh
@@ -41,20 +41,9 @@
 #include <type_traits>
 #include <vector>
 
-namespace Opm
-{
-class FieldPropsManager;
-}
-
 namespace Dune
 {
 class CpGrid;
-
-namespace cpgrid
-{
-template<int codim> class Entity;
-}
-
 }
 
 namespace Opm
@@ -83,125 +72,63 @@ public:
     {
     }
 
-    /// \brief: Call operator taking an EntityObject, a FieldPropVector, and a level.
+    /// \brief: Get field propertry for an element in the leaf grid view, from a vector.
     ///
-    ///         Return field property of the entity, via (ACTIVE) INDEX
     ///         For general grids, the field property vector is assumed to be given for the gridView_.
     ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
     ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
-    ///
-    /// \tparam     EntityType    Element type.
-    /// \tparam     FieldPropType Type of the field property of the element, e.g. int, double, float, etc.
-    /// \param [in] element       EntityType object.
-    /// \param [in] fieldProp     Vector with each entry, the feature of an element of
-    ///                           the gridView_ [for general grids], or level 0 for CpGrid.
-    /// \return field property of the given leaf grid view element.
     template<typename EntityType, typename FieldPropType>
     FieldPropType operator()(const EntityType& elem, const std::vector<FieldPropType>& fieldProp) const;
 
-    /// \brief: Call operator taking an Index, a FieldPropertyVector, and a level.
+    /// \brief: Get field propertry for an element in the leaf grid view, from a vector and element index.
     ///
-    ///         Return field property of the entity, via (ACTIVE) INDEX
     ///         For general grids, the field property vector is assumed to be given for the gridView_.
     ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
     ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
-    ///
-    /// \tparam     FieldPropType   Type of the field property of the element, e.g. int, double, float, etc.
-    /// \param [in] element index
-    /// \param [in] fieldProp       Vector with each entry, the feature of an element of
-    ///                             the gridView_ [for general grids], or level 0 for CpGrid.
-    /// \return field property of the given leaf grid view element.
     template<typename FieldPropType>
     FieldPropType operator()(const int& elemIdx, const std::vector<FieldPropType>& fieldProp) const;
 
-    /// \brief: fieldPropDouble() taking a FieldPropsManager, std::string, and an element.
-    ///                           Return field property of type double of the entity, via (ACTIVE) INDEX
-    ///
-    /// \tparam     EntityType          Element type.
-    /// \param [in] FieldPropsManager
-    /// \param [in] propString          String to lookup the field property in the FieldPropsManager
-    /// \param [in] element             EntityType object.
-    /// \return field property of the given leaf grid view element.
-    template<typename EntityType>
-    double fieldPropDoubleFromEntity(const FieldPropsManager& fieldPropsManager,
-                                     const std::string& propString,
-                                     const EntityType& elem) const;
-
-
-    /// \brief: fieldPropDouble() taking a FieldPropsManager, std::string, and an element index.
-    ///                           Return field property of type double of the entity, via (ACTIVE) INDEX
-    ///
-    /// \tparam     EntityType          Element type.
-    /// \param [in] FieldPropsManager
-    /// \param [in] propString          String to lookup the field property in the FieldPropsManager
-    /// \param [in] elemIdx             Element index
-    /// \return field property of the given leaf grid view element.
+    /// \brief: Get property of type double from field properties manager by name, via element or its index.
+    template<typename ElemOrIndex>
     double fieldPropDouble(const FieldPropsManager& fieldPropsManager,
                            const std::string& propString,
-                           const int& elemIdx) const;
+                           const ElemOrIndex& elemOrIndex) const;
 
-    /// \brief: fieldPropInt() taking a FieldPropsManager, std::string, and an element.
-    ///                        Return field property of type int of the entity, via (ACTIVE) INDEX
-    ///
-    /// \tparam     EntityType          Element type.
-    /// \param [in] FieldPropsManager
-    /// \param [in] propString          String to lookup the field property in the FieldPropsManager
-    /// \param [in] element             EntityType object.
-    /// \return field property of the given leaf grid view element.
-    template<typename EntityType>
-    int fieldPropIntFromEntity(const FieldPropsManager& fieldPropsManager,
-                               const std::string& propString,
-                               const EntityType& elem) const;
-
-    /// \brief: fieldPropDouble() taking a FieldPropsManager, std::string, and an element index.
-    ///                           Return field property of type double of the entity, via (ACTIVE) INDEX
-    ///
-    /// \tparam     EntityType          Element type.
-    /// \param [in] FieldPropsManager
-    /// \param [in] propString          String to lookup the field property in the FieldPropsManager
-    /// \param [in] elemIdx             Element index
-    /// \return field property of the given leaf grid view element.
+    /// \brief: Get property of type int from field properties manager by name, via element.
+    template<typename ElemOrIndex>
     int fieldPropInt(const FieldPropsManager& fieldPropsManager,
                      const std::string& propString,
-                     const int& elemIdx) const;
+                     const ElemOrIndex& elemOrIndex) const;
 
-    /// \brief: For general grids, it retunrs the same Entity index.
+    /// \brief: Retunrs the same element index for all grids different from CpGrid.
     ///
-    /// \tparam     EntityType  Element type.
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
-    /// \param [in] element     EntityType object.
-    /// \return fieldPropIdx    Element Index
     template<typename EntityType, typename GridType = Grid>
     typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
-    getFieldPropIdxFromEntity(const EntityType& elem) const;
+    getFieldPropIdx(const EntityType& elem) const;
 
-    /// \brief: For CpGrid, it returns index to search for the field propertries.
+    /// \brief: Returns index to search for the field propertries, for CpGrids.
     ///
     ///         When isFieldPropInLgr_ == false : fieldPropIdx == Index of the origin cell (parent/equivalent cell when element
     ///                                           has nofather) in level 0.
     ///         When isFieldPropInLgr_ == true  : fieldPropIdx == Index of the equivalent cell in the LGR (level>0).
     ///
-    /// \tparam     EntityType  Element type.
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
-    /// \param [in] element     EntityType object.
-    /// \return fieldPropIdx
     template<typename EntityType, typename GridType = Grid>
     typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
-    getFieldPropIdxFromEntity(const EntityType& elem) const;
+    getFieldPropIdx(const EntityType& elem) const;
 
-    /// \brief: For general grids, it retunrs the same element index.
+    /// \brief: Retunrs the same element index for all grids different from CpGrid.
     ///
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
-    /// \param [in] elemIdx
-    /// \return fieldPropIdx    Element index.
     template<typename GridType>
     typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
     getFieldPropIdx(const int& elemIdx) const;
 
-    /// \brief: For CpGrid, it returns the index to search for the field properties.
+    /// \brief: Returns the index to search for the field properties, for CpGrids.
     ///
     ///         When isFieldPropInLgr_ == false : fieldPropIdx == Index of the origin cell (parent/equivalent cell when element
     ///                                           has nofather) in level 0.
@@ -209,8 +136,6 @@ public:
     ///
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
-    /// \param [in] element index
-    /// \return fieldPropIdx
     template<typename GridType = Grid>
     typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
     getFieldPropIdx(const int& elemIdx) const;
@@ -250,133 +175,68 @@ public:
     {
     }
 
-    /// \brief: Call operator taking an EntityObject, a FieldPropVector, and a level.
+    /// \brief: Get field propertry for an element in the leaf grid view, from a vector, via Cartesian Index.
     ///
-    ///         Return field property of the entity, via CARTESIAN INDEX
     ///         For general grids, the field property vector is assumed to be given for the gridView_.
     ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
     ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
-    ///
-    /// \tparam     EntityType    Element type.
-    /// \tparam     FieldPropType Type of the field property of the element, e.g. int, double, float, etc.
-    /// \param [in] element       EntityType object.
-    /// \param [in] fieldProp     Vector with each entry, the feature of an element of
-    ///                           the gridView_ [for general grids], or level 0 for CpGrid.
-    /// \return field property of the given leaf grid view element.
     template<typename EntityType, typename FieldPropType>
     FieldPropType operator()(const EntityType& elem,const std::vector<FieldPropType>& fieldProp) const;
 
-    /// \brief: Call operator taking an Index and a FeatureVector. a FieldPropertyVector, and a level.
+    /// \brief: Get field propertry for an element in the leaf grid view, from a vector, via Cartesian Index.
     ///
-    ///         Return field property of the entity, via CARTESIAN INDEX
     ///         For general grids, the field property vector is assumed to be given for the gridView_.
     ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
     ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
-    ///
-    /// \tparam     FieldPropType   Type of the field property of the element, e.g. int, double, float, etc.
-    /// \param [in] element index
-    /// \param [in] fieldProp       Vector with each entry, the feature of an element of
-    ///                             the gridView_ [for general grids], or level 0 for CpGrid.
-    /// \return field property of the given leaf grid view element.
     template<typename FieldPropType>
     FieldPropType operator()(const int& elemIdx, const std::vector<FieldPropType>& fieldProp) const;
 
-    /// \brief: fieldPropDouble() taking a FieldPropsManager, std::string, and an element.
-    ///                           Return field property of type double of the entity, via CARTESIAN INDEX
-    ///
-    /// \tparam     EntityType          Element type.
-    /// \param [in] FieldPropsManager
-    /// \param [in] propString          String to lookup the field property in the FieldPropsManager
-    /// \param [in] element             EntityType object.
-    /// \return field property of the given leaf grid view element.
-    template<typename EntityType>
-    double fieldPropDoubleFromEntity(const FieldPropsManager& fieldPropsManager,
-                                     const std::string& propString,
-                                     const EntityType& elem) const;
-
-    /// \brief: fieldPropDouble() taking a FieldPropsManager, std::string, and an element index.
-    ///                           Return field property of type double of the entity, via (ACTIVE) INDEX
-    ///
-    /// \tparam     EntityType          Element type.
-    /// \param [in] FieldPropsManager
-    /// \param [in] propString          String to lookup the field property in the FieldPropsManager
-    /// \param [in] elemIdx             Element index
-    /// \return field property of the given leaf grid view element.
+    /// \brief: Get property of type double from field properties manager by name, via element or its index.
+    template<typename ElemOrIndex>
     double fieldPropDouble(const FieldPropsManager& fieldPropsManager,
                            const std::string& propString,
-                           const int& elemIdx) const;
+                           const ElemOrIndex& elemOrIndex) const;
 
-    /// \brief: fieldPropInt() taking a FieldPropsManager, std::string, and an element.
-    ///                        Return field property of type int of the entity, via CARTESIAN INDEX
-    ///
-    /// \tparam     EntityType          Element type.
-    /// \param [in] FieldPropsManager
-    /// \param [in] propString          String to lookup the field property in the FieldPropsManager
-    /// \param [in] element             EntityType object.
-    /// \return field property of the given leaf grid view element.
-    template<typename EntityType>
-    int fieldPropIntFromEntity(const FieldPropsManager& fieldPropsManager,
-                               const std::string& propString,
-                               const EntityType& elem) const;
-
-    /// \brief: fieldPropDouble() taking a FieldPropsManager, std::string, and an element index.
-    ///                           Return field property of type double of the entity, via CARTESIAN INDEX
-    ///
-    /// \tparam     EntityType          Element type.
-    /// \param [in] FieldPropsManager
-    /// \param [in] propString          String to lookup the field property in the FieldPropsManager
-    /// \param [in] elemIdx             Element index
-    /// \return field property of the given leaf grid view element.
+    /// \brief: Get property of type int from field properties manager by name, via element or its index.
+    template<typename ElemOrIndex>
     int fieldPropInt(const FieldPropsManager& fieldPropsManager,
                      const std::string& propString,
-                     const int& elemIdx) const;
+                     const ElemOrIndex& elemOrIndex) const;
 
-    /// \brief: For general grids, it retunrs the same Entity index.
+    /// \brief: Retunrs the same element index for all grids different from CpGrid.
     ///
-    /// \tparam     EntityType  Element type.
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
-    /// \param [in] element     EntityType object.
-    /// \return fieldPropIdx    Element Index
     template<typename EntityType, typename GridType = Grid>
     typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
-    getFieldPropCartesianIdxFromEntity(const EntityType& elem) const;
+    getFieldPropCartesianIdx(const EntityType& elem) const;
 
-    /// \brief: For CpGrid, it returns index to search for the field propertries.
+    /// \brief: Returns index to search for the field propertries, for CpGrids.
     ///
     ///         When isFieldPropInLgr_ == false : fieldPropIdx == Index of the origin cell (parent/equivalent cell when element
     ///                                           has nofather) in level 0.
     ///         When isFieldPropInLgr_ == true  : fieldPropIdx == Index of the equivalent cell in the LGR (level>0).
-    ///
-    /// \tparam     EntityType  Element type.
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
-    /// \param [in] element     EntityType object.
-    /// \return fieldPropIdx
     template<typename EntityType, typename GridType = Grid>
     typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
-    getFieldPropCartesianIdxFromEntity(const EntityType& elem) const;
+    getFieldPropCartesianIdx(const EntityType& elem) const;
 
-    /// \brief: For general grids, it retunrs the same element index.
+    /// \brief: Retunrs the same element index for all grids different from CpGrid.
     ///
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
-    /// \param [in] elemIdx
-    /// \return fieldPropIdx    Element index.
     template<typename GridType = Grid>
     typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
     getFieldPropCartesianIdx(const int& elemIdx) const;
 
-    /// \brief: For CpGrid, it returns the index to search for the field properties.
+    /// \brief: Returns index to search for the field propertries, for CpGrids.
     ///
     ///         When isFieldPropInLgr_ == false : fieldPropIdx == Index of the origin cell (parent/equivalent cell when element
     ///                                           has nofather) in level 0.
     ///         When isFieldPropInLgr_ == true  : fieldPropIdx == Index of the equivalent cell in the LGR (level>0).
-    ///
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
-    /// \param [in] element index
-    /// \return fieldPropIdx
     template<typename GridType = Grid>
     typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
     getFieldPropCartesianIdx(const int& elemIdx) const;
@@ -399,7 +259,7 @@ template<typename EntityType, typename FieldPropType>
 FieldPropType Opm::LookUpData<Grid,GridView>::operator()(const EntityType& elem,
                                                          const std::vector<FieldPropType>& fieldProp) const
 {
-    const auto& fieldPropIdx = this->getFieldPropIdxFromEntity<EntityType,Grid>(elem);
+    const auto& fieldPropIdx = this->getFieldPropIdx<EntityType,Grid>(elem);
     assert( (0 <= fieldPropIdx) && (static_cast<int>(fieldProp.size()) > fieldPropIdx));
     return fieldProp[fieldPropIdx];
 }
@@ -415,47 +275,29 @@ FieldPropType Opm::LookUpData<Grid,GridView>::operator()(const int& elemIdx,
 }
 
 template<typename Grid, typename GridView>
-template<typename EntityType>
-double Opm::LookUpData<Grid,GridView>::fieldPropDoubleFromEntity(const FieldPropsManager& fieldPropsManager,
-                                                                 const std::string& propString,
-                                                                 const EntityType& elem) const
-{
-    const auto& fieldPropVec = fieldPropsManager.get_double(propString);
-    return this ->operator()(elem,fieldPropVec);
-}
-
-template<typename Grid, typename GridView>
+template<typename ElemOrIndex>
 double Opm::LookUpData<Grid,GridView>::fieldPropDouble(const FieldPropsManager& fieldPropsManager,
                                                        const std::string& propString,
-                                                       const int& elemIdx) const
+                                                       const ElemOrIndex& elemOrIndex) const
 {
     const auto& fieldPropVec = fieldPropsManager.get_double(propString);
-    return this ->operator()(elemIdx,fieldPropVec);
+    return this ->operator()(elemOrIndex,fieldPropVec);
 }
 
 template<typename Grid, typename GridView>
-template<typename EntityType>
-int Opm::LookUpData<Grid,GridView>::fieldPropIntFromEntity(const FieldPropsManager& fieldPropsManager,
-                                                           const std::string& propString,
-                                                           const EntityType& elem) const
-{
-    const auto& fieldPropVec = fieldPropsManager.get_int(propString);
-    return this ->operator()(elem,fieldPropVec);
-}
-
-template<typename Grid, typename GridView>
+template<typename ElemOrIndex>
 int Opm::LookUpData<Grid,GridView>::fieldPropInt(const FieldPropsManager& fieldPropsManager,
                                                  const std::string& propString,
-                                                 const int& elemIdx) const
+                                                 const ElemOrIndex& elemOrIndex) const
 {
     const auto& fieldPropVec = fieldPropsManager.get_int(propString);
-    return this ->operator()(elemIdx,fieldPropVec);
+    return this ->operator()(elemOrIndex,fieldPropVec);
 }
 
 template<typename Grid, typename GridView>
 template<typename EntityType, typename GridType>
 typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpData<Grid,GridView>::getFieldPropIdxFromEntity(const EntityType& elem) const
+Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const EntityType& elem) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
     assert(elem.level() == 0); // LGRs (level>0) only supported for CpGrid.
@@ -463,14 +305,15 @@ Opm::LookUpData<Grid,GridView>::getFieldPropIdxFromEntity(const EntityType& elem
 }
 
 template<typename Grid, typename GridView>
-template<typename EntityType, typename GridType>
+template<typename EntityType,typename GridType>
 typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpData<Grid,GridView>::getFieldPropIdxFromEntity(const EntityType& elem) const
+Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const EntityType& elem) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
+    static_assert(std::is_same_v<EntityType,Dune::cpgrid::Entity<0>>);
     if (isFieldPropInLgr_ && elem.level()) { // level > 0 == true ; level == 0 == false
         // In case some LGRs do not have refined field properties, the next line need to be modified.
-        return elem.getLgrElem().index(); // getLgrElem() returns equivalent refined Entity in the LGR the leafGridView cell was born.
+        return elem.getLevelElem().index(); // getLgrElem() returns equivalent refined Entity in the LGR the leafGridView cell was born.
     }
     else {
         return elem.getOrigin().index(); // getOrign() returns parent Entity or the equivalent Entity in level 0.
@@ -497,7 +340,7 @@ Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const int& elemIdx) const
     const auto& elem = Dune::cpgrid::Entity<0>(*(gridView_.grid().current_view_data_), elemIdx, true);
     if (isFieldPropInLgr_ && elem.level()) { // level > 0 == true ; level == 0 == false
         // In case some LGRs do not have refined field properties, the next line need to be modified.
-        return elem.getLgrElem().index(); // getLgrElem() returns equivalent refined Entity in the LGR the leafGridView cell was born.
+        return elem.getLevelElem().index(); // getLgrElem() returns equivalent refined Entity in the LGR the leafGridView cell was born.
     }
     else {
         return elem.getOrigin().index(); // getOrign() returns parent Entity or the equivalent Entity in level 0.
@@ -514,7 +357,7 @@ FieldPropType Opm::LookUpCartesianData<Grid,GridView>::operator()(const EntityTy
                                                                   const std::vector<FieldPropType>& fieldProp) const
 {
     assert(cartMapper_);
-    const auto fieldPropCartIdx = this->getFieldPropCartesianIdxFromEntity<EntityType,Grid>(elem);
+    const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<EntityType,Grid>(elem);
     assert( (0 <= fieldPropCartIdx) && (static_cast<int>(fieldProp.size()) > fieldPropCartIdx) );
     return fieldProp[fieldPropCartIdx];
 }
@@ -533,48 +376,29 @@ FieldPropType Opm::LookUpCartesianData<Grid,GridView>::operator()(const int& ele
 
 
 template<typename Grid, typename GridView>
-template<typename EntityType>
-double Opm::LookUpCartesianData<Grid,GridView>::fieldPropDoubleFromEntity(const FieldPropsManager& fieldPropsManager,
-                                                                          const std::string& propString,
-                                                                          const EntityType& elem) const
-{
-    const auto& fieldPropVec = fieldPropsManager.get_double(propString);
-    return this ->operator()(elem,fieldPropVec);
-}
-
-template<typename Grid, typename GridView>
+template<typename ElemOrIndex>
 double Opm::LookUpCartesianData<Grid,GridView>::fieldPropDouble(const FieldPropsManager& fieldPropsManager,
                                                                 const std::string& propString,
-                                                                const int& elemIdx) const
+                                                                const ElemOrIndex& elemOrIndex) const
 {
     const auto& fieldPropVec = fieldPropsManager.get_double(propString);
-    return this ->operator()(elemIdx,fieldPropVec);
+    return this ->operator()(elemOrIndex,fieldPropVec);
 }
 
 template<typename Grid, typename GridView>
-template<typename EntityType>
-int Opm::LookUpCartesianData<Grid,GridView>::fieldPropIntFromEntity(const FieldPropsManager& fieldPropsManager,
-                                                                    const std::string& propString,
-                                                                    const EntityType& elem) const
-{
-    const auto& fieldPropVec = fieldPropsManager.get_int(propString);
-    return this ->operator()(elem,fieldPropVec);
-}
-
-template<typename Grid, typename GridView>
+template<typename ElemOrIndex>
 int Opm::LookUpCartesianData<Grid,GridView>::fieldPropInt(const FieldPropsManager& fieldPropsManager,
                                                           const std::string& propString,
-                                                          const int& elemIdx) const
+                                                          const ElemOrIndex& elemOrIndex) const
 {
     const auto& fieldPropVec = fieldPropsManager.get_int(propString);
-    return this ->operator()(elemIdx,fieldPropVec);
+    return this ->operator()(elemOrIndex,fieldPropVec);
 }
-
 
 template<typename Grid, typename GridView>
 template<typename EntityType, typename GridType>
 typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdxFromEntity(const EntityType& elem) const
+Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const EntityType& elem) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
     // Check there are no LGRs. LGRs (level>0) only supported for CpGrid.
@@ -585,11 +409,11 @@ Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdxFromEntity(cons
 template<typename Grid, typename GridView>
 template<typename EntityType, typename GridType>
 typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdxFromEntity(const EntityType& elem) const
+Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const EntityType& elem) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
     if (isFieldPropInLgr_ && elem.level()) { // level == 0 false; level > 0 true
-        return elem.getLgrCartesianIdx();
+        return elem.getLevelCartesianIdx();
     }
     else {
         return cartMapper_-> cartesianIndex(this->elemMapper_.index(elem));
@@ -612,5 +436,5 @@ Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const int& ele
 {
     static_assert(std::is_same_v<Grid,GridType>);
     const auto& elem = Dune::cpgrid::Entity<0>(*(gridView_.grid().current_view_data_), elemIdx, true);
-    return this -> getFieldPropCartesianIdxFromEntity<Dune::cpgrid::Entity<0>,Dune::CpGrid>(elem);
+    return this -> getFieldPropCartesianIdx<Dune::cpgrid::Entity<0>,Dune::CpGrid>(elem);
 }

--- a/opm/grid/LookUpData.hh
+++ b/opm/grid/LookUpData.hh
@@ -34,10 +34,17 @@
 
 #include <dune/grid/common/mcmgmapper.hh>
 
+#include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/grid/cpgrid/Entity.hpp>
 
+#include <string>
 #include <type_traits>
 #include <vector>
+
+namespace Opm
+{
+class FieldPropsManager;
+}
 
 namespace Dune
 {
@@ -53,7 +60,7 @@ template<int codim> class Entity;
 namespace Opm
 {
 
-/// LookUpData class - To search data via element index
+/// LookUpData class - To search field properties of leaf grid view elements via element/elementIndex
 ///
 /// Instead of using a specialitation for Dune::CpGrid, we implement std::enable_if
 /// to overload methods with different definitions: for Dune:CpGrid and for other
@@ -63,42 +70,100 @@ template <typename Grid, typename GridView>
 class LookUpData
 {
 public:
-    /// \brief:     Constructor taking a GridView
+    /// \brief:     Constructor taking a GridView and a bool
     /// \param [in] GridView
-    explicit LookUpData(const  GridView& gridView) :
+    /// \param [in] isFieldPropInLgr   bool: default false (search field property in unrefined grid)
+    ///                                      true (search field property in refined grid; LGR-id/level required)
+    ///                                      Currently, isFieldPropInLgr_ == false means that all the field
+    ///                                      properties are given in the unrefined grid (level 0).
+    explicit LookUpData(const  GridView& gridView, bool isFieldPropInLgr = false) :
         gridView_(gridView),
-        elemMapper_(gridView, Dune::mcmgElementLayout())
+        elemMapper_(gridView, Dune::mcmgElementLayout()),
+        isFieldPropInLgr_(isFieldPropInLgr)
     {
     }
 
-    /// \brief: Call operator taking an EntityObject and a FeatureVector.
+    /// \brief: Call operator taking an EntityObject, a FieldPropVector, and a level.
     ///
-    ///         Return feature of the entity, via (ACTIVE) INDEX
-    ///         For general grids, the feature vector is given for the gridView_.
-    ///         For CpGrid, the feature vector is given for level 0.
+    ///         Return field property of the entity, via (ACTIVE) INDEX
+    ///         For general grids, the field property vector is assumed to be given for the gridView_.
+    ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
+    ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
     ///
-    /// \tparam     EntityType  Element type.
-    /// \tparam     FeatureType Type of the property of the element, e.g. int, double, float, etc.
-    /// \param [in] element     EntityType object.
-    /// \param [in] feature_vec Vector with each entry, the feature of an element of
-    ///                         the gridView_ [for general grids], or level 0 for CpGrid.
-    /// \return feature of the given element.
-    template<typename EntityType, typename FeatureType>
-    FeatureType operator()(const EntityType& elem, const std::vector<FeatureType>& feature_vec) const;
+    /// \tparam     EntityType    Element type.
+    /// \tparam     FieldPropType Type of the field property of the element, e.g. int, double, float, etc.
+    /// \param [in] element       EntityType object.
+    /// \param [in] fieldProp     Vector with each entry, the feature of an element of
+    ///                           the gridView_ [for general grids], or level 0 for CpGrid.
+    /// \return field property of the given leaf grid view element.
+    template<typename EntityType, typename FieldPropType>
+    FieldPropType operator()(const EntityType& elem, const std::vector<FieldPropType>& fieldProp) const;
 
-    /// \brief: Call operator taking an Index and a FeatureVector.
+    /// \brief: Call operator taking an Index, a FieldPropertyVector, and a level.
     ///
-    ///         Return feature of the entity, via (ACTIVE) INDEX
-    ///         For general grids, the feature vector is given for the gridView_.
-    ///         For CpGrid, the feature vector is given for level 0.
-    /// 
-    /// \tparam     FeatureType       Type of the property of the element, e.g. int, double, float, etc.
+    ///         Return field property of the entity, via (ACTIVE) INDEX
+    ///         For general grids, the field property vector is assumed to be given for the gridView_.
+    ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
+    ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
+    ///
+    /// \tparam     FieldPropType   Type of the field property of the element, e.g. int, double, float, etc.
     /// \param [in] element index
-    /// \param [in] feature_vec       Vector with each entry, the feature of an element of
-    ///                               the gridView_ [for general grids], or level 0 for CpGrid.
-    /// \return feature of the element of the gridView_ associated to the given index.
-    template<typename FeatureType>
-    FeatureType operator()(const int& elemIdx, const std::vector<FeatureType>& feature_vec) const;
+    /// \param [in] fieldProp       Vector with each entry, the feature of an element of
+    ///                             the gridView_ [for general grids], or level 0 for CpGrid.
+    /// \return field property of the given leaf grid view element.
+    template<typename FieldPropType>
+    FieldPropType operator()(const int& elemIdx, const std::vector<FieldPropType>& fieldProp) const;
+
+    /// \brief: fieldPropDouble() taking a FieldPropsManager, std::string, and an element.
+    ///                           Return field property of type double of the entity, via (ACTIVE) INDEX
+    ///
+    /// \tparam     EntityType          Element type.
+    /// \param [in] FieldPropsManager
+    /// \param [in] propString          String to lookup the field property in the FieldPropsManager
+    /// \param [in] element             EntityType object.
+    /// \return field property of the given leaf grid view element.
+    template<typename EntityType>
+    double fieldPropDoubleFromEntity(const FieldPropsManager& fieldPropsManager,
+                                     const std::string& propString,
+                                     const EntityType& elem) const;
+
+
+    /// \brief: fieldPropDouble() taking a FieldPropsManager, std::string, and an element index.
+    ///                           Return field property of type double of the entity, via (ACTIVE) INDEX
+    ///
+    /// \tparam     EntityType          Element type.
+    /// \param [in] FieldPropsManager
+    /// \param [in] propString          String to lookup the field property in the FieldPropsManager
+    /// \param [in] elemIdx             Element index
+    /// \return field property of the given leaf grid view element.
+    double fieldPropDouble(const FieldPropsManager& fieldPropsManager,
+                           const std::string& propString,
+                           const int& elemIdx) const;
+
+    /// \brief: fieldPropInt() taking a FieldPropsManager, std::string, and an element.
+    ///                        Return field property of type int of the entity, via (ACTIVE) INDEX
+    ///
+    /// \tparam     EntityType          Element type.
+    /// \param [in] FieldPropsManager
+    /// \param [in] propString          String to lookup the field property in the FieldPropsManager
+    /// \param [in] element             EntityType object.
+    /// \return field property of the given leaf grid view element.
+    template<typename EntityType>
+    int fieldPropIntFromEntity(const FieldPropsManager& fieldPropsManager,
+                               const std::string& propString,
+                               const EntityType& elem) const;
+
+    /// \brief: fieldPropDouble() taking a FieldPropsManager, std::string, and an element index.
+    ///                           Return field property of type double of the entity, via (ACTIVE) INDEX
+    ///
+    /// \tparam     EntityType          Element type.
+    /// \param [in] FieldPropsManager
+    /// \param [in] propString          String to lookup the field property in the FieldPropsManager
+    /// \param [in] elemIdx             Element index
+    /// \return field property of the given leaf grid view element.
+    int fieldPropInt(const FieldPropsManager& fieldPropsManager,
+                     const std::string& propString,
+                     const int& elemIdx) const;
 
     /// \brief: For general grids, it retunrs the same Entity index.
     ///
@@ -106,45 +171,58 @@ public:
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
     /// \param [in] element     EntityType object.
-    /// \return element index.
+    /// \return fieldPropIdx    Element Index
     template<typename EntityType, typename GridType = Grid>
-    typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int> getOriginIndexFromEntity(const EntityType& elem) const;
+    typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
+    getFieldPropIdxFromEntity(const EntityType& elem) const;
 
-    /// \brief: For CpGrid, it returns index of origin cell (parent/equivalent cell when element has no father) in level 0.
+    /// \brief: For CpGrid, it returns index to search for the field propertries.
+    ///
+    ///         When isFieldPropInLgr_ == false : fieldPropIdx == Index of the origin cell (parent/equivalent cell when element
+    ///                                           has nofather) in level 0.
+    ///         When isFieldPropInLgr_ == true  : fieldPropIdx == Index of the equivalent cell in the LGR (level>0).
     ///
     /// \tparam     EntityType  Element type.
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
     /// \param [in] element     EntityType object.
-    /// \return element origin index  Index of the origin cell (parent/equivalent cell when element has no father) in level 0.
+    /// \return fieldPropIdx
     template<typename EntityType, typename GridType = Grid>
-    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int> getOriginIndexFromEntity(const EntityType& elem) const;
+    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
+    getFieldPropIdxFromEntity(const EntityType& elem) const;
 
     /// \brief: For general grids, it retunrs the same element index.
     ///
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
-    /// \param [in] element index
-    /// \return element index
+    /// \param [in] elemIdx
+    /// \return fieldPropIdx    Element index.
     template<typename GridType>
-    typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int> getOriginIndex(const int& elemIdx) const;
+    typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
+    getFieldPropIdx(const int& elemIdx) const;
 
-    /// \brief: For CpGrid, it returns index of origin cell (parent/equivalent cell when elem has no father) in level 0.
+    /// \brief: For CpGrid, it returns the index to search for the field properties.
+    ///
+    ///         When isFieldPropInLgr_ == false : fieldPropIdx == Index of the origin cell (parent/equivalent cell when element
+    ///                                           has nofather) in level 0.
+    ///         When isFieldPropInLgr_ == true  : fieldPropIdx == Index of the equivalent cell in the LGR (level>0).
     ///
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
     /// \param [in] element index
-    /// \return element origin index  Index of the origin cell (parent/equivalent cell when element has no father) in level 0.
+    /// \return fieldPropIdx
     template<typename GridType = Grid>
-    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int> getOriginIndex(const int& elemIdx) const;
+    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
+    getFieldPropIdx(const int& elemIdx) const;
 
 
 protected:
     const GridView& gridView_;
     Dune::MultipleCodimMultipleGeomTypeMapper<GridView> elemMapper_;
+    bool isFieldPropInLgr_;
 }; // end LookUpData class
 
-/// LookUpCartesianData - To search data via CartesianIndex (cartesianMapper)
+/// LookUpCartesianData - To search field properties of leaf grid view elements via CartesianIndex (cartesianMapper)
 ///
 /// Instead of using a specialitation for Dune::CpGrid, we implement std::enable_if
 /// to overload methods with different definitions: for Dune:CpGrid and for other
@@ -154,46 +232,104 @@ template<typename Grid, typename GridView>
 class LookUpCartesianData
 {
 public:
-    /// \brief: Constructor taking a GridView and a CartesianIndexMapper
+    /// \brief: Constructor taking a GridView, a CartesianIndexMapper, and a bool
     ///
     /// \param [in] gridView
-    /// \param [in] mapper   Dune::CartesianIndexMapper<Grid>. 
+    /// \param [in] mapper   Dune::CartesianIndexMapper<Grid>.
+    /// \param [in] isFieldPropInLgr bool: default false (search field property in unrefined grid)
+    ///                                    true (search field property in refined grid; LGR-id/level required)
+    ///                                    Currently, isFieldPropInLgr_ == false means that all the field
+    ///                                    properties are given in the unrefined grid (level 0).
     explicit LookUpCartesianData(const GridView& gridView,
-                                 const Dune::CartesianIndexMapper<Grid>& mapper) :
+                                 const Dune::CartesianIndexMapper<Grid>& mapper,
+                                 bool isFieldPropInLgr = false) :
         gridView_(gridView),
         elemMapper_(gridView, Dune::mcmgElementLayout()),
-        cartMapper_(&mapper)
+        cartMapper_(&mapper),
+        isFieldPropInLgr_(isFieldPropInLgr)
     {
     }
 
-    /// \brief: Call operator taking an EntityObject and a FeatureVector.
+    /// \brief: Call operator taking an EntityObject, a FieldPropVector, and a level.
     ///
-    ///         Return feature of the entity, via CARTESIAN INDEX
-    ///         For general grids, the feature vector is given for the gridView_.
-    ///         For CpGrid, the feature vector is given for level 0.
+    ///         Return field property of the entity, via CARTESIAN INDEX
+    ///         For general grids, the field property vector is assumed to be given for the gridView_.
+    ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
+    ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
     ///
-    /// \tparam     EntityType  Element type.
-    /// \tparam     FeatureType Type of the property of the element, e.g. int, double, float, etc.
-    /// \param [in] element     EntityType object.
-    /// \param [in] feature_vec Vector with each entry, the feature of an element of
-    ///                         the gridView_ [for general grids], or level 0 for CpGrid.
-    /// \return feature of the given element.
-    template<typename EntityType, typename FeatureType>
-    FeatureType operator()(const EntityType& elem,const std::vector<FeatureType>& feature_vec) const;
+    /// \tparam     EntityType    Element type.
+    /// \tparam     FieldPropType Type of the field property of the element, e.g. int, double, float, etc.
+    /// \param [in] element       EntityType object.
+    /// \param [in] fieldProp     Vector with each entry, the feature of an element of
+    ///                           the gridView_ [for general grids], or level 0 for CpGrid.
+    /// \return field property of the given leaf grid view element.
+    template<typename EntityType, typename FieldPropType>
+    FieldPropType operator()(const EntityType& elem,const std::vector<FieldPropType>& fieldProp) const;
 
-    /// \brief: Call operator taking an Index and a FeatureVector.
+    /// \brief: Call operator taking an Index and a FeatureVector. a FieldPropertyVector, and a level.
     ///
-    ///         Return feature of the entity, via CARTESIAN INDEX
-    ///         For general grids, the feature vector is given for the gridView_.
-    ///         For CpGrid, the feature vector is given for level 0.
+    ///         Return field property of the entity, via CARTESIAN INDEX
+    ///         For general grids, the field property vector is assumed to be given for the gridView_.
+    ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
+    ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
     ///
-    /// \tparam     FeatureType     Type of the property of the element, e.g. int, double, float, etc.
+    /// \tparam     FieldPropType   Type of the field property of the element, e.g. int, double, float, etc.
     /// \param [in] element index
-    /// \param [in] feature_vec     Vector with each entry, the feature of an element of
+    /// \param [in] fieldProp       Vector with each entry, the feature of an element of
     ///                             the gridView_ [for general grids], or level 0 for CpGrid.
-    /// \return feature of the element of the gridView_ associated to the given index.
-    template<typename FeatureType>
-    FeatureType operator()(const int& elemIdx, const std::vector<FeatureType>& feature_vec) const;
+    /// \return field property of the given leaf grid view element.
+    template<typename FieldPropType>
+    FieldPropType operator()(const int& elemIdx, const std::vector<FieldPropType>& fieldProp) const;
+
+    /// \brief: fieldPropDouble() taking a FieldPropsManager, std::string, and an element.
+    ///                           Return field property of type double of the entity, via CARTESIAN INDEX
+    ///
+    /// \tparam     EntityType          Element type.
+    /// \param [in] FieldPropsManager
+    /// \param [in] propString          String to lookup the field property in the FieldPropsManager
+    /// \param [in] element             EntityType object.
+    /// \return field property of the given leaf grid view element.
+    template<typename EntityType>
+    double fieldPropDoubleFromEntity(const FieldPropsManager& fieldPropsManager,
+                                     const std::string& propString,
+                                     const EntityType& elem) const;
+
+    /// \brief: fieldPropDouble() taking a FieldPropsManager, std::string, and an element index.
+    ///                           Return field property of type double of the entity, via (ACTIVE) INDEX
+    ///
+    /// \tparam     EntityType          Element type.
+    /// \param [in] FieldPropsManager
+    /// \param [in] propString          String to lookup the field property in the FieldPropsManager
+    /// \param [in] elemIdx             Element index
+    /// \return field property of the given leaf grid view element.
+    double fieldPropDouble(const FieldPropsManager& fieldPropsManager,
+                           const std::string& propString,
+                           const int& elemIdx) const;
+
+    /// \brief: fieldPropInt() taking a FieldPropsManager, std::string, and an element.
+    ///                        Return field property of type int of the entity, via CARTESIAN INDEX
+    ///
+    /// \tparam     EntityType          Element type.
+    /// \param [in] FieldPropsManager
+    /// \param [in] propString          String to lookup the field property in the FieldPropsManager
+    /// \param [in] element             EntityType object.
+    /// \return field property of the given leaf grid view element.
+    template<typename EntityType>
+    int fieldPropIntFromEntity(const FieldPropsManager& fieldPropsManager,
+                               const std::string& propString,
+                               const EntityType& elem) const;
+
+    /// \brief: fieldPropDouble() taking a FieldPropsManager, std::string, and an element index.
+    ///                           Return field property of type double of the entity, via CARTESIAN INDEX
+    ///
+    /// \tparam     EntityType          Element type.
+    /// \param [in] FieldPropsManager
+    /// \param [in] propString          String to lookup the field property in the FieldPropsManager
+    /// \param [in] elemIdx             Element index
+    /// \return field property of the given leaf grid view element.
+    int fieldPropInt(const FieldPropsManager& fieldPropsManager,
+                     const std::string& propString,
+                     const int& elemIdx) const;
 
     /// \brief: For general grids, it retunrs the same Entity index.
     ///
@@ -201,57 +337,55 @@ public:
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
     /// \param [in] element     EntityType object.
-    /// \return element index.
+    /// \return fieldPropIdx    Element Index
     template<typename EntityType, typename GridType = Grid>
-    typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int> getOriginIndexFromEntity(const EntityType& elem) const;
+    typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
+    getFieldPropCartesianIdxFromEntity(const EntityType& elem) const;
 
-    /// \brief: For CpGrid, it returns index of origin cell (parent/equivalent cell when element has no father) in level 0.
+    /// \brief: For CpGrid, it returns index to search for the field propertries.
+    ///
+    ///         When isFieldPropInLgr_ == false : fieldPropIdx == Index of the origin cell (parent/equivalent cell when element
+    ///                                           has nofather) in level 0.
+    ///         When isFieldPropInLgr_ == true  : fieldPropIdx == Index of the equivalent cell in the LGR (level>0).
     ///
     /// \tparam     EntityType  Element type.
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
     /// \param [in] element     EntityType object.
-    /// \return element origin index  Index of the origin cell (parent/equivalent cell when element has no father) in level 0.
+    /// \return fieldPropIdx
     template<typename EntityType, typename GridType = Grid>
-    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int> getOriginIndexFromEntity(const EntityType& elem) const;
+    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
+    getFieldPropCartesianIdxFromEntity(const EntityType& elem) const;
 
     /// \brief: For general grids, it retunrs the same element index.
     ///
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
-    /// \param [in] element index
-    /// \return element index
+    /// \param [in] elemIdx
+    /// \return fieldPropIdx    Element index.
     template<typename GridType = Grid>
-    typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int> getOriginIndex(const int& elemIdx) const;
+    typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
+    getFieldPropCartesianIdx(const int& elemIdx) const;
 
-    /// \brief: For CpGrid, it returns index of origin cell (parent/equivalent cell when elem has no father) in level 0.
+    /// \brief: For CpGrid, it returns the index to search for the field properties.
+    ///
+    ///         When isFieldPropInLgr_ == false : fieldPropIdx == Index of the origin cell (parent/equivalent cell when element
+    ///                                           has nofather) in level 0.
+    ///         When isFieldPropInLgr_ == true  : fieldPropIdx == Index of the equivalent cell in the LGR (level>0).
     ///
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
     /// \param [in] element index
-    /// \return element origin index  Index of the origin cell (parent/equivalent cell when element has no father) in level 0.
+    /// \return fieldPropIdx
     template<typename GridType = Grid>
-    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int> getOriginIndex(const int& elemIdx) const;
-
-    /// \brief: It returns the Cartesian index of origin cell (parent/equivalent cell when elem has no father) in level 0.
-    ///
-    /// \tparam     EntityType
-    /// \param [in] element
-    /// \return     Cartesian Index of the origin cell (parent/equivalent cell when element has no father) in level 0.
-    template<typename EntityType>
-    int getCartesianOriginIdxFromEntity(const EntityType& elem) const;
-
-    /// \brief: It returns the Cartesian index of origin cell (parent/equivalent cell when elem has no father) in level 0.
-    ///
-    /// \param [in] element index
-    /// \return     Cartesian Index of the origin cell (parent/equivalent cell when element has no father) in level 0.
-    int getCartesianOriginIndex(const int& elemIdx) const;
-
+    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
+    getFieldPropCartesianIdx(const int& elemIdx) const;
 
 protected:
     const GridView& gridView_;
     Dune::MultipleCodimMultipleGeomTypeMapper<GridView> elemMapper_;
     const Dune::CartesianIndexMapper<Grid>* cartMapper_;
+    bool isFieldPropInLgr_;
 }; // end LookUpCartesianData class
 }
 // end namespace Opm
@@ -261,57 +395,113 @@ protected:
 /// LookUpData
 
 template<typename Grid, typename GridView>
-template<typename EntityType, typename FeatureType>
-FeatureType Opm::LookUpData<Grid,GridView>::operator()(const EntityType& elem, const std::vector<FeatureType>& feature_vec) const
+template<typename EntityType, typename FieldPropType>
+FieldPropType Opm::LookUpData<Grid,GridView>::operator()(const EntityType& elem,
+                                                         const std::vector<FieldPropType>& fieldProp) const
 {
-    assert( (0 <= this->getOriginIndexFromEntity<EntityType,Grid>(elem)) &&
-            (static_cast<int>(feature_vec.size()) > this->getOriginIndexFromEntity<EntityType,Grid>(elem)) );
-    return feature_vec[this->getOriginIndexFromEntity<EntityType,Grid>(elem)];
+    const auto& fieldPropIdx = this->getFieldPropIdxFromEntity<EntityType,Grid>(elem);
+    assert( (0 <= fieldPropIdx) && (static_cast<int>(fieldProp.size()) > fieldPropIdx));
+    return fieldProp[fieldPropIdx];
 }
 
 template<typename Grid, typename GridView>
-template<typename FeatureType>
-FeatureType Opm::LookUpData<Grid,GridView>::operator()(const int& elemIdx, const std::vector<FeatureType>& feature_vec) const
+template<typename FieldPropType>
+FieldPropType Opm::LookUpData<Grid,GridView>::operator()(const int& elemIdx,
+                                                         const std::vector<FieldPropType>& fieldProp) const
 {
-    assert(0 <= this-> getOriginIndex<Grid>(elemIdx) && static_cast<int>(feature_vec.size()) > this-> getOriginIndex<Grid>(elemIdx));
-    return feature_vec[getOriginIndex<Grid>(elemIdx)];
+    const auto& fieldPropIdx = this->getFieldPropIdx<Grid>(elemIdx);
+    assert(0 <= fieldPropIdx && static_cast<int>(fieldProp.size()) > fieldPropIdx);
+    return fieldProp[fieldPropIdx];
+}
+
+template<typename Grid, typename GridView>
+template<typename EntityType>
+double Opm::LookUpData<Grid,GridView>::fieldPropDoubleFromEntity(const FieldPropsManager& fieldPropsManager,
+                                                                 const std::string& propString,
+                                                                 const EntityType& elem) const
+{
+    const auto& fieldPropVec = fieldPropsManager.get_double(propString);
+    return this ->operator()(elem,fieldPropVec);
+}
+
+template<typename Grid, typename GridView>
+double Opm::LookUpData<Grid,GridView>::fieldPropDouble(const FieldPropsManager& fieldPropsManager,
+                                                       const std::string& propString,
+                                                       const int& elemIdx) const
+{
+    const auto& fieldPropVec = fieldPropsManager.get_double(propString);
+    return this ->operator()(elemIdx,fieldPropVec);
+}
+
+template<typename Grid, typename GridView>
+template<typename EntityType>
+int Opm::LookUpData<Grid,GridView>::fieldPropIntFromEntity(const FieldPropsManager& fieldPropsManager,
+                                                           const std::string& propString,
+                                                           const EntityType& elem) const
+{
+    const auto& fieldPropVec = fieldPropsManager.get_int(propString);
+    return this ->operator()(elem,fieldPropVec);
+}
+
+template<typename Grid, typename GridView>
+int Opm::LookUpData<Grid,GridView>::fieldPropInt(const FieldPropsManager& fieldPropsManager,
+                                                 const std::string& propString,
+                                                 const int& elemIdx) const
+{
+    const auto& fieldPropVec = fieldPropsManager.get_int(propString);
+    return this ->operator()(elemIdx,fieldPropVec);
 }
 
 template<typename Grid, typename GridView>
 template<typename EntityType, typename GridType>
 typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpData<Grid,GridView>::getOriginIndexFromEntity(const EntityType& elem) const
+Opm::LookUpData<Grid,GridView>::getFieldPropIdxFromEntity(const EntityType& elem) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
+    assert(elem.level() == 0); // LGRs (level>0) only supported for CpGrid.
     return this-> elemMapper_.index(elem);
 }
 
 template<typename Grid, typename GridView>
 template<typename EntityType, typename GridType>
 typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpData<Grid,GridView>::getOriginIndexFromEntity(const EntityType& elem) const
+Opm::LookUpData<Grid,GridView>::getFieldPropIdxFromEntity(const EntityType& elem) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
-    return elem.getOrigin().index();
+    if (isFieldPropInLgr_ && elem.level()) { // level > 0 == true ; level == 0 == false
+        // In case some LGRs do not have refined field properties, the next line need to be modified.
+        return elem.getLgrElem().index(); // getLgrElem() returns equivalent refined Entity in the LGR the leafGridView cell was born.
+    }
+    else {
+        return elem.getOrigin().index(); // getOrign() returns parent Entity or the equivalent Entity in level 0.
+    }
 }
 
 template<typename Grid, typename GridView>
 template<typename GridType>
 typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpData<Grid,GridView>::getOriginIndex(const int& elemIdx) const
+Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const int& elemIdx) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
+    // Check there are no LGRs. LGRs (level>0) only supported for CpGrid.
+    assert(gridView_.grid().maxLevel() == 0);
     return elemIdx;
 }
 
 template<typename Grid, typename GridView>
 template<typename GridType>
 typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpData<Grid,GridView>::getOriginIndex(const int& elemIdx) const
+Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const int& elemIdx) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
     const auto& elem = Dune::cpgrid::Entity<0>(*(gridView_.grid().current_view_data_), elemIdx, true);
-    return elem.getOrigin().index(); // getOrign() returns parent Entity or the equivalent Entity in level 0.
+    if (isFieldPropInLgr_ && elem.level()) { // level > 0 == true ; level == 0 == false
+        // In case some LGRs do not have refined field properties, the next line need to be modified.
+        return elem.getLgrElem().index(); // getLgrElem() returns equivalent refined Entity in the LGR the leafGridView cell was born.
+    }
+    else {
+        return elem.getOrigin().index(); // getOrign() returns parent Entity or the equivalent Entity in level 0.
+    }
 }
 
 
@@ -319,73 +509,108 @@ Opm::LookUpData<Grid,GridView>::getOriginIndex(const int& elemIdx) const
 /// LookUpCartesianData
 
 template<typename Grid, typename GridView>
-template<typename EntityType, typename FeatureType>
-FeatureType Opm::LookUpCartesianData<Grid,GridView>::operator()
-    (const EntityType& elem, const std::vector<FeatureType>& feature_vec) const
+template<typename EntityType, typename FieldPropType>
+FieldPropType Opm::LookUpCartesianData<Grid,GridView>::operator()(const EntityType& elem,
+                                                                  const std::vector<FieldPropType>& fieldProp) const
 {
     assert(cartMapper_);
-    assert( (0 <= this->getOriginIndexFromEntity<EntityType,Grid>(elem)) &&
-            (static_cast<int>(feature_vec.size()) > this-> getOriginIndexFromEntity<EntityType,Grid>(elem)) );
-    return feature_vec[cartMapper_-> cartesianIndex(this->elemMapper_.index(elem))]; 
+    const auto fieldPropCartIdx = this->getFieldPropCartesianIdxFromEntity<EntityType,Grid>(elem);
+    assert( (0 <= fieldPropCartIdx) && (static_cast<int>(fieldProp.size()) > fieldPropCartIdx) );
+    return fieldProp[fieldPropCartIdx];
 }
 
 template<typename Grid, typename GridView>
-template<typename FeatureType>
-FeatureType Opm::LookUpCartesianData<Grid,GridView>::operator()(const int& elemIdx, const std::vector<FeatureType>& feature_vec) const
+template<typename FieldPropType>
+FieldPropType Opm::LookUpCartesianData<Grid,GridView>::operator()(const int& elemIdx,
+                                                                  const std::vector<FieldPropType>& fieldProp) const
 {
     assert(cartMapper_);
-    assert(0 <= this->getOriginIndex<Grid>(elemIdx) &&
-           static_cast<int>(feature_vec.size()) > this-> getOriginIndex<Grid>(elemIdx));
-    return feature_vec[cartMapper_-> cartesianIndex(elemIdx)];
+    const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<Grid>(elemIdx);
+    assert(0 <=  fieldPropCartIdx && (static_cast<int>(fieldProp.size()) > fieldPropCartIdx));
+    return fieldProp[fieldPropCartIdx];
+}
+
+
+
+template<typename Grid, typename GridView>
+template<typename EntityType>
+double Opm::LookUpCartesianData<Grid,GridView>::fieldPropDoubleFromEntity(const FieldPropsManager& fieldPropsManager,
+                                                                          const std::string& propString,
+                                                                          const EntityType& elem) const
+{
+    const auto& fieldPropVec = fieldPropsManager.get_double(propString);
+    return this ->operator()(elem,fieldPropVec);
 }
 
 template<typename Grid, typename GridView>
-template<typename EntityType, typename GridType>
-typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpCartesianData<Grid,GridView>::getOriginIndexFromEntity(const EntityType& elem) const
+double Opm::LookUpCartesianData<Grid,GridView>::fieldPropDouble(const FieldPropsManager& fieldPropsManager,
+                                                                const std::string& propString,
+                                                                const int& elemIdx) const
 {
-    static_assert(std::is_same_v<Grid,GridType>);
-    return elemMapper_.index(elem);
-}
-
-template<typename Grid, typename GridView>
-template<typename EntityType, typename GridType>
-typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpCartesianData<Grid,GridView>::getOriginIndexFromEntity(const EntityType& elem) const
-{
-    static_assert(std::is_same_v<Grid,GridType>);
-    return elem.getOrigin().index();
-}
-
-template<typename Grid, typename GridView>
-template<typename GridType>
-typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpCartesianData<Grid,GridView>::getOriginIndex(const int& elemIdx) const
-{
-    static_assert(std::is_same_v<Grid,GridType>);
-    return elemIdx;
-}
-
-template<typename Grid, typename GridView>
-template<typename GridType>
-typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpCartesianData<Grid,GridView>::getOriginIndex(const int& elemIdx) const
-{
-    static_assert(std::is_same_v<Grid,GridType>);
-    const auto& elem = Dune::cpgrid::Entity<0>(*(gridView_.grid().current_view_data_), elemIdx, true);
-    return elem.getOrigin().index(); // getOrign() returns parent Entity or the equivalent Entity in level 0.
+    const auto& fieldPropVec = fieldPropsManager.get_double(propString);
+    return this ->operator()(elemIdx,fieldPropVec);
 }
 
 template<typename Grid, typename GridView>
 template<typename EntityType>
-int Opm::LookUpCartesianData<Grid,GridView>::getCartesianOriginIdxFromEntity(const EntityType& elem) const
+int Opm::LookUpCartesianData<Grid,GridView>::fieldPropIntFromEntity(const FieldPropsManager& fieldPropsManager,
+                                                                    const std::string& propString,
+                                                                    const EntityType& elem) const
 {
+    const auto& fieldPropVec = fieldPropsManager.get_int(propString);
+    return this ->operator()(elem,fieldPropVec);
+}
+
+template<typename Grid, typename GridView>
+int Opm::LookUpCartesianData<Grid,GridView>::fieldPropInt(const FieldPropsManager& fieldPropsManager,
+                                                          const std::string& propString,
+                                                          const int& elemIdx) const
+{
+    const auto& fieldPropVec = fieldPropsManager.get_int(propString);
+    return this ->operator()(elemIdx,fieldPropVec);
+}
+
+
+template<typename Grid, typename GridView>
+template<typename EntityType, typename GridType>
+typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
+Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdxFromEntity(const EntityType& elem) const
+{
+    static_assert(std::is_same_v<Grid,GridType>);
+    // Check there are no LGRs. LGRs (level>0) only supported for CpGrid.
+    assert(gridView_.grid().maxLevel() == 0);
     return cartMapper_-> cartesianIndex(this->elemMapper_.index(elem));
 }
 
 template<typename Grid, typename GridView>
-int Opm::LookUpCartesianData<Grid,GridView>::getCartesianOriginIndex(const int& elemIdx) const
+template<typename EntityType, typename GridType>
+typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
+Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdxFromEntity(const EntityType& elem) const
 {
-    return cartMapper_-> cartesianIndex(elemIdx);
+    static_assert(std::is_same_v<Grid,GridType>);
+    if (isFieldPropInLgr_ && elem.level()) { // level == 0 false; level > 0 true
+        return elem.getLgrCartesianIdx();
+    }
+    else {
+        return cartMapper_-> cartesianIndex(this->elemMapper_.index(elem));
+    }
 }
 
+template<typename Grid, typename GridView>
+template<typename GridType>
+typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
+Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const int& elemIdx) const
+{
+    static_assert(std::is_same_v<Grid,GridType>);
+    return  cartMapper_-> cartesianIndex(elemIdx);
+}
+
+template<typename Grid, typename GridView>
+template<typename GridType>
+typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
+Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const int& elemIdx) const
+{
+    static_assert(std::is_same_v<Grid,GridType>);
+    const auto& elem = Dune::cpgrid::Entity<0>(*(gridView_.grid().current_view_data_), elemIdx, true);
+    return this -> getFieldPropCartesianIdxFromEntity<Dune::cpgrid::Entity<0>,Dune::CpGrid>(elem);
+}

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -606,9 +606,7 @@ const std::vector<int>& CpGrid::globalCell() const
     // Temporary. For a grid with LGRs, we set the globalCell() of the as the one for level 0.
     //            Goal: CartesianIndexMapper well-defined for CpGrid LeafView with LGRs.
     if (current_view_data_ == this-> data_.back().get()){
-        return current_view_data_
-            //this -> data_[0]
-            -> global_cell_;
+        return current_view_data_ -> global_cell_;
     }
     else{
         return this -> distributed_data_[0] ->global_cell_;

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -265,14 +265,12 @@ public:
     /// Returns parent entity in level 0, if the entity was born in any LGR.
     /// Otherwise, returns itself. 
     Entity<0> getOrigin() const;
+    
+    /// \brief Get equivalent element on the level grid view for an element on the leaf grid view. 
+    Entity<0> getLevelElem() const;
 
-    /// getLgrElem()   ONLY FOR Entities in the leaf grid view.
-    /// Returns refined entity in level > 0 (equivalent to the leaf grid view entity), if the entity was born in any LGR.
-    Entity<0> getLgrElem() const;
-
-    /// getLgrCartesianIdx()   ONLY FOR Entities in the leaf grid view.
-    ///            Compute the Cartesian Index in the LGR where the Entity was born.
-    int getLgrCartesianIdx() const;
+    /// \brief Get Cartesian Index in the level grid view where the Entity was born. 
+    int getLevelCartesianIdx() const;
 
 protected:
     const CpGridData* pgrid_;
@@ -575,15 +573,15 @@ Dune::cpgrid::Entity<0> Dune::cpgrid::Entity<codim>::getOrigin() const
 }
 
 template<int codim>
-Dune::cpgrid::Entity<0> Dune::cpgrid::Entity<codim>::getLgrElem() const
+Dune::cpgrid::Entity<0> Dune::cpgrid::Entity<codim>::getLevelElem() const
 {
     // Check that the element belongs to the leaf grid view
     if (!(pgrid_ -> leaf_to_level_cells_.empty())) // entity on the LeafGridView
     {
         const auto entityLevel = this -> level(); // pgrid_->leaf_to_level_cells_[this->index()][0]
-        const int& entityLgrIdx = pgrid_->leaf_to_level_cells_[this->index()][1]; // leaf_to_level_cells_ [leaf idx] = {level, cell idx}
-        const auto& lgr_grid = (*(pgrid_ -> level_data_ptr_))[entityLevel].get();
-        return Dune::cpgrid::Entity<0>( *lgr_grid, entityLgrIdx, true);
+        const int& entityLevelIdx = pgrid_->leaf_to_level_cells_[this->index()][1]; // leaf_to_level_cells_ [leaf idx] = {level, cell idx}
+        const auto& level_grid = (*(pgrid_ -> level_data_ptr_))[entityLevel].get();
+        return Dune::cpgrid::Entity<0>( *level_grid, entityLevelIdx, true);
     }
     else {
         throw std::invalid_argument("The entity provided does not belong to the leaf grid view. ");
@@ -591,15 +589,15 @@ Dune::cpgrid::Entity<0> Dune::cpgrid::Entity<codim>::getLgrElem() const
 }
 
 template<int codim>
-int Dune::cpgrid::Entity<codim>::getLgrCartesianIdx() const
+int Dune::cpgrid::Entity<codim>::getLevelCartesianIdx() const
 {
     // Check that the element belongs to the leaf grid view
     if (!(pgrid_ -> leaf_to_level_cells_.empty())) // entity on the LeafGridView
     {
         const auto entityLevel = this -> level(); // pgrid_->leaf_to_level_cells_[this->index()][0]
-        const auto lgr = (*(pgrid_ -> level_data_ptr_))[entityLevel].get();
-        const auto& elemInLgr = this->getLgrElem();
-        return lgr -> global_cell_[elemInLgr.index()];
+        const auto level = (*(pgrid_ -> level_data_ptr_))[entityLevel].get();
+        const auto& elemInLevel = this->getLevelElem();
+        return level -> global_cell_[elemInLevel.index()];
     }
     else {
         throw std::invalid_argument("The entity provided does not belong to the leaf grid view. ");

--- a/tests/cpgrid/lookupdataCpGrid_test.cpp
+++ b/tests/cpgrid/lookupdataCpGrid_test.cpp
@@ -44,6 +44,15 @@
 
 #include <dune/grid/common/mcmgmapper.hh>
 
+
+#include <opm/input/eclipse/Parser/Parser.hpp>
+#include <opm/input/eclipse/Deck/DeckSection.hpp>
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+
 struct Fixture
 {
     Fixture()
@@ -67,20 +76,37 @@ BOOST_GLOBAL_FIXTURE(Fixture);
 void lookup_check(const Dune::CpGrid& grid)
 {
     const auto& data = grid.data_;
-    
+
     std::vector<int> fake_feature(data[0]->size(0), 0);
     std::iota(fake_feature.begin(), fake_feature.end(), 3);
 
     std::vector<double> fake_feature_double(data[0]->size(0), 0.);
     std::iota(fake_feature_double.begin(), fake_feature_double.end(), .5);
 
+    std::vector<std::vector<int>> fakeLgrFeatures;
+    fakeLgrFeatures.resize(data.size()-1);
+    // Creating fake field properties for each LGR
+    if (data.size()>1) {
+        for (long unsigned int lgr = 1; lgr < data.size(); ++lgr)
+        {
+            std::vector<int> fake_feature_lgr(data[lgr]->size(0), lgr);
+            fakeLgrFeatures[lgr-1] = fake_feature_lgr;
+        }
+    }
+
+
     // LookUpData
     const auto& leaf_view = grid.leafGridView();
     const Opm::LookUpData<Dune::CpGrid, Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>> lookUpData(leaf_view);
+    // LookUpData with LGR field properties
+    const Opm::LookUpData<Dune::CpGrid, Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>> lookUpDataLGR(leaf_view, true);
     // LookUpCartesianData
     const Dune::CartesianIndexMapper<Dune::CpGrid> cartMapper(grid);
     const Opm::LookUpCartesianData<Dune::CpGrid, Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>
         lookUpCartesianData(leaf_view, cartMapper);
+    // LookUpCartesianData with LGR field properties
+    const Opm::LookUpCartesianData<Dune::CpGrid, Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>
+        lookUpCartesianDataLGR(leaf_view, cartMapper, true);
 
     const auto& level0_view = grid.levelGridView(0);
     const Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LeafGridView> leafMapper(leaf_view, Dune::mcmgElementLayout());
@@ -95,32 +121,44 @@ void lookup_check(const Dune::CpGrid& grid)
         const auto featureInElemDouble = lookUpData(elem, fake_feature_double);
         const auto featureInElemCartesian = lookUpCartesianData(elem, fake_feature);
         const auto featureInElemDoubleCartesian = lookUpCartesianData(elem,fake_feature_double);
-        BOOST_CHECK(featureInElem == lookUpData.getOriginIndexFromEntity(elem) +3);
-        BOOST_CHECK(featureInElemDouble == lookUpData.getOriginIndexFromEntity(elem) +.5);
-        BOOST_CHECK(featureInElemCartesian == lookUpData.getOriginIndexFromEntity(elem) +3);
-        BOOST_CHECK(featureInElemDoubleCartesian == lookUpData.getOriginIndexFromEntity(elem) +.5);
-        BOOST_CHECK(elem.getOrigin().index() == lookUpData.getOriginIndexFromEntity(elem));
+        BOOST_CHECK(featureInElem == lookUpData.getFieldPropIdxFromEntity(elem) +3);
+        BOOST_CHECK(featureInElemDouble == lookUpData.getFieldPropIdxFromEntity(elem) +.5);
+        BOOST_CHECK(featureInElemCartesian == lookUpData.getFieldPropIdxFromEntity(elem) +3);
+        BOOST_CHECK(featureInElemDoubleCartesian == lookUpData.getFieldPropIdxFromEntity(elem) +.5);
+        BOOST_CHECK(elem.getOrigin().index() == lookUpData.getFieldPropIdxFromEntity(elem));
         // Search via INDEX
         const auto featureInElemIDX = lookUpData(elem.index(), fake_feature);
         const auto featureInElemDoubleIDX = lookUpData(elem.index(), fake_feature_double);
         const auto featureInElemCartesianIDX = lookUpCartesianData(elem.index(), fake_feature);
         const auto featureInElemDoubleCartesianIDX = lookUpCartesianData(elem.index(),fake_feature_double);
-        BOOST_CHECK(featureInElemIDX == lookUpData.getOriginIndex(elem.index()) +3);
-        BOOST_CHECK(featureInElemDoubleIDX == lookUpData.getOriginIndex(elem.index()) +.5);
-        BOOST_CHECK(featureInElemCartesianIDX == lookUpData.getOriginIndex(elem.index()) +3);
-        BOOST_CHECK(featureInElemDoubleCartesianIDX == lookUpData.getOriginIndex(elem.index()) +.5);
-        BOOST_CHECK(elem.getOrigin().index() == lookUpData.getOriginIndex(elem.index()));
+        BOOST_CHECK(featureInElemIDX == lookUpData.getFieldPropIdx(elem.index()) +3);
+        BOOST_CHECK(featureInElemDoubleIDX == lookUpData.getFieldPropIdx(elem.index()) +.5);
+        BOOST_CHECK(featureInElemCartesianIDX == lookUpData.getFieldPropIdx(elem.index()) +3);
+        BOOST_CHECK(featureInElemDoubleCartesianIDX == lookUpData.getFieldPropIdx(elem.index()) +.5);
+        BOOST_CHECK(elem.getOrigin().index() == lookUpData.getFieldPropIdx(elem.index()));
         BOOST_CHECK(featureInElemIDX == featureInElem);
         BOOST_CHECK(featureInElemDoubleIDX == featureInElemDouble);
         BOOST_CHECK(featureInElemCartesianIDX == featureInElemCartesian);
         BOOST_CHECK(featureInElemDoubleCartesianIDX == featureInElemDoubleCartesian);
         // Extra checks related to Cartesian Index
         const auto cartIdx = cartMapper.cartesianIndex(elem.index());
-        BOOST_CHECK(cartIdx == lookUpCartesianData.getCartesianOriginIdxFromEntity(elem));
-        BOOST_CHECK(cartIdx == lookUpCartesianData.getCartesianOriginIndex(elem.index()));
+        BOOST_CHECK(cartIdx == lookUpCartesianData.getFieldPropCartesianIdxFromEntity(elem));
+        BOOST_CHECK(cartIdx == lookUpCartesianData.getFieldPropCartesianIdx(elem.index()));
+        // Checks related to LGR field properties
+        if (elem.level())
+        {
+            const auto featureInLGR = lookUpDataLGR(elem, fakeLgrFeatures[elem.level()-1]);
+            const auto featureInLGR_Cartesian = lookUpCartesianDataLGR(elem, fakeLgrFeatures[elem.level()-1]);
+            const auto featureInLGR_FromIdx = lookUpDataLGR(elem.index(), fakeLgrFeatures[elem.level()-1]);
+            const auto featureInLGR_Cartesian_FromIdx = lookUpCartesianDataLGR(elem.index(), fakeLgrFeatures[elem.level()-1]);
+            BOOST_CHECK(featureInLGR == elem.level());
+            BOOST_CHECK(featureInLGR == featureInLGR_Cartesian);
+            BOOST_CHECK(featureInLGR == featureInLGR_FromIdx);
+            BOOST_CHECK(featureInLGR == featureInLGR_Cartesian_FromIdx);
+        }
         // Extra checks related to ElemMapper
         BOOST_CHECK(featureInElem == level0Mapper.index(elem.getOrigin()) +3);
-        BOOST_CHECK(featureInElem == fake_feature[lookUpData.getOriginIndexFromEntity(elem)]);
+        BOOST_CHECK(featureInElem == fake_feature[lookUpData.getFieldPropIdxFromEntity(elem)]);
         if (elem.hasFather()) { // leaf_cell has a father!
             const auto& id = (*leaf_idSet).id(elem);
             const auto& parent_id = (*level0_idSet).id(elem.father());
@@ -132,7 +170,6 @@ void lookup_check(const Dune::CpGrid& grid)
         }
     }
 }
-
 
 BOOST_AUTO_TEST_CASE(one_lgr_grid)
 {
@@ -229,3 +266,121 @@ BOOST_AUTO_TEST_CASE(no_lgrs_grid)
     grid.createCartesian(grid_dim, cell_sizes);
     lookup_check(grid);
 }
+
+
+void fieldProp_check(const Dune::CpGrid& grid, Opm::EclipseGrid eclGrid, std::string deck_string)
+{
+    Opm::Deck deck = Opm::Parser{}.parseString(deck_string);
+    Opm::FieldPropsManager fpm(deck, Opm::Phases{true, true, true}, eclGrid, Opm::TableManager());
+    const auto& poro = fpm.get_double("PORO");
+    // LookUpData
+    auto leaf_view = grid.leafGridView();
+    const Opm::LookUpData<Dune::CpGrid,Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>> lookUpData(leaf_view);
+    // LookUpCartesianData
+    const Dune::CartesianIndexMapper<Dune::CpGrid> cartMapper(grid);
+    const Opm::LookUpCartesianData<Dune::CpGrid, Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>
+        lookUpCartesianData(leaf_view, cartMapper);
+    // Element mapper
+    const Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>
+        mapper(leaf_view, Dune::mcmgElementLayout());
+    for (const auto& elem : elements(leaf_view))
+    {
+        const auto elemIdx = mapper.index(elem);
+        const auto elemOriginIdx = elem.getOrigin().index();
+        BOOST_CHECK_EQUAL(poro[elemOriginIdx], lookUpData.fieldPropDoubleFromEntity<Dune::cpgrid::Entity<0>>(fpm, "PORO", elem));
+        BOOST_CHECK_EQUAL(poro[elemOriginIdx], lookUpData.fieldPropDouble(fpm, "PORO", elemIdx));
+        BOOST_CHECK_EQUAL(poro[elemOriginIdx], lookUpCartesianData.fieldPropDoubleFromEntity<Dune::cpgrid::Entity<0>>(fpm, "PORO", elem));
+        BOOST_CHECK_EQUAL(poro[elemOriginIdx], lookUpCartesianData.fieldPropDouble(fpm, "PORO", elemIdx));
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(fieldProp) {
+    std::string deckString =
+        R"( RUNSPEC
+        DIMENS
+        1  1  5 /
+        GRID
+        COORD
+        0 0 0
+        0 0 1
+        1 0 0
+        1 0 1
+        0 1 0
+        0 1 1
+        1 1 0
+        1 1 1
+        /
+        ZCORN
+        4*0
+        8*1
+        8*2
+        8*3
+        8*4
+        4*5
+        /
+        ACTNUM
+        5*1
+        /
+        PORO
+        5*0.15
+        /)";
+
+    Opm::Parser parser;
+    const auto deck = parser.parseString(deckString);
+
+    Dune::CpGrid grid;
+    Opm::EclipseGrid eclGrid(deck);
+
+    grid.processEclipseFormat(&eclGrid, nullptr, false, false, false);
+
+    fieldProp_check(grid, eclGrid, deckString);
+}
+
+
+BOOST_AUTO_TEST_CASE(fieldPropLgr) {
+    std::string deckString = R"( RUNSPEC
+DIMENS
+1 1 5
+/
+GRID
+DX
+-- There are in total 1 cell with length 1ft in x-direction
+1*1
+/
+DY
+-- There are in total 1 cell with length 1ft in y-direction
+1*1
+/
+DZ
+-- The layers are 2 ft thick, in each layer there is 1 cell
+1*2 1*2 1*2 1*2 1*2
+/
+TOPS
+40*1
+/
+ACTNUM
+5*1
+/
+PORO
+5*0.15
+/)";
+
+    Opm::Parser parser;
+    const auto deck = parser.parseString(deckString);
+
+    Dune::CpGrid grid;
+    Opm::EclipseGrid eclGrid(deck);
+
+    grid.processEclipseFormat(&eclGrid, nullptr, false, false, false);
+
+    // Add LGRs and update LeafGridView
+    const std::vector<std::array<int,3>>& cells_per_dim_vec = {{2,2,2}, {2,2,2}};
+    const std::vector<std::array<int,3>>& startIJK_vec = {{0,0,0}, {0,0,3}};
+    const std::vector<std::array<int,3>>& endIJK_vec = {{1,1,1}, {1,1,4}};
+    const std::vector<std::string>& lgr_name_vec = {"LGR1", "LGR2"};
+    grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+
+    fieldProp_check(grid, eclGrid, deckString);
+}
+

--- a/tests/cpgrid/lookupdataCpGrid_test.cpp
+++ b/tests/cpgrid/lookupdataCpGrid_test.cpp
@@ -274,7 +274,7 @@ void fieldProp_check(const Dune::CpGrid& grid, Opm::EclipseGrid eclGrid, std::st
     Opm::FieldPropsManager fpm(deck, Opm::Phases{true, true, true}, eclGrid, Opm::TableManager());
     const auto& poro = fpm.get_double("PORO");
     // const auto& eqlnum =  fpm.get_int("EQLNUM");
-    
+
     // LookUpData
     auto leaf_view = grid.leafGridView();
     const Opm::LookUpData<Dune::CpGrid,Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>> lookUpData(leaf_view);
@@ -336,10 +336,10 @@ BOOST_AUTO_TEST_CASE(fieldProp) {
 
     /*
      /
-        PROPS
+      REGIONS
 
-        EQLNUM
-        1 2 3 4 5
+      EQLNUM
+      1 2 3 4 5
     */
     Opm::Parser parser;
     const auto deck = parser.parseString(deckString);
@@ -380,13 +380,12 @@ ACTNUM
 PORO
 1.0 2.0 3.0 4.0 5.0
 /)";
-
     /*
-PROPS
+      REGIONS
 
-EQLNUM
-1 2 3 4 5
-     */
+      EQLNUM
+      1 2 3 4 5
+    */
 
     Opm::Parser parser;
     const auto deck = parser.parseString(deckString);

--- a/tests/test_lookupdata_polyhedral.cpp
+++ b/tests/test_lookupdata_polyhedral.cpp
@@ -166,8 +166,8 @@ void fieldProp_check(const Dune::PolyhedralGrid<3,3>& grid, Opm::EclipseGrid ecl
     Opm::Deck deck = Opm::Parser{}.parseString(deck_string);
     Opm::FieldPropsManager fpm(deck, Opm::Phases{true, true, true}, eclGrid, Opm::TableManager());
     const auto& poro = fpm.get_double("PORO");
-    // const auto& eqlnum = fpm.get_int("EQLNUM");
-    
+    //const auto& eqlnum = fpm.get_int("EQLNUM");
+
     // LookUpData
     auto leaf_view = grid.leafGridView();
     using GridView = std::remove_cv_t< typename std::remove_reference<decltype(leaf_view)>>::type;
@@ -185,11 +185,11 @@ void fieldProp_check(const Dune::PolyhedralGrid<3,3>& grid, Opm::EclipseGrid ecl
         BOOST_CHECK_EQUAL(poro[elemIdx], lookUpData.fieldPropDouble<int>(fpm, "PORO", elemIdx));
         BOOST_CHECK_EQUAL(poro[elemIdx], lookUpCartesianData.fieldPropDouble(fpm, "PORO", elem));
         BOOST_CHECK_EQUAL(poro[elemIdx], lookUpCartesianData.fieldPropDouble(fpm, "PORO", elemIdx));
-        /* // EQLNUM
+        /*// EQLNUM
         BOOST_CHECK_EQUAL(eqlnum[elemIdx], lookUpData.fieldPropDouble(fpm, "EQLNUM", elem));
         BOOST_CHECK_EQUAL(eqlnum[elemIdx], lookUpData.fieldPropDouble<int>(fpm, "EQLNUM", elemIdx));
         BOOST_CHECK_EQUAL(eqlnum[elemIdx], lookUpCartesianData.fieldPropDouble(fpm, "EQLNUM", elem));
-        BOOST_CHECK_EQUAL(eqlnum[elemIdx], lookUpCartesianData.fieldPropDouble(fpm, "EQLNUM", elemIdx));  */
+        BOOST_CHECK_EQUAL(eqlnum[elemIdx], lookUpCartesianData.fieldPropDouble(fpm, "EQLNUM", elemIdx));*/
     }
 }
 
@@ -202,12 +202,9 @@ PORO
    1.0 2.0 3.0 4.0 5.0 6.0
         /
 )";
-    /*
-       PROPS
-
-        EQLNUM
-        1 2 3 4 5 6
-     */
+    /*REGIONS
+      EQLNUM
+      1 2 3 4 5 6*/
     std::vector<int> actnum1 = {1,1,1,1,1,1};
     Opm::EclipseGrid eclGrid(3,2,1);
     eclGrid.resetACTNUM(actnum1);

--- a/tests/test_lookupdata_polyhedral.cpp
+++ b/tests/test_lookupdata_polyhedral.cpp
@@ -106,10 +106,10 @@ void lookup_check(const Dune::PolyhedralGrid<3,3>& grid)
         const auto featureInElemDouble = lookUpData(elem, fake_feature_double);
         const auto featureInElemCartesian = lookUpCartesianData(elem, fake_feature);
         const auto featureInElemDoubleCartesian = lookUpCartesianData(elem,fake_feature_double);
-        BOOST_CHECK(featureInElem == lookUpData.getFieldPropIdxFromEntity(elem) +3);
-        BOOST_CHECK(featureInElemDouble == lookUpData.getFieldPropIdxFromEntity(elem) +.5);
-        BOOST_CHECK(featureInElemCartesian == lookUpData.getFieldPropIdxFromEntity(elem) +3);
-        BOOST_CHECK(featureInElemDoubleCartesian == lookUpData.getFieldPropIdxFromEntity(elem) +.5);
+        BOOST_CHECK(featureInElem == lookUpData.getFieldPropIdx(elem) +3);
+        BOOST_CHECK(featureInElemDouble == lookUpData.getFieldPropIdx(elem) +.5);
+        BOOST_CHECK(featureInElemCartesian == lookUpData.getFieldPropIdx(elem) +3);
+        BOOST_CHECK(featureInElemDoubleCartesian == lookUpData.getFieldPropIdx(elem) +.5);
         // Search via INDEX
         const auto idx = mapper.index(elem);
         const auto featureInElemIDX = lookUpData(idx, fake_feature);
@@ -127,7 +127,7 @@ void lookup_check(const Dune::PolyhedralGrid<3,3>& grid)
         BOOST_CHECK(featureInElemDoubleCartesianIDX == featureInElemDoubleCartesian);
         // Extra checks related to Cartesian Index
         const auto cartIdx = cartMapper.cartesianIndex(idx);
-        BOOST_CHECK(cartIdx == lookUpCartesianData.getFieldPropCartesianIdxFromEntity(elem));
+        BOOST_CHECK(cartIdx == lookUpCartesianData.getFieldPropCartesianIdx(elem));
         BOOST_CHECK(cartIdx == lookUpCartesianData.getFieldPropCartesianIdx(idx));
     }
 }
@@ -166,6 +166,8 @@ void fieldProp_check(const Dune::PolyhedralGrid<3,3>& grid, Opm::EclipseGrid ecl
     Opm::Deck deck = Opm::Parser{}.parseString(deck_string);
     Opm::FieldPropsManager fpm(deck, Opm::Phases{true, true, true}, eclGrid, Opm::TableManager());
     const auto& poro = fpm.get_double("PORO");
+    // const auto& eqlnum = fpm.get_int("EQLNUM");
+    
     // LookUpData
     auto leaf_view = grid.leafGridView();
     using GridView = std::remove_cv_t< typename std::remove_reference<decltype(leaf_view)>>::type;
@@ -178,10 +180,16 @@ void fieldProp_check(const Dune::PolyhedralGrid<3,3>& grid, Opm::EclipseGrid ecl
     for (const auto& elem : elements(leaf_view))
     {
         const auto elemIdx = mapper.index(elem);
-        BOOST_CHECK_EQUAL(poro[elemIdx], lookUpData.fieldPropDoubleFromEntity(fpm, "PORO", elem));
-        BOOST_CHECK_EQUAL(poro[elemIdx], lookUpData.fieldPropDouble(fpm, "PORO", elemIdx));
-        BOOST_CHECK_EQUAL(poro[elemIdx], lookUpCartesianData.fieldPropDoubleFromEntity(fpm, "PORO", elem));
+        // PORO
+        BOOST_CHECK_EQUAL(poro[elemIdx], lookUpData.fieldPropDouble(fpm, "PORO", elem));
+        BOOST_CHECK_EQUAL(poro[elemIdx], lookUpData.fieldPropDouble<int>(fpm, "PORO", elemIdx));
+        BOOST_CHECK_EQUAL(poro[elemIdx], lookUpCartesianData.fieldPropDouble(fpm, "PORO", elem));
         BOOST_CHECK_EQUAL(poro[elemIdx], lookUpCartesianData.fieldPropDouble(fpm, "PORO", elemIdx));
+        /* // EQLNUM
+        BOOST_CHECK_EQUAL(eqlnum[elemIdx], lookUpData.fieldPropDouble(fpm, "EQLNUM", elem));
+        BOOST_CHECK_EQUAL(eqlnum[elemIdx], lookUpData.fieldPropDouble<int>(fpm, "EQLNUM", elemIdx));
+        BOOST_CHECK_EQUAL(eqlnum[elemIdx], lookUpCartesianData.fieldPropDouble(fpm, "EQLNUM", elem));
+        BOOST_CHECK_EQUAL(eqlnum[elemIdx], lookUpCartesianData.fieldPropDouble(fpm, "EQLNUM", elemIdx));  */
     }
 }
 
@@ -191,8 +199,15 @@ BOOST_AUTO_TEST_CASE(fieldProp) {
 GRID
 
 PORO
-   6*0.1 /
+   1.0 2.0 3.0 4.0 5.0 6.0
+        /
 )";
+    /*
+       PROPS
+
+        EQLNUM
+        1 2 3 4 5 6
+     */
     std::vector<int> actnum1 = {1,1,1,1,1,1};
     Opm::EclipseGrid eclGrid(3,2,1);
     eclGrid.resetACTNUM(actnum1);

--- a/tests/test_lookupdata_polyhedral.cpp
+++ b/tests/test_lookupdata_polyhedral.cpp
@@ -47,8 +47,17 @@
 #include <dune/grid/io/file/vtk/vtkwriter.hh>
 #include <opm/grid/cpgrid/dgfparser.hh>
 #include <opm/grid/polyhedralgrid/dgfparser.hh>
+#include <dune/grid/common/mcmgmapper.hh>
 
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+
+#include <opm/input/eclipse/Parser/Parser.hpp>
+#include <opm/input/eclipse/Deck/DeckSection.hpp>
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 
 #include <sstream>
 #include <iostream>
@@ -84,10 +93,10 @@ void lookup_check(const Dune::PolyhedralGrid<3,3>& grid)
     const auto& leaf_view = grid.leafGridView();
     using GridView = std::remove_cv_t< typename std::remove_reference<decltype(grid.leafGridView())>::type>;
     // LookUpData
-    const Opm::LookUpData<Dune::PolyhedralGrid<3,3>, GridView> lookUpData(leaf_view);
+    const Opm::LookUpData<Dune::PolyhedralGrid<3,3>, GridView> lookUpData(leaf_view, false);
     // LookUpCartesianData
     const Dune::CartesianIndexMapper<Dune::PolyhedralGrid<3,3>> cartMapper(grid);
-    const Opm::LookUpCartesianData<Dune::PolyhedralGrid<3,3>, GridView> lookUpCartesianData(leaf_view, cartMapper);
+    const Opm::LookUpCartesianData<Dune::PolyhedralGrid<3,3>, GridView> lookUpCartesianData(leaf_view, cartMapper, false);
     // Mapper
     const Dune::MultipleCodimMultipleGeomTypeMapper<GridView> mapper(grid.leafGridView(), Dune::mcmgElementLayout());
 
@@ -97,29 +106,29 @@ void lookup_check(const Dune::PolyhedralGrid<3,3>& grid)
         const auto featureInElemDouble = lookUpData(elem, fake_feature_double);
         const auto featureInElemCartesian = lookUpCartesianData(elem, fake_feature);
         const auto featureInElemDoubleCartesian = lookUpCartesianData(elem,fake_feature_double);
-        BOOST_CHECK(featureInElem == lookUpData.getOriginIndexFromEntity(elem) +3);
-        BOOST_CHECK(featureInElemDouble == lookUpData.getOriginIndexFromEntity(elem) +.5);
-        BOOST_CHECK(featureInElemCartesian == lookUpData.getOriginIndexFromEntity(elem) +3);
-        BOOST_CHECK(featureInElemDoubleCartesian == lookUpData.getOriginIndexFromEntity(elem) +.5);
+        BOOST_CHECK(featureInElem == lookUpData.getFieldPropIdxFromEntity(elem) +3);
+        BOOST_CHECK(featureInElemDouble == lookUpData.getFieldPropIdxFromEntity(elem) +.5);
+        BOOST_CHECK(featureInElemCartesian == lookUpData.getFieldPropIdxFromEntity(elem) +3);
+        BOOST_CHECK(featureInElemDoubleCartesian == lookUpData.getFieldPropIdxFromEntity(elem) +.5);
         // Search via INDEX
         const auto idx = mapper.index(elem);
         const auto featureInElemIDX = lookUpData(idx, fake_feature);
         const auto featureInElemDoubleIDX = lookUpData(idx, fake_feature_double);
         const auto featureInElemCartesianIDX = lookUpCartesianData(idx, fake_feature);
         const auto featureInElemDoubleCartesianIDX = lookUpCartesianData(idx, fake_feature_double);
-        BOOST_CHECK(featureInElemIDX == (lookUpData.getOriginIndex<Dune::PolyhedralGrid<3,3>>(idx))+3);
-        BOOST_CHECK(featureInElemDoubleIDX == (lookUpData.getOriginIndex<Dune::PolyhedralGrid<3,3>>(idx)) +.5);
-        BOOST_CHECK(featureInElemCartesianIDX == (lookUpData.getOriginIndex<Dune::PolyhedralGrid<3,3>>(idx)) +3);
-        BOOST_CHECK(featureInElemDoubleCartesianIDX == (lookUpData.getOriginIndex<Dune::PolyhedralGrid<3,3>>(idx)) +.5);
-        BOOST_CHECK(idx == (lookUpData.getOriginIndex<Dune::PolyhedralGrid<3,3>>(idx)));
+        BOOST_CHECK(featureInElemIDX == (lookUpData.getFieldPropIdx<Dune::PolyhedralGrid<3,3>>(idx))+3);
+        BOOST_CHECK(featureInElemDoubleIDX == (lookUpData.getFieldPropIdx<Dune::PolyhedralGrid<3,3>>(idx)) +.5);
+        BOOST_CHECK(featureInElemCartesianIDX == (lookUpData.getFieldPropIdx<Dune::PolyhedralGrid<3,3>>(idx)) +3);
+        BOOST_CHECK(featureInElemDoubleCartesianIDX == (lookUpData.getFieldPropIdx<Dune::PolyhedralGrid<3,3>>(idx)) +.5);
+        BOOST_CHECK(idx == (lookUpData.getFieldPropIdx<Dune::PolyhedralGrid<3,3>>(idx)));
         BOOST_CHECK(featureInElemIDX == featureInElem);
         BOOST_CHECK(featureInElemDoubleIDX == featureInElemDouble);
         BOOST_CHECK(featureInElemCartesianIDX == featureInElemCartesian);
         BOOST_CHECK(featureInElemDoubleCartesianIDX == featureInElemDoubleCartesian);
         // Extra checks related to Cartesian Index
         const auto cartIdx = cartMapper.cartesianIndex(idx);
-        BOOST_CHECK(cartIdx == lookUpCartesianData.getCartesianOriginIdxFromEntity(elem));
-        BOOST_CHECK(cartIdx == lookUpCartesianData.getCartesianOriginIndex(idx));
+        BOOST_CHECK(cartIdx == lookUpCartesianData.getFieldPropCartesianIdxFromEntity(elem));
+        BOOST_CHECK(cartIdx == lookUpCartesianData.getFieldPropCartesianIdx(idx));
     }
 }
 
@@ -149,5 +158,47 @@ BOOST_AUTO_TEST_CASE(PolyGridFromEcl)
     Dune::PolyhedralGrid<3,3> grid(eclgrid, porv);
     lookup_check(grid);
 #endif
+}
+
+void fieldProp_check(const Dune::PolyhedralGrid<3,3>& grid, Opm::EclipseGrid eclGrid, std::string deck_string)
+{
+
+    Opm::Deck deck = Opm::Parser{}.parseString(deck_string);
+    Opm::FieldPropsManager fpm(deck, Opm::Phases{true, true, true}, eclGrid, Opm::TableManager());
+    const auto& poro = fpm.get_double("PORO");
+    // LookUpData
+    auto leaf_view = grid.leafGridView();
+    using GridView = std::remove_cv_t< typename std::remove_reference<decltype(leaf_view)>>::type;
+    const Opm::LookUpData<Dune::PolyhedralGrid<3,3>, GridView> lookUpData(leaf_view);
+    // LookUpCartesianData
+    const Dune::CartesianIndexMapper<Dune::PolyhedralGrid<3,3>> cartMapper(grid);
+    const Opm::LookUpCartesianData<Dune::PolyhedralGrid<3,3>, GridView> lookUpCartesianData(leaf_view, cartMapper);
+    // Element mapper
+    const Dune::MultipleCodimMultipleGeomTypeMapper<GridView> mapper(leaf_view, Dune::mcmgElementLayout());
+    for (const auto& elem : elements(leaf_view))
+    {
+        const auto elemIdx = mapper.index(elem);
+        BOOST_CHECK_EQUAL(poro[elemIdx], lookUpData.fieldPropDoubleFromEntity(fpm, "PORO", elem));
+        BOOST_CHECK_EQUAL(poro[elemIdx], lookUpData.fieldPropDouble(fpm, "PORO", elemIdx));
+        BOOST_CHECK_EQUAL(poro[elemIdx], lookUpCartesianData.fieldPropDoubleFromEntity(fpm, "PORO", elem));
+        BOOST_CHECK_EQUAL(poro[elemIdx], lookUpCartesianData.fieldPropDouble(fpm, "PORO", elemIdx));
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(fieldProp) {
+    std::string deck_string = R"(
+GRID
+
+PORO
+   6*0.1 /
+)";
+    std::vector<int> actnum1 = {1,1,1,1,1,1};
+    Opm::EclipseGrid eclGrid(3,2,1);
+    eclGrid.resetACTNUM(actnum1);
+    std::vector<double> porv;
+
+    Dune::PolyhedralGrid<3,3> grid(eclGrid, porv);
+    fieldProp_check(grid, eclGrid, deck_string);
 }
 


### PR DESCRIPTION
The class to search for field properties (to be used in opm-simulators/ebos) now takes into account that field properties can be also given for some LGRs (refined level). 

New methods added to search (int/double) field properties via FieldPropsManager and strings. Small test case added for PolyhedralGrid and CpGrid.