### PR TITLE
Static invalid index member added in CpGrid and Entity

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -48,9 +48,10 @@
 #include <opm/grid/cpgpreprocess/preprocess.h>
 #include <opm/grid/utility/platform_dependent/reenable_warnings.h> //  Not really needed it seems, but alas.
 #include "common/GridEnums.hpp"   
-#include <opm/grid/utility/OpmWellType.hpp>  
+#include <opm/grid/utility/OpmWellType.hpp>
 
 #include <iostream>
+#include <limits>
 #if ! HAVE_MPI
 #include <list>
 #endif
@@ -1250,6 +1251,8 @@ namespace Dune
         std::vector<std::shared_ptr<cpgrid::CpGridData>> distributed_data_;
         /** @brief To get the level given the lgr-name. Default, {"GLOBAL", 0}. */
         std::map<std::string,int> lgr_names_ = {{"GLOBAL", 0}};
+        /** Invalid index. To be used when an entity lacks of certain index (level, parent, child, etc).*/
+        static constexpr int invalidIdx = std::numeric_limits<int>::min();
         /**
          * @brief Interface for scattering and gathering cell data.
          *

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -712,23 +712,30 @@ private:
     std::shared_ptr<LevelGlobalIdSet> global_id_set_;
     /** @brief The indicator of the partition type of the entities */
     std::shared_ptr<PartitionTypeIndicator> partition_type_indicator_;
-    /** Level of the current CpGridData (0 when it's "GLOBAL", 1,2,.. for LGRs, created via CpGrid::createGridWithLgrs()). */
+    
+    /** Level of the current CpGridData (0 when it's "GLOBAL", 1,2,.. for LGRs. */
     int level_{0};
-    /** Copy of (CpGrid object).data_ associated with the CpGridData object, via created via CpGrid::createGridWithLgrs(). */
+    /** Copy of (CpGrid object).data_ associated with the CpGridData object. */
     std::vector<std::shared_ptr<CpGridData>>* level_data_ptr_;
     // SUITABLE FOR ALL LEVELS EXCEPT FOR LEAFVIEW
-    /** Map between level and leafview cell indices. Only cells (from that level) that appear in leafview count. */  
+    /** invalidIdx is a static member of CpGrid class. To be used when an entity lacks of certain index (level, parent, child, etc).
+     *
+     *
+     * Map between level and leafview cell indices. Only cells (from that level) that appear in leafview count.
+     * For level 0, level_to_leaf_cells_[ cell from level 0 that got refined index ] = invalidElemIdx since it
+     * does not appear on the leaf grid view.
+     */
     std::vector<int> level_to_leaf_cells_; // In entry 'level cell index', we store 'leafview cell index'
-    /** Parent cells and their children. Entry is {-1, {}} when cell has no children.*/ // {level LGR, {child0, child1, ...}}
-    std::vector<std::tuple<int,std::vector<int>>> parent_to_children_cells_; 
-    /** Amount of children cells per parent cell in each direction. */ // {# children in x-direction, ... y-, ... z-}
-    std::array<int,3> cells_per_dim_;
+    /** Parent cells and their children. Entry is {invalidIdx, {}} when cell has no children.*/
+    std::vector<std::tuple<int,std::vector<int>>> parent_to_children_cells_; // {level LGR, {child0, child1, ...}}
+    /** Amount of children cells per parent cell in each direction. */ 
+    std::array<int,3> cells_per_dim_; // {# children in x-direction, ... y-, ... z-}
     // SUITABLE ONLY FOR LEAFVIEW
-    /** Relation between leafview and (possible different) level(s) cell indices. */ // {level, cell index in that level}
-    std::vector<std::array<int,2>> leaf_to_level_cells_;
+    /** Relation between leafview and (possible different) level(s) cell indices. */
+    std::vector<std::array<int,2>> leaf_to_level_cells_;  // {level, cell index in that level}
     // SUITABLE FOR ALL LEVELS INCLUDING LEAFVIEW
-    /** Child cells and their parents. Entry is {-1,-1} when cell has no father. */ // {level parent cell, parent cell index}
-    std::vector<std::array<int,2>> child_to_parent_cells_;
+    /** Child cells and their parents. Entry is {invalidIdx,invalidIdx} when cell has no father. */
+    std::vector<std::array<int,2>> child_to_parent_cells_;  // {level parent cell, parent cell index}
 
 
     /// \brief Object for collective communication operations.

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -279,6 +279,8 @@ private:
     // constexpr to allow for in-class instantiation
     /// \brief Indices of corners in entity's geometry in father reference element, for the Geometry returned by geometryInFather
     static constexpr std::array<int,8> in_father_reference_elem_corner_indices_ = {0,1,2,3,4,5,6,7};
+    /// \brief Invalid index. To be used when an entity lacks of certain index (level, parent, child, etc).*/
+    static constexpr int invalidIdx = std::numeric_limits<int>::min();
 };
 
 } // namespace cpgrid
