### PR TITLE
Get level idx added to lookup cell indices

### DIFF
--- a/tests/cpgrid/lookupdataCpGrid_test.cpp
+++ b/tests/cpgrid/lookupdataCpGrid_test.cpp
@@ -184,6 +184,10 @@ void lookup_check(const Dune::CpGrid& grid)
             BOOST_CHECK(elem.father().index() == featureInElem -3);
             BOOST_CHECK(elem.father().index() == parent_id);
             BOOST_CHECK(elem.father().index() == level0Mapper.index(elem.father()));
+            BOOST_CHECK(elem.getLevelElem().index() == lookUpData.getLevelIdx(elem.index()));
+        }
+        else {
+            BOOST_CHECK(elem.getOrigin().index() == lookUpData.getLevelIdx(elem.index()));
         }
     }
 }

--- a/tests/test_lookupdata_polyhedral.cpp
+++ b/tests/test_lookupdata_polyhedral.cpp
@@ -122,6 +122,7 @@ void lookup_check(const Dune::PolyhedralGrid<3,3>& grid)
         BOOST_CHECK(featureInElemCartesianIDX == (lookUpData.getFieldPropIdx<Dune::PolyhedralGrid<3,3>>(idx)) +3);
         BOOST_CHECK(featureInElemDoubleCartesianIDX == (lookUpData.getFieldPropIdx<Dune::PolyhedralGrid<3,3>>(idx)) +.5);
         BOOST_CHECK(idx == (lookUpData.getFieldPropIdx<Dune::PolyhedralGrid<3,3>>(idx)));
+        BOOST_CHECK(idx == (lookUpData.getLevelIdx<Dune::PolyhedralGrid<3,3>>(idx)));
         BOOST_CHECK(featureInElemIDX == featureInElem);
         BOOST_CHECK(featureInElemDoubleIDX == featureInElemDouble);
         BOOST_CHECK(featureInElemCartesianIDX == featureInElemCartesian);


### PR DESCRIPTION
For lookup indices, a new method has been added. Given a cell index from the leaf grid view:
- For general grids, returns the same index. 
- For CpGrid with LGRs, return the index on the level when the cell has a father, or the index in level zero otherwise. 

This method will be used in a coming PR in opm-simulators, to skip repeated computation of transmissibilities. 