### PR TITLE
Avoid NNC in LGRs

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -113,6 +113,8 @@ list (APPEND TEST_SOURCE_FILES
 
 if(Boost_VERSION_STRING VERSION_GREATER 1.53)
 	list(APPEND TEST_SOURCE_FILES
+	  tests/cpgrid/avoidNNCinLGRs_test.cpp
+	  tests/cpgrid/avoidNNCinLGRsCpGrid_test.cpp
 	  tests/cpgrid/disjointPatches_test.cpp
 	  tests/cpgrid/eclCentroid_test.cpp
 	  tests/cpgrid/geometry_test.cpp

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -61,6 +61,7 @@ class EclipseGrid;
 class EclipseState;
 template<typename Grid, typename GridView> class LookUpData;
 template<typename Grid, typename GridView> class LookUpCartesianData;
+class NNC;
 }
 
 namespace Dune
@@ -85,6 +86,20 @@ namespace Dune
     
     }
 }
+
+void noNNC_check(Dune::CpGrid&,
+                 const std::vector<std::array<int,3>>&,
+                 const std::vector<std::array<int,3>>&,
+                 const std::vector<std::array<int,3>>&,
+                 const std::vector<std::string>&);
+
+void testCase(const std::string&,
+              const Opm::NNC&,
+              const std::vector<std::array<int,3>>&,
+              const std::vector<std::array<int,3>>&,
+              const std::vector<std::array<int,3>>&,
+              const std::vector<std::string>&,
+              bool);
 
 void disjointPatches_check(Dune::CpGrid&,
                            const std::vector<std::array<int,3>>&,
@@ -231,9 +246,21 @@ namespace Dune
         template<typename Grid, typename GridView> friend class Opm::LookUpCartesianData;
         template<int dim>
         friend cpgrid::Entity<dim> createEntity(const CpGrid&,int,bool);
+        friend void ::noNNC_check(Dune::CpGrid&,
+                                  const std::vector<std::array<int,3>>&,
+                                  const std::vector<std::array<int,3>>&,
+                                  const std::vector<std::array<int,3>>&,
+                                  const std::vector<std::string>&);
+        friend void ::testCase(const std::string&,
+                               const Opm::NNC&,
+                               const std::vector<std::array<int,3>>&,
+                               const std::vector<std::array<int,3>>&,
+                               const std::vector<std::array<int,3>>&,
+                               const std::vector<std::string>&,
+                               bool);
         friend void ::disjointPatches_check(Dune::CpGrid&,
-                                          const std::vector<std::array<int,3>>&,
-                                          const std::vector<std::array<int,3>>&);
+                                            const std::vector<std::array<int,3>>&,
+                                            const std::vector<std::array<int,3>>&);
         friend void ::lookup_check(const Dune::CpGrid&);
         friend
         void ::refine_and_check(const Dune::cpgrid::Geometry<3,3>&,

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -77,6 +77,7 @@
 namespace Opm
 {
 class EclipseState;
+class NNC;
 }
 namespace Dune
 {
@@ -94,6 +95,12 @@ template<int> class Entity;
 template<int> class EntityRep;
 }
 }
