### PR TITLE
Get coarse face from a refined face on the boundary of an LGR

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1010,7 +1010,7 @@ namespace Dune
         /// \brief cell_index The index of the specific cell.
         double cellCenterDepth(int cell_index) const;
 
-        const Vector faceCenterEcl(int cell_index, int faceIdxOnLeafGridView) const;
+        const Vector faceCenterEcl(int cell_index, int face, const Dune::cpgrid::Intersection& intersection) const;
 
         const Vector faceAreaNormalEcl(int face) const;
 

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -534,6 +534,19 @@ namespace Dune
         // @brief TO BE DONE
         const std::map<std::string,int>& getLgrNameToLevel() const;
 
+        /** To be removed - similar method has been introduce in LookUpData.hh for general grids **/
+        // @brief Return parent (coarse) face of a refined face on the leaf grid view, whose neighboring cells
+        //        are two: one coarse cell (equivalent to its origin cell from level 0), and one refined cell
+        //        from certain LGR.
+        //
+        // @param [in] faceOnBoundaryLgrIdx         Index of a refined face on the leaf grid view, 'touching' a coarse cell.
+        // @return     parent face                  'Parent' face on the level zero.
+        const cpgrid::EntityRep<1> getParentFaceFromLgrBoundaryFace(int faceOnBoundaryLgrIdx) const;
+
+
+        
+        Dune::cpgrid::Intersection getParentIntersectionFromLgrBoundaryFace(const Dune::cpgrid::Intersection& intersection) const;
+
         // @breif Compute center of an entity/element/cell in the Eclipse way:
         //        - Average of the 4 corners of the bottom face.
         //        - Average of the 4 corners of the top face.
@@ -997,8 +1010,7 @@ namespace Dune
         /// \brief cell_index The index of the specific cell.
         double cellCenterDepth(int cell_index) const;
 
-
-        const Vector faceCenterEcl(int cell_index, int face) const;
+        const Vector faceCenterEcl(int cell_index, int faceIdxOnLeafGridView) const;
 
         const Vector faceAreaNormalEcl(int face) const;
 

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1130,13 +1130,9 @@ const Dune::FieldVector<double,3> CpGrid::faceCenterEcl(int cell_index, int face
         isCoarseCellOutside = (intersection.outside().level() == 0);
     }
     bool twoCoarseNeighboringCells = isCoarseCellInside && isCoarseCellOutside;
+    bool isOnGridBoundary_coarseNeighboringCell = intersection.boundary() && isCoarseCellInside && (!intersection.neighbor());
 
-    if ((maxLevel() == 0) || twoCoarseNeighboringCells) {
-        for( int i=0; i<4; ++i ) {
-            center += vertexPosition(current_view_data_->cell_to_point_[cell_index][ faceVxMap[ face ][ i ] ]);
-        }
-    }
-
+    
     // For CpGrid with LGRs, a refined face with a coarse neighboring cell and a refined neighboring cell
     // (that is when the face belongs to the boundary of an LGR and is located in the interior of the grid),
     // unfortunately leads us to a different order of the faces, in cell_to_face_, depending on if the
