### PR TITLE
Refine cells taking into account width, length, height

### DIFF
--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -1808,14 +1808,14 @@ void CpGridData::checkCuboidShape(const std::vector<int>& cellIdx_vec) const
     }
 }
 
-std::array<std::vector<double>,3> CpGridData::getDxDyDz(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
+std::array<std::vector<double>,3> CpGridData::getWidthsLengthsHeights(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
 {
-    std::vector<double> dx;
-    dx.reserve(endIJK[0] - startIJK[0]);
-    std::vector<double> dy;
-    dy.reserve(endIJK[1] - startIJK[1]);
-    std::vector<double> dz;
-    dz.reserve(endIJK[2] - startIJK[2]);
+    std::vector<double> widthsX;
+    widthsX.reserve(endIJK[0] - startIJK[0]);
+    std::vector<double> lengthsY;
+    lengthsY.reserve(endIJK[1] - startIJK[1]);
+    std::vector<double> heightsZ;
+    heightsZ.reserve(endIJK[2] - startIJK[2]);
 
     const std::array<int,3>& grid_dim = this -> logicalCartesianSize();
 
@@ -1823,50 +1823,35 @@ std::array<std::vector<double>,3> CpGridData::getDxDyDz(const std::array<int,3>&
         int cellIdx = (startIJK[2]*grid_dim[0]*grid_dim[1]) + (startIJK[1]*grid_dim[0]) + i;
         const auto cellToPoint = cell_to_point_[cellIdx]; // bottom face corners {0,1,2,3}, top face corners {4,5,6,7}
         // x = |corn[1]-corn[0]|
-        std::vector<cpgrid::Geometry<0,3>::GlobalCoordinate> aFewCorners;
-        aFewCorners.resize(2); // {'0', '1'}
-        aFewCorners[0] = (*(this -> geometry_.geomVector(std::integral_constant<int,3>()))).get(cellToPoint[0]).center();
-        aFewCorners[1] = (*(this -> geometry_.geomVector(std::integral_constant<int,3>()))).get(cellToPoint[1]).center();
-
-        double  x;
-        x = std::sqrt( ((aFewCorners[1][0] -aFewCorners[0][0])*(aFewCorners[1][0] -aFewCorners[0][0])) +
-                       ((aFewCorners[1][1] -aFewCorners[0][1])*(aFewCorners[1][1] -aFewCorners[0][1])) +
-                       ((aFewCorners[1][2] -aFewCorners[0][2])*(aFewCorners[1][2] -aFewCorners[0][2])));
-        dx.push_back(x);
+        // Compute difference and dot using DUNE functionality
+        auto difference = (*(this -> geometry_.geomVector(std::integral_constant<int,3>()))).get(cellToPoint[0]).center();
+        difference -= (*(this -> geometry_.geomVector(std::integral_constant<int,3>()))).get(cellToPoint[1]).center();
+        auto x = difference.two_norm();
+        widthsX.push_back(x);
     }
     for (int j = startIJK[1]; j < endIJK[1]; ++j)
     {
         int cellIdx = (startIJK[2]*grid_dim[0]*grid_dim[1]) + (j*grid_dim[0]) + startIJK[0];
         const auto cellToPoint = cell_to_point_[cellIdx]; // bottom face corners {0,1,2,3}, top face corners {4,5,6,7}
         // y = |corn[3]-corn[1]|
-        std::vector<cpgrid::Geometry<0,3>::GlobalCoordinate> aFewCorners;
-        aFewCorners.resize(2); // {'1', '3'}
-        aFewCorners[0] = (*(this -> geometry_.geomVector(std::integral_constant<int,3>()))).get(cellToPoint[1]).center();
-        aFewCorners[1] = (*(this -> geometry_.geomVector(std::integral_constant<int,3>()))).get(cellToPoint[3]).center();
-
-        double y;
-        y = std::sqrt( ((aFewCorners[1][0] -aFewCorners[0][0])*(aFewCorners[1][0] -aFewCorners[0][0])) +
-                       ((aFewCorners[1][1] -aFewCorners[0][1])*(aFewCorners[1][1] -aFewCorners[0][1])) +
-                       ((aFewCorners[1][2] -aFewCorners[0][2])*(aFewCorners[1][2] -aFewCorners[0][2])));
-        dy.push_back(y);
+        // Compute difference and dot using DUNE functionality
+        auto difference = (*(this -> geometry_.geomVector(std::integral_constant<int,3>()))).get(cellToPoint[3]).center();
+        difference -= (*(this -> geometry_.geomVector(std::integral_constant<int,3>()))).get(cellToPoint[1]).center();
+        auto y = difference.two_norm();
+        lengthsY.push_back(y);
     }
     for (int k = startIJK[2]; k < endIJK[2]; ++k)
     {
         int cellIdx = (k*grid_dim[0]*grid_dim[1]) + (startIJK[1]*grid_dim[0]) + startIJK[0];
         const auto cellToPoint = cell_to_point_[cellIdx]; // bottom face corners {0,1,2,3}, top face corners {4,5,6,7}
         // z = |corn[4]-corn[0]|
-        std::vector<cpgrid::Geometry<0,3>::GlobalCoordinate> aFewCorners;
-        aFewCorners.resize(2); // {'0', '4'}
-        aFewCorners[0] = (*(this -> geometry_.geomVector(std::integral_constant<int,3>()))).get(cellToPoint[0]).center();
-        aFewCorners[1] = (*(this -> geometry_.geomVector(std::integral_constant<int,3>()))).get(cellToPoint[4]).center();
-
-        double  z;
-        z = std::sqrt( ((aFewCorners[1][0] -aFewCorners[0][0])*(aFewCorners[1][0] -aFewCorners[0][0])) +
-                       ((aFewCorners[1][1] -aFewCorners[0][1])*(aFewCorners[1][1] -aFewCorners[0][1])) +
-                       ((aFewCorners[1][2] -aFewCorners[0][2])*(aFewCorners[1][2] -aFewCorners[0][2])));
-        dz.push_back(z);
+        // Compute difference and dot using DUNE functionality
+        auto difference = (*(this -> geometry_.geomVector(std::integral_constant<int,3>()))).get(cellToPoint[4]).center();
+        difference -= (*(this -> geometry_.geomVector(std::integral_constant<int,3>()))).get(cellToPoint[0]).center();
+        auto z = difference.two_norm();
+        heightsZ.push_back(z);
     }
-    return {dx, dy, dz};
+    return {widthsX, lengthsY, heightsZ};
 }
 
 std::vector<int> CpGridData::getPatchBoundaryCorners(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
@@ -2219,7 +2204,7 @@ CpGridData::refinePatch(const std::array<int,3>& cells_per_dim, const std::array
     const auto& patch_cells = getPatchCells(startIJK, endIJK);
     checkCuboidShape(patch_cells);
     // Get dx,dy,dz for each cell of the patch to be refined
-    const auto& [dx, dy, dz] = getDxDyDz(startIJK, endIJK);
+    const auto& [widthsX, lengthsY, heightsZ] = getWidthsLengthsHeights(startIJK, endIJK);
     // Construct the Geometry of the cellified patch.
     DefaultGeometryPolicy cellified_patch_geometry;
     std::array<int,8> cellifiedPatch_to_point;
@@ -2237,7 +2222,7 @@ CpGridData::refinePatch(const std::array<int,3>& cells_per_dim, const std::array
                                          refined_face_tags,
                                          refined_face_normals,
                                          patch_dim,
-                                         dx, dy, dz);
+                                         widthsX, lengthsY, heightsZ);
 
     // Some integers to reduce notation later.
     const int& xfactor = cells_per_dim[0]*patch_dim[0];

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -318,9 +318,6 @@ public:
     /// @brief Check that every cell to be refined has cuboid shape.
     void checkCuboidShape(const std::vector<int>& cellIdx_vec) const;
 
-    /// @brief For selected cell indices, computes the variation in x-,y-, and z-direction, assuming each cell has cubiod shape.
-    std::array<std::vector<double>,3> getDxDyDz(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
-
 private:
     /// @brief Compute amount of cells in each direction of a patch of cells. (Cartesian grid required).
     ///
@@ -366,6 +363,9 @@ private:
     ///
     /// @return patch_boundary_corners
     std::vector<int> getPatchBoundaryCorners(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
+
+    /// @brief For selected cell indices, computes the variation in x-,y-, and z-direction, assuming each cell has cubiod shape.
+    std::array<std::vector<double>,3> getWidthsLengthsHeights(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
 
     /// @brief Construct a 'fake cell (Geometry<3,3> object)' out of a patch of cells.(Cartesian grid required).
     ///

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -318,6 +318,9 @@ public:
     /// @brief Check that every cell to be refined has cuboid shape.
     void checkCuboidShape(const std::vector<int>& cellIdx_vec) const;
 
+    /// @brief For selected cell indices, computes the variation in x-,y-, and z-direction, assuming each cell has cubiod shape.
+    std::array<std::vector<double>,3> getDxDyDz(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
+
 private:
     /// @brief Compute amount of cells in each direction of a patch of cells. (Cartesian grid required).
     ///

--- a/opm/grid/cpgrid/Geometry.hpp
+++ b/opm/grid/cpgrid/Geometry.hpp
@@ -986,6 +986,425 @@ namespace Dune
                 /// --- END REFINED CELLS ---
             } /// --- END of refine()
 
+
+             /**
+             * @brief Refine a single cell considering different widths, lengths, and heights.
+             *
+             * For each cell to be created, storage must be passed for its corners and the indices. That storage
+             * must be externally managed, since the newly created geometry structures only store pointers and do
+             * not free them on destruction.
+             *
+             * @param cells_per_dim                  The number of sub-cells in each direction,
+             * @param all_geom                       Geometry Policy for the refined geometries. Those will be added there.
+             * @param refined_cell_to_point          Map from cell to its 8 corners.
+             * @param refined_cell_to_face           Map from cell to its oriented faces, used to build face_to_cell_.
+             * @param refined_face_to_point          Map from face to its points.
+             * @param refined_face_to_cell           Map from face to its neighboring cells.
+             * @param refined_face_tags              Face tags (I_FACE, J_FACE, K_FACE).
+             * @param refined_face_normals           Face normal(s) (only one per face is computed).
+             * @param patch_dim                      Amount of cells to be refined, in each direction.
+             * @param dx, dy, dz                     Vectors of widths (x-dir), lengths (y-dir), and heights (z-dir)
+             */
+            void refineCellifiedPatch(const std::array<int,3>& cells_per_dim,
+                                      DefaultGeometryPolicy& all_geom,
+                                      std::vector<std::array<int,8>>&  refined_cell_to_point,
+                                      cpgrid::OrientedEntityTable<0,1>& refined_cell_to_face,
+                                      Opm::SparseTable<int>& refined_face_to_point,
+                                      cpgrid::OrientedEntityTable<1,0>& refined_face_to_cell,
+                                      cpgrid::EntityVariable<enum face_tag, 1>& refined_face_tags,
+                                      cpgrid::SignedEntityVariable<PointType, 1>& refined_face_normals,
+                                      const std::array<int,3>& patch_dim, 
+                                      const std::vector<double>& dx,
+                                      const std::vector<double>& dy,
+                                      const std::vector<double>& dz) const
+            {
+                EntityVariableBase<cpgrid::Geometry<0,3>>& refined_corners =
+                    *(all_geom.geomVector(std::integral_constant<int,3>()));
+                EntityVariableBase<cpgrid::Geometry<2,3>>& refined_faces =
+                    *(all_geom.geomVector(std::integral_constant<int,1>()));
+                EntityVariableBase<cpgrid::Geometry<3,3>>& refined_cells =
+                    *(all_geom.geomVector(std::integral_constant<int,0>()));
+                EntityVariableBase<enum face_tag>& mutable_face_tags = refined_face_tags;
+                EntityVariableBase<PointType>& mutable_face_normals = refined_face_normals;
+    
+                /// --- REFINED CORNERS ---
+                // The strategy is to compute the local refined corners
+                // of the unit/reference cube, and then apply the map global().
+                // Determine the size of the vector containing all the corners
+                // of all the global refined cells (children cells).
+                // For easier notation:
+                const std::array<int,3>& refined_dim = { cells_per_dim[0]*patch_dim[0], cells_per_dim[1]*patch_dim[1], cells_per_dim[2]*patch_dim[2]};
+                refined_corners.resize((refined_dim[0] + 1)*(refined_dim[1] + 1)*(refined_dim[2] + 1));
+                // The nummbering starts at the botton, so k=0 (z-axis), and j=0 (y-axis), i=0 (x-axis).
+                // Then, increasing k ('going up'), followed by increasing i ('going right->'),
+                // and finally, increasing j ('going back'). This order criteria for corners
+                // 'Up [increasing k]- Right [incresing i]- Back [increasing j]'
+                // is consistant with cpgrid numbering.
+                //
+                assert(static_cast<int>(dx.size()) == patch_dim[0]);
+                assert(static_cast<int>(dy.size()) == patch_dim[1]);
+                assert(static_cast<int>(dz.size()) == patch_dim[2]);
+                const auto localCoordNumerator = []( const std::vector<double>& vec, int sumLimit, double multiplier) {
+                    double lcn = 0;
+                    assert(!vec.empty());
+                    assert(sumLimit <= static_cast<int>(vec.size()));
+                    lcn += multiplier*vec[sumLimit];
+                    for (int m = 0; m < sumLimit; ++m) {
+                        lcn += vec[m];
+                    }
+                    return lcn;
+                };
+                // E.g. localCoordNumerator( dx, 3, 0.25) =  x0 + x1 + x2 + 0.25.x3
+                //
+                const double sum_dx = std::accumulate(dx.begin(), dx.end(), double(0)); // x0 + x1 + ... + xL, if dx = {x0, x1, ..., xL}
+                const double sum_dy = std::accumulate(dy.begin(), dy.end(), double(0)); // y0 + y1 + ... + yM, if dy = {y0, y1, ..., yM}
+                const double sum_dz = std::accumulate(dz.begin(), dz.end(), double(0)); // z0 + z1 + ... + zN, if dz = {z0, z1, ..., zN}
+                std::cout << "sum_x: " << sum_dx << " sum_y: " << sum_dy << " sum_z: " << sum_dz << std::endl;
+                for (int j = 0; j < refined_dim[1] +1; ++j) {
+                    for (int i = 0; i < refined_dim[0] +1; ++i) {
+                        for (int k = 0; k < refined_dim[2] +1; ++k) {
+                            // Compute the index of each global refined corner associated with 'jik'.
+                            int refined_corner_idx =
+                                (j*(refined_dim[0]+1)*(refined_dim[2]+1)) + (i*(refined_dim[2]+1)) + k;
+                            // Compute the local refined corner of the unit/reference cube associated with 'jik'.
+                            const double local_x = localCoordNumerator(dx, i/cells_per_dim[0], double((i % cells_per_dim[0])) / cells_per_dim[0]);
+                            const double local_y = localCoordNumerator(dy, j/cells_per_dim[1], double((j % cells_per_dim[1])) / cells_per_dim[1]);
+                            const double local_z = localCoordNumerator(dz, k/cells_per_dim[2], double((k % cells_per_dim[2])) /cells_per_dim[2]);
+                            std::cout << "local_x, y, z: " << local_x << " " <<  local_y << " "<< local_z << std::endl;
+                            const LocalCoordinate& local_refined_corner = { local_x/sum_dx, local_y/sum_dy, local_z/sum_dz };
+                            assert(local_x/sum_dx <= 1.);
+                            assert(local_y/sum_dy <= 1.);
+                            assert(local_z/sum_dz <= 1.);
+                            // { (x0 ...+ x(l-1) + (l*xl / cells_per_dim[0]))/ (x0 +...+ xL),
+                            //   (y0+ ...+ y(m-1) + (m*ym / cells_per_dim[1]))/(y0 +...+ yM),
+                            //   (z0+ ...+ z(n-1) + (n*zn / cells_per_dim[2]))/(z0 +...+ zN)}
+                            // Compute the global refined corner 'jik' and add it in its corresponfing entry in "refined_corners".
+                            refined_corners[refined_corner_idx] = Geometry<0, 3>(this->global(local_refined_corner));
+                        } // end k-for-loop
+                    } // end j-for-loop
+                } // end i-for-loop
+                /// --- END REFINED CORNERS ---
+                //
+                /// --- REFINED FACES ---
+                // We want to populate "refined_faces". The size of "refined_faces" is
+                const int refined_faces_size =
+                    (refined_dim[0]*refined_dim[1]*(refined_dim[2]+1)) // 'bottom/top faces'
+                    + ((refined_dim[0]+1)*refined_dim[1]*refined_dim[2]) // 'left/right faces'
+                    + (refined_dim[0]*(refined_dim[1]+1)*refined_dim[2]); // 'front/back faces'
+                refined_faces.resize(refined_faces_size);
+                refined_face_tags.resize(refined_faces_size);
+                refined_face_normals.resize(refined_faces_size);
+                //
+                // To create a face as a Geometry<2,3> type object we need its CENTROID and its VOLUME(area).
+                // We store the centroids/areas  in the following order:
+                // - Bottom-top faces -> 3rd coordinate constant in each face.
+                // - Left-right faces -> 1st coordinate constant in each face.
+                // - Front-back faces -> 2nd coordinate constant in each face.
+                //
+                // REFINED FACE AREAS
+                // To compute the area of each face, we divide it in 4 triangles,
+                // compute the area of those with "area()", where the arguments
+                // are the 3 corners of each triangle. Then, sum them up to get the area
+                // of the global refined face.
+                // For each face, we construct 4 triangles with
+                // (1) centroid of the face,
+                // (2) one of the edges of the face.
+                //
+                // A triangle has 3 edges. Once we choose a face to base a triangle on,
+                // we choose an edge of that face as one of the edges of the triangle.
+                // The other 2 edges are fixed, since the centroid of the face the triangle
+                // is based on is one of its corners. That's why to identify
+                // a triangle we only need two things:
+                // (1) the face it's based on and
+                // (2) one of the four edges of that face.
+                //
+                // For each face, we need
+                // 1. index of the refined face
+                //    [needed to access indices of the 4 edges of the face in "refined_face_to_edges"]
+                // 2. centroid of the face (common corner of the 4 triangles based on that face).
+                //    [available via "['face'].center()"
+                // 3. container of 4 entries (the 4 edges of the face).
+                //    Each entry consists in the 2 indices defining each edge of the face.
+                //    [available in "refined_face_to_edges"].
+                //
+                // Populate "mutable_face_tags/normals", "refined_face_to_point/cell",
+                // "refined_faces".
+                //
+                for (int constant_direction = 0; constant_direction < 3; ++constant_direction){
+                    // adding %3 and constant_direction, we go through the 3 type of faces.
+                    // 0 -> 3rd coordinate constant: l('k') < cells_per_dim[2]+1, m('j') < cells_per_dim[1], n('i') < cells_per_dim[0]
+                    // 1 -> 1rt coordinate constant: l('i') < cells_per_dim[0]+1, m('k') < cells_per_dim[2], n('j') < cells_per_dim[1]
+                    // 2 -> 2nd coordinate constant: l('j') < cells_per_dim[1]+1, m('i') < cells_per_dim[0], n('k') < cells_per_dim[2]
+                    std::array<int,3> refined_dim_mixed = {
+                        refined_dim[(2+constant_direction)%3],
+                        refined_dim[(1+constant_direction)%3],
+                        refined_dim[constant_direction % 3] };
+                    for (int l = 0; l < refined_dim_mixed[0] + 1; ++l) {
+                        for (int m = 0; m < refined_dim_mixed[1]; ++m) {
+                            for (int n = 0; n < refined_dim_mixed[2]; ++n) {
+                                // Compute the face data.
+                                auto [face_tag, idx, face_to_point, face_to_cell, wrong_local_centroid] =
+                                    getIndicesFace(l, m, n, constant_direction, refined_dim);
+                                // Add the tag to "refined_face_tags".
+                                mutable_face_tags[idx]= face_tag;
+                                // Add the 4 corners of the face to "refined_face_to_point".
+                                refined_face_to_point.appendRow(face_to_point.begin(), face_to_point.end());
+                                // Add the neighboring cells of the face to "refined_face_to_cell".
+                                refined_face_to_cell.appendRow(face_to_cell.begin(), face_to_cell.end());
+                                // Compute the centroid as the average of the 4 corners of the face
+                                GlobalCoordinate face_center = { 0., 0., 0.};
+                                for (int corn = 0; corn < 4; ++corn){
+                                    face_center += refined_corners[face_to_point[corn]].center();
+                                }
+                                face_center /= 4.;
+                                // Construct global face normal(s) (only one 'needed') and add it to "mutable_face_normals"
+                                // Construct two vectors in the face, e.g. difference of two conners with the centroid,
+                                // then obtain an orthogonal vector to both of them. Finally, normalize.
+                                // Auxuliary vectors on the face:
+                                GlobalCoordinate face_vector0 = refined_corners[face_to_point[0]].center() - face_center;
+                                GlobalCoordinate face_vector1 = refined_corners[face_to_point[1]].center() - face_center;
+                                mutable_face_normals[idx] = {
+                                    (face_vector0[1]*face_vector1[2]) -  (face_vector0[2]*face_vector1[1]),
+                                    (face_vector0[2]*face_vector1[0]) -  (face_vector0[0]*face_vector1[2]),
+                                    (face_vector0[0]*face_vector1[1]) -  (face_vector0[1]*face_vector1[0])};
+                                mutable_face_normals[idx] /= mutable_face_normals[idx].two_norm();
+                                if (face_tag == J_FACE) {
+                                    mutable_face_normals[idx] *= -1;
+                                }
+                                // Construct "refined_face_to_edges"
+                                // with the {edge_indix[0], edge_index[1]} for each edge of the refined face.
+                                std::vector<std::array<int,2>> refined_face_to_edges = {
+                                    { face_to_point[0], face_to_point[1] },
+                                    { face_to_point[0], face_to_point[2] },
+                                    { face_to_point[1], face_to_point[3] },
+                                    { face_to_point[2], face_to_point[3] }
+                                };
+                                // Calculate the AREA of each face of a global refined face,
+                                // by adding the 4 areas of the triangles partitioning each face.
+                                double refined_face_area = 0.0;
+                                for (int edge = 0; edge < 4; ++edge) {
+                                    // Construction of each triangle on the current face with one
+                                    // of its edges equal to "edge".
+                                    Geometry<0,3>::GlobalCoordinate trian_corners[3] = {
+                                        refined_corners[refined_face_to_edges[edge][0]].center(),
+                                        refined_corners[refined_face_to_edges[edge][1]].center(),
+                                        face_center };
+                                    refined_face_area += std::fabs(area(trian_corners));
+                                } // end edge-for-loop
+                                //
+                                //
+                                // Construct the Geometry<2,3> of the global refined face.
+                                refined_faces[idx] = Geometry<2,cdim>(face_center, refined_face_area);
+                            } // end n-for-loop
+                        } // end m-for-loop
+                    } // end l-for-loop
+                } // end r-for-loop
+                /// --- END REFINED FACES ---
+                //
+                /// --- REFINED CELLS ---
+                // We need to populate "refined_cells"
+                // "refined_cells"'s size is cells_per_dim[0] * cells_per_dim[1] * cells_per_dim[2].
+                // To build each global refined cell, we need
+                // 1. its global refined CENTER
+                // 2. its VOLUME
+                // 3. all global refined corners [available in "refined_corners"]
+                // 4. indices of its 8 corners.
+                //
+                refined_cells.resize(refined_dim[0] * refined_dim[1] * refined_dim[2]);
+                // Vector to store, in each entry, the 8 indices of the 8 corners
+                // of each global refined cell. Determine its size.
+                refined_cell_to_point.resize(refined_dim[0] * refined_dim[1] * refined_dim[2]);
+                // The numembering starts with index 0 for the refined cell with corners
+                // {0,0,0}, ...,{1/cells_per_dim[0], 1/cells_per_dim[1], 1/cells_per_dim[2]},
+                // then the indices grow first picking the cells in the x-axis (Right, i), then y-axis (Back, j), and
+                // finally, z-axis (Up, k).
+                //
+                // CENTERS
+                // REFINED CELL CENTERS
+                // The strategy is to compute the centers of the refined local
+                // unit/reference cube, and then apply the map global().
+                //
+                // VOLUMES OF THE REFINED CELLS
+                // REMARK: Each global refined 'cell' is a hexahedron since it may not be cube-shaped
+                // since its a 'deformation' of unit/reference cube. We may use 'hexahedron' to refer
+                // to the global refined cell in the computation of its volume.
+                //
+                // The strategy is to construct 24 tetrahedra in each hexahedron.
+                // Each tetrahedron is built with
+                // (1) the center of the hexahedron,
+                // (2) the middle point of the face the tetrahedron is based on, and
+                // (3) one of the edges of the face mentioned in 2.
+                // Each face 'supports' 4 tetrahedra, and we have 6 faces per hexahedron, which
+                // gives us the 24 tetrahedra per 'cell' (hexahedron).
+                //
+                // To compute the volume of each tetrahedron, we use "simplex_volume()" with
+                // the 6 corners of the tetrahedron as arguments. Summing up the 24 volumes,
+                // we get the volumne of the hexahedorn (global refined 'cell').
+                //
+                // Sum of all the volumes of all the (children) global refined cells.
+                double sum_all_refined_cell_volumes = 0.0;
+                //
+                // For each (global refined 'cell') hexahedron, to create 24 tetrahedra and their volumes,
+                // we introduce
+                // Vol1. "hexa_to_face" (needed to access face centroids).
+                // Vol2. "hexa_face_centroids" (one of the 6 corners of all 4 tetrahedra based on that face).
+                // Vol3.  the center of the global refined 'cell' (hexahedron)
+                //       (common corner of the 24 tetrahedra).
+                // Vol4. "tetra_edge_indices" indices of the 4x6 tetrahedra per 'cell',
+                //        grouped by the face they are based on.
+                // Then we construct and compute the volume of the 24 tetrahedra with mainly
+                // "hexa_face_centroids" (Vol2.), global refined cell center (Vol3.), and "tetra_edge_indices" (Vol4.).
+                //
+                for (int k = 0; k < refined_dim[2]; ++k) {
+                    for (int j = 0; j < refined_dim[1]; ++j) {
+                        for (int i = 0; i < refined_dim[0]; ++i) {
+                            // INDEX of the global refined cell associated with 'kji'.
+                            int refined_cell_idx = (k*refined_dim[0]*refined_dim[1]) + (j*refined_dim[0]) +i;
+                            // Obtain the global refined center with 'this->global(local_refined_cell_center)'.
+                            // 2. VOLUME of the global refined 'kji' cell
+                            double refined_cell_volume = 0.0; // (computed below!)
+                            // 3. All Global refined corners ("refined_corners")
+                            // 4. Indices of the 8 corners of the global refined cell associated with 'kji'.
+                            std::array<int,8> cell_to_point = { //
+                                (j*(refined_dim[0]+1)*(refined_dim[2]+1))     + (i*(refined_dim[2]+1))      +k, // fake '0' {0,0,0}
+                                (j*(refined_dim[0]+1)*(refined_dim[2]+1))     + ((i+1)*(refined_dim[2]+1))  +k, // fake '1' {1,0,0}
+                                ((j+1)*(refined_dim[0]+1)*(refined_dim[2]+1)) + (i*(refined_dim[2]+1))      +k, // fake '2' {0,1,0}
+                                ((j+1)*(refined_dim[0]+1)*(refined_dim[2]+1)) + ((i+1)*(refined_dim[2]+1))  +k, // fake '3' {1,1,0}
+                                (j*(refined_dim[0]+1)*(refined_dim[2]+1))     + (i*(refined_dim[2]+1))      +k+1, // fake '4' {0,0,1}
+                                (j*(refined_dim[0]+1)*(refined_dim[2]+1))     + ((i+1)*(refined_dim[2]+1))  +k+1, // fake '5' {1,0,1}
+                                ((j+1)*(refined_dim[0]+1)*(refined_dim[2]+1)) + (i*(refined_dim[2]+1))      +k+1, // fake '6' {0,1,1}
+                                ((j+1)*(refined_dim[0]+1)*(refined_dim[2]+1)) + ((i+1)*(refined_dim[2]+1))  +k+1 // fake '7' {1,1,1}
+                            };
+                            // Add this 8 corners to the corresponding entry of "refined_cell_to_point".
+                            refined_cell_to_point[refined_cell_idx] = cell_to_point;
+                            // 1. CENTER of the global refined cell associated with 'kji' (Vol3.)
+                            // Compute the center of the local refined unit/reference cube associated with 'kji'.
+                            GlobalCoordinate refined_cell_center = {0., 0., 0.};
+                            for (int corn = 0; corn < 8; ++corn) {
+                                refined_cell_center += refined_corners[cell_to_point[corn]].center();
+                            }
+                            refined_cell_center /= 8.;
+                            //
+                            // VOLUME HEXAHEDRON (GLOBAL REFINED 'CELL')
+                            // Vol1. INDICES ('from 0 to 5') of the faces of the hexahedron (needed to access face centroids).
+                            std::vector<int> hexa_to_face = { //hexa_face_0to5_indices = {
+                                // index face '0' bottom
+                                (k*refined_dim[0]*refined_dim[1]) + (j*refined_dim[0]) + i,
+                                // index face '1' front
+                                (refined_dim[0]*refined_dim[1]*(refined_dim[2]+1))
+                                +  ((refined_dim[0]+1)*refined_dim[1]*refined_dim[2])
+                                + (j*refined_dim[0]*refined_dim[2]) + (i*refined_dim[2]) + k,
+                                // index face '2' left
+                                (refined_dim[0]*refined_dim[1]*(refined_dim[2]+1))
+                                + (i*refined_dim[1]*refined_dim[2]) + (k*refined_dim[1]) + j,
+                                // index face '3' right
+                                (refined_dim[0]*refined_dim[1]*(refined_dim[2]+1))
+                                + ((i+1)*refined_dim[1]*refined_dim[2]) + (k*refined_dim[1]) + j,
+                                // index face '4' back
+                                (refined_dim[0]*refined_dim[1]*(refined_dim[2]+1)) +
+                                ((refined_dim[0]+1)*refined_dim[1]*refined_dim[2])
+                                + ((j+1)*refined_dim[0]*refined_dim[2]) + (i*refined_dim[2]) + k,
+                                // index face '5' top
+                                ((k+1)*refined_dim[0]*refined_dim[1]) + (j*refined_dim[0]) + i};
+                            //
+                            //  We add the 6 faces of the cell into "refined_cell_to_face".
+                            using cpgrid::EntityRep;
+                            // First value is index, Second is orientation.
+                            // Still have to find out what the orientation should be.
+                            // right face ('3') outer normal points 'from left to right' -> orientation true
+                            // back face ('4') outer normal points 'from front to back' -> orientation true
+                            // top face ('5') outer normal points 'from bottom to top' -> orientation true
+                            // (the other cases are false)
+                            std::vector<cpgrid::EntityRep<1>> cell_to_face = {
+                                { hexa_to_face[0], false}, {hexa_to_face[1], false},
+                                { hexa_to_face[2], false}, {hexa_to_face[3], true},
+                                { hexa_to_face[4], true},  {hexa_to_face[5], true} };
+                            refined_cell_to_face.appendRow(cell_to_face.begin(), cell_to_face.end());
+                            //
+                            // Vol2. CENTROIDS of the faces of the hexahedron.
+                            // (one of the 6 corners of all 4 tetrahedra based on that face).
+                            std::vector<Geometry<0,3>::GlobalCoordinate> hexa_face_centroids;
+                            for (auto& idx : hexa_to_face) {
+                                hexa_face_centroids.push_back(refined_faces[idx].center());
+                            }
+                            // Indices of the 4 edges of each face of the hexahedron.
+                            // A tetrahedron has six edges. Once we choose a face to base a
+                            // tetrahedron on, we choose an edge of that face as one of the
+                            // edges of the tetrahedron. The other five edges are fixed, since
+                            // the center of the hexahedron and the center of the face are
+                            // the reminder 2 corners of the tetrahedron. That's why to identify
+                            // a tetrahedron we only need two things:
+                            // (1) the face it's based on and
+                            // (2) one of the four edges of that face.
+                            //
+                            // Container with 6 entries, one per face. Each entry has the
+                            // 4 indices of the 4 corners of each face.
+                            std::vector<std::array<int,4>> cell_face4corners;
+                            cell_face4corners.reserve(6);
+                            for (int face = 0; face < 6;  ++face) {
+                                cell_face4corners.push_back({
+                                        refined_face_to_point[hexa_to_face[face]][0],
+                                        refined_face_to_point[hexa_to_face[face]][1],
+                                        refined_face_to_point[hexa_to_face[face]][2],
+                                        refined_face_to_point[hexa_to_face[face]][3] });
+                            }
+                            // Vol4. Container with indices of the edges of the 4 tetrahedra per face
+                            // [according to description above]
+                            std::vector<std::vector<std::array<int,2>>> tetra_edge_indices;
+                            tetra_edge_indices.reserve(6);
+                            for (auto& face_indices : cell_face4corners)
+                            {
+                                std::vector<std::array<int,2>> face4edges_indices = {
+                                    { face_indices[0], face_indices[1]}, // fake '{0,1}'/'{4,5}'
+                                    { face_indices[0], face_indices[2]}, // fake '{0,2}'/'{4,6}'
+                                    { face_indices[1], face_indices[3]}, // fake '{1,3}'/'{5,7}'
+                                    { face_indices[2], face_indices[3]} }; // fake '{2,3}'/'{6,7}'
+                                tetra_edge_indices.push_back(face4edges_indices);
+                            }
+                            // Sum of the 24 volumes to get the volume of the hexahedron,
+                            // stored in "refined_cell_volume".
+                            // Calculate the volume of each hexahedron, by adding
+                            // the 4 tetrahedra at each face (4x6 = 24 tetrahedra).
+                            for (int face = 0; face < 6; ++face) {
+                                for (int edge = 0; edge < 4; ++edge) {
+                                    // Construction of each tetrahedron based on "face" with one
+                                    // of its edges equal to "edge".
+                                    const Geometry<0, 3>::GlobalCoordinate tetra_corners[4] = {
+                                        refined_corners[tetra_edge_indices[face][edge][0]].center(),  // (see Vol4.)
+                                        refined_corners[tetra_edge_indices[face][edge][1]].center(),  // (see Vol4.)
+                                        hexa_face_centroids[face],  // (see Vol2.)
+                                        refined_cell_center };  // (see Vol3.)
+                                    refined_cell_volume += std::fabs(simplex_volume(tetra_corners));
+                                } // end edge-for-loop
+                            } // end face-for-loop
+                            // Add the volume of the hexahedron (global refined 'cell')
+                            // to the container with of all volumes of all the refined cells.
+                            sum_all_refined_cell_volumes += refined_cell_volume;
+                            // Create a pointer to the first element of "refined_cell_to_point"
+                            // (required as the fourth argement to construct a Geometry<3,3> type object).
+                            int* indices_storage_ptr = refined_cell_to_point[refined_cell_idx].data();
+                            // Construct the Geometry of the refined cell associated with 'kji'.
+                            refined_cells[refined_cell_idx] =
+                                Geometry<3,cdim>(refined_cell_center,
+                                                 refined_cell_volume,
+                                                 all_geom.geomVector(std::integral_constant<int,3>()),
+                                                 indices_storage_ptr);
+                        } // end i-for-loop
+                    }  // end j-for-loop
+                } // end k-for-loop
+                // Rescale all volumes if the sum of volume of all the global refined 'cells' does not match the
+                // volume of the 'parent cell'.
+                // Compare the sum of all the volumes of all refined cells with 'parent cell' volume.
+                if (std::fabs(sum_all_refined_cell_volumes - this->volume())
+                    > std::numeric_limits<Geometry<3, cdim>::ctype>::epsilon()) {
+                    Geometry<3, cdim>::ctype correction = this->volume() / sum_all_refined_cell_volumes;
+                    for(auto& cell: refined_cells){
+                        cell.vol_ *= correction;
+                    }
+                } // end if-statement
+                /// --- END REFINED CELLS ---
+            } /// --- END of refine(dx, dy, dz)
+
         private:
             GlobalCoordinate pos_;
             double vol_;

--- a/tests/cpgrid/grid_lgr_test.cpp
+++ b/tests/cpgrid/grid_lgr_test.cpp
@@ -429,15 +429,6 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
                     {
                         face_count +=1;
                     }
-                    /*std::cout << "Entity old index: " << entityOldIdx << "Entity leaf idx: " << entity.index() << '\n';
-                    std::cout << "Leaf cell_to_face_.size(): " << leaf_cell_to_face.size() << '\n';
-                    std::cout << "Face count: " << face_count << '\n';
-                    std::cout << "touch_patch_onLeftFace: " << touch_patch_onLeftFace << '\n';
-                    std::cout << "touch_patch_onRightFace: " << touch_patch_onRightFace << '\n';
-                    std::cout << "touch_patch_onFrontFace: " << touch_patch_onFrontFace << '\n';
-                    std::cout << "touch_patch_onBackFace: " << touch_patch_onBackFace << '\n';
-                    std::cout << "touch_patch_onBottomFace: " << touch_patch_onBottomFace << '\n';
-                    std::cout << "touch_patch_onTopFace: " << touch_patch_onTopFace << '\n';*/
                     BOOST_CHECK( leaf_cell_to_face.size() == face_count);
                 } // end else
             }
@@ -477,6 +468,21 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
             }
         }
     }
+}
+
+
+BOOST_AUTO_TEST_CASE(refine_patch_different_cell_sizes)
+{
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {2.0, 1.0, 4.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {2,2,2};
+    const std::array<int, 3> startIJK = {1,0,1};
+    const std::array<int, 3> endIJK = {3,2,3};  // patch_dim = {3-1, 2-0, 3-1} ={2,2,2}
+    const std::string lgr_name = {"LGR1"};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+    refinePatch_and_check(coarse_grid, {cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
 }
 
 BOOST_AUTO_TEST_CASE(refine_patch)

--- a/tests/cpgrid/grid_lgr_test.cpp
+++ b/tests/cpgrid/grid_lgr_test.cpp
@@ -641,7 +641,6 @@ void check_global_refine(const Dune::CpGrid& refined_grid, const Dune::CpGrid& e
     for(const auto& element: elements(grid_view))
     {
         BOOST_CHECK( element.getOrigin().level() == 0);
-        //BOOST_CHECK( element.getOrigin().index() == element.index());
         for(const auto& intersection: intersections(grid_view, element))
         {
             // find matching intersection (needed as ordering is allowed to be different


### PR DESCRIPTION
A new method has been added in Geometry, to refine a single cell taking into account different widths, lengths, and heights.  It generalizes the previous refine() whose refinement is uniform. 
