### PR TITLE
[refactor] Remove numElems as function argument

### DIFF
--- a/opm/grid/LookUpData.hh
+++ b/opm/grid/LookUpData.hh
@@ -94,14 +94,12 @@ public:
 
     /// \brief: Get field property of type double from field properties manager by name.
     std::vector<double> assignFieldPropsDoubleOnLeaf(const FieldPropsManager& fieldPropsManager,
-                                                     const std::string& propString,
-                                                     const unsigned int& numElements) const;
+                                                     const std::string& propString) const;
 
     /// \brief: Get field property of type int from field properties manager by name.
     template<typename IntType>
     std::vector<IntType> assignFieldPropsIntOnLeaf(const FieldPropsManager& fieldPropsManager,
                                                    const std::string& propString,
-                                                   const unsigned int& numElements,
                                                    const bool& needsTranslation,
                                                    std::function<void(IntType, int)> valueCheck = [](IntType, int){}) const;
 
@@ -211,14 +209,12 @@ public:
 
     /// \brief: Get field property of type double from field properties manager by name.
     std::vector<double> assignFieldPropsDoubleOnLeaf(const FieldPropsManager& fieldPropsManager,
-                                                     const std::string& propString,
-                                                     const unsigned int& numElements) const;
+                                                     const std::string& propString) const;
 
     /// \brief: Get field property of type int from field properties manager by name.
     template<typename IntType>
     std::vector<IntType> assignFieldPropsIntOnLeaf(const FieldPropsManager& fieldPropsManager,
                                                    const std::string& propString,
-                                                   const unsigned int& numElements,
                                                    const bool& needsTranslation,
                                                    std::function<void(IntType, int)> valueCheck = [](IntType, int){}) const;
 