+
+void noNNC_check(Dune::CpGrid&,
+                 const std::vector<std::array<int,3>>&,
+                 const std::vector<std::array<int,3>>&,
+                 const std::vector<std::array<int,3>>&,
+                 const std::vector<std::string>&);
 
 void disjointPatches_check(Dune::CpGrid&,
                            const std::vector<std::array<int,3>>&,
@@ -138,7 +145,14 @@ class CpGridData
     friend class GlobalIdSet;
     friend class HierarchicIterator;
     friend class Dune::cpgrid::IndexSet;
-    
+
+    friend
+    void ::noNNC_check(Dune::CpGrid&,
+                       const std::vector<std::array<int,3>>&,
+                       const std::vector<std::array<int,3>>&,
+                       const std::vector<std::array<int,3>>&,
+                       const std::vector<std::string>&);
+
     friend
     void ::disjointPatches_check(Dune::CpGrid&,
                                  const std::vector<std::array<int,3>>&,
@@ -358,6 +372,18 @@ private:
     /// @return allPatches_cells
     std::vector<int>
     getPatchesCells(const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
+
+    /// @brief Check all cells selected for refinement have no NNCs (no neighbor connections).
+    ///        Assumption: all grid cells are active.
+    bool hasNNCs(const std::vector<int>& cellIndices) const;
+
+    /// @brief Check startIJK and endIJK of each patch of cells to be refined are valid, i.e.
+    ///        startIJK and endIJK vectors have the same size and, startIJK < endIJK coordenate by coordenate.
+    ///
+    /// @param [in]  startIJK_vec  Vector of Cartesian triplet indices where each patch starts.
+    /// @param [in]  endIJK_vec    Vector of Cartesian triplet indices where each patch ends.
+    ///                            Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
+    void validStartEndIJKs(const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
 
     /// @brief Construct a 'fake cell (Geometry<3,3> object)' out of a patch of cells.(Cartesian grid required).
     ///

--- a/tests/cpgrid/avoidNNCinLGRsCpGrid_test.cpp
+++ b/tests/cpgrid/avoidNNCinLGRsCpGrid_test.cpp
@@ -1,0 +1,164 @@
+//===========================================================================
+//
+// File: avoidNNCinLGRsCpGrid_test.cpp
+//
+// Created:  Nov 09 2023 15:25:00
+//
+// Author(s): Antonella Ritorto   <antonella.ritorto@opm-op.com>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2023 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#define NVERBOSE
+
+#define BOOST_TEST_MODULE CpGridWithNNC
+
+#include <boost/test/unit_test.hpp>
+
+#include <dune/common/version.hh>
+#include <dune/grid/common/mcmgmapper.hh>
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Parser/Parser.hpp>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/grid/CpGrid.hpp>
+
+#include <iostream>
+#include <vector>
+#include <utility>
+
+struct Fixture
+{
+    Fixture()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        Dune::MPIHelper::instance(m_argc, m_argv);
+        Opm::OpmLog::setupSimpleDefaultLogging();
+    }
+
+    static int rank()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        return Dune::MPIHelper::instance(m_argc, m_argv).rank();
+    }
+};
+
+void testCase(const std::string& deckString,
+              const Opm::NNC& nnc,
+              const std::vector<std::array<int,3>>& cells_per_dim_vec,
+              const std::vector<std::array<int,3>>& startIJK_vec,
+              const std::vector<std::array<int,3>>& endIJK_vec,
+              const std::vector<std::string>& lgr_name_vec,
+              bool hasNNC)
+{
+
+    Opm::Parser parser;
+    const auto deck = parser.parseString(deckString);
+    Opm::EclipseState es(deck);
+    es.appendInputNNC(nnc.input());
+
+    Dune::CpGrid grid;
+    grid.processEclipseFormat(&es.getInputGrid(), &es, false, false, false);
+    
+    if(hasNNC){
+        BOOST_CHECK_THROW(grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec), std::logic_error);
+    }
+    else{
+        grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+    }
+}
+
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+const std::string deckString =
+    R"( RUNSPEC
+        DIMENS
+        1  1  5 /
+        GRID
+        COORD
+        0 0 0
+        0 0 1
+        1 0 0
+        1 0 1
+        0 1 0
+        0 1 1
+        1 1 0
+        1 1 1
+        /
+        ZCORN
+        4*0
+        8*1
+        8*2
+        8*3
+        8*4
+        4*5
+        /
+        ACTNUM
+        5*1
+        /
+        PORO
+        5*0.15
+        /)";
+
+BOOST_AUTO_TEST_CASE(NNCatAnLgr)
+{
+    Opm::NNC nnc;
+    nnc.addNNC(2, 4, 1.0); // connect cell 2 (does not belong to any LGR) and cell 4 (belongs to LGR2)
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}};
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,4}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {1,1,5}};
+    // LGR1 cell indices = {0,1}, LGR2 cell indices = {4}.
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2"};
+    testCase(deckString, nnc,  cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec, true);
+}
+
+BOOST_AUTO_TEST_CASE(NNCAtSeveralLgrs)
+{
+    Opm::NNC nnc;
+    nnc.addNNC(0, 1, 1.0); // connect cell 0 and cell 1 (both belong to LGR1)
+    nnc.addNNC(2, 4, 1.0); // connect cell 2 (belongs to LGR2) and cell 4 (belongs to LGR3)
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}, {4,4,4}};
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,2}, {0,0,4}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{1,1,1}, {1,1,3}, {1,1,5}};
+    // LGR1 cell indices = {0}, LGR2 cell indices = {2}, LGR3 cell indices = {4}.
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
+    testCase(deckString, nnc,  cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec, true);
+}
+
+BOOST_AUTO_TEST_CASE(NNCoutsideLgrs)
+{
+    Opm::NNC nnc;
+    nnc.addNNC(1, 3, 1.0); // connect cell 1 and cell 3 (both do NOT belong to any LGR)
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}, {4,4,4}};
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,2}, {0,0,4}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{1,1,1}, {1,1,3}, {1,1,5}};
+    // LGR1 cell indices = {0}, LGR2 cell indices = {2}, LGR3 cell indices = {4}.
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
+    testCase(deckString, nnc,  cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec, false);
+}
+

