### PR TITLE
Duplicated wrong forward LookUpData declaration removed

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -67,8 +67,6 @@ namespace Dune
 {
 
     class CpGrid;
-    template<typename Grid, typename GridView> class LookUpData;
-    template<typename Grid, typename GridView> class LookUpCartesianData;
 
     namespace cpgrid
     {


### PR DESCRIPTION
In CpGrid header, duplicated (incorrect) forward declarations of the classes LookUpData and LookUpCartesianData have been removed. 