### PR TITLE
Improve refinement and partially support adaptivity for CpGrid

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -113,6 +113,7 @@ list (APPEND TEST_SOURCE_FILES
 
 if(Boost_VERSION_STRING VERSION_GREATER 1.53)
 	list(APPEND TEST_SOURCE_FILES
+	  tests/cpgrid/adapt_cpgrid_test.cpp
 	  tests/cpgrid/avoidNNCinLGRs_test.cpp
 	  tests/cpgrid/avoidNNCinLGRsCpGrid_test.cpp
 	  tests/cpgrid/cuboidShape_test.cpp

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -71,6 +71,7 @@
 #include "Geometry.hpp"
 
 #include <array>
+#include <initializer_list>
 #include <set>
 #include <vector>
 
@@ -95,6 +96,15 @@ template<int> class EntityRep;
 }
 }
 
+
+void markAndAdapt_check(Dune::CpGrid&,
+                        const std::array<int,3>&,
+                        const std::vector<int>&,
+                        Dune::CpGrid&,
+                        bool,
+                        bool,
+                        bool);
+
 void refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,
                       const std::array<int, 3>&,
                       bool);
@@ -111,6 +121,8 @@ void refinePatch_and_check(Dune::CpGrid&,
 
 void check_global_refine(const Dune::CpGrid&,
                          const Dune::CpGrid&);
+
+void lookup_check(const Dune::CpGrid&);
 
 void fieldProp_check(const Dune::CpGrid& grid, Opm::EclipseGrid eclGrid, std::string deck_string);
 
@@ -135,13 +147,22 @@ class CpGridData
     friend class Dune::cpgrid::IndexSet;
 
     friend
+    void ::markAndAdapt_check(Dune::CpGrid&,
+                              const std::array<int,3>&,
+                              const std::vector<int>&,
+                              Dune::CpGrid&,
+                              bool,
+                              bool,
+                              bool);
+
+    friend
     void ::refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,
                             const std::array<int, 3>&,
                             bool);
     friend
     void ::refinePatch_and_check(const std::array<int,3>&,
-                        const std::array<int,3>&,
-                        const std::array<int,3>&);
+                                 const std::array<int,3>&,
+                                 const std::array<int,3>&);
 
     friend
     void ::refinePatch_and_check(Dune::CpGrid&,
@@ -149,11 +170,13 @@ class CpGridData
                                  const std::vector<std::array<int,3>>&,
                                  const std::vector<std::array<int,3>>&,
                                  const std::vector<std::string>&);
-    
+
     friend
     void ::check_global_refine(const Dune::CpGrid&,
                                const Dune::CpGrid&);
 
+    friend
+    void ::lookup_check(const Dune::CpGrid&);
     friend
     void ::fieldProp_check(const Dune::CpGrid& grid, Opm::EclipseGrid eclGrid, std::string deck_string);
 
