### PR TITLE
Delete default value in assignFieldPropDoubleOnLeaf

### DIFF
--- a/opm/grid/LookUpData.hh
+++ b/opm/grid/LookUpData.hh
@@ -93,8 +93,7 @@ public:
     /// \brief: Get field property of type double from field properties manager by name.
     std::vector<double> assignFieldPropsDoubleOnLeaf(const FieldPropsManager& fieldPropsManager,
                                                      const std::string& propString,
-                                                     const unsigned int& numElements,
-                                                     const double& defaultValue) const;
+                                                     const unsigned int& numElements) const;
 
     /// \brief: Get field property of type int from field properties manager by name.
     template<typename IntType>
@@ -211,8 +210,7 @@ public:
     /// \brief: Get field property of type double from field properties manager by name.
     std::vector<double> assignFieldPropsDoubleOnLeaf(const FieldPropsManager& fieldPropsManager,
                                                      const std::string& propString,
-                                                     const unsigned int& numElements,
-                                                     const double& defaultValue) const;
+                                                     const unsigned int& numElements) const;
 
     /// \brief: Get field property of type int from field properties manager by name.
     template<typename IntType>
@@ -309,11 +307,10 @@ Opm::LookUpData<Grid,GridView>::operator()(const EntityType& elem,
 template<typename Grid, typename GridView>
 std::vector<double> Opm::LookUpData<Grid,GridView>::assignFieldPropsDoubleOnLeaf(const FieldPropsManager& fieldPropsManager,
                                                                                  const std::string& propString,
-                                                                                 const unsigned int& numElements,
-                                                                                 const double& defaultValue) const
+                                                                                 const unsigned int& numElements) const
 {
     std::vector<double> fieldPropOnLeaf;
-    fieldPropOnLeaf.resize(numElements, defaultValue);
+    fieldPropOnLeaf.resize(numElements);
     const auto& fieldProp = fieldPropsManager.get_double(propString);
     for (unsigned int elemIdx = 0; elemIdx < numElements; ++elemIdx) {
         const auto& fieldPropIdx = this->getFieldPropIdx<Grid>(elemIdx);
@@ -444,11 +441,10 @@ Opm::LookUpCartesianData<Grid,GridView>::operator()(const EntityType& elem,
 template<typename Grid, typename GridView>
 std::vector<double> Opm::LookUpCartesianData<Grid,GridView>::assignFieldPropsDoubleOnLeaf(const FieldPropsManager& fieldPropsManager,
                                                                                           const std::string& propString,
-                                                                                          const unsigned int& numElements,
-                                                                                          const double& defaultValue) const
+                                                                                          const unsigned int& numElements) const
 {
     std::vector<double> fieldPropOnLeaf;
-    fieldPropOnLeaf.resize(numElements, defaultValue);
+    fieldPropOnLeaf.resize(numElements);
     const auto& fieldProp = fieldPropsManager.get_double(propString);
     for (unsigned int elemIdx = 0; elemIdx < numElements; ++elemIdx) {
         const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<Grid>(elemIdx);

--- a/tests/cpgrid/lookupdataCpGrid_test.cpp
+++ b/tests/cpgrid/lookupdataCpGrid_test.cpp
@@ -286,8 +286,8 @@ void fieldProp_check(const Dune::CpGrid& grid, Opm::EclipseGrid eclGrid, std::st
     const Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>
         mapper(leaf_view, Dune::mcmgElementLayout());
 
-    const auto& poroOnLeaf = lookUpData.assignFieldPropsDoubleOnLeaf(fpm, "PORO", leaf_view.size(0),0.0);
-    const auto& poroOnLeafCart = lookUpCartesianData.assignFieldPropsDoubleOnLeaf(fpm, "PORO", leaf_view.size(0),0.0);
+    const auto& poroOnLeaf = lookUpData.assignFieldPropsDoubleOnLeaf(fpm, "PORO", leaf_view.size(0));
+    const auto& poroOnLeafCart = lookUpCartesianData.assignFieldPropsDoubleOnLeaf(fpm, "PORO", leaf_view.size(0));
 
     const auto& eqlnumOnLeaf = lookUpData.assignFieldPropsIntOnLeaf<int>(fpm, "EQLNUM", leaf_view.size(0), true);
     const auto& eqlnumOnLeafCart = lookUpCartesianData.assignFieldPropsIntOnLeaf<int>(fpm, "EQLNUM", leaf_view.size(0), true);

--- a/tests/test_lookupdata_polyhedral.cpp
+++ b/tests/test_lookupdata_polyhedral.cpp
@@ -178,8 +178,8 @@ void fieldProp_check(const Dune::PolyhedralGrid<3,3>& grid, Opm::EclipseGrid ecl
     // Element mapper
     const Dune::MultipleCodimMultipleGeomTypeMapper<GridView> mapper(leaf_view, Dune::mcmgElementLayout());
 
-    const auto& poroOnLeaf = lookUpData.assignFieldPropsDoubleOnLeaf(fpm, "PORO", leaf_view.size(0),0.0);
-    const auto& poroOnLeafCart = lookUpCartesianData.assignFieldPropsDoubleOnLeaf(fpm, "PORO", leaf_view.size(0),0.0);
+    const auto& poroOnLeaf = lookUpData.assignFieldPropsDoubleOnLeaf(fpm, "PORO", leaf_view.size(0));
+    const auto& poroOnLeafCart = lookUpCartesianData.assignFieldPropsDoubleOnLeaf(fpm, "PORO", leaf_view.size(0));
 
     const auto& eqlnumOnLeaf = lookUpData.assignFieldPropsIntOnLeaf<int>(fpm, "EQLNUM", leaf_view.size(0), true);
     const auto& eqlnumOnLeafCart = lookUpCartesianData.assignFieldPropsIntOnLeaf<int>(fpm, "EQLNUM", leaf_view.size(0), true);


### PR DESCRIPTION
Deleting the unnecessary function argument "default value" from the method that assigns field properties of type double, on the Leaf Grid View.  Followed up of OPM/opm-grid#683. 
