### PR TITLE
Fix cmake warning with line order change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,11 @@
 #                                                                         #
 ###########################################################################
 
+cmake_minimum_required (VERSION 3.10)
+
 # Mandatory call to project
 project(opm-grid C CXX)
 
-cmake_minimum_required (VERSION 3.10)
 # project information is in dune.module. Read this file and set variables.
 # we cannot generate dune.module since it is read by dunecontrol before
 # the build starts, so it makes sense to keep the data there then.


### PR DESCRIPTION
Change line order to remove this warning:

> CMake Warning (dev) at CMakeLists.txt:16 (project):
>   cmake_minimum_required() should be called prior to this top-level project()
>   call.  Please see the cmake-commands(7) manual for usage documentation of
>   both commands.
> This warning is for project developers.  Use -Wno-dev to suppress it.