### PR TITLE
Get access to private members needed in ecltrans

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -532,6 +532,9 @@ namespace Dune
         // @brief TO BE DONE
         const std::map<std::string,int>& getLgrNameToLevel() const;
 
+        // @bried Get leaf grid
+        Dune::cpgrid::CpGridData* getCurrentViewData() const;
+
         // @breif Compute center of an entity/element/cell in the Eclipse way:
         //        - Average of the 4 corners of the bottom face.
         //        - Average of the 4 corners of the top face.

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1856,6 +1856,11 @@ const std::map<std::string,int>& CpGrid::getLgrNameToLevel() const{
     return lgr_names_;
 }
 
+Dune::cpgrid::CpGridData* CpGrid::getCurrentViewData() const
+{
+    return  current_view_data_;
+}
+
 std::array<double,3> CpGrid::getEclCentroid(const int& elemIdx) const
 {
     return this-> current_view_data_ -> computeEclCentroid(elemIdx);

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -2326,5 +2326,11 @@ std::array<double,3> CpGridData::computeEclCentroid(const Entity<0>& elem) const
     return this->computeEclCentroid(elem.index());
 }
 
+enum face_tag CpGridData::getFaceTag(int faceIdx) const
+{
+    Dune::cpgrid::EntityRep<1> face(faceIdx, true);
+    return this->face_tag_[face];
+}
+
 } // end namespace cpgrid
 } // end namespace Dune

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -477,6 +477,9 @@ public:
     // @return                   'eclipse centroid'
     std::array<double,3> computeEclCentroid(const Entity<0>& elem) const;
 
+    // @brief Get face tag
+    enum face_tag getFaceTag(int faceIdx) const;
+
     // Make unique boundary ids for all intersections.
     void computeUniqueBoundaryIds();
 

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -266,10 +266,10 @@ public:
     /// Otherwise, returns itself. 
     Entity<0> getOrigin() const;
     
-    /// \brief Get equivalent element on the level grid view for an element on the leaf grid view. 
+    /// \brief Get equivalent element on the level grid view for an element on the leaf grid view.
     Entity<0> getLevelElem() const;
 
-    /// \brief Get Cartesian Index in the level grid view where the Entity was born. 
+    /// \brief Get Cartesian Index in the level grid view where the Entity was born.
     int getLevelCartesianIdx() const;
 
 protected:


### PR DESCRIPTION
To support LGRs for CpGrid, access to current view data is needed (or maybe there is another way around, suggestions are welcome!). 
A method to get the face tag given its index is added too. 

This is needed in certain refactored code in opm-simulators/ebos/ecltransmissibilities_impl.hh.