### PR TITLE
Fix integer (`int`) overflow in `preprocess.c` and `uniquepoints.c`

### DIFF
--- a/opm/grid/cpgpreprocess/preprocess.c
+++ b/opm/grid/cpgpreprocess/preprocess.c
@@ -172,7 +172,7 @@ checkmemory(int nz, struct processed_grid *out, int **intersections)
         n += MAX(n / 2, 12 * r);
     }
 
-    ok = m == out->m;
+    ok = m == ((size_t)(out->m));
     if (! ok) {
         void *p1, *p2, *p3, *p4;
 
@@ -191,7 +191,7 @@ checkmemory(int nz, struct processed_grid *out, int **intersections)
         if (ok) { out->m = m; }
     }
 
-    if (ok && (n != out->n)) {
+    if (ok && (n != ((size_t)(out->n)))) {
         void *p1;
 
         p1 = realloc(out->face_nodes, n * sizeof *out->face_nodes);

--- a/opm/grid/cpgpreprocess/preprocess.c
+++ b/opm/grid/cpgpreprocess/preprocess.c
@@ -154,7 +154,8 @@ compute_cell_index(const int dims[3], int i, int j,
 static int
 checkmemory(int nz, struct processed_grid *out, int **intersections)
 {
-    int r, m, n, ok;
+    size_t r, m, n;
+    int ok;
 
     /* Ensure there is enough space to manage the (pathological) case
      * of every single cell on one side of a fault connecting to all

--- a/opm/grid/cpgpreprocess/uniquepoints.c
+++ b/opm/grid/cpgpreprocess/uniquepoints.c
@@ -277,7 +277,7 @@ int finduniquepoints(const struct grdecl *g,
     const int nx = out->dimensions[0];
     const int ny = out->dimensions[1];
     const int nz = out->dimensions[2];
-    const int nc = g->dims[0]*g->dims[1]*g->dims[2];
+    const size_t nc = g->dims[0]*g->dims[1]*g->dims[2];
 
 
     /* zlist may need extra space temporarily due to simple boundary


### PR DESCRIPTION
Running large grids (134M cells, 512^3 logical Cartesian) causes segmentation faults from the function `finduniquepoints` and an error from `checkmemory`. The issue stems from `int` being used for variables that can overflow beyond `MAX_INT` or that are later being used in expressions that will overflow `MAX_INT`.

This PR makes two changes:

1) Change the type of `nc` in `finduniquepoints` to `size_t`

2) Change the type of `r, m, n` in `checkmemory` to `size_t`.

Note that the general usage of `int` in `preprecoss.c` and its siblings will have limitations on the number of cells, but these limitations are slightly larger than 134 M cells. Longer term solution would be to change to `size_t` or `long long`.