### PR TITLE
Support shared corners on LGRs for CpGrid

### DIFF
--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -1887,38 +1887,38 @@ std::array<std::vector<int>,6> CpGridData::getBoundaryPatchFaces(const std::arra
     // Auxiliary integers to simplify notation.
     const int& i_grid_faces =  (grid_dim[0]+1)*grid_dim[1]*grid_dim[2];
     const int& j_grid_faces =  grid_dim[0]*(grid_dim[1]+1)*grid_dim[2];
-    
+
     std::array<std::vector<int>,6> boundary_patch_faces;
     // { I_FACE false vector, I_FACE true vector, J_FACE false vector, J_FACE true vector, K_FACE false vector, K_FACE true vector}
-    boundary_patch_faces[0].reserve(2*patch_dim[1]*patch_dim[2]); // I_FACE false vector 
+    boundary_patch_faces[0].reserve(2*patch_dim[1]*patch_dim[2]); // I_FACE false vector
     boundary_patch_faces[1].reserve(2*patch_dim[1]*patch_dim[2]); // I_FACE true vector
     boundary_patch_faces[2].reserve(2*patch_dim[0]*patch_dim[2]); // J_FACE false vector (front)
     boundary_patch_faces[3].reserve(2*patch_dim[0]*patch_dim[2]); // J_FACE true vector  (back)
     boundary_patch_faces[4].reserve(2*patch_dim[0]*patch_dim[1]); // K_FACE false vector (bottom)
     boundary_patch_faces[5].reserve(2*patch_dim[0]*patch_dim[1]); // K_FACE true vector  (top)
-    //Boundary I_FACE faces
-     for (int j = startIJK[1]; j < endIJK[1]; ++j) {
+    // Boundary I_FACE faces
+    for (int j = startIJK[1]; j < endIJK[1]; ++j) {
         for (int k = startIJK[2]; k < endIJK[2]; ++k) {
             boundary_patch_faces[0].push_back( (j*(grid_dim[0]+1)*grid_dim[2]) + (startIJK[0]*grid_dim[2])+ k); // I_FACE false
             boundary_patch_faces[1].push_back( (j*(grid_dim[0]+1)*grid_dim[2]) + (endIJK[0]*grid_dim[2])+ k); // I_FACE true
         }
-     }
-       //Boundary J_FACE faces
-     for (int i = startIJK[0]; i < endIJK[0]; ++i) {
+    }
+    // Boundary J_FACE faces
+    for (int i = startIJK[0]; i < endIJK[0]; ++i) {
         for (int k = startIJK[2]; k < endIJK[2]; ++k) {
             boundary_patch_faces[2].push_back(i_grid_faces + (startIJK[1]*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2])+ k); // J_FACE false
             boundary_patch_faces[3].push_back(i_grid_faces + (endIJK[1]*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2])+ k); // J_FACE true
         }
-     }
-       //Boundary K_FACE faces
-     for (int j = startIJK[1]; j < endIJK[1]; ++j) {
+    }
+    // Boundary K_FACE faces
+    for (int j = startIJK[1]; j < endIJK[1]; ++j) {
         for (int i = startIJK[0]; i < endIJK[0]; ++i) {
             boundary_patch_faces[4].push_back( i_grid_faces + j_grid_faces +
                                                (j*grid_dim[0]*(grid_dim[2]+1)) + (i*(grid_dim[2]+1))+ startIJK[2] ); // K_FACE false
             boundary_patch_faces[5].push_back( i_grid_faces + j_grid_faces +
                                                (j*grid_dim[0]*(grid_dim[2]+1)) + (i*(grid_dim[2]+1))+ endIJK[2]); // K_FACE true
         }
-     }
+    }
     return boundary_patch_faces;
 }
 
@@ -2005,9 +2005,7 @@ bool CpGridData::patchesShareFace(const std::vector<std::array<int,3>>& startIJK
         return faceIsShared; // should be false here
     };
 