--- a/tests/cpgrid/avoidNNCinLGRs_test.cpp
+++ b/tests/cpgrid/avoidNNCinLGRs_test.cpp
@@ -1,0 +1,111 @@
+//===========================================================================
+//
+// File: avoidNNCinLGRs_test.cpp
+//
+// Created: Nov 07 2023 15:25:00
+//
+// Author(s): Antonella Ritorto   <antonella.ritorto@opm-op.com>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+/*
+  Copyright 2023 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#define BOOST_TEST_MODULE NNCINLGRTest
+#include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
+#include <opm/grid/CpGrid.hpp>
+
+
+#include <sstream>
+#include <iostream>
+
+struct Fixture
+{
+    Fixture()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        Dune::MPIHelper::instance(m_argc, m_argv);
+        Opm::OpmLog::setupSimpleDefaultLogging();
+    }
+
+    static int rank()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        return Dune::MPIHelper::instance(m_argc, m_argv).rank();
+    }
+};
+
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+void noNNC_check(Dune::CpGrid& grid,
+                 const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                 const std::vector<std::array<int,3>>& startIJK_vec,
+                 const std::vector<std::array<int,3>>& endIJK_vec,
+                 const std::vector<std::string>& lgr_name_vec)
+{
+    try
+    {
+        grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+
+    }
+    catch(const std::exception& e)
+    {
+        std::cout << e.what() << '\n';
+    }
+}
+
+BOOST_AUTO_TEST_CASE(noNNC1)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    grid.createCartesian(grid_dim, cell_sizes);
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}, {4,4,4}};
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,2}, {3,2,2}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {1,1,3}, {4,3,3}};
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
+    noNNC_check(grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+}
+
+BOOST_AUTO_TEST_CASE(noNNC2)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    grid.createCartesian(grid_dim, cell_sizes);
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}};
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {3,2,0}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1}, {4,3,3}};
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2"};
+    noNNC_check(grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+}

--- a/tests/cpgrid/grid_lgr_test.cpp
+++ b/tests/cpgrid/grid_lgr_test.cpp
@@ -538,7 +538,7 @@ BOOST_AUTO_TEST_CASE(patches_share_corners)
     coarse_grid.createCartesian(grid_dim, cell_sizes);
     const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {2,2,2}, {2,2,2}};
     const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {2,0,1}, {3,2,2}};
-    const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {3,1,1}, {4,3,3}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {3,1,2}, {4,3,3}};
     const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
     BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec), std::logic_error);
     std::cout << "Patches are NOT disjoint" << "\n";
@@ -568,7 +568,7 @@ BOOST_AUTO_TEST_CASE(pathces_share_faceB)
     coarse_grid.createCartesian(grid_dim, cell_sizes);
     const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {2,2,2}, {2,2,2}};
     const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,1}, {1,1,2}};
-    const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1}, {3,2,1}, {4,3,3}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1}, {3,2,2}, {4,3,3}};
     const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
     BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec), std::logic_error);
     std::cout << "Patches are NOT disjoint" << "\n";


### PR DESCRIPTION
To prevent NNC (no neighbor connections) in coarse cells that will get refined. A test with cases containing NNCs is pendent. 