### PR TITLE
[Bugfix] Invalid corners on (leafGridView)face_to_point_

### DIFF
--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1689,17 +1689,12 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
             // Add the amount of points to the count num_points.
             num_points += old_face_to_point.size();
             for (int corn = 0; corn < 4; ++corn) {
-                // Auxiliary bool to identify boundary patch corners.
-                bool is_there_allPatchBoundCorn = false;
-                for(const auto& [l0_oldCorner, level_newCorner] : old_to_new_boundaryPatchCorners){
-                    is_there_allPatchBoundCorn = is_there_allPatchBoundCorn || (corn == l0_oldCorner[1]);
-                    //true-> boundary patch corner
-                    if (is_there_allPatchBoundCorn) {
-                        aux_face_to_point[leafFaceIdx].push_back(level_to_leaf_corners[level_newCorner[0]][level_newCorner[1]]);
-                        break; // Go to the next corner (on the boundary of a patch)
-                    }
+                if (level_to_leaf_corners[0][old_face_to_point[corn]] == -1) {
+                    const auto [lgr, lgrCornIdx] = old_to_new_boundaryPatchCorners[{0, old_face_to_point[corn]}];
+                    aux_face_to_point[leafFaceIdx].push_back(level_to_leaf_corners[lgr][lgrCornIdx]);
                 }
-                if (!is_there_allPatchBoundCorn) {// Corner not involded in any LGR.
+                else{// Corner not involded in any LGR.
+                    assert(level_to_leaf_corners[0][old_face_to_point[corn]] != -1);
                     aux_face_to_point[leafFaceIdx].push_back(level_to_leaf_corners[0][old_face_to_point[corn]]);
                 }
             } // end-corn-forloop

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1694,7 +1694,6 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
                     aux_face_to_point[leafFaceIdx].push_back(level_to_leaf_corners[lgr][lgrCornIdx]);
                 }
                 else{// Corner not involded in any LGR.
-                    assert(level_to_leaf_corners[0][old_face_to_point[corn]] != -1);
                     aux_face_to_point[leafFaceIdx].push_back(level_to_leaf_corners[0][old_face_to_point[corn]]);
                 }
             } // end-corn-forloop

--- a/tests/cpgrid/grid_lgr_test.cpp
+++ b/tests/cpgrid/grid_lgr_test.cpp
@@ -224,10 +224,31 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
                 // If entity.isLeaf(), then it == endIt (when dristibuted_data_ is empty)
                 BOOST_CHECK( it == endIt);
             }
+
+            // LeafView faces
+            for (int face = 0; face <  data[startIJK_vec.size()+1]-> face_to_cell_.size(); ++face)
+            {
+                const auto& faceToPoint =  (*data[startIJK_vec.size() +1]).face_to_point_[face];
+                BOOST_CHECK(faceToPoint.size() == 4);
+                for (int i = 0; i < 4; ++i)
+                {
+                    BOOST_CHECK((*data[startIJK_vec.size() +1]).face_to_point_[face][i] != -1);
+                }
+            }
+
             // LeafView
             for (int cell = 0; cell <  data[startIJK_vec.size()+1]-> size(0); ++cell)
             {
+                BOOST_CHECK( data[startIJK_vec.size()+1] -> cell_to_point_[cell].size() == 8);
+                for (int i = 0; i < 8; ++i)
+                {
+                    BOOST_CHECK( data[startIJK_vec.size()+1] -> cell_to_point_[cell][i] != -1);
+                }
                 Dune::cpgrid::Entity<0> entity = Dune::cpgrid::Entity<0>((*coarse_grid.data_[startIJK_vec.size()+1]), cell, true);
+                for (int i = 0; i < data[startIJK_vec.size()+1] -> cell_to_face_[entity].size(); ++i)
+                {
+                    BOOST_CHECK( data[startIJK_vec.size()+1] -> cell_to_face_[entity][i].index() != -1);
+                }
                 const auto& child_to_parent = (*data[startIJK_vec.size()+1]).child_to_parent_cells_[cell];
                 const auto& level_cellIdx = (*data[startIJK_vec.size()+1]).leaf_to_level_cells_[entity.index()];
                 auto it = entity.hbegin(coarse_grid.maxLevel());


### PR DESCRIPTION
On the leaf grid view of a CpGrid with LGRs, there are faces equivalent to the ones from level zero which have not been refined. In particular, when populating face_to_point_ of coarse faces that happen to touch an LGR on its boundary on (at least) one corner, get the refined corner. 

There was a bug assigning  -1 in those cases, instead of the actual correct leaf grid view corner index. This PR fixes it. 