### PR TITLE
Add cartesianCoordinateLevel()

### DIFF
--- a/opm/grid/common/CartesianIndexMapper.hpp
+++ b/opm/grid/common/CartesianIndexMapper.hpp
@@ -59,6 +59,12 @@ namespace Dune
         void cartesianCoordinate(const int /* compressedElementIndex */, std::array<int,dimension>& /* coords */) const
         {
         }
+
+        /** \brief return Cartesian coordinate, i.e. IJK, for a given cell. Only relevant for CpGrid specialization.*/
+        void cartesianCoordinateLevel(const int /* compressedElementIndexOnLevel */,
+                                      std::array<int,dimension>& /* coordsOnLevel */, int /*level*/) const
+        {
+        }
     };
 
 } // end namespace Opm

--- a/opm/grid/cpgrid/CartesianIndexMapper.hpp
+++ b/opm/grid/cpgrid/CartesianIndexMapper.hpp
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <cassert>
+#include <stdexcept>
 
 #include <opm/grid/common/CartesianIndexMapper.hpp>
 #include <opm/grid/CpGrid.hpp>
@@ -64,6 +65,14 @@ namespace Dune
         void cartesianCoordinate(const int compressedElementIndex, std::array<int,dimension>& coords) const
         {
             grid_.getIJK( compressedElementIndex, coords );
+        }
+
+        void cartesianCoordinateLevel(const int compressedElementIndexOnLevel, std::array<int,dimension>& coordsOnLevel, int level) const
+        {
+            if ((level < 0) || (level > grid_.maxLevel())) {
+                throw std::invalid_argument("Invalid level.\n");
+            }
+            (*grid_.chooseData()[level]).getIJK( compressedElementIndexOnLevel, coordsOnLevel);
         }
     };
 

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1847,6 +1847,8 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
     (*data_[num_patches +1]).index_set_ = std::make_unique<cpgrid::IndexSet>(data_[num_patches+1]->size(0), data_[num_patches+1]->size(3));
     // Leaf local_id_set_
     (*data_[num_patches +1]).local_id_set_ = std::make_shared<const cpgrid::IdSet>(*data_[num_patches+1]);
+    // Leaf logical_cartesian_size_
+    (*data_[num_patches +1]).logical_cartesian_size_ =  (*data_[0]).logical_cartesian_size_;
 }
 
 

--- a/opm/grid/polyhedralgrid/cartesianindexmapper.hh
+++ b/opm/grid/polyhedralgrid/cartesianindexmapper.hh
@@ -72,6 +72,15 @@ namespace Dune
           else
               coords[ 0 ] = gc ;
         }
+
+        // Only for unifying calls with CartesianIndexMapper<CpGrid> where levels are relevant.
+        void cartesianCoordinateLevel(const int compressedElementIndexOnLevel, std::array<int,dimension>& coordsOnLevel, int level) const
+        {
+            if (level) {
+                throw std::invalid_argument("Invalid level.\n");
+            }
+            cartesianCoordinate(compressedElementIndexOnLevel, coordsOnLevel);
+        }
     };
 
 } // end namespace Opm


### PR DESCRIPTION
For a cell on the leaf grid view, cartesianIndexMapper.cartesianCoordinate( cell idx, ...) computes the ijk index of the parent cell or the equivalent cell on level zero, for CpGrid with LGRs. 

Now, for every level, included level 0, a new method to compute the ijk index, given the index cell on a certain level and its level, is included. 

Such a method is needed in RelpermDiagnostics.cpp, to create the string of a cell index, from level zero. See also OPM/opm-simulators#5029