@@ -442,15 +444,15 @@ bool Entity<codim>::isLeaf() const
     if ((pgrid_ -> parent_to_children_cells_).empty()){ // LGR cells
         return true;
     }
-    else {
-        return (std::get<0>((pgrid_ -> parent_to_children_cells_)[this-> index()]) == -1);  // Cells from GLOBAL, not involved in any LGR
+    else { // Cells from GLOBAL, not involved in any LGR
+        return (std::get<0>((pgrid_ -> parent_to_children_cells_)[this-> index()]) == invalidIdx);  
     }
 }
 
 template<int codim>
 bool Entity<codim>::hasFather() const
 {
-    if ((pgrid_ -> child_to_parent_cells_.empty()) || (pgrid_ -> child_to_parent_cells_[this->index()][0] == -1)){
+    if ((pgrid_ -> child_to_parent_cells_.empty()) || (pgrid_ -> child_to_parent_cells_[this->index()][0] == invalidIdx)){
         return false;
     }
     else{

--- a/tests/cpgrid/grid_lgr_test.cpp
+++ b/tests/cpgrid/grid_lgr_test.cpp
@@ -146,17 +146,17 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
                 auto endIt = entity.hend(coarse_grid.maxLevel());
                 const auto& [lgr, childrenList] = (*coarse_grid.data_[0]).parent_to_children_cells_[cell];
                 if (std::find(all_parent_cell_indices.begin(), all_parent_cell_indices.end(), cell) == all_parent_cell_indices.end()){
-                    BOOST_CHECK_EQUAL(lgr, -1);
+                    BOOST_CHECK_EQUAL(lgr, coarse_grid.invalidIdx);
                     BOOST_CHECK(childrenList.empty());
                     BOOST_CHECK( entity.isLeaf() == true);
                     // If it == endIt, then entity.isLeaf() true (when dristibuted_data_ is empty)
                     BOOST_CHECK( it == endIt);
                 }
                 else{
-                    BOOST_CHECK(lgr != -1);
+                    BOOST_CHECK(lgr != coarse_grid.invalidIdx);
                     BOOST_CHECK(childrenList.size() > 1);
                     for (const auto& child : childrenList) {
-                        BOOST_CHECK( child != -1);
+                        BOOST_CHECK( child != coarse_grid.invalidIdx);
                         BOOST_CHECK( data[lgr]-> child_to_parent_cells_[child][0] == 0);
                         BOOST_CHECK( data[lgr]-> child_to_parent_cells_[child][1] == cell);
                     }
@@ -176,7 +176,6 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
                         {
                             referenceElem_entity_center[c] += (it-> geometryInFather().center())[c];
                         }
-                        // std::cout << it->index() << '\n';
                     }
                     for (int c = 0; c < 3; ++c)
                     {
@@ -206,7 +205,7 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
                 BOOST_CHECK_EQUAL((std::find(patch_cells.begin(), patch_cells.end(),
                                              entity.father().index()) == patch_cells.end()) , false);
                 const auto& child_to_parent = (*data[level]).child_to_parent_cells_[cell];
-                BOOST_CHECK_EQUAL( child_to_parent[0] == -1, false);
+                BOOST_CHECK_EQUAL( child_to_parent[0] == coarse_grid.invalidIdx, false);
                 BOOST_CHECK_EQUAL( child_to_parent[0] == 0, true);
                 BOOST_CHECK_EQUAL( child_to_parent[1], entity.father().index());
                 BOOST_CHECK( std::get<0>((*data[0]).parent_to_children_cells_[child_to_parent[1]]) == entity.level());
@@ -265,10 +264,10 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
                 else{
                     BOOST_CHECK_THROW(entity.father(), std::logic_error);
                     BOOST_CHECK_THROW(entity.geometryInFather(), std::logic_error);
-                    BOOST_CHECK_EQUAL(child_to_parent[0], -1);
-                    BOOST_CHECK_EQUAL(child_to_parent[1], -1);
+                    BOOST_CHECK_EQUAL(child_to_parent[0], coarse_grid.invalidIdx);
+                    BOOST_CHECK_EQUAL(child_to_parent[1], coarse_grid.invalidIdx);
                     BOOST_CHECK( level_cellIdx[0] == 0);
-                    BOOST_CHECK( std::get<0>((*data[0]).parent_to_children_cells_[level_cellIdx[1]]) == -1);
+                    BOOST_CHECK( std::get<0>((*data[0]).parent_to_children_cells_[level_cellIdx[1]]) == coarse_grid.invalidIdx);
                     BOOST_CHECK( std::get<1>((*data[0]).parent_to_children_cells_[level_cellIdx[1]]).empty());
                     BOOST_CHECK( entity.level() == 0);
                     // Get index of the cell in level 0


### PR DESCRIPTION
Replace the use of "-1" for invalid indices (of type int, e.g. level, index cell, etc) by a static member of type int, with value std::numeric_limits<int>::max(). 
