### PR TITLE
[bugfix] Deprecated getCollectiveCommunication() in cpgrid_aquifer_test

### DIFF
--- a/tests/cpgrid/cpgrid_aquifer_test.cpp
+++ b/tests/cpgrid/cpgrid_aquifer_test.cpp
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(CpGridAquiferTest)
         cell = grid.globalCell()[cell];
     }
 
-    auto [gathered_aquifer_cells, offset] = Opm::allGatherv(load_balanced_aquifer_cells, CommandLineDataFileMpiInit::helper().getCollectiveCommunication());
+    auto [gathered_aquifer_cells, offset] = Opm::allGatherv(load_balanced_aquifer_cells, CommandLineDataFileMpiInit::helper().getCommunication());
 
     (void)offset;
     std::sort(aquifer_cells.begin(), aquifer_cells.end());


### PR DESCRIPTION
After DUNE version 2.7, the method getCollectiveCommunication() was changed to getCommunication(). The getCollectiveCommunication() issues the deprecation warning and assumes all process take part in the communication. However, this might not be the case, namely, only a subset might be used.

In CpGrid Aquifer test, getCollectiveCommunication() was deprecated. The fix consists in replacing it by getCommunication(). 