### PR TITLE
Correction in maxLevel() for PolyhedralGrid

### DIFF
--- a/opm/grid/polyhedralgrid/grid.hh
+++ b/opm/grid/polyhedralgrid/grid.hh
@@ -413,7 +413,7 @@ namespace Dune
      */
     int maxLevel () const
     {
-      return 1;
+      return 0;
     }
 
     /** \brief obtain number of entites on a level


### PR DESCRIPTION
Correction in maxLevel() for PolyhedralGrid, retruns 0 instead of 1.