### PR TITLE
fixed: explicitly check against double precision 0.0

### DIFF
--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -484,7 +484,7 @@ void refine_and_check(const cpgrid::Geometry<3, 3>& parent_geometry,
 
                         CHECK_COORDINATES(intersection_match.centerUnitOuterNormal(), intersection.centerUnitOuterNormal());
                         const auto& geom_match = intersection_match.geometry();
-                        BOOST_TEST(0 == 1e-11, boost::test_tools::tolerance(1e-8));
+                        BOOST_TEST(0.0 == 1e-11, boost::test_tools::tolerance(1e-8));
                         const auto& geom =  intersection.geometry();
                         BOOST_CHECK_CLOSE(geom_match.volume(), geom.volume(), 1e-6);
                         CHECK_COORDINATES(geom_match.center(), geom.center());

--- a/tests/cpgrid/grid_lgr_test.cpp
+++ b/tests/cpgrid/grid_lgr_test.cpp
@@ -638,7 +638,7 @@ void check_global_refine(const Dune::CpGrid& refined_grid, const Dune::CpGrid& e
 
                     CHECK_COORDINATES(intersection_match.centerUnitOuterNormal(), intersection.centerUnitOuterNormal());
                     const auto& geom_match = intersection_match.geometry();
-                    BOOST_TEST(0 == 1e-11, boost::test_tools::tolerance(1e-8));
+                    BOOST_TEST(0.0 == 1e-11, boost::test_tools::tolerance(1e-8));
                     const auto& geom =  intersection.geometry();
                     BOOST_CHECK_CLOSE(geom_match.volume(), geom.volume(), 1e-6);
                     CHECK_COORDINATES(geom_match.center(), geom.center());


### PR DESCRIPTION
For some reason I didn't really care to investigate further, Boost 1.66 ends up in an integer path and shit meets f*n.