### PR TITLE
Get compressed size for level 0

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -66,7 +66,7 @@ class NNC;
 
 namespace Dune
 {
-
+    template<typename Grid> class CartesianIndexMapper;
     class CpGrid;
 
     namespace cpgrid
@@ -237,6 +237,7 @@ namespace Dune
     class CpGrid
         : public GridDefaultImplementation<3, 3, double, CpGridFamily>
     {
+        friend class Dune::CartesianIndexMapper<CpGrid>;
         friend class cpgrid::CpGridData;
         friend class cpgrid::Entity<0>;
         friend class cpgrid::Entity<1>;

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -66,7 +66,6 @@ class NNC;
 
 namespace Dune
 {
-    template<typename Grid> class CartesianIndexMapper;
     class CpGrid;
 
     namespace cpgrid
@@ -237,7 +236,6 @@ namespace Dune
     class CpGrid
         : public GridDefaultImplementation<3, 3, double, CpGridFamily>
     {
-        friend class Dune::CartesianIndexMapper<CpGrid>;
         friend class cpgrid::CpGridData;
         friend class cpgrid::Entity<0>;
         friend class cpgrid::Entity<1>;
@@ -398,6 +396,9 @@ namespace Dune
         /// those dealing with permeability fields from the input deck
         /// from whence the current CpGrid was constructed.
         const std::vector<int>& globalCell() const;
+
+        /// @brief Returns either data_ or distributed_data_(if non empty).
+        const std::vector<std::shared_ptr<Dune::cpgrid::CpGridData>>& chooseData() const;
 
         /// @brief
         ///    Extract Cartesian index triplet (i,j,k) of an active cell.

--- a/opm/grid/common/CartesianIndexMapper.hpp
+++ b/opm/grid/common/CartesianIndexMapper.hpp
@@ -43,6 +43,12 @@ namespace Dune
             return 0;
         }
 
+        /** \brief return number of cells in the active level zero grid. Only relevant for CpGrid specialization. */
+        int compressedLevelZeroSize() const
+        {
+            return 0;
+        }
+
         /** \brief return index of the cells in the logical Cartesian grid */
         int cartesianIndex( const int /* compressedElementIndex */) const
         {

--- a/opm/grid/cpgrid/CartesianIndexMapper.hpp
+++ b/opm/grid/cpgrid/CartesianIndexMapper.hpp
@@ -49,6 +49,11 @@ namespace Dune
             return grid_.globalCell().size();
         }
 
+        int compressedLevelZeroSize() const
+        {
+            return (*(grid_.data_[0])).global_cell_.size();
+        }
+
         int cartesianIndex( const int compressedElementIndex ) const
         {
             assert(  compressedElementIndex >= 0 && compressedElementIndex < compressedSize() );

--- a/opm/grid/cpgrid/CartesianIndexMapper.hpp
+++ b/opm/grid/cpgrid/CartesianIndexMapper.hpp
@@ -51,7 +51,8 @@ namespace Dune
 
         int compressedLevelZeroSize() const
         {
-            return (*(grid_.data_[0])).global_cell_.size();
+            
+            return (*grid_.chooseData()[0]).size(0);
         }
 
         int cartesianIndex( const int compressedElementIndex ) const

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -601,16 +601,21 @@ const std::array<int, 3>& CpGrid::logicalCartesianSize() const
     return current_view_data_ -> logical_cartesian_size_;
 }
 
+const std::vector<std::shared_ptr<Dune::cpgrid::CpGridData>>& CpGrid::chooseData() const
+{
+    if (current_view_data_ == this-> data_.back().get()){
+        return data_;
+    }
+    else{
+        return distributed_data_;
+    }
+}
+
 const std::vector<int>& CpGrid::globalCell() const
 {
     // Temporary. For a grid with LGRs, we set the globalCell() of the as the one for level 0.
     //            Goal: CartesianIndexMapper well-defined for CpGrid LeafView with LGRs.
-    if (current_view_data_ == this-> data_.back().get()){
-        return current_view_data_ -> global_cell_;
-    }
-    else{
-        return this -> distributed_data_[0] ->global_cell_;
-    }
+    return chooseData().back() -> global_cell_;
 }
 
 void CpGrid::getIJK(const int c, std::array<int,3>& ijk) const
@@ -917,14 +922,7 @@ const CpGridFamily::Traits::LevelIndexSet& CpGrid::levelIndexSet(int level) cons
 {
     if (level<0 || level>maxLevel())
         DUNE_THROW(GridError, "levelIndexSet of nonexisting level " << level << " requested!");
-    if (current_view_data_ == data_.back().get())
-    {
-        return *data_[level] -> index_set_;
-    }
-    else
-    {
-        return *distributed_data_[level] -> index_set_;
-    }
+    return *chooseData()[level] -> index_set_;
 }
 
 const CpGridFamily::Traits::LeafIndexSet& CpGrid::leafIndexSet() const

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -81,7 +81,6 @@ class NNC;
 }
 namespace Dune
 {
-template<typename Grid> class CartesianIndexMapper;
 class CpGrid;
 
 namespace cpgrid
@@ -142,7 +141,6 @@ template<class T, int i> struct Mover;
 class CpGridData
 {
     template<class T, int i> friend struct mover::Mover;
-    friend Dune::CartesianIndexMapper<CpGrid>;
     friend class GlobalIdSet;
     friend class HierarchicIterator;
     friend class Dune::cpgrid::IndexSet;

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -81,6 +81,7 @@ class NNC;
 }
 namespace Dune
 {
+template<typename Grid> class CartesianIndexMapper;
 class CpGrid;
 
 namespace cpgrid
@@ -141,7 +142,7 @@ template<class T, int i> struct Mover;
 class CpGridData
 {
     template<class T, int i> friend struct mover::Mover;
-
+    friend Dune::CartesianIndexMapper<CpGrid>;
     friend class GlobalIdSet;
     friend class HierarchicIterator;
     friend class Dune::cpgrid::IndexSet;

--- a/opm/grid/polyhedralgrid/cartesianindexmapper.hh
+++ b/opm/grid/polyhedralgrid/cartesianindexmapper.hh
@@ -44,6 +44,12 @@ namespace Dune
             return grid_.size( 0 );
         }
 
+        // Only for unifying calls with CartesianIndexMapper<CpGrid> where levels are relevant.
+        int compressedLevelZeroSize() const
+        {
+            return grid_.size( 0 );
+        }
+
         int cartesianIndex( const int compressedElementIndex ) const
         {
             assert( compressedElementIndex >= 0 && compressedElementIndex < compressedSize() );


### PR DESCRIPTION
When reading relative permeability defined by the input file, (currently) done for a grid without LGRs, the compressed index used has to be the one for level 0 grid. Therefore, a method compressedLevelZeroSize() has been added in the CartesianIndexMapper interface, for CpGrid and Polyhedral specializations. 
 