### PR TITLE
[refactor] Pore volume taking into account LGRs

### DIFF
--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -719,9 +719,9 @@ private:
     std::shared_ptr<LevelGlobalIdSet> global_id_set_;
     /** @brief The indicator of the partition type of the entities */
     std::shared_ptr<PartitionTypeIndicator> partition_type_indicator_;
-    /** Level of the current CpGridData (0 when it's "GLOBAL", 1,2,.. for LGRs, created via CpGrid::createGridWithLgrs()). */
+    /** Level of the current CpGridData (0 when it's "GLOBAL", 1,2,.. for LGRs). */
     int level_{0};
-    /** Copy of (CpGrid object).data_ associated with the CpGridData object, via created via CpGrid::createGridWithLgrs(). */
+    /** Copy of (CpGrid object).data_ associated with the CpGridData object. */
     std::vector<std::shared_ptr<CpGridData>>* level_data_ptr_;
     // SUITABLE FOR ALL LEVELS EXCEPT FOR LEAFVIEW
     /** Map between level and leafview cell indices. Only cells (from that level) that appear in leafview count. */  

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -112,6 +112,8 @@ void refinePatch_and_check(Dune::CpGrid&,
 void check_global_refine(const Dune::CpGrid&,
                          const Dune::CpGrid&);
 
+void fieldProp_check(const Dune::CpGrid& grid, Opm::EclipseGrid eclGrid, std::string deck_string);
+
 namespace Dune
 {
 namespace cpgrid
@@ -152,9 +154,12 @@ class CpGridData
     void ::check_global_refine(const Dune::CpGrid&,
                                const Dune::CpGrid&);
 
+    friend
+    void ::fieldProp_check(const Dune::CpGrid& grid, Opm::EclipseGrid eclGrid, std::string deck_string);
+
 private:
-    CpGridData(const CpGridData& g); 
-    
+    CpGridData(const CpGridData& g);
+
 public:
     enum{
 #ifndef MAX_DATA_COMMUNICATED_PER_ENTITY

--- a/tests/cpgrid/lookupdataCpGrid_test.cpp
+++ b/tests/cpgrid/lookupdataCpGrid_test.cpp
@@ -333,14 +333,13 @@ void fieldProp_check(const Dune::CpGrid& grid, Opm::EclipseGrid eclGrid, std::st
         // PORV
         if (elem.hasFather()) {
             // Pore volume of the father must be equalivalent to the sum of the pore volume of its chidren.
-            // TO BE MODIFIED - Repeted computation for children with the same parent cell.
-            //                  A (data/function) member will be added in CpGrid, to return list of child indices
-            //                  on the leaf grid view, given its parent cell index from level zero.
+            // Remark: not optimal, repeted computation for children with the same parent cell.
             const auto& parentIdx = elem.father().index();
             const auto& parentPorv = porv[parentIdx];
             // Remark: children_list indices are the indices on the LGR - Not on the leaf grid View.
             const auto& [lgr, children_list] = (*grid.chooseData()[0]).parent_to_children_cells_[parentIdx];
-            // Get child indices on the leaf grid view, get the porv value of each child, sum them up, and check.
+            // Get child indices on the leaf grid view, get their porv value, sum them up, and compare
+            // the sum with the pore volume of their parent.
             double sumChildrenPorv = 0.;
             for (const auto& child : children_list) {
                 const auto& childIdxOnLeaf = (*grid.chooseData()[lgr]).level_to_leaf_cells_[child];


### PR DESCRIPTION
For the field property "PORV" (pore volume), when the grid is a CpGrid with LGRs, the pore volume of a leaf grid view cell is compute as the pore volume of its parent cells, multiplied by the leaf grid view cell volume, divided by the parent cell volume. In this way, the pore volume of the parent cell coincides with the sum of the pore volume of its children (cells).

This is "hidden" in the field property assigners defined in the class LookUpData. These methods are used in opm-simulators/ebos, when refactor is needed to support LGRs.