### PR TITLE
[bugfix] Fix support for PINCH(4) ALL for zero pinched out permeability

### DIFF
--- a/opm/grid/MinpvProcessor.cpp
+++ b/opm/grid/MinpvProcessor.cpp
@@ -204,10 +204,10 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                         // Skip NNC if PINCH option 4 is ALL and we know that Z transmissibilty will
                         // be zero because of multz or permz
                         nnc_allowed = nnc_allowed &&
-                            (!pinchOption4ALL || (permz[c] != 0.0 && multz(c) != 0.0));
+                            (!pinchOption4ALL || (permz[c_below] != 0.0 && multz(c_below) != 0.0));
 
                         if (pinchOption4ALL) {
-                            option4ALLSupported = option4ALLSupported || permz[c] == 0 || multz(c) == 0;
+                            option4ALLSupported = option4ALLSupported || permz[c_below] == 0 || multz(c_below) == 0;
                         }
 
                         // move to next lower cell
@@ -273,10 +273,10 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                                 }
 
                                 nnc_allowed = nnc_allowed &&
-                                    (!pinchOption4ALL || (permz[c] != 0.0 && multz(c) != 0.0) );
+                                    (!pinchOption4ALL || (permz[c_above] != 0.0 && multz(c_above) != 0.0) );
 
                                 if (pinchOption4ALL) {
-                                    option4ALLSupported =  option4ALLSupported || permz[c] == 0.0 || multz(c) == 0.0;
+                                    option4ALLSupported =  option4ALLSupported || permz[c_above] == 0.0 || multz(c_above) == 0.0;
                                 }
                             }
                         }
@@ -291,7 +291,7 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                              (actnum.empty() || (actnum[c_above] && actnum[c_below])) &&
                              pv[c_above] > minpvv[c_above] && pv[c_below] > minpvv[c_below]) {
                             result.add_nnc(c_above, c_below);
-                            if (pinchOption4ALL)
+                            if (pinchOption4ALL && !option4ALLSupported)
                             {
                                 // Transmissiblities would be calculated wrong in the simulator in this case.
                                 // They would be deduced from top and bottom cells while they should be calculated as

--- a/tests/test_minpvprocessor.cpp
+++ b/tests/test_minpvprocessor.cpp
@@ -87,6 +87,48 @@ BOOST_AUTO_TEST_CASE(GAP_MAXGAP_no_pinched_cells)
       BOOST_CHECK_EQUAL(minpv_result.nnc[1], 2);
 }
 
+BOOST_AUTO_TEST_CASE(Pinch4ALL)
+{
+    // Set up a simple example.
+    std::vector<double> zcorn = { 0, 0, 0, 0,
+                                  2, 2, 2, 2,
+                                  2, 2, 2, 2,
+                                  2.5, 2.5, 2.5, 2.5,
+                                  2.5, 2.5, 2.5, 2.5,
+                                  3.5, 3.5, 3.5, 3.5,
+                                  3.5, 3.5, 3.5, 3.5,
+                                  6, 6, 6, 6 };
+
+    std::vector<double> pv = { 2, 0.5, 0.5, 2.5};
+    std::vector<int> actnum = { 1, 1, 1, 1 };
+    std::vector<double> thickness = {2, 0.5, 0.5, 2.5};
+    std::vector<double> permz = {2, 2, 0, 2.5};
+    auto multz = [](int){ return 1.0;};
+    double z_threshold = 0.4;
+
+    Opm::MinpvProcessor mp1(1, 1, 4);
+    auto z1 = zcorn;
+    std::vector<double> minpvv(4, 0.6);
+    bool fill_removed_cells = false;
+    bool pinch_no_gap = false;
+    bool option4all = true;
+
+    // THis is suported because one of the permz entries is zero.
+    auto minpv_result = mp1.process(thickness, z_threshold, 1e20, pv, minpvv, actnum,
+				    fill_removed_cells, z1.data(), pinch_no_gap,
+				    option4all, permz, multz);
+    BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 0);
+
+    permz = {2, 2, 1, 2.5}; // Not supported
+    BOOST_CHECK_THROW(mp1.process(thickness, z_threshold, 1e20, pv, minpvv, actnum,
+				  fill_removed_cells, z1.data(), pinch_no_gap,
+				  option4all, permz, multz), std::runtime_error);
+    auto multz2 = [](int i){ if (i==2) return 0.0; else return 1.0;};
+    
+    minpv_result = mp1.process(thickness, z_threshold, 1e20, pv, minpvv, actnum,
+			       fill_removed_cells, z1.data(), pinch_no_gap,
+			       option4all, permz, multz2);
+}
 BOOST_AUTO_TEST_CASE(Pinch)
 {
     // Set up a simple example.


### PR DESCRIPTION
Fixes embarrasing bug that caused a throw whenever option 4 of PINCH was ALL. Now we support the corner case where one the cells in between has a zero permeability (or multz) set.

Full support for ALL is still lacking.