-    // bool shared_face = false;
     for (long unsigned int patch = 0; patch < startIJK_vec.size(); ++patch) {
-        //  bool patch_otherPatch_shareFace = false;
         const auto& [iFalse, iTrue, jFalse, jTrue, kFalse, kTrue] = this->getBoundaryPatchFaces(startIJK_vec[patch], endIJK_vec[patch]);
         for (long unsigned int other_patch = patch+1; other_patch < startIJK_vec.size(); ++other_patch) {
             const auto& [iFalseOther, iTrueOther, jFalseOther, jTrueOther, kFalseOther, kTrueOther] =
@@ -2038,8 +2036,6 @@ bool CpGridData::patchesShareFace(const std::vector<std::array<int,3>>& startIJK
     } // patch for-loop
     return false;
 }
-
-
 
 std::vector<int>
 CpGridData::getPatchesCells(const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -1878,6 +1878,50 @@ std::vector<int> CpGridData::getPatchBoundaryCorners(const std::array<int,3>& st
     return patch_boundary_corners;
 }
 
+std::array<std::vector<int>,6> CpGridData::getBoundaryPatchFaces(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const
+{
+    // Get the patch dimension (total cells in each direction). Used to 'reserve vectors'.
+    const std::array<int,3>& patch_dim = getPatchDim(startIJK, endIJK);
+    // Get grid dimension (total cells in each direction).
+    const std::array<int,3>& grid_dim = this -> logicalCartesianSize();
+    // Auxiliary integers to simplify notation.
+    const int& i_grid_faces =  (grid_dim[0]+1)*grid_dim[1]*grid_dim[2];
+    const int& j_grid_faces =  grid_dim[0]*(grid_dim[1]+1)*grid_dim[2];
+    
+    std::array<std::vector<int>,6> boundary_patch_faces;
+    // { I_FACE false vector, I_FACE true vector, J_FACE false vector, J_FACE true vector, K_FACE false vector, K_FACE true vector}
+    boundary_patch_faces[0].reserve(2*patch_dim[1]*patch_dim[2]); // I_FACE false vector 
+    boundary_patch_faces[1].reserve(2*patch_dim[1]*patch_dim[2]); // I_FACE true vector
+    boundary_patch_faces[2].reserve(2*patch_dim[0]*patch_dim[2]); // J_FACE false vector (front)
+    boundary_patch_faces[3].reserve(2*patch_dim[0]*patch_dim[2]); // J_FACE true vector  (back)
+    boundary_patch_faces[4].reserve(2*patch_dim[0]*patch_dim[1]); // K_FACE false vector (bottom)
+    boundary_patch_faces[5].reserve(2*patch_dim[0]*patch_dim[1]); // K_FACE true vector  (top)
+    //Boundary I_FACE faces
+     for (int j = startIJK[1]; j < endIJK[1]; ++j) {
+        for (int k = startIJK[2]; k < endIJK[2]; ++k) {
+            boundary_patch_faces[0].push_back( (j*(grid_dim[0]+1)*grid_dim[2]) + (startIJK[0]*grid_dim[2])+ k); // I_FACE false
+            boundary_patch_faces[1].push_back( (j*(grid_dim[0]+1)*grid_dim[2]) + (endIJK[0]*grid_dim[2])+ k); // I_FACE true
+        }
+     }
+       //Boundary J_FACE faces
+     for (int i = startIJK[0]; i < endIJK[0]; ++i) {
+        for (int k = startIJK[2]; k < endIJK[2]; ++k) {
+            boundary_patch_faces[2].push_back(i_grid_faces + (startIJK[1]*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2])+ k); // J_FACE false
+            boundary_patch_faces[3].push_back(i_grid_faces + (endIJK[1]*grid_dim[0]*grid_dim[2]) + (i*grid_dim[2])+ k); // J_FACE true
+        }
+     }
+       //Boundary K_FACE faces
+     for (int j = startIJK[1]; j < endIJK[1]; ++j) {
+        for (int i = startIJK[0]; i < endIJK[0]; ++i) {
+            boundary_patch_faces[4].push_back( i_grid_faces + j_grid_faces +
+                                               (j*grid_dim[0]*(grid_dim[2]+1)) + (i*(grid_dim[2]+1))+ startIJK[2] ); // K_FACE false
+            boundary_patch_faces[5].push_back( i_grid_faces + j_grid_faces +
+                                               (j*grid_dim[0]*(grid_dim[2]+1)) + (i*(grid_dim[2]+1))+ endIJK[2]); // K_FACE true
+        }
+     }
+    return boundary_patch_faces;
+}
+
 bool CpGridData::disjointPatches(const std::vector<std::array<int,3>>& startIJK_vec,
                                  const std::vector<std::array<int,3>>& endIJK_vec) const
 {
@@ -1926,6 +1970,75 @@ bool CpGridData::disjointPatches(const std::vector<std::array<int,3>>& startIJK_
     }
     return are_disjoint; // should be true
 }
+
+bool CpGridData::patchesShareFace(const std::vector<std::array<int,3>>& startIJK_vec,
+                                  const std::vector<std::array<int,3>>& endIJK_vec) const
+{
+    assert(!startIJK_vec.empty());
+    assert(!endIJK_vec.empty());
+    if ((startIJK_vec.size() == 1) && (endIJK_vec.size() == 1)){
+        return false;
+    }
+    if (startIJK_vec.size() != endIJK_vec.size() ){
+        OPM_THROW(std::logic_error, "Sizes of the arguments differ. Not enough information provided.");
+    }
+    for (long unsigned int patch = 0; patch < startIJK_vec.size(); ++patch){
+        bool valid_patch = true;
+        for (int c = 0; c < 3; ++c){
+            valid_patch = valid_patch && (startIJK_vec[patch][c] < endIJK_vec[patch][c]);
+        }
+        if (!valid_patch){
+            OPM_THROW(std::logic_error, "There is at least one invalid patch.");
+        }
+    }
+
+    const auto& detectSharing = [](std::vector<int> faceIdxs, std::vector<int> otherFaceIdxs){
+        bool faceIsShared = false;
+        for (const auto& face : faceIdxs) {
+            for (const auto& otherFace : otherFaceIdxs) {
+                faceIsShared = faceIsShared || (face == otherFace);
+                if (faceIsShared) {
+                    return faceIsShared; // should be true here
+                }
+            }
+        }
+        return faceIsShared; // should be false here
+    };
+
+    // bool shared_face = false;
+    for (long unsigned int patch = 0; patch < startIJK_vec.size(); ++patch) {
+        //  bool patch_otherPatch_shareFace = false;
+        const auto& [iFalse, iTrue, jFalse, jTrue, kFalse, kTrue] = this->getBoundaryPatchFaces(startIJK_vec[patch], endIJK_vec[patch]);
+        for (long unsigned int other_patch = patch+1; other_patch < startIJK_vec.size(); ++other_patch) {
+            const auto& [iFalseOther, iTrueOther, jFalseOther, jTrueOther, kFalseOther, kTrueOther] =
+                getBoundaryPatchFaces(startIJK_vec[other_patch], endIJK_vec[other_patch]);
+            bool isShared = false;
+            if (startIJK_vec[other_patch][0] == endIJK_vec[patch][0]) {
+                isShared = isShared || detectSharing(iTrue, iFalseOther);
+            }
+            if (endIJK_vec[other_patch][0] == startIJK_vec[patch][0]) {
+                isShared = isShared || detectSharing(iFalse, iTrueOther);
+            }
+            if (startIJK_vec[other_patch][1] == endIJK_vec[patch][1]) {
+                isShared = isShared || detectSharing(jTrue, jFalseOther);
+            }
+            if (endIJK_vec[other_patch][1] == startIJK_vec[patch][1]) {
+                isShared = isShared || detectSharing(jFalse, jTrueOther);
+            }
+            if (startIJK_vec[other_patch][2] == endIJK_vec[patch][2]) {
+                isShared = isShared || detectSharing(kTrue, kFalseOther);
+            }
+            if (endIJK_vec[other_patch][2] == startIJK_vec[patch][2]) {
+                isShared = isShared || detectSharing(kFalse, kTrueOther);
+            }
+            if (isShared) {
+                return isShared;
+            }
+        } // other patch for-loop
+    } // patch for-loop
+    return false;
+}
+
 
 
 std::vector<int>

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -318,6 +318,13 @@ public:
     /// @brief Check that every cell to be refined has cuboid shape.
     void checkCuboidShape(const std::vector<int>& cellIdx_vec) const;
 
+    /// @brief Determine if a finite amount of patches (of cells) share a face.
+    ///
+    /// @param [in]  startIJK_vec  Vector of Cartesian triplet indices where each patch starts.
+    /// @param [in]  endIJK_vec    Vector of Cartesian triplet indices where each patch ends.
+    ///                            Last cell part of the lgr will be {endIJK_vec[<patch>][0]-1, ... ,endIJK_vec[<patch>][2]-1}.
+    bool patchesShareFace(const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
+
 private:
     /// @brief Compute amount of cells in each direction of a patch of cells. (Cartesian grid required).
     ///
@@ -363,6 +370,15 @@ private:
     ///
     /// @return patch_boundary_corners
     std::vector<int> getPatchBoundaryCorners(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
+
+    /// @brief Compute patch boundary face indices (Cartesian grid required).
+    ///
+    /// @param [in]  startIJK  Cartesian triplet index where the patch starts.
+    /// @param [in]  endIJK    Cartesian triplet index where the patch ends.
+    ///                        Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
+    ///
+    /// @return patch_boundary_faces
+    std::array<std::vector<int>,6> getBoundaryPatchFaces(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;
 
     /// @brief For selected cell indices, computes the variation in x-,y-, and z-direction, assuming each cell has cubiod shape.
     std::array<std::vector<double>,3> getWidthsLengthsHeights(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK) const;

--- a/tests/cpgrid/grid_lgr_test.cpp
+++ b/tests/cpgrid/grid_lgr_test.cpp
@@ -113,8 +113,8 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
 {
     auto& data = coarse_grid.data_;
     // Add LGRs and update grid.
-    const bool are_disjoint = (*data[0]).disjointPatches(startIJK_vec, endIJK_vec);
-    if (are_disjoint){
+    const bool faceSharing = (*data[0]).patchesShareFace(startIJK_vec, endIJK_vec);
+    if (!faceSharing){
         coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
 
         BOOST_CHECK(data.size() == startIJK_vec.size() + 2);
@@ -562,12 +562,11 @@ BOOST_AUTO_TEST_CASE(patches_share_corner)
     const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {1,1,1}, {3,2,2}};
     const std::vector<std::array<int,3>> endIJK_vec = {{1,1,1}, {2,2,2}, {4,3,3}};
     const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
-    BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec), std::logic_error);
+    refinePatch_and_check(coarse_grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
     BOOST_CHECK_EQUAL(coarse_grid.chooseData()[0]->patchesShareFace(startIJK_vec, endIJK_vec), false);
-    std::cout << "Patches do not share faces." << "\n";
 }
 
-BOOST_AUTO_TEST_CASE(patches_share_corners)
+BOOST_AUTO_TEST_CASE(patches_share_edge)
 {
     // Create a grid
     Dune::CpGrid coarse_grid;
@@ -578,10 +577,8 @@ BOOST_AUTO_TEST_CASE(patches_share_corners)
     const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {2,0,1}, {3,2,2}};
     const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {3,1,2}, {4,3,3}};
     const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
-    BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec), std::logic_error);
-    std::cout << "Patches are NOT disjoint" << "\n";
+    refinePatch_and_check(coarse_grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
     BOOST_CHECK_EQUAL(coarse_grid.chooseData()[0]->patchesShareFace(startIJK_vec, endIJK_vec), false);
-    std::cout << "Patches do not share faces." << "\n";
 }
 
 BOOST_AUTO_TEST_CASE(pathces_share_face)
@@ -751,3 +748,4 @@ BOOST_AUTO_TEST_CASE(global_norefine)
 
     check_global_refine(coarse_grid, fine_grid);
 }
+

--- a/tests/cpgrid/grid_lgr_test.cpp
+++ b/tests/cpgrid/grid_lgr_test.cpp
@@ -483,6 +483,8 @@ BOOST_AUTO_TEST_CASE(refine_patch_different_cell_sizes)
     const std::string lgr_name = {"LGR1"};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
     refinePatch_and_check(coarse_grid, {cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+    BOOST_CHECK_EQUAL(coarse_grid.chooseData()[0]->patchesShareFace({startIJK}, {endIJK}), false);
+    std::cout << "Patches do not share faces." << "\n";
 }
 
 BOOST_AUTO_TEST_CASE(refine_patch)
@@ -497,6 +499,8 @@ BOOST_AUTO_TEST_CASE(refine_patch)
     const std::string lgr_name = {"LGR1"};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
     refinePatch_and_check(coarse_grid, {cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+    BOOST_CHECK_EQUAL(coarse_grid.chooseData()[0]->patchesShareFace({startIJK}, {endIJK}), false);
+    std::cout << "Patches do not share faces." << "\n";
 }
 
 BOOST_AUTO_TEST_CASE(refine_patch_one_cell)
@@ -511,6 +515,8 @@ BOOST_AUTO_TEST_CASE(refine_patch_one_cell)
     const std::string lgr_name = {"LGR1"};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
     refinePatch_and_check(coarse_grid, {cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+    BOOST_CHECK_EQUAL(coarse_grid.chooseData()[0]->patchesShareFace({startIJK}, {endIJK}), false);
+    std::cout << "Patches do not share faces." << "\n";
 }
 
 BOOST_AUTO_TEST_CASE(lgrs_disjointPatches)
@@ -525,6 +531,8 @@ BOOST_AUTO_TEST_CASE(lgrs_disjointPatches)
     const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {1,1,3}, {4,3,3}};
     const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
     refinePatch_and_check(coarse_grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+    BOOST_CHECK_EQUAL(coarse_grid.chooseData()[0]->patchesShareFace(startIJK_vec, endIJK_vec), false);
+    std::cout << "Patches do not share faces." << "\n";
 }
 
 BOOST_AUTO_TEST_CASE(lgrs_disjointPatchesB)
@@ -539,6 +547,8 @@ BOOST_AUTO_TEST_CASE(lgrs_disjointPatchesB)
     const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1}, {4,3,3}};
     const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2"};
     refinePatch_and_check(coarse_grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+    BOOST_CHECK_EQUAL(coarse_grid.chooseData()[0]->patchesShareFace(startIJK_vec, endIJK_vec), false);
+    std::cout << "Patches do not share faces." << "\n";
 }
 
 BOOST_AUTO_TEST_CASE(patches_share_corner)
@@ -553,7 +563,8 @@ BOOST_AUTO_TEST_CASE(patches_share_corner)
     const std::vector<std::array<int,3>> endIJK_vec = {{1,1,1}, {2,2,2}, {4,3,3}};
     const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
     BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec), std::logic_error);