@@ -325,7 +348,41 @@ public:
     ///                            Last cell part of the lgr will be {endIJK_vec[<patch>][0]-1, ... ,endIJK_vec[<patch>][2]-1}.
     bool patchesShareFace(const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
 
+    int sharedFaceTag(const std::vector<std::array<int,3>>& startIJK_2Patches, const std::vector<std::array<int,3>>& endIJK_2Patches) const;
+
+    
+    /// @brief Mark entity for refinement or coarsening.
+    ///
+    /// Refinement on CpGrid is partially supported for Cartesian grids, with the keyword CARFIN.
+    /// This only works for entities of codim 0.
+    ///
+    /// @param [in] refCount   To mark the element for
+    ///                        - refinement, refCount == 1
+    ///                        - doing nothing, refCount == 0
+    ///                        - coarsening, refCount == -1 (not applicable yet)
+    /// @param [in] element    Entity<0>. Currently, an element from the GLOBAL grid (level zero).
+    /// @return true, if marking was succesfull.
+    ///         false, if marking was not possible.
+    bool mark(int refCount, const cpgrid::Entity<0>& element);
+
+    /// @brief Return refinement mark for entity.
+    ///
+    /// @return refinement mark (1 refinement, 0 doing nothing, -1 coarsening - not supported yet).
+    int getMark(const cpgrid::Entity<0>& element) const;
+
+    /// @brief Set mightVanish flags for elements that will be refined in the next adapt() call
+    ///        Need to be called after elements have been marked for refinement.
+    bool preAdapt();
+
+    /// TO DO: Documentation. Triggers the grid refinement process - Currently, returns preAdapt()
+    bool adapt();
+
+    /// @brief Clean up refinement/coarsening markers - set every element to the mark 0 which represents 'doing nothing'
+    void postAdapt();
+
 private:
+    std::array<Dune::FieldVector<double,3>,8> getReferenceRefinedCorners(int idxInParentCell, const std::array<int,3>& cells_per_dim) const;
+
     /// @brief Compute amount of cells in each direction of a patch of cells. (Cartesian grid required).
     ///
     /// @param [in]  startIJK  Cartesian triplet index where the patch starts.
@@ -738,12 +795,14 @@ private:
     std::shared_ptr<LevelGlobalIdSet> global_id_set_;
     /** @brief The indicator of the partition type of the entities */
     std::shared_ptr<PartitionTypeIndicator> partition_type_indicator_;
+    /** Mark elements to be refined **/
+    std::vector<int> mark_;
     /** Level of the current CpGridData (0 when it's "GLOBAL", 1,2,.. for LGRs). */
     int level_{0};
     /** Copy of (CpGrid object).data_ associated with the CpGridData object. */
     std::vector<std::shared_ptr<CpGridData>>* level_data_ptr_;
     // SUITABLE FOR ALL LEVELS EXCEPT FOR LEAFVIEW
-    /** Map between level and leafview cell indices. Only cells (from that level) that appear in leafview count. */  
+    /** Map between level and leafview cell indices. Only cells (from that level) that appear in leafview count. -1 when the cell vanished.*/  
     std::vector<int> level_to_leaf_cells_; // In entry 'level cell index', we store 'leafview cell index'
     /** Parent cells and their children. Entry is {-1, {}} when cell has no children.*/ // {level LGR, {child0, child1, ...}}
     std::vector<std::tuple<int,std::vector<int>>> parent_to_children_cells_; 
@@ -755,6 +814,10 @@ private:
     // SUITABLE FOR ALL LEVELS INCLUDING LEAFVIEW
     /** Child cells and their parents. Entry is {-1,-1} when cell has no father. */ // {level parent cell, parent cell index}
     std::vector<std::array<int,2>> child_to_parent_cells_;
+    /** Level-grid or Leaf-grid cell to parent cell and refined-cell-in-parent-cell index (number between zero and total amount
+        of children per parent (cells_per_dim[0]_*cells_per_dim_[1]*cells_per_dim_[2])). Entry is -1 when cell has no father. */
+    std::vector<int> cell_to_idxInParentCell_;
+    
 
 
     /// \brief Object for collective communication operations.

--- a/opm/grid/cpgrid/EntityRep.hpp
+++ b/opm/grid/cpgrid/EntityRep.hpp
@@ -250,6 +250,11 @@ namespace Dune
                 return V::operator[](i);
             }
 
+            void swap(EntityVariableBase& other)
+            {
+                V::swap(static_cast<V&>(other));
+            }
+
         };
 
 

--- a/opm/grid/cpgrid/OrientedEntityTable.hpp
+++ b/opm/grid/cpgrid/OrientedEntityTable.hpp
@@ -211,6 +211,12 @@ namespace Dune
                 return super_t::operator==(other);
             }
 