@@ -308,10 +304,10 @@ Opm::LookUpData<Grid,GridView>::operator()(const EntityType& elem,
 
 template<typename Grid, typename GridView>
 std::vector<double> Opm::LookUpData<Grid,GridView>::assignFieldPropsDoubleOnLeaf(const FieldPropsManager& fieldPropsManager,
-                                                                                 const std::string& propString,
-                                                                                 const unsigned int& numElements) const
+                                                                                 const std::string& propString) const
 {
     std::vector<double> fieldPropOnLeaf;
+    unsigned int numElements = gridView_.size(0);
     fieldPropOnLeaf.resize(numElements);
     const auto& fieldProp = fieldPropsManager.get_double(propString);
     for (unsigned int elemIdx = 0; elemIdx < numElements; ++elemIdx) {
@@ -325,11 +321,11 @@ template<typename Grid, typename GridView>
 template<typename IntType>
 std::vector<IntType> Opm::LookUpData<Grid,GridView>::assignFieldPropsIntOnLeaf(const FieldPropsManager& fieldPropsManager,
                                                                                const std::string& propString,
-                                                                               const unsigned int& numElements,
                                                                                const bool& needsTranslation,
                                                                                std::function<void(IntType, int)> valueCheck) const
 {
     std::vector<IntType> fieldPropOnLeaf;
+    unsigned int numElements = gridView_.size(0);
     fieldPropOnLeaf.resize(numElements);
     const auto& fieldProp = fieldPropsManager.get_int(propString);
     for (unsigned elemIdx = 0; elemIdx < numElements; ++elemIdx) {
@@ -442,10 +438,10 @@ Opm::LookUpCartesianData<Grid,GridView>::operator()(const EntityType& elem,
 
 template<typename Grid, typename GridView>
 std::vector<double> Opm::LookUpCartesianData<Grid,GridView>::assignFieldPropsDoubleOnLeaf(const FieldPropsManager& fieldPropsManager,
-                                                                                          const std::string& propString,
-                                                                                          const unsigned int& numElements) const
+                                                                                          const std::string& propString) const
 {
     std::vector<double> fieldPropOnLeaf;
+    unsigned int numElements = gridView_.size(0);
     fieldPropOnLeaf.resize(numElements);
     const auto& fieldProp = fieldPropsManager.get_double(propString);
     for (unsigned int elemIdx = 0; elemIdx < numElements; ++elemIdx) {
@@ -459,11 +455,11 @@ template<typename Grid, typename GridView>
 template<typename IntType>
 std::vector<IntType> Opm::LookUpCartesianData<Grid,GridView>::assignFieldPropsIntOnLeaf(const FieldPropsManager& fieldPropsManager,
                                                                                         const std::string& propString,
-                                                                                        const unsigned int& numElements,
                                                                                         const bool& needsTranslation,
                                                                                         std::function<void(IntType, int)> valueCheck) const
 {
     std::vector<IntType> fieldPropOnLeaf;
+    unsigned int numElements = gridView_.size(0);
     fieldPropOnLeaf.resize(numElements);
     const auto& fieldProp = fieldPropsManager.get_int(propString);
     for (unsigned elemIdx = 0; elemIdx < numElements; ++elemIdx) {

--- a/tests/cpgrid/lookupdataCpGrid_test.cpp
+++ b/tests/cpgrid/lookupdataCpGrid_test.cpp
@@ -303,11 +303,11 @@ void fieldProp_check(const Dune::CpGrid& grid, Opm::EclipseGrid eclGrid, std::st
     const Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>
         mapper(leaf_view, Dune::mcmgElementLayout());
 
-    const auto& poroOnLeaf = lookUpData.assignFieldPropsDoubleOnLeaf(fpm, "PORO", leaf_view.size(0));
-    const auto& poroOnLeafCart = lookUpCartesianData.assignFieldPropsDoubleOnLeaf(fpm, "PORO", leaf_view.size(0));
+    const auto& poroOnLeaf = lookUpData.assignFieldPropsDoubleOnLeaf(fpm, "PORO");
+    const auto& poroOnLeafCart = lookUpCartesianData.assignFieldPropsDoubleOnLeaf(fpm, "PORO");
 
-    const auto& eqlnumOnLeaf = lookUpData.assignFieldPropsIntOnLeaf<int>(fpm, "EQLNUM", leaf_view.size(0), true);
-    const auto& eqlnumOnLeafCart = lookUpCartesianData.assignFieldPropsIntOnLeaf<int>(fpm, "EQLNUM", leaf_view.size(0), true);
+    const auto& eqlnumOnLeaf = lookUpData.assignFieldPropsIntOnLeaf<int>(fpm, "EQLNUM", true);
+    const auto& eqlnumOnLeafCart = lookUpCartesianData.assignFieldPropsIntOnLeaf<int>(fpm, "EQLNUM", true);
 
     for (const auto& elem : elements(leaf_view))
     {

--- a/tests/test_lookupdata_polyhedral.cpp
+++ b/tests/test_lookupdata_polyhedral.cpp
@@ -189,11 +189,11 @@ void fieldProp_check(const Dune::PolyhedralGrid<3,3>& grid, Opm::EclipseGrid ecl
     // Element mapper
     const Dune::MultipleCodimMultipleGeomTypeMapper<GridView> mapper(leaf_view, Dune::mcmgElementLayout());
 
-    const auto& poroOnLeaf = lookUpData.assignFieldPropsDoubleOnLeaf(fpm, "PORO", leaf_view.size(0));
-    const auto& poroOnLeafCart = lookUpCartesianData.assignFieldPropsDoubleOnLeaf(fpm, "PORO", leaf_view.size(0));
+    const auto& poroOnLeaf = lookUpData.assignFieldPropsDoubleOnLeaf(fpm, "PORO");
+    const auto& poroOnLeafCart = lookUpCartesianData.assignFieldPropsDoubleOnLeaf(fpm, "PORO");
 
-    const auto& eqlnumOnLeaf = lookUpData.assignFieldPropsIntOnLeaf<int>(fpm, "EQLNUM", leaf_view.size(0), true);
-    const auto& eqlnumOnLeafCart = lookUpCartesianData.assignFieldPropsIntOnLeaf<int>(fpm, "EQLNUM", leaf_view.size(0), true);
+    const auto& eqlnumOnLeaf = lookUpData.assignFieldPropsIntOnLeaf<int>(fpm, "EQLNUM", true);
+    const auto& eqlnumOnLeafCart = lookUpCartesianData.assignFieldPropsIntOnLeaf<int>(fpm, "EQLNUM", true);
 
     for (const auto& elem : elements(leaf_view))
     {


### PR DESCRIPTION
Unnecessary function argument numElements removed. Associated OPM/opm-common#3876 and OPM/opm-simulators#5125 