-    std::cout << "Patches are NOT disjoint" << "\n";
+    BOOST_CHECK_EQUAL(coarse_grid.chooseData()[0]->patchesShareFace(startIJK_vec, endIJK_vec), false);
+    std::cout << "Patches do not share faces." << "\n";
 }
 
 BOOST_AUTO_TEST_CASE(patches_share_corners)
@@ -569,6 +580,8 @@ BOOST_AUTO_TEST_CASE(patches_share_corners)
     const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
     BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec), std::logic_error);
     std::cout << "Patches are NOT disjoint" << "\n";
+    BOOST_CHECK_EQUAL(coarse_grid.chooseData()[0]->patchesShareFace(startIJK_vec, endIJK_vec), false);
+    std::cout << "Patches do not share faces." << "\n";
 }
 
 BOOST_AUTO_TEST_CASE(pathces_share_face)
@@ -583,7 +596,8 @@ BOOST_AUTO_TEST_CASE(pathces_share_face)
     const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {3,1,1}, {4,3,3}};
     const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
     BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec), std::logic_error);
-    std::cout << "Patches are NOT disjoint" << "\n";
+    BOOST_CHECK_EQUAL(coarse_grid.chooseData()[0]->patchesShareFace(startIJK_vec, endIJK_vec), true);
+    std::cout << "Patches shared at least one face." << "\n";
 }
 
 BOOST_AUTO_TEST_CASE(pathces_share_faceB)
@@ -598,7 +612,8 @@ BOOST_AUTO_TEST_CASE(pathces_share_faceB)
     const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1}, {3,2,2}, {4,3,3}};
     const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
     BOOST_CHECK_THROW(coarse_grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec), std::logic_error);
-    std::cout << "Patches are NOT disjoint" << "\n";
+    BOOST_CHECK_EQUAL(coarse_grid.chooseData()[0]->patchesShareFace(startIJK_vec, endIJK_vec), true);
+    std::cout << "Patches shared at least one face." << "\n";
 }
 
 


### PR DESCRIPTION
This PR removes the (now old) restriction of not sharing corners on the cell sets to be refined, for CpGrid. 

The test associated with this is SPE1CASE1_CARFIN.DATA.