+            /// Swap contents for other OrientedEntityTable
+            void swap(OrientedEntityTable& other)
+            {
+                super_t::swap(other);
+            }
+
             /** @brief Prints the relation matrix corresponding to the table, sparse format.
 
              Let the entities of codimensions f and t be given by

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -1,0 +1,562 @@
+//===========================================================================
+//
+// File: adapt_cpgrid_test.cpp
+//
+// Created: Apr 22 2024 16:45
+//
+// Author(s): Antonella Ritorto   <antonella.ritorto@opm-op.com>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+/*
+  Copyright 2024 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#define BOOST_TEST_MODULE AdaptTests
+#include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
+#include <opm/grid/CpGrid.hpp>
+#include <opm/grid/cpgrid/CpGridData.hpp>
+#include <opm/grid/cpgrid/DefaultGeometryPolicy.hpp>
+#include <opm/grid/cpgrid/Entity.hpp>
+#include <opm/grid/cpgrid/EntityRep.hpp>
+#include <opm/grid/cpgrid/Geometry.hpp>
+#include <opm/grid/LookUpData.hh>
+
+#include <dune/grid/common/mcmgmapper.hh>
+
+#include <sstream>
+#include <iostream>
+
+struct Fixture
+{
+    Fixture()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        Dune::MPIHelper::instance(m_argc, m_argv);
+        Opm::OpmLog::setupSimpleDefaultLogging();
+    }
+
+    static int rank()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        return Dune::MPIHelper::instance(m_argc, m_argv).rank();
+    }
+};
+
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+#define CHECK_COORDINATES(c1, c2)                                       \
+    for (int c = 0; c < 3; c++) {                                       \
+        BOOST_TEST(c1[c] == c2[c], boost::test_tools::tolerance(1e-12)); \
+    }
+
+void markAndAdapt_check(Dune::CpGrid& coarse_grid,
+                        const std::array<int,3>& cells_per_dim,
+                        const std::vector<int>& markedCells,
+                        Dune::CpGrid& other_grid,
+                        bool isBlockShape,
+                        bool hasBeenRefinedAtLeastOnce,
+                        bool isGlobalRefinement)
+{
+    const int startingGridIdx = coarse_grid.chooseData().size() -1; // size before calling adapt
+
+    std::vector<int> assignRefinedLevel(coarse_grid.chooseData()[startingGridIdx]->size(0));
+
+    for (const auto& elemIdx : markedCells)
+    {
+        const auto& elem =  Dune::cpgrid::Entity<0>(*(coarse_grid.chooseData()[startingGridIdx]), elemIdx, true);
+        coarse_grid.mark(1, elem);
+        assignRefinedLevel[elemIdx] = coarse_grid.maxLevel() + 1;
+        BOOST_CHECK( coarse_grid.getMark(elem) == 1);
+        BOOST_CHECK( elem.mightVanish() == true);
+    }
+    bool preAdapt = coarse_grid.preAdapt();
+    const auto& data = coarse_grid.chooseData();
+    if(preAdapt) {
+        coarse_grid.adapt({cells_per_dim}, assignRefinedLevel, {"LGR"});
+        coarse_grid.postAdapt();
+        BOOST_CHECK(static_cast<int>(data.size()) == startingGridIdx+3);
+        const auto& adapted_leaf = *data[startingGridIdx+2];
+
+        if(isBlockShape) {
+            const auto& blockRefinement_data = other_grid.chooseData();
+            const auto& blockRefinement_leaf = *blockRefinement_data.back();
+
+            // Check the container sizes
+            BOOST_CHECK_EQUAL(adapted_leaf.geomVector<3>().size(), blockRefinement_leaf.geomVector<3>().size());
+            BOOST_CHECK_EQUAL(adapted_leaf.face_to_cell_.size(), blockRefinement_leaf.face_to_cell_.size());
+            BOOST_CHECK_EQUAL(adapted_leaf.face_to_point_.size(), blockRefinement_leaf.face_to_point_.size());
+            BOOST_CHECK_EQUAL(adapted_leaf.face_normals_.size(), blockRefinement_leaf.face_normals_.size());
+            BOOST_CHECK_EQUAL(adapted_leaf.face_tag_.size(), blockRefinement_leaf.face_tag_.size());
+            BOOST_CHECK_EQUAL(adapted_leaf.cell_to_point_.size(), blockRefinement_leaf.cell_to_point_.size());
+            BOOST_CHECK_EQUAL(adapted_leaf.cell_to_face_.size(), blockRefinement_leaf.cell_to_face_.size());
+            BOOST_CHECK_EQUAL(coarse_grid.size(3), other_grid.size(3));
+            BOOST_CHECK_EQUAL(coarse_grid.size(0), other_grid.size(0));
+            if(!hasBeenRefinedAtLeastOnce) {
+                BOOST_CHECK_EQUAL(coarse_grid.size(1,0), other_grid.size(1,0)); // equal amount of cells in level 1
+                BOOST_CHECK_EQUAL(coarse_grid.size(1,3), other_grid.size(1,3)); // equal amount of corners in level 1
+            }
+
+            for(const auto& point: adapted_leaf.geomVector<3>()){
+                auto equiv_point_iter = blockRefinement_leaf.geomVector<3>().begin();
+                while ((equiv_point_iter != blockRefinement_leaf.geomVector<3>().end()) && (point.center() != equiv_point_iter->center())) {
+                    ++equiv_point_iter;
+                }
+                CHECK_COORDINATES(point.center(), equiv_point_iter->center());
+                for(const auto& coord: point.center())
+                    BOOST_TEST(std::isfinite(coord));
+
+            }
+            for(const auto& cell: adapted_leaf.geomVector<3>()) {
+                auto equiv_cell_iter = blockRefinement_leaf.geomVector<3>().begin();
+                while ((equiv_cell_iter != blockRefinement_leaf.geomVector<3>().end()) && (cell.center() != equiv_cell_iter->center())) {
+                    ++equiv_cell_iter;
+                }
+                CHECK_COORDINATES(cell.center(), equiv_cell_iter->center());
+                for(const auto& coord: cell.center())
+                    BOOST_TEST(std::isfinite(coord));
+                BOOST_CHECK_CLOSE(cell.volume(), equiv_cell_iter->volume(), 1e-24);
+            }
+
+            /////  THE FOLLOWING CODE WOULD FIT FOR TESTING GLOBAL REFINEMENT
+            if (isGlobalRefinement) {
+                const auto& grid_view = coarse_grid.leafGridView();
+                const auto& equiv_grid_view = other_grid.leafGridView();
+
+
+                for(const auto& element: elements(grid_view)) {
+                    BOOST_CHECK( element.getOrigin().level() == 0);
+                    auto equiv_element_iter = equiv_grid_view.begin<0>();
+                    bool closedCenter =  (std::abs(element.geometry().center()[0] - equiv_element_iter->geometry().center()[0]) < 1e-12) &&
+                        (std::abs(element.geometry().center()[1] - equiv_element_iter->geometry().center()[1]) < 1e-12) &&
+                        (std::abs(element.geometry().center()[2] - equiv_element_iter->geometry().center()[2])< 1e-12);
+
+                    while ((equiv_element_iter != equiv_grid_view.end<0>()) && (!closedCenter)) {
+                        ++equiv_element_iter;
+                        closedCenter = (std::abs(element.geometry().center()[0] - equiv_element_iter->geometry().center()[0]) < 1e-12) &&
+                            (std::abs(element.geometry().center()[1] - equiv_element_iter->geometry().center()[1]) < 1e-12) &&
+                            (std::abs(element.geometry().center()[2] - equiv_element_iter->geometry().center()[2])< 1e-12);
+                    }
+                    for(const auto& intersection: intersections(grid_view, element)) {
+                        // find matching intersection (needed as ordering is allowed to be different
+                        bool matching_intersection_found = false;
+                        for(auto& intersection_match: intersections(equiv_grid_view, *equiv_element_iter)) {
+                            if(intersection_match.indexInInside() == intersection.indexInInside()) {
+                                BOOST_CHECK(intersection_match.neighbor() == intersection.neighbor());
+
+                                if(intersection.neighbor()) {
+                                    BOOST_CHECK(intersection_match.indexInOutside() == intersection.indexInOutside());
+                                }
+
+                                CHECK_COORDINATES(intersection_match.centerUnitOuterNormal(), intersection.centerUnitOuterNormal());
+                                const auto& geom_match = intersection_match.geometry();
+                                BOOST_TEST(0.0 == 1e-11, boost::test_tools::tolerance(1e-8));
+                                const auto& geom =  intersection.geometry();
+                                bool closedGeomCenter =  (std::abs(geom_match.center()[0] - geom.center()[0]) < 1e-12) &&
+                                    (std::abs(geom_match.center()[1] - geom.center()[1]) < 1e-12) &&
+                                    (std::abs(geom_match.center()[2] - geom.center()[2])< 1e-12);
+                                if (!closedGeomCenter) {
+                                    break; // Check next intersection_match
+                                }
+                                BOOST_CHECK_CLOSE(geom_match.volume(), geom.volume(), 1e-6);
+                                CHECK_COORDINATES(geom_match.center(), geom.center());
+                                BOOST_CHECK(geom_match.corners() == geom.corners());
+
+                                decltype(geom.corner(0)) sum_match{}, sum{};
+
+                                for(int cor = 0; cor < geom.corners(); ++cor) {
+                                    sum += geom.corner(cor);
+                                    sum_match += geom_match.corner(1);
+                                }
+                                CHECK_COORDINATES(sum, sum_match);
+                                matching_intersection_found = true;
+                                break;
+                            }
+                        } // end-for-loop-intersection_match
+                        BOOST_CHECK(matching_intersection_found);
+                    }
+                }
+            } // end-if-isGlobalRefinement
+        } // end-if-isBlockShape
+
+        const auto& grid_view = coarse_grid.leafGridView();
+
+        const auto& preAdapt_view = coarse_grid.levelGridView(startingGridIdx);
+        // Note: preAdapt grid in level "startingGridIdx"
+        //       refined grid in level  "startingGridIdx+1"
+        //       adapted grid in level  "startingGridIdx+2"
+        Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LeafGridView> adaptMapper(grid_view, Dune::mcmgElementLayout());
+        Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LevelGridView> preAdaptMapper(preAdapt_view, Dune::mcmgElementLayout());
+        const auto& adapt_idSet = adapted_leaf.local_id_set_;
+        const auto& preAdapt_idSet = (*data[startingGridIdx+1]).local_id_set_;
+
+        for(const auto& element: elements(grid_view)) {
+            // postAdapt() has been called, therefore every element gets marked with 0
+            BOOST_CHECK( coarse_grid.getMark(element) == 0);
+            BOOST_CHECK(  adapted_leaf.cell_to_point_[element.index()].size() == 8);
+            for (int i = 0; i < 8; ++i) {
+                BOOST_CHECK(  adapted_leaf.cell_to_point_[element.index()][i] != -1);
+            }
+            for (int i = 0; i <  adapted_leaf.cell_to_face_[element].size(); ++i) {
+                BOOST_CHECK(  adapted_leaf.cell_to_face_[element][i].index() != -1);
+            }
+            const auto& child_to_parent =  adapted_leaf.child_to_parent_cells_[element.index()];
+            const auto& level_cellIdx =  adapted_leaf.leaf_to_level_cells_[element.index()];
+            auto it = element.hbegin(level_cellIdx[0] /*level*/);//coarse_grid.maxLevel());
+            auto endIt = element.hend(level_cellIdx[0] /*level*/); //coarse_grid.maxLevel());
+            BOOST_CHECK(element.isLeaf());
+            BOOST_CHECK(it == endIt);
+            if (element.hasFather()){
+                BOOST_CHECK( element.isNew() == true);
+                BOOST_CHECK_CLOSE(element.geometryInFather().volume(), 1./(cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]), 1e-6);
+                if (hasBeenRefinedAtLeastOnce){
+                    BOOST_CHECK(element.father().level() <= startingGridIdx); // Remove? Not that useful...
+                    BOOST_CHECK( element.getOrigin().level() <= startingGridIdx);
+                }
+                else {
+                    BOOST_CHECK(element.father().level() == 0);
+                    BOOST_CHECK( element.getOrigin().level() == 0);  // To do: check Entity::getOrigin()
+                }
+                BOOST_CHECK_EQUAL( (std::find(markedCells.begin(), markedCells.end(), element.father().index()) == markedCells.end()), false);
+                BOOST_CHECK(child_to_parent[0] != -1);
+                BOOST_CHECK_EQUAL( child_to_parent[0] == startingGridIdx, true);
+                BOOST_CHECK_EQUAL( child_to_parent[1], element.father().index());
+                BOOST_CHECK( element.father() == element.getOrigin());
+                BOOST_CHECK(  ( adapted_leaf.global_cell_[element.index()]) == (data[startingGridIdx]->global_cell_[element.getOrigin().index()]) );
+                BOOST_CHECK( std::get<0>(data[startingGridIdx]->parent_to_children_cells_[child_to_parent[1]]) == element.level());
+                // Check amount of children cells of the parent cell
+                BOOST_CHECK_EQUAL(std::get<1>(data[startingGridIdx]->parent_to_children_cells_[child_to_parent[1]]).size(),
+                                  cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]);
+                BOOST_CHECK( element.father().isLeaf() == false);
+                BOOST_CHECK( (element.level() > 0) || (element.level() < coarse_grid.maxLevel() +1));
+                BOOST_CHECK( level_cellIdx[0] == element.level());
+                //
+                const auto& id = (*adapt_idSet).id(element);
+                const auto& parent_id = (*preAdapt_idSet).id(element.father());
+                BOOST_CHECK(element.index() == id);
+                BOOST_CHECK(element.index() == adaptMapper.index(element));
+                BOOST_CHECK(element.father().index() == parent_id);
+                BOOST_CHECK(element.father().index() == preAdaptMapper.index(element.father()));
+            }
+            else{
+                BOOST_CHECK_THROW(element.father(), std::logic_error);
+                BOOST_CHECK_THROW(element.geometryInFather(), std::logic_error);
+                BOOST_CHECK_EQUAL(child_to_parent[0], -1);
+                BOOST_CHECK_EQUAL(child_to_parent[1], -1);
+                if (hasBeenRefinedAtLeastOnce){
+                    BOOST_CHECK( level_cellIdx[0] == startingGridIdx); // Equal when the grid has been refined only once. Remove this check?
+                    BOOST_CHECK( element.level() == startingGridIdx);
+                    BOOST_CHECK( element.getOrigin().level() <= startingGridIdx);
+                }
+                else  {
+                    BOOST_CHECK( level_cellIdx[0] == 0);
+                    BOOST_CHECK( element.level() == 0);
+                    BOOST_CHECK( element.getOrigin().level() == 0);
+                }
+                BOOST_CHECK( std::get<0>(data[startingGridIdx]-> parent_to_children_cells_[level_cellIdx[1]]) == -1);
+                BOOST_CHECK( std::get<1>(data[startingGridIdx]->parent_to_children_cells_[level_cellIdx[1]]).empty());
+                // Get index of the cell in level 0
+                const auto& entityOldIdx =   adapted_leaf.leaf_to_level_cells_[element.index()][1];
+                BOOST_CHECK( element.getOrigin().index() == entityOldIdx);
+                BOOST_CHECK( element.getOrigin().level() == 0);
+                BOOST_CHECK( element.isNew() == false);
+            }
+            BOOST_CHECK( element.mightVanish() == false); // marks get rewrtitten and set to 0 via postAdapt call
+        } // end-element-for-loop
+
+        // Some checks on the preAdapt grid
+        for(const auto& element: elements(preAdapt_view)) {
+            if (!hasBeenRefinedAtLeastOnce){
+                BOOST_CHECK( element.hasFather() == false);
+                BOOST_CHECK_THROW(element.father(), std::logic_error);
+                BOOST_CHECK_THROW(element.geometryInFather(), std::logic_error);
+                BOOST_CHECK( element.getOrigin() ==  element);
+                BOOST_CHECK( element.getOrigin().level() == startingGridIdx);
+                BOOST_CHECK( element.isNew() == false);
+            }
+            auto it = element.hbegin(coarse_grid.maxLevel()); // With element.level(), fails
+            auto endIt = element.hend(coarse_grid.maxLevel());
+            const auto& [lgr, childrenList] = (*data[startingGridIdx]).parent_to_children_cells_[element.index()];
+            if (std::find(markedCells.begin(), markedCells.end(), element.index()) == markedCells.end()){
+                BOOST_CHECK_EQUAL(lgr, -1);
+                BOOST_CHECK(childrenList.empty());
+                BOOST_CHECK( element.isLeaf() == true);
+                // If it == endIt, then entity.isLeaf() true (when dristibuted_data_ is empty)
+                BOOST_CHECK( it == endIt);
+                BOOST_CHECK( element.mightVanish() == false);
+            }
+            else{
+                BOOST_CHECK(lgr != -1);
+                BOOST_CHECK(static_cast<int>(childrenList.size()) == cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]);
+                // If it != endIt, then entity.isLeaf() false (when dristibuted_data_ is empty)
+                BOOST_CHECK_EQUAL( it == endIt, false);
+                BOOST_CHECK( element.mightVanish() == true);
+                BOOST_CHECK( element.isNew() == false);
+                BOOST_CHECK_EQUAL( element.isLeaf(), false); // parent cells do not appear in the LeafView
+                // Auxiliary int to check amount of children
+                double referenceElemOneParent_volume = 0.;
+                std::array<double,3> referenceElem_entity_center = {0.,0.,0.}; // Expected {.5,.5,.5}
+                for (const auto& child : childrenList) {
+                    BOOST_CHECK( child != -1);
+                    BOOST_CHECK( data[startingGridIdx+1]-> child_to_parent_cells_[child][0] == startingGridIdx);  //
+                    BOOST_CHECK( data[startingGridIdx+1]-> child_to_parent_cells_[child][1] == element.index());
+
+                    const auto& childElem =  Dune::cpgrid::Entity<0>(*data[startingGridIdx+1], child, true);
+                    BOOST_CHECK(childElem.hasFather() == true);
+                    BOOST_CHECK(childElem.level() == lgr);
+                    referenceElemOneParent_volume += childElem.geometryInFather().volume();
+                    for (int c = 0; c < 3; ++c)  {
+                        referenceElem_entity_center[c] += (childElem.geometryInFather().center())[c];
+                    }
+                }
+                /// Auxiliary int to check amount of children
+                double referenceElemOneParent_volume_it = 0.;
+                std::array<double,3> referenceElem_entity_center_it = {0.,0.,0.}; // Expected {.5,.5,.5}
+                for (; it != endIt; ++it)
+                {
+                    BOOST_CHECK(it ->hasFather() == true);
+                    BOOST_CHECK(it ->level() == lgr);
+                    referenceElemOneParent_volume_it += it-> geometryInFather().volume();
+                    for (int c = 0; c < 3; ++c)
+                    {
+                        referenceElem_entity_center_it[c] += (it-> geometryInFather().center())[c];
+                    }
+                }
+                for (int c = 0; c < 3; ++c) {
+                    referenceElem_entity_center[c] /= cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2];
+                    referenceElem_entity_center_it[c] /= cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2];
+                }
+                BOOST_CHECK_CLOSE(referenceElemOneParent_volume, 1, 1e-13);
+                BOOST_CHECK_CLOSE(referenceElem_entity_center[0], .5, 1e-13);
+                BOOST_CHECK_CLOSE(referenceElem_entity_center[1], .5, 1e-13);
+                BOOST_CHECK_CLOSE(referenceElem_entity_center[2], .5, 1e-13);
+
+                BOOST_CHECK_CLOSE(referenceElemOneParent_volume_it, 1, 1e-13);
+                BOOST_CHECK_CLOSE(referenceElem_entity_center_it[0], .5, 1e-13);
+                BOOST_CHECK_CLOSE(referenceElem_entity_center_it[1], .5, 1e-13);
+                BOOST_CHECK_CLOSE(referenceElem_entity_center_it[2], .5, 1e-13);
+            }
+            BOOST_CHECK( element.level() == 0);
+        } // end-preAdaptElements-for-loop
+    } // end-if-preAdapt
+}
+
+BOOST_AUTO_TEST_CASE(doNothing)
+{
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {2,2,2};
+    std::vector<int> markedCells;
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, false, false);
+}
+
+BOOST_AUTO_TEST_CASE(globalRefinement)
+{
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {2,2,2};
+    std::vector<int> markedCells(36);
+    std::iota(markedCells.begin(), markedCells.end(), 0);
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+
+    // Create other grid for comparison
+    Dune::CpGrid other_grid;
+    other_grid.createCartesian(grid_dim, cell_sizes);
+
+    const std::array<int, 3> startIJK = {0,0,0};
+    const std::array<int, 3> endIJK = {4,3,3};
+    const std::string lgr_name = {"LGR1"};
+    other_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, true, false, true);
+}
+
+BOOST_AUTO_TEST_CASE(mark2consequtiveCells)
+{
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {2,2,2};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+
+
+    // Create other grid for comparison
+    Dune::CpGrid other_grid;
+    other_grid.createCartesian(grid_dim, cell_sizes);
+
+    const std::array<int, 3> startIJK = {2,0,0};
+    const std::array<int, 3> endIJK = {4,1,1};  // -> marked elements 2 and 3
+    const std::string lgr_name = {"LGR1"};
+    other_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+
+    std::vector<int> markedCells = {2,3};
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, true, false, false);
+}
+
+BOOST_AUTO_TEST_CASE(mark2InteriorConsequtiveCells)
+{
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {2,2,2};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+
+
+    // Create other grid for comparison
+    Dune::CpGrid other_grid;
+    other_grid.createCartesian(grid_dim, cell_sizes);
+
+    const std::array<int, 3> startIJK = {1,1,1};
+    const std::array<int, 3> endIJK = {3,2,2};  // -> marked elements 17 and 18
+    const std::string lgr_name = {"LGR1"};
+    other_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+
+    std::vector<int> markedCells = {17,18};
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, true, false, false);
+}
+
+BOOST_AUTO_TEST_CASE(markNonBlockShapeCells)
+{
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {2,2,2};
+    std::vector<int> markedCells = {0}; //,1,2,5,13};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, false, false);
+}
+
+
+BOOST_AUTO_TEST_CASE(markNonBlockShapeCells_II)
+{
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {2,3,4};
+    std::vector<int> markedCells = {1,4,6,9,17,22,28,32,33};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, false, false);
+}
+
+
+BOOST_AUTO_TEST_CASE(markNonBlockCells_compareAdapt)
+{
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {3,3,3};
+    std::vector<int> markedCells = {1,4,6,9,17,22,28,32,33};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+
+    // Create a grid
+    Dune::CpGrid other_grid;
+    other_grid.createCartesian(grid_dim, cell_sizes);
+    for (const auto& elemIdx : markedCells)
+    {
+        const auto& elem =  Dune::cpgrid::Entity<0>(*(other_grid.chooseData()[0]), elemIdx, true);
+        other_grid.mark(1, elem);
+    }
+    other_grid.preAdapt();
+    other_grid.adapt();
+    other_grid.postAdapt();
+    
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, false, false, false);
+}
+
+/*BOOST_AUTO_TEST_CASE(adaptFromAMixedGrid)
+  {
+  // Create a grid
+  Dune::CpGrid coarse_grid;
+  const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+  const std::array<int, 3> grid_dim = {4,3,3};
+  const std::array<int, 3> cells_per_dim = {2,2,2};
+  coarse_grid.createCartesian(grid_dim, cell_sizes);
+
+
+  const std::array<int, 3> startIJK = {1,1,1};
+  const std::array<int, 3> endIJK = {3,2,2};  // -> marked elements 17 and 18
+  const std::string lgr_name = {"LGR1"};
+  coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+
+  std::vector<int> markedCells = {0,1}; // coarse cells
+  markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, true, true, false);
+  }
+
+  BOOST_AUTO_TEST_CASE(adaptFromAMixedGridRefinedCell)
+  {
+  // Create a grid
+  Dune::CpGrid coarse_grid;
+  const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+  const std::array<int, 3> grid_dim = {4,3,3};
+  const std::array<int, 3> cells_per_dim = {2,2,2};
+  coarse_grid.createCartesian(grid_dim, cell_sizes);
+
+
+  const std::array<int, 3> startIJK = {1,1,1};
+  const std::array<int, 3> endIJK = {3,2,2};  // -> marked elements 17 and 18
+  const std::string lgr_name = {"LGR1"};
+  coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+
+  std::vector<int> markedCells = {34}; // {34, 35} refined cells (with parent cell 17) -> check conversion of corners between neighboring lgrs definition!
+  // Error:  Cannot convert corner index from one LGR to its neighboring LGR
+  // 42 refined cell with parent cell 18.
+  markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, true, true, false);
+  }
+
+
+  BOOST_AUTO_TEST_CASE(adaptFromAMixedGridMixedCells)
+  {
+  // Create a grid
+  Dune::CpGrid coarse_grid;
+  const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+  const std::array<int, 3> grid_dim = {4,3,3};
+  const std::array<int, 3> cells_per_dim = {2,2,2};
+  coarse_grid.createCartesian(grid_dim, cell_sizes);
+
+
+  const std::array<int, 3> startIJK = {1,1,1};
+  const std::array<int, 3> endIJK = {3,2,2};  // -> marked elements 17 and 18
+  const std::string lgr_name = {"LGR1"};
+  coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+
+  std::vector<int> markedCells = {2,3,34}; // {34, 41} refined cells (with parent cell 17),
+  // 42, 49 refined cell with parent cell 18-> check conversion of corners between neighboring lgrs definition!
+  markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, true, false);
+  }*/

