### PR TITLE
Refactor faceCenterEcl and track parent coarse intersection on LGR boundary

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -550,7 +550,10 @@ namespace Dune
         // @return                   'eclipse centroid'
         std::array<double,3> getEclCentroid(const cpgrid::Entity<0>& elem) const;
 
-
+        // @brief Return parent (coarse) intersection (face) of a refined face on the leaf grid view, whose neighboring cells
+        //        are two: one coarse cell (equivalent to its origin cell from level 0), and one refined cell
+        //        from certain LGR
+        Dune::cpgrid::Intersection getParentIntersectionFromLgrBoundaryFace(const Dune::cpgrid::Intersection& intersection) const;
 
         /*  No refinement implemented. GridDefaultImplementation's methods will be used.
 
@@ -998,7 +1001,7 @@ namespace Dune
         double cellCenterDepth(int cell_index) const;
 
 
-        const Vector faceCenterEcl(int cell_index, int face) const;
+        const Vector faceCenterEcl(int cell_index, int face, const Dune::cpgrid::Intersection& intersection) const;
 
         const Vector faceAreaNormalEcl(int face) const;
 

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1114,13 +1114,11 @@ Dune::cpgrid::Intersection CpGrid::getParentIntersectionFromLgrBoundaryFace(cons
                 }
             }
         }
-        else {
-            OPM_THROW(std::invalid_argument, "Parent intersection not found");
-        }
+        OPM_THROW(std::invalid_argument, "Parent intersection not found for face with index: " + std::to_string(intersection.id()) +
+                  " and index in inside: " + std::to_string(intersection.indexInInside()));
     }
     OPM_THROW(std::invalid_argument, "Face is on the boundary of the grid");
 }
-
 
 double CpGrid::cellCenterDepth(int cell_index) const
 {

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1085,6 +1085,43 @@ int CpGrid::faceVertex(int face, int local_index) const
     return current_view_data_->face_to_point_[face][local_index];
 }
 
+Dune::cpgrid::Intersection CpGrid::getParentIntersectionFromLgrBoundaryFace(const Dune::cpgrid::Intersection& intersection) const
+{
+    if ( intersection.neighbor()) {
+        if ((intersection.inside().level() != intersection.outside().level())) {
+            // one coarse and one refined neighboring cell
+            const auto& cellIn = intersection.inside();
+            const auto& cellOut = intersection.outside();
+
+            // Identify the coarse and the refined neighboring cell
+            const auto coarseCell =  (cellIn.level() == 0) ? cellIn : cellOut;
+            const auto refinedCell =  (coarseCell == cellIn) ? cellOut : cellIn;
+            assert(coarseCell.level() == 0);
+            assert(refinedCell.level() > 0);
+
+            // Get parent cell (on level zero) of the refined cell
+            const auto& parentCell = refinedCell.father();
+            assert(refinedCell.father().level() == 0);
+
+            // Get the index inside and orientation from the leaf grid (refined) face
+            const auto& intersectionIdxInInside = intersection.indexInInside();
+
+            for(const auto& parentIntersection : intersections(this->levelGridView(0), parentCell)){
+                // Get the inInsideIdx and orientation from the parent intersection
+                const auto& parentIdxInInside = parentIntersection.indexInInside();
+                if (parentIdxInInside == intersectionIdxInInside) {
+                    return parentIntersection;
+                }
+            }
+        }
+        else {
+            OPM_THROW(std::invalid_argument, "Parent intersection not found");
+        }
+    }
+    OPM_THROW(std::invalid_argument, "Face is on the boundary of the grid");
+}
+
+
 double CpGrid::cellCenterDepth(int cell_index) const
 {
     // Here cell center depth is computed as a raw average of cell corner depths.
@@ -1098,7 +1135,7 @@ double CpGrid::cellCenterDepth(int cell_index) const
     return zz/nv;
 }
 
-const Dune::FieldVector<double,3> CpGrid::faceCenterEcl(int cell_index, int face) const
+const Dune::FieldVector<double,3> CpGrid::faceCenterEcl(int cell_index, int face, const Dune::cpgrid::Intersection& intersection) const
 {
     // This method is an alternative to the method faceCentroid(...).
     // The face center is computed as a raw average of cell corners.
@@ -1113,20 +1150,42 @@ const Dune::FieldVector<double,3> CpGrid::faceCenterEcl(int cell_index, int face
     //   0---1
 
     // this follows the DUNE reference cube
-    static const int faceVxMap[ 6 ][ 4 ] = { {0, 2, 4, 6}, // face 0
-                                             {1, 3, 5, 7}, // face 1
-                                             {0, 1, 4, 5}, // face 2
-                                             {2, 3, 6, 7}, // face 3
-                                             {0, 1, 2, 3}, // face 4
-                                             {4, 5, 6, 7}  // face 5
+    static const int faceVxMap[ 6 ][ 4 ] = { {0, 2, 4, 6}, // face 0 - I_FACE false
+                                             {1, 3, 5, 7}, // face 1 - I_FACE true
+                                             {0, 1, 4, 5}, // face 2 - J_FACE false
+                                             {2, 3, 6, 7}, // face 3 - J_FACE true
+                                             {0, 1, 2, 3}, // face 4 - K_FACE false
+                                             {4, 5, 6, 7}  // face 5 - K_FACE true
     };
 
 
     assert (current_view_data_->cell_to_point_[cell_index].size() == 8);
     Dune::FieldVector<double,3> center(0.0);
-    for( int i=0; i<4; ++i )
-    {
-        center += vertexPosition(current_view_data_->cell_to_point_[cell_index][ faceVxMap[ face ][ i ] ]);
+
+    bool isCoarseCellInside = (intersection.inside().level() == 0);
+    bool isCoarseCellOutside = false;
+    if (intersection.neighbor()){
+        isCoarseCellOutside = (intersection.outside().level() == 0);
+    }
+    bool twoCoarseNeighboringCells = isCoarseCellInside && isCoarseCellOutside;
+    bool isOnGridBoundary_coarseNeighboringCell = intersection.boundary() && isCoarseCellInside && (!intersection.neighbor());
+
+    // For CpGrid with LGRs, a refined face with a coarse neighboring cell and a refined neighboring cell
+    // (that is when the face belongs to the boundary of an LGR and is located in the interior of the grid),
+    // unfortunately leads us to a different order of the faces, in cell_to_face_, depending on if the
+    // neighboring cell, here with cell_index index, is the coarse one or the refined one. Preceisely,
+    // cell_to_face_[cell_index - coarse neighboring cell] = { left, right, front, back, bottom, top} = {0,1,2,3,4,5} with
+    // the notation above, and
+    // cell_to_face_[cell_index - refined neighboring cell] = {bottom, front, left, right, back, top} = {2,3,1,4,0,5} with
+    // the notation used in faceVxMap.
+
+    for( int i=0; i<4; ++i ) {
+        if ((maxLevel() == 0) || twoCoarseNeighboringCells || isOnGridBoundary_coarseNeighboringCell) {
+            center += vertexPosition(current_view_data_->cell_to_point_[cell_index][ faceVxMap[ face ][ i ] ]);
+        }
+        else { //  (refined) intersection with one coarse neighboring cell and one refined neighboring cell
+            center += vertexPosition(current_view_data_->face_to_point_[intersection.id()][i]);
+        }
     }
 
     for (int i=0; i<3; ++i) {

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -2068,9 +2068,15 @@ CpGridData::refineSingleCell(const std::array<int,3>& cells_per_dim, const int& 
     if (nonRepeated_parentCorners.size() != 8){
         OPM_THROW(std::logic_error, "Cell is not a hexahedron. Cannot be refined (yet).");
     }
+    // Get ijk from parent cell (Cartesian index). Needed to compute width, length, and height of the parent cell.
+    std::array<int,3> ijk;
+    getIJK(parent_idx, ijk);
+    // Get dx,dy,dz for each cell of the patch to be refined
+    const auto& [widthX, lengthY, heightZ] = getWidthsLengthsHeights(ijk, {ijk[0]+1, ijk[1]+1, ijk[2]+1});
     // Refine parent cell
-    parent_cell.refine(cells_per_dim, refined_geometries, refined_cell_to_point, refined_cell_to_face,
-                       refined_face_to_point, refined_face_to_cell, refined_face_tags, refined_face_normals);
+    parent_cell.refineCellifiedPatch(cells_per_dim, refined_geometries, refined_cell_to_point, refined_cell_to_face,
+                                     refined_face_to_point, refined_face_to_cell, refined_face_tags, refined_face_normals,
+                                     {1,1,1}, widthX, lengthY, heightZ);
     const std::vector<std::array<int,2>>& parent_to_refined_corners{
         // corIdx (J*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (I*(cells_per_dim[2]+1)) +K
         // replacing parent-cell corner '0' {0,0,0}

--- a/opm/grid/cpgrid/Geometry.hpp
+++ b/opm/grid/cpgrid/Geometry.hpp
@@ -611,383 +611,6 @@ namespace Dune
             }
 
             /**
-             * @brief Refine a single cell with regular intervals.
-             *
-             * For each cell to be created, storage must be passed for its corners and the indices. That storage
-             * must be externally managed, since the newly created geometry structures only store pointers and do
-             * not free them on destruction.
-             *
-             * @param cells_per_dim                  The number of sub-cells in each direction,
-             * @param all_geom                       Geometry Policy for the refined geometries. Those will be added there.
-             * @param refined_cell_to_point          Map from cell to its 8 corners.
-             * @param refined_cell_to_face           Map from cell to its oriented faces, used to build face_to_cell_.
-             * @param refined_face_to_point          Map from face to its points.
-             * @param refined_face_to_cell           Map from face to its neighboring cells.
-             * @param refined_face_tags              Face tags (I_FACE, J_FACE, K_FACE).
-             * @param refined_face_normals           Face normal(s) (only one per face is computed).
-             */
-            typedef Dune::FieldVector<double,3> PointType;
-            void refine(const std::array<int,3>& cells_per_dim,
-                        DefaultGeometryPolicy& all_geom,
-                        std::vector<std::array<int,8>>&  refined_cell_to_point,
-                        cpgrid::OrientedEntityTable<0,1>& refined_cell_to_face,
-                        Opm::SparseTable<int>& refined_face_to_point,
-                        cpgrid::OrientedEntityTable<1,0>& refined_face_to_cell,
-                        cpgrid::EntityVariable<enum face_tag, 1>& refined_face_tags,
-                        cpgrid::SignedEntityVariable<PointType, 1>& refined_face_normals) const
-            {
-                EntityVariableBase<cpgrid::Geometry<0,3>>& refined_corners =
-                    *(all_geom.geomVector(std::integral_constant<int,3>()));
-                EntityVariableBase<cpgrid::Geometry<2,3>>& refined_faces =
-                    *(all_geom.geomVector(std::integral_constant<int,1>()));
-                EntityVariableBase<cpgrid::Geometry<3,3>>& refined_cells =
-                    *(all_geom.geomVector(std::integral_constant<int,0>()));
-                EntityVariableBase<enum face_tag>& mutable_face_tags = refined_face_tags;
-                EntityVariableBase<PointType>& mutable_face_normals = refined_face_normals;
-                /// --- REFINED CORNERS ---
-                // The strategy is to compute the local refined corners
-                // of the unit/reference cube, and then apply the map global().
-                // Determine the size of the vector containing all the corners
-                // of all the global refined cells (children cells).
-                refined_corners.resize((cells_per_dim[0] + 1) *(cells_per_dim[1] + 1) * (cells_per_dim[2] + 1));
-                // The nummbering starts at the botton, so k=0 (z-axis), and j=0 (y-axis), i=0 (x-axis).
-                // Then, increasing k ('going up'), followed by increasing i ('going right->'),
-                // and finally, increasing j ('going back'). This order criteria for corners
-                // 'Up [increasing k]- Right [incresing i]- Back [increasing j]'
-                // is consistant with cpgrid numbering.
-                for (int j = 0; j < cells_per_dim[1] + 1; ++j) {
-                    for (int i = 0; i < cells_per_dim[0] + 1; ++i) {
-                        for (int k = 0; k < cells_per_dim[2] + 1; ++k) {
-                            // Compute the index of each global refined corner associated with 'jik'.
-                            int refined_corner_idx =
-                                (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k;
-                            // Compute the local refined corner of the unit/reference cube associated with 'jik'.
-                            const LocalCoordinate& local_refined_corner = {
-                                double(i)/cells_per_dim[0], double(j)/cells_per_dim[1], double(k)/cells_per_dim[2] };
-                            // Compute the global refined corner 'jik' and add it in its corresponfing entry in "refined_corners".
-                            refined_corners[refined_corner_idx] = Geometry<0, 3>(this->global(local_refined_corner));
-                        } // end k-for-loop
-                    } // end i-for-loop
-                } // end j-for-loop
-                /// --- END REFINED CORNERS ---
-                //
-                /// --- REFINED FACES ---
-                // We want to populate "refined_faces". The size of "refined_faces" is
-                const int refined_faces_size =
-                    (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1)) // 'bottom/top faces'
-                    + ((cells_per_dim[0]+1)*cells_per_dim[1]*cells_per_dim[2]) // 'left/right faces'
-                    + (cells_per_dim[0]*(cells_per_dim[1]+1)*cells_per_dim[2]); // 'front/back faces'
-                refined_faces.resize(refined_faces_size);
-                refined_face_tags.resize(refined_faces_size);
-                refined_face_normals.resize(refined_faces_size);
-                //
-                // To create a face as a Geometry<2,3> type object we need its CENTROID and its VOLUME(area).
-                // We store the centroids/areas  in the following order:
-                // - Bottom-top faces -> 3rd coordinate constant in each face.
-                // - Left-right faces -> 1st coordinate constant in each face.
-                // - Front-back faces -> 2nd coordinate constant in each face.
-                //
-                // REFINED FACE AREAS
-                // To compute the area of each face, we divide it in 4 triangles,
-                // compute the area of those with "area()", where the arguments
-                // are the 3 corners of each triangle. Then, sum them up to get the area
-                // of the global refined face.
-                // For each face, we construct 4 triangles with
-                // (1) centroid of the face,
-                // (2) one of the edges of the face.
-                //
-                // A triangle has 3 edges. Once we choose a face to base a triangle on,
-                // we choose an edge of that face as one of the edges of the triangle.
-                // The other 2 edges are fixed, since the centroid of the face the triangle
-                // is based on is one of its corners. That's why to identify
-                // a triangle we only need two things:
-                // (1) the face it's based on and
-                // (2) one of the four edges of that face.
-                //
-                // For each face, we need
-                // 1. index of the refined face
-                //    [needed to access indices of the 4 edges of the face in "refined_face_to_edges"]
-                // 2. centroid of the face (common corner of the 4 triangles based on that face).
-                //    [available via "['face'].center()"
-                // 3. container of 4 entries (the 4 edges of the face).
-                //    Each entry consists in the 2 indices defining each edge of the face.
-                //    [available in "refined_face_to_edges"].
-                //
-                // Populate "mutable_face_tags/normals", "refined_face_to_point/cell",
-                // "refined_faces".
-                //
-                for (int constant_direction = 0; constant_direction < 3; ++constant_direction){
-                    // adding %3 and constant_direction, we go through the 3 type of faces.
-                    // 0 -> 3rd coordinate constant: l('k') < cells_per_dim[2]+1, m('j') < cells_per_dim[1], n('i') < cells_per_dim[0]
-                    // 1 -> 1rt coordinate constant: l('i') < cells_per_dim[0]+1, m('k') < cells_per_dim[2], n('j') < cells_per_dim[1]
-                    // 2 -> 2nd coordinate constant: l('j') < cells_per_dim[1]+1, m('i') < cells_per_dim[0], n('k') < cells_per_dim[2]
-                    std::array<int,3> cells_per_dim_mixed = {
-                        cells_per_dim[(2+constant_direction)%3],
-                        cells_per_dim[(1+constant_direction)%3],
-                        cells_per_dim[constant_direction % 3] };
-                    for (int l = 0; l < cells_per_dim_mixed[0] + 1; ++l) {
-                        for (int m = 0; m < cells_per_dim_mixed[1]; ++m) {
-                            for (int n = 0; n < cells_per_dim_mixed[2]; ++n) {
-                                // Compute the face data.
-                                auto [face_type, idx, face4corners,
-                                      neighboring_cells_of_one_face, local_refined_face_centroid] =
-                                    getIndicesFace(l, m, n, constant_direction, cells_per_dim);
-                                // Add the tag to "refined_face_tags".
-                                mutable_face_tags[idx]= face_type;
-                                // Add the 4 corners of the face to "refined_face_to_point".
-                                refined_face_to_point.appendRow(face4corners.begin(), face4corners.end());
-                                // Add the neighboring cells of the face to "refined_face_to_cell".
-                                refined_face_to_cell.appendRow(neighboring_cells_of_one_face.begin(),
-                                                               neighboring_cells_of_one_face.end());
-                                // Construct global face normal(s) (only one 'needed') and add it to "mutable_face_normals"
-                                // Construct two vectors in the face, e.g. difference of two conners with the centroid,
-                                // then obtain an orthogonal vector to both of them. Finally, normalize.
-                                // Auxuliary vectors on the face:
-                                GlobalCoordinate face_vector0 =
-                                    refined_corners[face4corners[0]].center() - global(local_refined_face_centroid);
-                                GlobalCoordinate face_vector1 =
-                                    refined_corners[face4corners[1]].center() - global(local_refined_face_centroid);
-                                mutable_face_normals[idx] = {
-                                    (face_vector0[1]*face_vector1[2]) -  (face_vector0[2]*face_vector1[1]),
-                                    (face_vector0[2]*face_vector1[0]) -  (face_vector0[0]*face_vector1[2]),
-                                    (face_vector0[0]*face_vector1[1]) -  (face_vector0[1]*face_vector1[0])};
-                                mutable_face_normals[idx] /= mutable_face_normals[idx].two_norm();
-                                if (face_type == J_FACE) {
-                                    mutable_face_normals[idx] *= -1;
-                                }
-                                // Construct "refined_face_to_edges"
-                                // with the {edge_indix[0], edge_index[1]} for each edge of the refined face.
-                                std::vector<std::array<int,2>> refined_face_to_edges = {
-                                    { face4corners[0], face4corners[1]},
-                                    { face4corners[0], face4corners[2]},
-                                    { face4corners[1], face4corners[3]},
-                                    { face4corners[2], face4corners[3]}};
-                                // Calculate the AREA of each face of a global refined face,
-                                // by adding the 4 areas of the triangles partitioning each face.
-                                double refined_face_area = 0.0;
-                                for (int edge = 0; edge < 4; ++edge) {
-                                    // Construction of each triangle on the current face with one
-                                    // of its edges equal to "edge".
-                                    Geometry<0,3>::GlobalCoordinate trian_corners[3] = {
-                                        refined_corners[refined_face_to_edges[edge][0]].center(),
-                                        refined_corners[refined_face_to_edges[edge][1]].center(),
-                                        global(local_refined_face_centroid)};
-                                    refined_face_area += std::fabs(area(trian_corners));
-                                } // end edge-for-loop
-                                //
-                                //
-                                // Construct the Geometry<2,3> of the global refined face.
-                                refined_faces[idx] = Geometry<2,cdim>(this->global(local_refined_face_centroid),
-                                                                      refined_face_area);
-                            } // end n-for-loop
-                        } // end m-for-loop
-                    } // end l-for-loop
-                } // end r-for-loop
-                /// --- END REFINED FACES ---
-                //
-                /// --- REFINED CELLS ---
-                // We need to populate "refined_cells"
-                // "refined_cells"'s size is cells_per_dim[0] * cells_per_dim[1] * cells_per_dim[2].
-                // To build each global refined cell, we need
-                // 1. its global refined CENTER
-                // 2. its VOLUME
-                // 3. all global refined corners [available in "refined_corners"]
-                // 4. indices of its 8 corners.
-                //
-                refined_cells.resize(cells_per_dim[0] * cells_per_dim[1] * cells_per_dim[2]);
-                // Vector to store, in each entry, the 8 indices of the 8 corners
-                // of each global refined cell. Determine its size.
-                refined_cell_to_point.resize(cells_per_dim[0] * cells_per_dim[1] * cells_per_dim[2]);
-                // The numembering starts with index 0 for the refined cell with corners
-                // {0,0,0}, ...,{1/cells_per_dim[0], 1/cells_per_dim[1], 1/cells_per_dim[2]},
-                // then the indices grow first picking the cells in the x-axis (Right, i), then y-axis (Back, j), and
-                // finally, z-axis (Up, k).
-                //
-                // CENTERS
-                // REFINED CELL CENTERS
-                // The strategy is to compute the centers of the refined local
-                // unit/reference cube, and then apply the map global().
-                //
-                // VOLUMES OF THE REFINED CELLS
-                // REMARK: Each global refined 'cell' is a hexahedron since it may not be cube-shaped
-                // since its a 'deformation' of unit/reference cube. We may use 'hexahedron' to refer
-                // to the global refined cell in the computation of its volume.
-                //
-                // The strategy is to construct 24 tetrahedra in each hexahedron.
-                // Each tetrahedron is built with
-                // (1) the center of the hexahedron,
-                // (2) the middle point of the face the tetrahedron is based on, and
-                // (3) one of the edges of the face mentioned in 2.
-                // Each face 'supports' 4 tetrahedra, and we have 6 faces per hexahedron, which
-                // gives us the 24 tetrahedra per 'cell' (hexahedron).
-                //
-                // To compute the volume of each tetrahedron, we use "simplex_volume()" with
-                // the 6 corners of the tetrahedron as arguments. Summing up the 24 volumes,
-                // we get the volumne of the hexahedorn (global refined 'cell').
-                //
-                // Sum of all the volumes of all the (children) global refined cells.
-                double sum_all_refined_cell_volumes = 0.0;
-                //
-                // For each (global refined 'cell') hexahedron, to create 24 tetrahedra and their volumes,
-                // we introduce
-                // Vol1. "hexa_to_face" (needed to access face centroids).
-                // Vol2. "hexa_face_centroids" (one of the 6 corners of all 4 tetrahedra based on that face).
-                // Vol3.  the center of the global refined 'cell' (hexahedron)
-                //       (common corner of the 24 tetrahedra).
-                // Vol4. "tetra_edge_indices" indices of the 4x6 tetrahedra per 'cell',
-                //        grouped by the face they are based on.
-                // Then we construct and compute the volume of the 24 tetrahedra with mainly
-                // "hexa_face_centroids" (Vol2.), global refined cell center (Vol3.), and "tetra_edge_indices" (Vol4.).
-                //
-                for (int k = 0; k < cells_per_dim[2]; ++k) {
-                    for (int j = 0; j < cells_per_dim[1]; ++j) {
-                        for (int i = 0; i < cells_per_dim[0]; ++i) {
-                            // INDEX of the global refined cell associated with 'kji'.
-                            int refined_cell_idx = (k*cells_per_dim[0]*cells_per_dim[1]) + (j*cells_per_dim[0]) +i;
-                            // 1. CENTER of the global refined cell associated with 'kji' (Vol3.)
-                            // Compute the center of the local refined unit/reference cube associated with 'kji'.
-                            const LocalCoordinate& local_refined_cell_center = {
-                                (.5 + i)/cells_per_dim[0], (.5 + j)/cells_per_dim[1], (.5 + k)/cells_per_dim[2]};
-                            // Obtain the global refined center with 'this->global(local_refined_cell_center)'.
-                            // 2. VOLUME of the global refined 'kji' cell
-                            double refined_cell_volume = 0.0; // (computed below!)
-                            // 3. All Global refined corners ("refined_corners")
-                            // 4. Indices of the 8 corners of the global refined cell associated with 'kji'.
-                            std::array<int,8> cell8corners_indices = { //
-                                (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k, // fake '0' {0,0,0}
-                                (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + ((i+1)*(cells_per_dim[2]+1)) +k, // fake '1' {1,0,0}
-                                ((j+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k, // fake '2' {0,1,0}
-                                ((j+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + ((i+1)*(cells_per_dim[2]+1)) +k, // fake '3' {1,1,0}
-                                (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k+1, // fake '4' {0,0,1}
-                                (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + ((i+1)*(cells_per_dim[2]+1)) +k+1, // fake '5' {1,0,1}
-                                ((j+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) +k+1, // fake '6' {0,1,1}
-                                ((j+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + ((i+1)*(cells_per_dim[2]+1)) +k+1 // fake '7' {1,1,1}
-                            };
-                            // Add this 8 corners to the corresponding entry of "refined_cell_to_point".
-                            refined_cell_to_point[refined_cell_idx] = cell8corners_indices;
-                            //
-                            // VOLUME HEXAHEDRON (GLOBAL REFINED 'CELL')
-                            // Vol1. INDICES ('from 0 to 5') of the faces of the hexahedron (needed to access face centroids).
-                            std::vector<int> hexa_to_face = { //hexa_face_0to5_indices = {
-                                // index face '0' bottom
-                                (k*cells_per_dim[0]*cells_per_dim[1]) + (j*cells_per_dim[0]) + i,
-                                // index face '1' front
-                                (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1))
-                                +  ((cells_per_dim[0]+1)*cells_per_dim[1]*cells_per_dim[2])
-                                + (j*cells_per_dim[0]*cells_per_dim[2]) + (i*cells_per_dim[2]) + k,
-                                // index face '2' left
-                                (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1))
-                                + (i*cells_per_dim[1]*cells_per_dim[2]) + (k*cells_per_dim[1]) + j,
-                                // index face '3' right
-                                (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1))
-                                + ((i+1)*cells_per_dim[1]*cells_per_dim[2]) + (k*cells_per_dim[1]) + j,
-                                // index face '4' back
-                                (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1)) +
-                                ((cells_per_dim[0]+1)*cells_per_dim[1]*cells_per_dim[2])
-                                + ((j+1)*cells_per_dim[0]*cells_per_dim[2]) + (i*cells_per_dim[2]) + k,
-                                // index face '5' top
-                                ((k+1)*cells_per_dim[0]*cells_per_dim[1]) + (j*cells_per_dim[0]) + i};
-                            //
-                            //  We add the 6 faces of the cell into "refined_cell_to_face".
-                            using cpgrid::EntityRep;
-                            // First value is index, Second is orientation.
-                            // Still have to find out what the orientation should be.
-                            // right face ('3') outer normal points 'from left to right' -> orientation true
-                            // back face ('4') outer normal points 'from front to back' -> orientation true
-                            // top face ('5') outer normal points 'from bottom to top' -> orientation true
-                            // (the other cases are false)
-                            std::vector<cpgrid::EntityRep<1>> faces_of_one_cell = {
-                                { hexa_to_face[0], false}, {hexa_to_face[1], false},
-                                { hexa_to_face[2], false}, {hexa_to_face[3], true},
-                                { hexa_to_face[4], true}, {hexa_to_face[5], true} };
-                            refined_cell_to_face.appendRow(faces_of_one_cell.begin(), faces_of_one_cell.end());
-                            //
-                            // Vol2. CENTROIDS of the faces of the hexahedron.
-                            // (one of the 6 corners of all 4 tetrahedra based on that face).
-                            std::vector<Geometry<0,3>::GlobalCoordinate> hexa_face_centroids;
-                            for (auto& idx : hexa_to_face) {
-                                hexa_face_centroids.push_back(refined_faces[idx].center());
-                            }
-                            // Indices of the 4 edges of each face of the hexahedron.
-                            // A tetrahedron has six edges. Once we choose a face to base a
-                            // tetrahedron on, we choose an edge of that face as one of the
-                            // edges of the tetrahedron. The other five edges are fixed, since
-                            // the center of the hexahedron and the center of the face are
-                            // the reminder 2 corners of the tetrahedron. That's why to identify
-                            // a tetrahedron we only need two things:
-                            // (1) the face it's based on and
-                            // (2) one of the four edges of that face.
-                            //
-                            // Container with 6 entries, one per face. Each entry has the
-                            // 4 indices of the 4 corners of each face.
-                            std::vector<std::array<int,4>> cell_face4corners;
-                            cell_face4corners.reserve(6);
-                            for (int face = 0; face < 6;  ++face) {
-                                cell_face4corners.push_back({ refined_face_to_point[hexa_to_face[face]][0],
-                                        refined_face_to_point[hexa_to_face[face]][1],
-                                        refined_face_to_point[hexa_to_face[face]][2],
-                                        refined_face_to_point[hexa_to_face[face]][3]});
-                            }
-                            // Vol4. Container with indices of the edges of the 4 tetrahedra per face
-                            // [according to description above]
-                            std::vector<std::vector<std::array<int,2>>> tetra_edge_indices;
-                            tetra_edge_indices.reserve(6);
-                            for (auto& face_indices : cell_face4corners)
-                            {
-                                std::vector<std::array<int,2>> face4edges_indices = {
-                                    { face_indices[0], face_indices[1]}, // fake '{0,1}'/'{4,5}'
-                                    { face_indices[0], face_indices[2]}, // fake '{0,2}'/'{4,6}'
-                                    { face_indices[1], face_indices[3]}, // fake '{1,3}'/'{5,7}'
-                                    { face_indices[2], face_indices[3]} }; // fake '{2,3}'/'{6,7}'
-                                tetra_edge_indices.push_back(face4edges_indices);
-                            }
-                            // Sum of the 24 volumes to get the volume of the hexahedron,
-                            // stored in "refined_cell_volume".
-                            // Calculate the volume of each hexahedron, by adding
-                            // the 4 tetrahedra at each face (4x6 = 24 tetrahedra).
-                            for (int face = 0; face < 6; ++face) {
-                                for (int edge = 0; edge < 4; ++edge) {
-                                    // Construction of each tetrahedron based on "face" with one
-                                    // of its edges equal to "edge".
-                                    const Geometry<0, 3>::GlobalCoordinate tetra_corners[4] = {
-                                        refined_corners[tetra_edge_indices[face][edge][0]].center(),  // (see Vol4.)
-                                        refined_corners[tetra_edge_indices[face][edge][1]].center(),  // (see Vol4.)
-                                        hexa_face_centroids[face],  // (see Vol2.)
-                                        // global_refined_cell_center
-                                        this->global(local_refined_cell_center)};  // (see Vol3.)
-                                    refined_cell_volume += std::fabs(simplex_volume(tetra_corners));
-                                } // end edge-for-loop
-                            } // end face-for-loop
-                            // Add the volume of the hexahedron (global refined 'cell')
-                            // to the container with of all volumes of all the refined cells.
-                            sum_all_refined_cell_volumes += refined_cell_volume;
-                            // Create a pointer to the first element of "refined_cell_to_point"
-                            // (required as the fourth argement to construct a Geometry<3,3> type object).
-                            int* indices_storage_ptr = refined_cell_to_point[refined_cell_idx].data();
-                            // Construct the Geometry of the refined cell associated with 'kji'.
-                            refined_cells[refined_cell_idx] =
-                                Geometry<3,cdim>(this->global(local_refined_cell_center),
-                                                 refined_cell_volume,
-                                                 all_geom.geomVector(std::integral_constant<int,3>()),
-                                                 indices_storage_ptr);
-                        } // end i-for-loop
-                    }  // end j-for-loop
-                } // end k-for-loop
-                // Rescale all volumes if the sum of volume of all the global refined 'cells' does not match the
-                // volume of the 'parent cell'.
-                // Compare the sum of all the volumes of all refined cells with 'parent cell' volume.
-                if (std::fabs(sum_all_refined_cell_volumes - this->volume())
-                    > std::numeric_limits<Geometry<3, cdim>::ctype>::epsilon()) {
-                    Geometry<3, cdim>::ctype correction = this->volume() / sum_all_refined_cell_volumes;
-                    for(auto& cell: refined_cells){
-                        cell.vol_ *= correction;
-                    }
-                } // end if-statement
-                /// --- END REFINED CELLS ---
-            } /// --- END of refine()
-
-
-             /**
              * @brief Refine a single cell considering different widths, lengths, and heights.
              *
              * For each cell to be created, storage must be passed for its corners and the indices. That storage
@@ -1005,6 +628,7 @@ namespace Dune
              * @param patch_dim                      Amount of cells to be refined, in each direction.
              * @param dx, dy, dz                     Vectors of widths (x-dir), lengths (y-dir), and heights (z-dir)
              */
+            typedef Dune::FieldVector<double,3> PointType;
             void refineCellifiedPatch(const std::array<int,3>& cells_per_dim,
                                       DefaultGeometryPolicy& all_geom,
                                       std::vector<std::array<int,8>>&  refined_cell_to_point,
@@ -1013,7 +637,7 @@ namespace Dune
                                       cpgrid::OrientedEntityTable<1,0>& refined_face_to_cell,
                                       cpgrid::EntityVariable<enum face_tag, 1>& refined_face_tags,
                                       cpgrid::SignedEntityVariable<PointType, 1>& refined_face_normals,
-                                      const std::array<int,3>& patch_dim, 
+                                      const std::array<int,3>& patch_dim,
                                       const std::vector<double>& widthsX,
                                       const std::vector<double>& lengthsY,
                                       const std::vector<double>& heightsZ) const
@@ -1033,7 +657,9 @@ namespace Dune
                 // Determine the size of the vector containing all the corners
                 // of all the global refined cells (children cells).
                 // For easier notation:
-                const std::array<int,3>& refined_dim = { cells_per_dim[0]*patch_dim[0], cells_per_dim[1]*patch_dim[1], cells_per_dim[2]*patch_dim[2]};
+                const std::array<int,3>& refined_dim = { cells_per_dim[0]*patch_dim[0],
+                                                         cells_per_dim[1]*patch_dim[1],
+                                                         cells_per_dim[2]*patch_dim[2]};
                 refined_corners.resize((refined_dim[0] + 1)*(refined_dim[1] + 1)*(refined_dim[2] + 1));
                 // The nummbering starts at the botton, so k=0 (z-axis), and j=0 (y-axis), i=0 (x-axis).
                 // Then, increasing k ('going up'), followed by increasing i ('going right->'),
@@ -1056,9 +682,12 @@ namespace Dune
                 };
                 // E.g. localCoordNumerator( dx, 3, 0.25) =  x0 + x1 + x2 + 0.25.x3
                 //
-                const double sumWidths = std::accumulate(widthsX.begin(), widthsX.end(), double(0)); // x0 + x1 + ... + xL, if dx = {x0, x1, ..., xL}
-                const double sumLengths = std::accumulate(lengthsY.begin(), lengthsY.end(), double(0)); // y0 + y1 + ... + yM, if dy = {y0, y1, ..., yM}
-                const double sumHeights = std::accumulate(heightsZ.begin(), heightsZ.end(), double(0)); // z0 + z1 + ... + zN, if dz = {z0, z1, ..., zN}
+                const double sumWidths = std::accumulate(widthsX.begin(), widthsX.end(), double(0));
+                // x0 + x1 + ... + xL, if dx = {x0, x1, ..., xL}
+                const double sumLengths = std::accumulate(lengthsY.begin(), lengthsY.end(), double(0));
+                // y0 + y1 + ... + yM, if dy = {y0, y1, ..., yM}
+                const double sumHeights = std::accumulate(heightsZ.begin(), heightsZ.end(), double(0));
+                // z0 + z1 + ... + zN, if dz = {z0, z1, ..., zN}
 
                 for (int j = 0; j < refined_dim[1] +1; ++j) {
                     double local_y = 0;
@@ -1438,8 +1067,8 @@ namespace Dune
             /// @param [out] refined_face_to_cell        For each face, the (at most 2) neighboring cells (used in "face_to_cell").
             /// @param [out] refined_face_centroid       Local centroid of the face of refined cell 'lmn' of the unit cube.
             const std::tuple< enum face_tag, int,
-                        std::array<int, 4>, std::vector<cpgrid::EntityRep<0>>,
-                        LocalCoordinate>
+                              std::array<int, 4>, std::vector<cpgrid::EntityRep<0>>,
+                              LocalCoordinate>
             getIndicesFace(int l, int m, int n, int constant_direction, const std::array<int, 3>& cells_per_dim) const
             {
                 using cpgrid::EntityRep;

--- a/opm/grid/cpgrid/GridHelpers.cpp
+++ b/opm/grid/cpgrid/GridHelpers.cpp
@@ -115,13 +115,13 @@ double cellCenterDepth(const Dune::CpGrid& grid, int cell_index)
     return grid.cellCenterDepth(cell_index);
 }
 
-Vector faceCenterEcl(const Dune::CpGrid& grid, int cell_index, int face_tag)
+Vector faceCenterEcl(const Dune::CpGrid& grid, int cell_index, int face_tag, const Dune::cpgrid::Intersection& intersection)
 {
     // This method is an alternative to the method faceCentroid(...) below.
     // The face center is computed as a raw average of cell corners.
     // For faulted grids, this is likely to give slightly different depths that seem
     // to agree with eclipse.
-    return grid.faceCenterEcl(cell_index, face_tag);
+    return grid.faceCenterEcl(cell_index, face_tag, intersection);
 }
 
 

--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -412,9 +412,10 @@ void refine_and_check(const cpgrid::Geometry<3, 3>& parent_geometry,
     cpgrid::EntityVariable<enum face_tag, 1>& face_tags = child_view_data.face_tag_;
     cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>, 1>& face_normals = child_view_data.face_normals_;
 
-    parent_geometry.refine(cells, geometries, cell_to_point,
-                           cell_to_face, face_to_point, face_to_cell,
-                           face_tags, face_normals);
+    parent_geometry.refineCellifiedPatch(cells, geometries, cell_to_point,
+                                         cell_to_face, face_to_point, face_to_cell,
+                                         face_tags, face_normals,
+                                         {1,1,1}, {1.}, {1.}, {1.});
     check_refined_grid(parent_geometry, geometries.template geomVector<0>(),
                        geometries.template geomVector<1>(),
                        geometries.template geomVector<3>(), cells);


### PR DESCRIPTION
To compute transmissibility, a reduction-argument is used based on certain symmetry between the 'usual' 6 faces of a cell. When the grid is a CpGrid with LGRs, (refined) faces with one neighboring coarse cell and one neighboring refined cell can be found. In these cases, the reduction-argument based on 'symmetry' may lead to wrong transmissibility values.

An alternative approach to compute transmissibilities of faces located on LGR boundaries, the 'parent coarse / original' face from level zero could be tracked and used. 

This PR 
- adds a method to get the (coarse) parent intersection, given an intersection on the boundary of an LGR with a coarse neighboring cell.
-  refactors faceCenterEcl. For CpGrids with LGRs, the centers of refined faces are computed as the average of its 4 corners.

(It includes OPM/opm-grid#715 for testing reasons)