@@ -1146,23 +1142,25 @@ const Dune::FieldVector<double,3> CpGrid::faceCenterEcl(int cell_index, int face
     // cell_to_face_[cell_index - refined neighboring cell] = {bottom, front, left, right, back, top} = {2,3,1,4,0,5} with
     // the notation used in faceVxMap. Therefore, we should consider:
     // --------- this follows the order created in Geometry::refine() for LGRs in CpGrid --------
-    static const int faceVxMapLGR[ 6 ][ 4 ] = { {0, 1, 4, 5}, // lgr_face 2 == face 0  -- left
+    /* static const int faceVxMapLGR[ 6 ][ 4 ] = { {0, 1, 4, 5}, // lgr_face 2 == face 0  -- left
                                                 {2, 3, 6, 7}, // lgr_face 3 == face 1  -- right
                                                 {1, 3, 5, 7}, // lgr_face 1 == face 2  -- front
                                                 {0, 1, 2, 3}, // lgr_face 4 == face 3  -- back
                                                 {0, 2, 4, 6}, // lgr_face 0 == face 4  -- bottom
                                                 {4, 5, 6, 7}  // lgr_face 5 == face 5  -- top
-    };
+                                                };*/
 
-    bool inInteriorLGR = (!isCoarseCellInside) && (!isCoarseCellOutside);
-    bool onGridBoundary_refinedCell = intersection.boundary() && (!isCoarseCellInside);
-    if (inInteriorLGR || onGridBoundary_refinedCell) { // (refined) intersection in the interior of an LGR, or on grid boundary
-        for( int i=0; i<4; ++i ) {
-            center += vertexPosition(current_view_data_->cell_to_point_[cell_index][ faceVxMapLGR[ face ][ i ] ]);
+    // bool inInteriorLGR = (!isCoarseCellInside) && (!isCoarseCellOutside);
+    // bool onGridBoundary_refinedCell = intersection.boundary() && (!isCoarseCellInside);
+
+    for( int i=0; i<4; ++i ) {
+        if ((maxLevel() == 0) || twoCoarseNeighboringCells || isOnGridBoundary_coarseNeighboringCell) {
+            center += vertexPosition(current_view_data_->cell_to_point_[cell_index][ faceVxMap[ face ][ i ] ]);
         }
-    }
-    else { //  (refined) intersection with one coarse neighboring cell and one refined neighboring cell
-        for( int i=0; i<4; ++i ) {
+        /* else if (inInteriorLGR || onGridBoundary_refinedCell) { // (refined) intersection in the interior of an LGR, or on grid boundary
+            center += vertexPosition(current_view_data_->cell_to_point_[cell_index][ faceVxMapLGR[ face ][ i ] ]);
+            }*/
+        else { //  (refined) intersection with one coarse neighboring cell and one refined neighboring cell
             center += vertexPosition(current_view_data_->face_to_point_[intersection.id()][i]);
         }
     }

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -412,7 +412,7 @@ public:
     ///                                           {parent face/cell index in coarse level, {indices of its children in refined level}}
     /// @return child_to_parent_faces/cells       {child index, parent index}
     std::tuple< const std::shared_ptr<CpGridData>,
-                const std::vector<std::array<int,2>>,                // parent_to_refined_corners(~boundary_old_to_new_corners)
+                const std::vector<std::array<int,2>>,                // parent_to_refined_corners(~old_to_new_corners)
                 const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces (~boundary_old_to_new_faces)
                 const std::tuple<int, std::vector<int>>,             // parent_to_children_cells
                 const std::vector<std::array<int,2>>,                // child_to_parent_faces
@@ -427,12 +427,13 @@ public:
     ///                                      Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
     ///
     /// @return refined_grid_ptr                   Shared pointer of CpGridData type, pointing at the refined_grid
-    /// @return boundary_old_to_new_corners/faces  Corner/face indices on the patch-boundary associated with new-born-entity indices.
+    /// @return old_to_new_corners                 Corner indices on the patch associated with new-born-entity indices.
+    /// @return boundary_old_to_new_faces          Face indices on the patch-boundary associated with new-born-entity indices.
     /// @return parent_to_children_faces/cell      For each parent face/cell, we store its child-face/cell indices.
     ///                                            {parent face/cell index in coarse level, {indices of its children in refined level}}
     /// @return child_to_parent_faces/cells        {child index, parent index}
     std::tuple< std::shared_ptr<CpGridData>,
-                const std::vector<std::array<int,2>>,                // boundary_old_to_new_corners
+                const std::vector<std::array<int,2>>,                // old_to_new_corners
                 const std::vector<std::tuple<int,std::vector<int>>>, // boundary_old_to_new_faces
                 const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces
                 const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_cell

--- a/opm/grid/cpgrid/GridHelpers.cpp
+++ b/opm/grid/cpgrid/GridHelpers.cpp
@@ -116,13 +116,13 @@ double cellCenterDepth(const Dune::CpGrid& grid, int cell_index)
 }
 
 
-Vector faceCenterEcl(const Dune::CpGrid& grid, int cell_index, int face_tag)
+Vector faceCenterEcl(const Dune::CpGrid& grid, int cell_index, int face_tag, const Dune::cpgrid::Intersection& intersection)
 {
     // This method is an alternative to the method faceCentroid(...) below.
     // The face center is computed as a raw average of cell corners.
     // For faulted grids, this is likely to give slightly different depths that seem
     // to agree with eclipse.
-    return grid.faceCenterEcl(cell_index, face_tag);
+    return grid.faceCenterEcl(cell_index, face_tag, intersection);
 }
 
 

--- a/opm/grid/cpgrid/GridHelpers.cpp
+++ b/opm/grid/cpgrid/GridHelpers.cpp
@@ -115,6 +115,7 @@ double cellCenterDepth(const Dune::CpGrid& grid, int cell_index)
     return grid.cellCenterDepth(cell_index);
 }
 
+
 Vector faceCenterEcl(const Dune::CpGrid& grid, int cell_index, int face_tag)
 {
     // This method is an alternative to the method faceCentroid(...) below.

--- a/tests/cpgrid/lookupdataCpGrid_test.cpp
+++ b/tests/cpgrid/lookupdataCpGrid_test.cpp
@@ -185,6 +185,20 @@ void lookup_check(const Dune::CpGrid& grid)
             BOOST_CHECK(elem.father().index() == parent_id);
             BOOST_CHECK(elem.father().index() == level0Mapper.index(elem.father()));
         }
+        // Lookupdata for parent faces
+        for(const auto& intersection: intersections(leaf_view, elem)){
+            const auto& intersectionId = intersection.id();
+            try {
+                const auto& parentFace =  grid.getParentFaceFromLgrBoundaryFace(intersectionId);
+                const auto& parentFaceLookupIdx = lookUpData.getParentFaceIdxFromLgrBoundaryFace(intersection);
+                BOOST_CHECK_EQUAL( intersection.indexInInside(), parentFaceLookupIdx.indexInInside() );
+                BOOST_CHECK_EQUAL( parentFace.index(), parentFaceLookupIdx.id());
+                BOOST_CHECK_EQUAL( lookUpData.template isOnLgrBoundaryInteriorGrid(intersection), true);
+            }
+            catch (const std::exception& e) {
+                std::cout<< e.what() << std::endl;
+            }
+        }
     }
 }
 

--- a/tests/test_lookupdata_polyhedral.cpp
+++ b/tests/test_lookupdata_polyhedral.cpp
@@ -47,6 +47,7 @@
 #include <dune/grid/io/file/vtk/vtkwriter.hh>
 #include <opm/grid/cpgrid/dgfparser.hh>
 #include <opm/grid/polyhedralgrid/dgfparser.hh>
+#include <opm/grid/polyhedralgrid/intersection.hh>
 #include <dune/grid/common/mcmgmapper.hh>
 
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
@@ -140,6 +141,18 @@ void lookup_check(const Dune::PolyhedralGrid<3,3>& grid)
         std::array<int,3> ijkThrow;
         BOOST_CHECK_THROW(cartMapper.cartesianCoordinateLevel(idx, ijkThrow, 4), std::invalid_argument);
         BOOST_CHECK_THROW(cartMapper.cartesianCoordinateLevel(idx, ijkThrow, -3), std::invalid_argument);
+        // Lookupdata for parent faces - nothing changes for Polyhedral grid since LGRs are not supported yet
+        for(const auto& intersection: intersections(leaf_view, elem)){
+            using IntersectionType = std::remove_cv_t< typename std::remove_reference<decltype(intersection)>::type>;
+            try {
+                const auto& parentIntersection [[maybe_unused]] = lookUpData.template getParentFaceIdxFromLgrBoundaryFace<IntersectionType, Dune::PolyhedralGrid<3,3> >(intersection);
+            }
+            catch (const std::exception& e) {
+                std::cout<< e.what() << std::endl;
+            }
+            bool isOnLgrBoundary = lookUpData.template isOnLgrBoundaryInteriorGrid<IntersectionType>(intersection);
+            BOOST_CHECK_EQUAL(isOnLgrBoundary, false);
+        }
     }
 }
 


### PR DESCRIPTION
To compute transmissibility, a reduction-argument is used based on certain symmetry between the 'usual' 6 faces of a cell. When the grid is a CpGrid with LGRs, (refined) faces with one neighboring coarse cell and one neighboring refined cell can be found. In these cases, the reduction-argument based on 'symmetry' may lead to wrong transmissibility values.
 
An alternative approach to compute transmissibilities of faces located on LGR boundaries, the 'parent coarse / original' face from level zero could be tracked and used. This PR  adds (and tests) the method getParentFace.