--- a/tests/cpgrid/lookupdataCpGrid_test.cpp
+++ b/tests/cpgrid/lookupdataCpGrid_test.cpp
@@ -86,8 +86,8 @@ void lookup_check(const Dune::CpGrid& grid)
     std::vector<std::vector<int>> fakeLgrFeatures;
     fakeLgrFeatures.resize(data.size()-1);
     // Creating fake field properties for each LGR
-    if (data.size()>1) {
-        for (long unsigned int lgr = 1; lgr < data.size(); ++lgr)
+    if (grid.maxLevel()>0) {
+        for (int lgr = 1; lgr < grid.maxLevel() +1; ++lgr)
         {
             std::vector<int> fake_feature_lgr(data[lgr]->size(0), lgr);
             fakeLgrFeatures[lgr-1] = fake_feature_lgr;


### PR DESCRIPTION
This PR 
- does not affect the update of the reference manual. 
- replaces OPM/opm-grid#721. 
- improves the refinement of CpGrid as well as partially support adaptivity, for general corner-point grids.
Marking cells with no neighboring connections for refinement is not supported yet.

Cells can be marked for refinement, without any assumption on the shape of the total cells to be refined. Previously, only a block of cells.

The adapted grid is the mix of coarse cells (not involved in refinement) and the refined entities.