### PR TITLE
Fix multiply defined symbols for shared libraries.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -42,6 +42,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/grid/cpgrid/writeSintefLegacyFormat.cpp
   opm/grid/common/GeometryHelpers.cpp
   opm/grid/common/GridPartitioning.cpp
+  opm/grid/common/MetisPartition.cpp
   opm/grid/common/WellConnections.cpp
   opm/grid/common/ZoltanGraphFunctions.cpp
   opm/grid/common/ZoltanPartition.cpp
@@ -200,6 +201,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/grid/cpgrid/PersistentContainer.hpp
   opm/grid/common/CartesianIndexMapper.hpp
   opm/grid/common/GridEnums.hpp
+  opm/grid/common/MetisPartition.hpp
   opm/grid/common/SubGridPart.hpp
   opm/grid/common/ZoltanGraphFunctions.hpp
   opm/grid/common/ZoltanPartition.hpp

--- a/opm-grid-prereqs.cmake
+++ b/opm-grid-prereqs.cmake
@@ -10,6 +10,7 @@ set (opm-grid_CONFIG_VAR
   DUNE_COMMON_VERSION_MINOR
   DUNE_COMMON_VERSION_REVISION
   HAVE_DUNE_ISTL
+  HAVE_METIS
   HAVE_MPI
   HAVE_ZOLTAN
   HAVE_OPM_COMMON
@@ -27,6 +28,7 @@ set (opm-grid_DEPS
   "dune-istl"
   "opm-common REQUIRED"
   "ZOLTAN"
+  "METIS"
   )
 
 find_package_deps(opm-grid)

--- a/opm-grid-prereqs.cmake
+++ b/opm-grid-prereqs.cmake
@@ -12,6 +12,7 @@ set (opm-grid_CONFIG_VAR
   HAVE_DUNE_ISTL
   HAVE_METIS
   HAVE_MPI
+  HAVE_PTSCOTCH
   HAVE_ZOLTAN
   HAVE_OPM_COMMON
   HAVE_ECL_INPUT
@@ -28,6 +29,7 @@ set (opm-grid_DEPS
   "dune-istl"
   "opm-common REQUIRED"
   "ZOLTAN"
+  "PTScotch"
   "METIS"
   )
 

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -634,6 +634,18 @@ namespace Dune
         // loadbalance is not part of the grid interface therefore we skip it.
 
         /// \brief Distributes this grid over the available nodes in a distributed machine
+        /// \param overlapLayers The number of layers of cells of the overlap region (default: 1).
+        /// \param partitionMethod The method used to partition the grid, one of Dune::PartitionMethod
+        /// \warning May only be called once.
+        bool loadBalanceSerial(int overlapLayers=1, int partitionMethod = Dune::PartitionMethod::zoltan)
+        {
+            using std::get;
+            return get<0>(scatterGrid(defaultTransEdgeWgt, false, nullptr, true /*serial partitioning*/, nullptr, true, overlapLayers, partitionMethod ));
+        }
+
+        // loadbalance is not part of the grid interface therefore we skip it.
+
+        /// \brief Distributes this grid over the available nodes in a distributed machine
         ///
         /// This will construct the corresponding graph to the grid and use the transmissibilities
         /// specified as weights associated with its edges. The graph will be passed to the load balancer.

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -666,7 +666,7 @@ namespace Dune
         /// This will construct the corresponding graph to the grid and use the transmissibilities
         /// specified to calculate the  weights associated with its edges. The graph will be passed
         ///  to the load balancer.
-        /// \param method The edge-weighting method to be used on the Zoltan partitioner.
+        /// \param method The edge-weighting method to be used on the graph partitioner.
         /// \param wells The wells of the eclipse If null wells will be neglected.
         ///            If this is not null then complete well information of
         ///            of the last scheduler step of the eclipse state will be
@@ -732,7 +732,7 @@ namespace Dune
         /// specified to calculate the  weights associated with its edges. The graph will be passed
         ///  to the load balancer.
         /// \param data A data handle describing how to distribute attached data.
-        /// \param method The edge-weighting method to be used on the Zoltan partitioner.
+        /// \param method The edge-weighting method to be used on the graph partitioner.
         /// \param wells The information about all possible wells. If null then
         ///            the wells will be neglected. Otherwise the wells will be
         ///            used to make sure that all the possible completion cells
@@ -745,7 +745,7 @@ namespace Dune
         /// \param addCornerCells Add corner cells to the overlap layer.
         /// \param overlapLayers The number of layers of cells of the overlap region (default: 1).
         /// \param partitionMethod The method used to partition the grid, one of Dune::PartitionMethod
-        /// \param zoltanImbalanceTol Set the imbalance tolerance used by Zoltan
+        /// \param imbalanceTol Set the imbalance tolerance used by the partitioner
         /// \param allowDistributedWells Allow the perforation of a well to be distributed to the
         ///        interior region of multiple processes.
         /// \tparam DataHandle The type implementing DUNE's DataHandle interface.
@@ -760,11 +760,11 @@ namespace Dune
                     bool serialPartitioning,
                     const double* transmissibilities = nullptr, bool ownersFirst=false,
                     bool addCornerCells=false, int overlapLayers=1, int partitionMethod = Dune::PartitionMethod::zoltan,
-                    double zoltanImbalanceTol = 1.1,
+                    double imbalanceTol = 1.1,
                     bool allowDistributedWells = false)
         {
             auto ret = scatterGrid(method, ownersFirst, wells, serialPartitioning, transmissibilities,
-                                   addCornerCells, overlapLayers, partitionMethod, zoltanImbalanceTol, allowDistributedWells);
+                                   addCornerCells, overlapLayers, partitionMethod, imbalanceTol, allowDistributedWells);
             using std::get;
             if (get<0>(ret))
             {
@@ -801,7 +801,7 @@ namespace Dune
                                    /* serialPartitioning = */ false,
                                    /* transmissibilities = */ {},
                                    addCornerCells, overlapLayers, /* partitionMethod =*/ Dune::PartitionMethod::simple,
-                                   /* zoltanImbalanceTol (ignored) = */ 0.0,
+                                   /* imbalanceTol (ignored) = */ 0.0,
                                    /* allowDistributedWells = */ true, parts);
             using std::get;
             if (get<0>(ret))
@@ -851,7 +851,7 @@ namespace Dune
                                       /* serialPartitioning = */ false,
                                       /* trabsmissibilities = */ {},
                                       addCornerCells, overlapLayers, /* partitionMethod =*/ Dune::PartitionMethod::simple,
-                                      /* zoltanImbalanceTol (ignored) = */ 0.0,
+                                      /* imbalanceTol (ignored) = */ 0.0,
                                       /* allowDistributedWells = */ true, parts));
         }
 
@@ -888,7 +888,7 @@ namespace Dune
          zoltanPartitionWithoutScatter(const std::vector<cpgrid::OpmWellType>* wells,
                                        const double* transmissibilities,
                                        const int     numParts,
-                                       const double  zoltanImbalanceTol) const;
+                                       const double  imbalanceTol) const;
 
         /// The new communication interface.
         /// \brief communicate objects for all codims on a given level
@@ -1199,7 +1199,7 @@ namespace Dune
 
     private:
         /// \brief Scatter a global grid to all processors.
-        /// \param method The edge-weighting method to be used on the Zoltan partitioner.
+        /// \param method The edge-weighting method to be used on the graph partitioner.
         /// \param ownersFirst Order owner cells before copy/overlap cells.
         /// \param wells The wells of the eclipse If null wells will be neglected.
         ///            If this is not null then complete well information of
@@ -1209,12 +1209,12 @@ namespace Dune
         ///            adding an edge with a very high edge weight for all
         ///            possible pairs of cells in the completion set of a well.
         /// \param transmissibilities The transmissibilities used to calculate the edge weights in
-        ///                           the Zoltan partitioner. This is done to improve the numerical
+        ///                           the graph partitioner. This is done to improve the numerical
         ///                           performance of the parallel preconditioner.
         /// \param addCornerCells Add corner cells to the overlap layer.
         /// \param overlapLayers The number of layers of cells of the overlap region.
         /// \param partitionMethod The method used to partition the grid, one of Dune::PartitionMethod
-        /// \param zoltanImbalanceTol Set the imbalance tolerance used by Zoltan
+        /// \param imbalanceTol Set the imbalance tolerance used by the partitioner
         /// \param allowDistributedWells Allow the perforation of a well to be distributed to the
         ///        interior region of multiple processes.
         /// \param cell_part When using an external loadbalancer the partition number for each cell.
@@ -1231,7 +1231,7 @@ namespace Dune
                     bool addCornerCells,
                     int overlapLayers,
                     int partitionMethod = Dune::PartitionMethod::zoltan,
-                    double zoltanImbalanceTol = 1.1,
+                    double imbalanceTol = 1.1,
                     bool allowDistributedWells = true,
                     const std::vector<int>& input_cell_part = {});
 
@@ -1265,7 +1265,7 @@ namespace Dune
 
 
         /**
-         * @brief Zoltan partitioning parameters
+         * @brief Partitioning parameters
          */
         std::map<std::string,std::string> zoltanParams;
 

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -623,13 +623,12 @@ namespace Dune
 
         /// \brief Distributes this grid over the available nodes in a distributed machine
         /// \param overlapLayers The number of layers of cells of the overlap region (default: 1).
-        /// \param useZoltan Whether to use Zoltan for partitioning or our simple approach based on
-        ///        rectangular partitioning the underlying cartesian grid.
+        /// \param partitionMethod The method used to partition the grid, one of Dune::PartitionMethod
         /// \warning May only be called once.
-        bool loadBalance(int overlapLayers=1, bool useZoltan=true)
+        bool loadBalance(int overlapLayers=1, int partitionMethod = Dune::PartitionMethod::zoltan)
         {
             using std::get;
-            return get<0>(scatterGrid(defaultTransEdgeWgt, false, nullptr, false, nullptr, true, overlapLayers, useZoltan ));
+            return get<0>(scatterGrid(defaultTransEdgeWgt, false, nullptr, false, nullptr, true, overlapLayers, partitionMethod ));
         }
 
         // loadbalance is not part of the grid interface therefore we skip it.
@@ -647,8 +646,7 @@ namespace Dune
         ///            possible pairs of cells in the completion set of a well.
         /// \param transmissibilities The transmissibilities used as the edge weights.
         /// \param overlapLayers The number of layers of cells of the overlap region (default: 1).
-        /// \param useZoltan Whether to use Zoltan for partitioning or our simple approach based on
-        ///        rectangular partitioning the underlying cartesian grid.
+        /// \param partitionMethod The method used to partition the grid, one of Dune::PartitionMethod
         /// \warning May only be called once.
         /// \return A pair consisting of a boolean indicating whether loadbalancing actually happened and
         ///         a vector containing a pair of name and a boolean, indicating whether this well has
@@ -656,9 +654,9 @@ namespace Dune
         std::pair<bool,std::vector<std::pair<std::string,bool>>>
         loadBalance(const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities = nullptr,
-                    int overlapLayers=1, bool useZoltan=true)
+                    int overlapLayers=1, int partitionMethod=Dune::PartitionMethod::zoltan)
         {
-            return scatterGrid(defaultTransEdgeWgt, false, wells, false, transmissibilities, false, overlapLayers, useZoltan);
+            return scatterGrid(defaultTransEdgeWgt, false, wells, false, transmissibilities, false, overlapLayers, partitionMethod);
         }
 
         // loadbalance is not part of the grid interface therefore we skip it.
@@ -680,8 +678,7 @@ namespace Dune
         /// \param ownersFirst Order owner cells before copy/overlap cells.
         /// \param addCornerCells Add corner cells to the overlap layer.
         /// \param overlapLayers The number of layers of cells of the overlap region (default: 1).
-        /// \param useZoltan Whether to use Zoltan for partitioning or our simple approach based on
-        ///        rectangular partitioning the underlying cartesian grid.
+        /// \param partitionMethod The method used to partition the grid, one of Dune::PartitionMethod
         /// \warning May only be called once.
         /// \return A pair consisting of a boolean indicating whether loadbalancing actually happened and
         ///         a vector containing a pair of name and a boolean, indicating whether this well has
@@ -690,9 +687,9 @@ namespace Dune
         loadBalance(EdgeWeightMethod method, const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities = nullptr, bool ownersFirst=false,
                     bool addCornerCells=false, int overlapLayers=1,
-                    bool useZoltan = true)
+                    int partitionMethod = Dune::PartitionMethod::zoltan)
         {
-            return scatterGrid(method, ownersFirst, wells, false, transmissibilities, addCornerCells, overlapLayers, useZoltan);
+            return scatterGrid(method, ownersFirst, wells, false, transmissibilities, addCornerCells, overlapLayers, partitionMethod);
         }
 
         /// \brief Distributes this grid and data over the available nodes in a distributed machine.
@@ -707,8 +704,7 @@ namespace Dune
         /// \param transmissibilities The transmissibilities used to calculate the edge weights.
         /// \param overlapLayers The number of layers of overlap cells to be added
         ///        (default: 1)
-        /// \param useZoltan Whether to use Zoltan for partitioning or our simple approach based on
-        ///        rectangular partitioning the underlying cartesian grid.
+        /// \param partitionMethod The method used to partition the grid, one of Dune::PartitionMethod
         /// \tparam DataHandle The type implementing DUNE's DataHandle interface.
         /// \warning May only be called once.
         /// \return A pair consisting of a boolean indicating whether loadbalancing actually happened and
@@ -719,9 +715,9 @@ namespace Dune
         loadBalance(DataHandle& data,
                     const std::vector<cpgrid::OpmWellType> * wells,
                     const double* transmissibilities = nullptr,
-                    int overlapLayers=1, bool useZoltan = true)
+                    int overlapLayers=1, int partitionMethod = 1)
         {
-            auto ret = loadBalance(wells, transmissibilities, overlapLayers, useZoltan);
+            auto ret = loadBalance(wells, transmissibilities, overlapLayers, partitionMethod);
             using std::get;
             if (get<0>(ret))
             {
@@ -748,8 +744,7 @@ namespace Dune
         /// \param ownersFirst Order owner cells before copy/overlap cells.
         /// \param addCornerCells Add corner cells to the overlap layer.
         /// \param overlapLayers The number of layers of cells of the overlap region (default: 1).
-        /// \param useZoltan Whether to use Zoltan for partitioning or our simple approach based on
-        ///        rectangular partitioning the underlying cartesian grid.
+        /// \param partitionMethod The method used to partition the grid, one of Dune::PartitionMethod
         /// \param zoltanImbalanceTol Set the imbalance tolerance used by Zoltan
         /// \param allowDistributedWells Allow the perforation of a well to be distributed to the
         ///        interior region of multiple processes.
@@ -764,12 +759,12 @@ namespace Dune
                     const std::vector<cpgrid::OpmWellType> * wells,
                     bool serialPartitioning,
                     const double* transmissibilities = nullptr, bool ownersFirst=false,
-                    bool addCornerCells=false, int overlapLayers=1, bool useZoltan = true,
+                    bool addCornerCells=false, int overlapLayers=1, int partitionMethod = Dune::PartitionMethod::zoltan,
                     double zoltanImbalanceTol = 1.1,
                     bool allowDistributedWells = false)
         {
             auto ret = scatterGrid(method, ownersFirst, wells, serialPartitioning, transmissibilities,
-                                   addCornerCells, overlapLayers, useZoltan, zoltanImbalanceTol, allowDistributedWells);
+                                   addCornerCells, overlapLayers, partitionMethod, zoltanImbalanceTol, allowDistributedWells);
             using std::get;
             if (get<0>(ret))
             {
@@ -805,7 +800,7 @@ namespace Dune
             auto ret = scatterGrid(defaultTransEdgeWgt,  ownersFirst, wells,
                                    /* serialPartitioning = */ false,
                                    /* transmissibilities = */ {},
-                                   addCornerCells, overlapLayers, /* useZoltan =*/ false,
+                                   addCornerCells, overlapLayers, /* partitionMethod =*/ Dune::PartitionMethod::simple,
                                    /* zoltanImbalanceTol (ignored) = */ 0.0,
                                    /* allowDistributedWells = */ true, parts);
             using std::get;
@@ -820,17 +815,16 @@ namespace Dune
         /// \param data A data handle describing how to distribute attached data.
         /// \param overlapLayers The number of layers of overlap cells to be added
         ///        (default: 1)
-        /// \param useZoltan Whether to use Zoltan for partitioning or our simple approach based on
-        ///        rectangular partitioning the underlying cartesian grid.
+        /// \param partitionMethod The method used to partition the grid, one of Dune::PartitionMethod
         /// \tparam DataHandle The type implementing DUNE's DataHandle interface.
         /// \warning May only be called once.
         template<class DataHandle>
         bool loadBalance(DataHandle& data,
-                         decltype(data.fixedSize(0,0)) overlapLayers=1, bool useZoltan = true)
+                         decltype(data.fixedSize(0,0)) overlapLayers=1, int partitionMethod = Dune::PartitionMethod::zoltan)
         {
             // decltype usage needed to tell the compiler not to use this function if first
             // argument is std::vector but rather loadbalance by parts
-            bool ret = loadBalance(overlapLayers, useZoltan);
+            bool ret = loadBalance(overlapLayers, partitionMethod);
             if (ret)
             {
                 scatterData(data);
@@ -856,7 +850,7 @@ namespace Dune
             return get<0>(scatterGrid(defaultTransEdgeWgt,  ownersFirst, /* wells = */ {},
                                       /* serialPartitioning = */ false,
                                       /* trabsmissibilities = */ {},
-                                      addCornerCells, overlapLayers, /* useZoltan =*/ false,
+                                      addCornerCells, overlapLayers, /* partitionMethod =*/ Dune::PartitionMethod::simple,
                                       /* zoltanImbalanceTol (ignored) = */ 0.0,
                                       /* allowDistributedWells = */ true, parts));
         }
@@ -1219,8 +1213,7 @@ namespace Dune
         ///                           performance of the parallel preconditioner.
         /// \param addCornerCells Add corner cells to the overlap layer.
         /// \param overlapLayers The number of layers of cells of the overlap region.
-        /// \param useZoltan Whether to use Zoltan for partitioning or our simple approach based on
-        ///        rectangular partitioning the underlying cartesian grid.
+        /// \param partitionMethod The method used to partition the grid, one of Dune::PartitionMethod
         /// \param zoltanImbalanceTol Set the imbalance tolerance used by Zoltan
         /// \param allowDistributedWells Allow the perforation of a well to be distributed to the
         ///        interior region of multiple processes.
@@ -1237,7 +1230,7 @@ namespace Dune
                     const double* transmissibilities,
                     bool addCornerCells,
                     int overlapLayers,
-                    bool useZoltan = true,
+                    int partitionMethod = Dune::PartitionMethod::zoltan,
                     double zoltanImbalanceTol = 1.1,
                     bool allowDistributedWells = true,
                     const std::vector<int>& input_cell_part = {});

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -636,11 +636,12 @@ namespace Dune
         /// \brief Distributes this grid over the available nodes in a distributed machine
         /// \param overlapLayers The number of layers of cells of the overlap region (default: 1).
         /// \param partitionMethod The method used to partition the grid, one of Dune::PartitionMethod
+        /// \param edgeWeightMethod The edge-weighting method to be used on the graph partitioner.
         /// \warning May only be called once.
-        bool loadBalanceSerial(int overlapLayers=1, int partitionMethod = Dune::PartitionMethod::zoltan)
+        bool loadBalanceSerial(int overlapLayers=1, int partitionMethod = Dune::PartitionMethod::zoltan, int edgeWeightMethod = Dune::EdgeWeightMethod::defaultTransEdgeWgt)
         {
             using std::get;
-            return get<0>(scatterGrid(defaultTransEdgeWgt, false, nullptr, true /*serial partitioning*/, nullptr, true, overlapLayers, partitionMethod ));
+            return get<0>(scatterGrid(EdgeWeightMethod(edgeWeightMethod), false, nullptr, true /*serial partitioning*/, nullptr, true, overlapLayers, partitionMethod ));
         }
 
         // loadbalance is not part of the grid interface therefore we skip it.

--- a/opm/grid/common/GridEnums.hpp
+++ b/opm/grid/common/GridEnums.hpp
@@ -24,7 +24,7 @@
 #define OPM_GRID_ENUMS_HPP
 
 namespace Dune {
-    /// \brief enum for choosing Methods for weighting graph-edges correspoding to cell interfaces in Zoltan's graph partitioner.
+    /// \brief enum for choosing Methods for weighting graph-edges correspoding to cell interfaces in Zoltan's or Metis' graph partitioner.
     ////
     /// uniform methods means all edges have weight 1. defaultTrans uses transmissibility as weights.
     /// logTrans uses the logarithm of the transmissibility.
@@ -38,6 +38,16 @@ namespace Dune {
         defaultTransEdgeWgt=1,
         /// \brief Use the log of the transmissibilities as edge weights
         logTransEdgeWgt=2
+    };
+
+    /// \brief enum for choosing methods for partitioning a graph.
+    enum PartitionMethod {
+        /// \brief Use simple approach based on rectangular partitioning the underlying cartesian grid.
+        simple=0,
+        /// \brief Use Zoltan for partitioning
+        zoltan=1,
+        /// \brief Use METIS for partitioning
+        metis=2
     };
 }
 

--- a/opm/grid/common/GridPartitioning.cpp
+++ b/opm/grid/common/GridPartitioning.cpp
@@ -594,7 +594,7 @@ namespace cpgrid
               std::vector<std::tuple<int,int,char> >,
               std::vector<std::tuple<int,int,char,int> >,
               WellConnections>
-    createZoltanListsFromParts(const CpGrid& grid, const std::vector<cpgrid::OpmWellType> * wells,
+    createListsFromParts(const CpGrid& grid, const std::vector<cpgrid::OpmWellType> * wells,
                                const double* transmissibilities, const std::vector<int>& parts,
                                bool allowDistributedWells)
     {
@@ -679,8 +679,7 @@ namespace cpgrid
             initialSplit[0]=cc.size()/(initialSplit[1]*initialSplit[2]);
             partition(grid, initialSplit, numParts, parts, false, false);
         }
-        return createZoltanListsFromParts(grid, wells, transmissibilities, parts,
-                                          allowDistributedWells);
+        return createListsFromParts(grid, wells, transmissibilities, parts, allowDistributedWells);
     }
 #endif
 } // namespace cpgrid

--- a/opm/grid/common/GridPartitioning.cpp
+++ b/opm/grid/common/GridPartitioning.cpp
@@ -596,7 +596,8 @@ namespace cpgrid
               WellConnections>
     createListsFromParts(const CpGrid& grid, const std::vector<cpgrid::OpmWellType> * wells,
                                const double* transmissibilities, const std::vector<int>& parts,
-                               bool allowDistributedWells)
+                               bool allowDistributedWells,
+                               std::shared_ptr<cpgrid::CombinedGridWellGraph> gridAndWells)
     {
         std::vector<int> exportGlobalIds;
         std::vector<int> exportLocalIds;
@@ -634,8 +635,7 @@ namespace cpgrid
             scatterExportInformation(numExport, exportGlobalIds.data(),
                                      exportToPart.data(), 0,
                                      grid.comm());
-        std::unique_ptr<cpgrid::CombinedGridWellGraph> gridAndWells;
-        if (wells)
+        if (wells and !gridAndWells)
         {
             bool partitionIsEmpty = (grid.size(0) == 0);
             EdgeWeightMethod method{}; // We don't care which method is used, we only need the graph.

--- a/opm/grid/common/GridPartitioning.hpp
+++ b/opm/grid/common/GridPartitioning.hpp
@@ -47,6 +47,7 @@
 
 #include <opm/grid/utility/OpmWellType.hpp>
 #include <opm/grid/common/WellConnections.hpp>
+#include <opm/grid/common/ZoltanGraphFunctions.hpp>
 
 namespace Dune
 {
@@ -134,7 +135,7 @@ namespace cpgrid
                WellConnections>
     createListsFromParts(const CpGrid& grid, const std::vector<cpgrid::OpmWellType> * wells,
                                const double* transmissibilities, const std::vector<int>& parts,
-                               bool allowDistributedWells);
+                               bool allowDistributedWells, std::shared_ptr<cpgrid::CombinedGridWellGraph> gridAndWells = nullptr);
 
     /// \brief Creates a vanilla partitioning without a real loadbalancer
     ///

--- a/opm/grid/common/GridPartitioning.hpp
+++ b/opm/grid/common/GridPartitioning.hpp
@@ -132,7 +132,7 @@ namespace cpgrid
                std::vector<std::tuple<int,int,char> >,
                std::vector<std::tuple<int,int,char,int> >,
                WellConnections>
-    createZoltanListsFromParts(const CpGrid& grid, const std::vector<cpgrid::OpmWellType> * wells,
+    createListsFromParts(const CpGrid& grid, const std::vector<cpgrid::OpmWellType> * wells,
                                const double* transmissibilities, const std::vector<int>& parts,
                                bool allowDistributedWells);
 

--- a/opm/grid/common/MetisPartition.cpp
+++ b/opm/grid/common/MetisPartition.cpp
@@ -21,6 +21,7 @@
 #endif
 
 #if HAVE_MPI // no code in this file without MPI, then skip includes.
+#include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/grid/common/ZoltanGraphFunctions.cpp>
 #include <opm/grid/common/MetisPartition.hpp>
 #include <opm/grid/utility/OpmWellType.hpp>
@@ -190,6 +191,7 @@ metisSerialGraphPartitionGridOnRoot(const CpGrid& cpgrid,
         // The advice is: Use METIS_PartGraphRecursive if k is small and if k is a power of two
         // (n & (n - 1) == 0) is true if n > 0 and n is a power of two, this is an efficient bitwise check.
         if (nparts < 65 && ((nparts & (nparts - 1)) == 0)) {
+            Opm::OpmLog::info("Partitioning grid using METIS_PartGraphRecursive.");
             rc = METIS_PartGraphRecursive(&n, 
                                           &ncon,
                                           xadj,
@@ -204,6 +206,7 @@ metisSerialGraphPartitionGridOnRoot(const CpGrid& cpgrid,
                                           &objval,
                                           gpart);
         } else {
+            Opm::OpmLog::info("Partitioning grid using METIS_PartGraphKway.");
             rc = METIS_PartGraphKway(&n, 
                                      &ncon,
                                      xadj,

--- a/opm/grid/common/MetisPartition.cpp
+++ b/opm/grid/common/MetisPartition.cpp
@@ -37,7 +37,10 @@ namespace Dune
 namespace cpgrid
 {
 
+// We want to use METIS, but if METIS is installed together with Scotch, then the following options are not available.
+#ifndef HAVE_PTSCOTCH
 void setMetisOptions(const std::map<std::string, std::string>& optionsMap, idx_t* options) {
+
     // Initialize all options to default values
     METIS_SetDefaultOptions(options);
 
@@ -76,6 +79,7 @@ void setMetisOptions(const std::map<std::string, std::string>& optionsMap, idx_t
         }
     }
 }
+#endif
 
 
 std::tuple<std::vector<int>,
@@ -91,7 +95,7 @@ metisSerialGraphPartitionGridOnRoot(const CpGrid& cpgrid,
                                     int root,
                                     const real_t imbalanceTol,
                                     bool allowDistributedWells,
-                                    const std::map<std::string,std::string>& params)
+                                    [[maybe_unused]] const std::map<std::string,std::string>& params)
 {
 #if defined(IDXTYPEWIDTH) && IDXTYPEWIDTH != 64
     if (edgeWeightsMethod == Dune::EdgeWeightMethod::defaultTransEdgeWgt )
@@ -159,12 +163,18 @@ metisSerialGraphPartitionGridOnRoot(const CpGrid& cpgrid,
         // of the jth’s constraint total weight. The load imbalances must be greater than 1.0.
         // A NULL value can be passed indicating that the load imbalance tolerance for each constraint should
         // be 1.001 (for ncon=1) or 1.01 (for ncon>1).
-        assert(imbalanceTol > 1.0);
+        // NOTE: Scotch and METIS interpret this parameter differently
         real_t ubvec = imbalanceTol;
         
+#ifndef HAVE_PTSCOTCH
         // This is the array of options as described in Section 5.4.
+        // The METIS options are not available if METIS is installed together with Scotch.
         idx_t* options = new idx_t[METIS_NOPTIONS];
         Dune::cpgrid::setMetisOptions(params, options);
+#else
+        idx_t* options = nullptr;
+        Opm::OpmLog::info("Not setting specific METIS Options since you're using the Scotch replacement for METIS.");
+#endif
 
         //////// Now, we define all variables that *do depend* on whether there are wells or not
 

--- a/opm/grid/common/MetisPartition.cpp
+++ b/opm/grid/common/MetisPartition.cpp
@@ -22,7 +22,7 @@
 
 #if HAVE_MPI // no code in this file without MPI, then skip includes.
 #include <opm/common/OpmLog/OpmLog.hpp>
-#include <opm/grid/common/ZoltanGraphFunctions.cpp>
+#include <opm/grid/common/ZoltanGraphFunctions.hpp>
 #include <opm/grid/common/MetisPartition.hpp>
 #include <opm/grid/utility/OpmWellType.hpp>
 #include <opm/grid/cpgrid/CpGridData.hpp>

--- a/opm/grid/common/MetisPartition.cpp
+++ b/opm/grid/common/MetisPartition.cpp
@@ -1,0 +1,253 @@
+/*
+  Copyright 2024 OPM-OP AS
+
+  This file is part of The Open Porous Media project  (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#if HAVE_MPI // no code in this file without MPI, then skip includes.
+#include <opm/grid/common/ZoltanGraphFunctions.cpp>
+#include <opm/grid/common/MetisPartition.hpp>
+#include <opm/grid/utility/OpmWellType.hpp>
+#include <opm/grid/cpgrid/CpGridData.hpp>
+#include <opm/grid/cpgrid/Entity.hpp>
+#include <algorithm>
+#include <type_traits>
+#endif
+
+#if defined(HAVE_METIS) && HAVE_MPI
+namespace Dune
+{
+namespace cpgrid
+{
+
+std::tuple<std::vector<int>,
+           std::vector<std::pair<std::string, bool>>,
+           std::vector<std::tuple<int, int, char>>,
+           std::vector<std::tuple<int, int, char, int>>,
+           WellConnections>
+metisSerialGraphPartitionGridOnRoot(const CpGrid& cpgrid,
+                                    const std::vector<OpmWellType> * wells,
+                                    const double* transmissibilities,
+                                    const Communication<MPI_Comm>& cc,
+                                    EdgeWeightMethod edgeWeightsMethod,
+                                    int root,
+                                    const real_t imbalanceTol,
+                                    bool allowDistributedWells,
+                                    const std::map<std::string,std::string>& params)
+{
+#if defined(IDXTYPEWIDTH) && IDXTYPEWIDTH != 64
+    if (edgeWeightsMethod == Dune::EdgeWeightMethod::defaultTransEdgeWgt )
+        OPM_THROW(std::runtime_error, "The selected partition method is METIS with default edge weights (i.e. transmissibilities).\
+            This combination works only for METIS with 64-bit integers, but the installed version of METIS does not use 64-bit integers.\
+            Either reinstall METIS with 64-bit integers or choose another edge weight method!");
+#endif
+
+    std::shared_ptr<CombinedGridWellGraph> gridAndWells;
+    if( wells )
+    {
+        gridAndWells.reset(new CombinedGridWellGraph(cpgrid,
+                                                       wells,
+                                                       transmissibilities,
+                                                       false,
+                                                       edgeWeightsMethod));
+    }
+
+    std::vector<int> partitionVector;
+    int rc = METIS_OK;
+
+    cc.barrier();
+    //Metis is a serial graph partitioner, we do everything only on root
+    if (cc.rank() == root) {
+
+        //////// First, we define all variables that *do not depend* on whether there are wells or not
+
+        // The number of vertices, every cell is a vertex in the graph.
+        idx_t n = cpgrid.numCells();
+        
+        // This is a vector of size n that upon successful completion stores the partition vector of the graph.
+        // The numbering of this vector starts from either 0 or 1, depending on the value of options[METIS_OPTION_NUMBERING].
+        idx_t* gpart = new idx_t[n];
+
+        // Upon successful completion, this variable stores the edge-cut or the total communication volume of
+        // the partitioning solution. The value returned depends on the partitioning’s objective function.
+        idx_t objval = 0;
+
+        // The number of partitions to split the graph into, we want to distribtue over all processes, so cc.size()
+        idx_t nparts = cc.size(); 
+
+        auto& globalIdSet         =  cpgrid.globalIdSet();
+        auto& localIdSet          =  cpgrid.localIdSet();
+
+        idx_t* gids = new idx_t[n];
+        idx_t* lids = new idx_t[n];
+
+        int idx = 0;
+        for (auto cell = cpgrid.leafbegin<0>(), cellEnd = cpgrid.leafend<0>(); cell != cellEnd; ++cell)
+        {
+            gids[idx]   = globalIdSet.id(*cell);
+            lids[idx++] = localIdSet.id(*cell);
+        }
+
+        //The number of balancing constraints, should be at least 1.
+        idx_t ncon = 1;
+
+        // The adjacency structure of a graph with n vertices and m edges is represented using two arrays xadj and adjncy.
+        // An array of size n+1 that specifies the adjacency structure of the graph. The adjacency list of vertex i is stored in adjncy[xadj[i]] to adjncy[xadj[i+1]-1].
+        idx_t* xadj = new idx_t[n+1];
+        xadj[0] = 0;
+
+        // This is an array of size ncon (in our case, of size 1) that specifies the allowed load imbalance tolerance for each constraint.
+        // For the ith partition and jth constraint the allowed weight is the ubvec[j]*tpwgts[i*ncon+j] fraction
+        // of the jth’s constraint total weight. The load imbalances must be greater than 1.0.
+        // A NULL value can be passed indicating that the load imbalance tolerance for each constraint should
+        // be 1.001 (for ncon=1) or 1.01 (for ncon>1).
+        assert(imbalanceTol > 1.0);
+        real_t ubvec = imbalanceTol;
+        
+        // This is the array of options as described in Section 5.4.
+        idx_t* options = new idx_t[METIS_NOPTIONS];
+        METIS_SetDefaultOptions(options);
+        // The following options are valid for METIS PartGraphRecursive:
+        // METIS_OPTION_CTYPE, METIS_OPTION_IPTYPE, METIS_OPTION_RTYPE,
+        // METIS_OPTION_NO2HOP, METIS_OPTION_NCUTS, METIS_OPTION_NITER,
+        // METIS_OPTION_SEED, METIS_OPTION_UFACTOR, METIS_OPTION_NUMBERING,
+        // METIS_OPTION_DBGLVL
+        // The following options are valid for METIS PartGraphKway:
+        // METIS_OPTION_OBJTYPE = this is edgecut by default -> minimize the edges that straddle partitions
+        //                        as opposed to vol -> minimize Total communication volume.
+        // METIS_OPTION_CTYPE, METIS_OPTION_IPTYPE,
+        // METIS_OPTION_RTYPE, METIS_OPTION_NO2HOP, METIS_OPTION_NCUTS,
+        // METIS_OPTION_NITER, METIS_OPTION_UFACTOR, METIS_OPTION_MINCONN,
+        // METIS_OPTION_CONTIG, METIS_OPTION_SEED, METIS_OPTION_NUMBERING,
+        // METIS_OPTION_DBGLVL
+
+
+        //////// Now, we define all variables that *do depend* on whether there are wells or not
+
+        if( wells )
+        {            
+            for (int i = 0; i < n;  i++) {
+                xadj[i+1] = xadj[i] + Dune::cpgrid::getNumberOfEdgesForSpecificCellForGridWithWells(*gridAndWells, lids[i]);
+            }
+        }
+        else
+        {
+            for (int i = 0; i < n;  i++) {
+                xadj[i+1] = xadj[i] + Dune::cpgrid::getNumberOfEdgesForSpecificCell(cpgrid, lids[i]);
+            }
+        }
+
+        // The number of edges depends on whether there are wells or not, twoM = 2*m, where m = number of edges.
+        idx_t twoM = xadj[n];
+
+        // An array that contains the adjacency list of the graph.
+        // The xadj array is of size n + 1 whereas the adjncy array is of size 2m (because for each edge between vertices v and u we actually store both (v, u) and (u, v)).
+        // The adjacency list of vertex i is stored in array adjncy starting at index xadj[i] and ending at (but not
+        // including) index xadj[i + 1] (i.e., adjncy[xadj[i]] through and including adjncy[xadj[i + 1]-1])
+        // So: xadj contains the indices where we start for the respective component
+        idx_t* adjncy = new idx_t[twoM]; 
+        
+        // An array that contains the weights of the edges. If all edges have the same weight, this can be set to NULL.
+        // The weights of the edges (if any) are stored in an additional array called adjwgt. This array contains 2m elements, and the weight of edge adjncy[j] is stored at location adjwgt[j]
+        idx_t* adjwgt = new idx_t[twoM];
+
+        if( wells )
+        {
+            int neighborCounter = 0;
+            for( int cell = 0; cell < n;  cell++ )
+            {
+                fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(*gridAndWells, lids[cell], gids, neighborCounter, adjncy, adjwgt);
+            }
+        }
+        else
+        {
+            int neighborCounter = 0;
+            for( int cell = 0; cell < n;  cell++ )
+            {
+                fillNBORGIDForSpecificCellAndIncrementNeighborCounter(cpgrid, lids[cell], gids, neighborCounter, adjncy);
+            }
+        }
+
+        // Decide which partition method to use, both methods create k partitions, where
+        // METIS_PartGraphRecursive uses multilevel recursive bisection and
+        // METIS_PartGraphKway uses multilevel k-way partition.
+        // The advice is: Use METIS_PartGraphRecursive if k is small and if k is a power of two
+        // (n & (n - 1) == 0) is true if n > 0 and n is a power of two, this is an efficient bitwise check.
+        if (nparts < 65 && ((nparts & (nparts - 1)) == 0)) {
+            rc = METIS_PartGraphRecursive(&n, 
+                                          &ncon,
+                                          xadj,
+                                          adjncy,
+                                          nullptr, // vwgt
+                                          nullptr, // vsize,
+                                          wells ? adjwgt : nullptr,
+                                          &nparts,
+                                          nullptr, // tpwgts,
+                                          &ubvec,
+                                          options,
+                                          &objval,
+                                          gpart);
+        } else {
+            rc = METIS_PartGraphKway(&n, 
+                                     &ncon,
+                                     xadj,
+                                     adjncy,
+                                     nullptr, // vwgt
+                                     nullptr, // vsize,
+                                     wells ? adjwgt : nullptr,
+                                     &nparts,
+                                     nullptr, // tpwgts,
+                                     &ubvec,
+                                     options,
+                                     &objval,
+                                     gpart);
+        }
+
+        for (int i = 0; i < n; i++)
+            partitionVector.push_back(gpart[i]);
+        
+        delete[] gids;
+        delete[] lids;
+        delete[] xadj;
+        delete[] adjncy;
+        delete[] adjwgt;
+        delete[] options;
+        delete[] gpart;
+    }
+
+    //Broadcast the return value to all processes
+    cc.broadcast(&rc, 1, root);
+    if (rc == METIS_OK) {
+        // Function returned normally :)
+    } else if (rc == METIS_ERROR_INPUT) {
+        OPM_THROW(std::runtime_error, "METIS Input Error!");
+    } else if (rc == METIS_ERROR_MEMORY) {
+        OPM_THROW(std::runtime_error, "METIS could not allocate the required memory!");
+    } else if (rc == METIS_ERROR) {
+        OPM_THROW(std::runtime_error, "Some other type of METIS error!");
+    } else {   
+        OPM_THROW(std::runtime_error, "Some other type of general error!");
+    }
+    
+    return cpgrid::createListsFromParts(cpgrid, wells, transmissibilities, partitionVector, allowDistributedWells, gridAndWells);
+}
+
+} // namespace cpgrid
+} // namespace Dune
+#endif // HAVE_METIS && HAVE_MPI

--- a/opm/grid/common/MetisPartition.cpp
+++ b/opm/grid/common/MetisPartition.cpp
@@ -249,8 +249,7 @@ metisSerialGraphPartitionGridOnRoot(const CpGrid& cpgrid,
                                      gpart);
         }
 
-        for (int i = 0; i < n; i++)
-            partitionVector.push_back(gpart[i]);
+        partitionVector.assign(gpart, gpart + n);
         
         delete[] gids;
         delete[] lids;

--- a/opm/grid/common/MetisPartition.hpp
+++ b/opm/grid/common/MetisPartition.hpp
@@ -1,0 +1,100 @@
+/*
+  Copyright 2024 OPM-OP AS
+
+  This file is part of The Open Porous Media project  (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef DUNE_CPGRID_METISPARTITION_HEADER
+#define DUNE_CPGRID_METISPARTITION_HEADER
+
+#include <unordered_set>
+
+#include <opm/grid/CpGrid.hpp>
+#include <opm/grid/common/ZoltanGraphFunctions.hpp>
+#include <opm/grid/common/WellConnections.hpp>
+#include <opm/grid/common/ZoltanPartition.hpp>
+#include <opm/grid/common/GridPartitioning.hpp>
+
+#if defined(HAVE_METIS) && HAVE_MPI 
+extern "C" {
+  #include <metis.h>
+}
+#endif // defined(HAVE_METIS) && HAVE_MPI
+
+#if defined(HAVE_METIS) && HAVE_MPI
+namespace Dune
+{
+namespace cpgrid
+{
+#if defined(REALTYPEWIDTH)
+  using real_t = ::real_t;
+#else
+  using real_t = double;
+#endif
+
+#if defined(IDXTYPEWIDTH)
+  using idx_t = ::idx_t;
+#else
+  using idx_t = int;
+#endif
+
+/// \brief Partition a CpGrid using METIS
+///
+/// This function will extract graph information
+/// from the grid, and the wells and use it to partition the grid.
+
+/// @param grid The grid to partition
+/// @param wells The wells of the eclipse If null wells will be neglected.
+/// @param transmissibilities The transmissibilities associated with the
+///             faces
+/// @paramm cc  The MPI communicator to use for the partitioning.
+///             The will be partitioned among the partiticipating processes.
+/// @param edgeWeightMethod The method used to calculate the weights associated
+///             with the edges of the graph (uniform, transmissibilities, log thereof)
+/// @param root The process number that holds the global grid.
+/// @param imbalanceTol Set the imbalance tolerance used by METIS, i.e. the entries of the parameter ubvec
+/// @param allowDistributedWells Allow the perforation of a well to be distributed to the
+///        interior region of multiple processes.
+/// @return A tuple consisting of a vector that contains for each local cell of the original grid the
+///         the number of the process that owns it after repartitioning,
+///         a vector containing a pair of name  and a boolean indicating whether this well has
+///         perforated cells local to the process of all wells,
+///         vector containing information for each exported cell (global id
+///         of cell, process id to send to, attribute there), a vector containing
+///         information for each imported cell (global index, process id that sends, attribute here, local index
+///         here), and a WellConnections object containing information about the well connections
+///         (if argument wells was not null and this is the root rank this will contain connections in
+///          form of global indices)
+
+std::tuple<std::vector<int>,
+           std::vector<std::pair<std::string, bool>>,
+           std::vector<std::tuple<int, int, char>>,
+           std::vector<std::tuple<int, int, char, int>>,
+           WellConnections>
+metisSerialGraphPartitionGridOnRoot(const CpGrid& grid,
+                                    const std::vector<OpmWellType> * wells,
+                                    const double* transmissibilities,
+                                    const Communication<MPI_Comm>& cc,
+                                    EdgeWeightMethod edgeWeightsMethod,
+                                    int root,
+                                    const real_t imbalanceTol,
+                                    bool allowDistributedWells,
+                                    const std::map<std::string,std::string>& params);
+}
+}
+
+
+#endif // HAVE_METIS && HAVE_MPI
+#endif // header guard

--- a/opm/grid/common/MetisPartition.hpp
+++ b/opm/grid/common/MetisPartition.hpp
@@ -27,7 +27,19 @@
 #include <opm/grid/common/ZoltanPartition.hpp>
 #include <opm/grid/common/GridPartitioning.hpp>
 
-#if defined(HAVE_METIS) && HAVE_MPI 
+// We want to use METIS, but if METIS is installed together with Scotch, then METIS uses some artifacts from Scotch.
+// For this type, we need to include scotch.h.
+#if HAVE_PTSCOTCH
+extern "C" {
+  #include <scotch.h>
+}
+// And also, we need to set the version number here manually to 5
+#ifndef SCOTCH_METIS_VERSION
+#define SCOTCH_METIS_VERSION 5
+#endif /* SCOTCH_METIS_VERSION */
+#endif
+
+#if defined(HAVE_METIS) && HAVE_MPI
 extern "C" {
   #include <metis.h>
 }
@@ -96,5 +108,5 @@ metisSerialGraphPartitionGridOnRoot(const CpGrid& grid,
 }
 
 
-#endif // HAVE_METIS && HAVE_MPI
+#endif // defined(HAVE_METIS) && HAVE_MPI
 #endif // header guard

--- a/opm/grid/common/ZoltanGraphFunctions.cpp
+++ b/opm/grid/common/ZoltanGraphFunctions.cpp
@@ -410,6 +410,15 @@ void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz,
         Zoltan_Set_Edge_List_Multi_Fn(zz, getCpGridWellsEdgeList, graphPointer);
     }
 }
+// Explicit template instantiation for METIS
+#if HAVE_METIS
+template
+void fillNBORGIDForSpecificCellAndIncrementNeighborCounter(const Dune::CpGrid&, int, int*, int&, int*& nborGID);
+template
+void fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(const CombinedGridWellGraph&, const int, int*, int&, int*&, int*);
+#endif
+
+
 } // end namespace cpgrid
 } // end namespace Dune
 #endif // defined(HAVE_ZOLTAN) && defined(HAVE_MPI)

--- a/opm/grid/common/ZoltanGraphFunctions.hpp
+++ b/opm/grid/common/ZoltanGraphFunctions.hpp
@@ -58,11 +58,18 @@ void getCpGridVertexList(void* cpGridPointer, int numGlobalIds,
                          ZOLTAN_ID_PTR lids, int wgtDim,
                          float *objWgts, int *err);
 
-/// \brief Get the number of edges the graph of the grid.
+/// \brief Get the number of edges for one vertex of the graph of the grid.
+int getNumberOfEdgesForSpecificCell(const Dune::CpGrid& grid, int localCellId);
+
+/// \brief Get the number of edges of the graph of the grid.
 void getCpGridNumEdgesList(void *cpGridPointer, int sizeGID, int sizeLID,
                            int numCells,
                            ZOLTAN_ID_PTR globalID, ZOLTAN_ID_PTR localID,
                            int *numEdges, int *err);
+
+/// \brief Get the list of edges for one cell of a grid witout wells
+template <typename ID>
+void fillNBORGIDForSpecificCellAndIncrementNeighborCounter(const Dune::CpGrid& grid, int localCellId, ID globalID, int& neighborCounter, ID& nborGID);
 
 /// \brief Get the list of edges of the graph of the grid.
 void getCpGridEdgeList(void *cpGridPointer, int sizeGID, int sizeLID,
@@ -230,6 +237,13 @@ private:
     WellConnections well_indices_;
     double log_min_;
 };
+
+/// \brief Get the number of edges of the graph of the grid and the wells for one cell
+int getNumberOfEdgesForSpecificCellForGridWithWells(const CombinedGridWellGraph& graph, int localCellId);
+
+/// \brief Get the list of edges and weights for one cell of a grid with wells
+template<typename ID, typename weightType>
+void fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(const CombinedGridWellGraph& graph, const int localCellId, ID globalID, int& neighborCounter, ID& nborGID, weightType *ewgts);
 
 #ifdef HAVE_ZOLTAN
 /// \brief Sets up the call-back functions for ZOLTAN's graph partitioning.

--- a/opm/grid/common/ZoltanPartition.hpp
+++ b/opm/grid/common/ZoltanPartition.hpp
@@ -152,7 +152,7 @@ zoltanGraphPartitionGridOnRoot(const CpGrid& grid,
 ///             with the edges of the graph (uniform, transmissibilities, log thereof)
 /// @param root The process number that holds the global grid.
 /// @param zoltanImbalanceTol Set the imbalance tolerance used by Zoltan
-/// \param allowDistributedWells Allow the perforation of a well to be distributed to the
+/// @param allowDistributedWells Allow the perforation of a well to be distributed to the
 ///        interior region of multiple processes.
 /// @return A tuple consisting of a vector that contains for each local cell of the original grid the
 ///         the number of the process that owns it after repartitioning,

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -50,6 +50,7 @@
 #endif
 
 #include "../CpGrid.hpp"
+#include <opm/grid/common/MetisPartition.hpp>
 #include <opm/grid/common/ZoltanPartition.hpp>
 //#include <opm/grid/common/ZoltanGraphFunctions.hpp>
 #include <opm/grid/common/GridPartitioning.hpp>
@@ -334,6 +335,17 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
 #else
                 OPM_THROW(std::runtime_error, "Parallel runs depend on ZOLTAN if useZoltan is true. Please install!");
 #endif // HAVE_ZOLTAN
+            }
+            else if (partitionMethod == 2)
+            {
+#ifdef HAVE_METIS
+                if (!serialPartitioning)
+                    OPM_MESSAGE("Warning: Serial partitioning is set to false and METIS was selected to partition the grid, but METIS is a serial partitioner. Continuing with serial partitioning...");
+                std::tie(computedCellPart, wells_on_proc, exportList, importList, wellConnections) = cpgrid::metisSerialGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0, imbalanceTol, allowDistributedWells, zoltanParams);
+#else
+                OPM_THROW(std::runtime_error, "Parallel runs depend on METIS if useMetis is true. Please install!");
+#endif // HAVE_METIS
+
             }
             else
             {

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -210,7 +210,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
                     [[maybe_unused]] bool addCornerCells,
                     int overlapLayers,
                     [[maybe_unused]] int partitionMethod,
-                    double zoltanImbalanceTol,
+                    double imbalanceTol,
                     [[maybe_unused]] bool allowDistributedWells,
                     [[maybe_unused]] const std::vector<int>& input_cell_part)
 {
@@ -219,7 +219,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
     static_cast<void>(transmissibilities);
     static_cast<void>(overlapLayers);
     static_cast<void>(method);
-    static_cast<void>(zoltanImbalanceTol);
+    static_cast<void>(imbalanceTol);
 
     if(!distributed_data_.empty())
     {
@@ -319,7 +319,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
 
             // Partitioning given externally
             std::tie(computedCellPart, wells_on_proc, exportList, importList, wellConnections) =
-                cpgrid::createZoltanListsFromParts(*this, wells, nullptr, input_cell_part,
+                cpgrid::createListsFromParts(*this, wells, nullptr, input_cell_part,
                                                    true);
         }
         else
@@ -329,8 +329,8 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
 #ifdef HAVE_ZOLTAN
                 std::tie(computedCellPart, wells_on_proc, exportList, importList, wellConnections)
                     = serialPartitioning
-                    ? cpgrid::zoltanSerialGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0, zoltanImbalanceTol, allowDistributedWells, zoltanParams)
-                    : cpgrid::zoltanGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0, zoltanImbalanceTol, allowDistributedWells, zoltanParams);
+                    ? cpgrid::zoltanSerialGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0, imbalanceTol, allowDistributedWells, zoltanParams)
+                    : cpgrid::zoltanGraphPartitionGridOnRoot(*this, wells, transmissibilities, cc, method, 0, imbalanceTol, allowDistributedWells, zoltanParams);
 #else
                 OPM_THROW(std::runtime_error, "Parallel runs depend on ZOLTAN if useZoltan is true. Please install!");
 #endif // HAVE_ZOLTAN
@@ -470,7 +470,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
             std::string msg = "At least one process has zero cells. Aborting. \n"
                 " Try decreasing the imbalance tolerance for zoltan with \n"
                 " --zoltan-imbalance-tolerance. The current value is "
-                + std::to_string(zoltanImbalanceTol);
+                + std::to_string(imbalanceTol);
             if (cc.rank()==0)
             {
                 OPM_THROW(std::runtime_error, msg );

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -209,7 +209,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
                     const double* transmissibilities,
                     [[maybe_unused]] bool addCornerCells,
                     int overlapLayers,
-                    [[maybe_unused]] bool useZoltan,
+                    [[maybe_unused]] int partitionMethod,
                     double zoltanImbalanceTol,
                     [[maybe_unused]] bool allowDistributedWells,
                     [[maybe_unused]] const std::vector<int>& input_cell_part)
@@ -324,7 +324,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
         }
         else
         {
-            if (useZoltan)
+            if (partitionMethod == Dune::PartitionMethod::zoltan)
             {
 #ifdef HAVE_ZOLTAN
                 std::tie(computedCellPart, wells_on_proc, exportList, importList, wellConnections)

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -344,7 +344,7 @@ private:
     std::vector<int>& cont_;
 };
 
-BOOST_AUTO_TEST_CASE(compareSerialZoltanAndMetis)
+BOOST_AUTO_TEST_CASE(serialZoltanAndMetis)
 {
 //Here, specifically compare serial Zoltan and Metis
 for (auto partition_method : partition_methods) {
@@ -354,7 +354,10 @@ for (auto partition_method : partition_methods) {
     std::array<double, 3> size={{ 1.0, 1.0, 1.0}};
     //grid.setUniqueBoundaryIds(true); // set and compute unique boundary ids.
     grid.createCartesian(dims, size);
-    grid.loadBalanceSerial(1, partition_method);
+    if (partition_method == 1)
+        grid.loadBalanceSerial(1, partition_method);
+    else if (partition_method == 2) // Use the logTransEdgeWgt method for METIS
+        grid.loadBalanceSerial(1, partition_method, Dune::EdgeWeightMethod::logTransEdgeWgt);
 #ifdef HAVE_DUNE_ISTL
     using AttributeSet = Dune::OwnerOverlapCopyAttributeSet::AttributeSet;
 #else
@@ -386,7 +389,10 @@ for (auto partition_method : partition_methods) {
     std::array<double, 3> size={{ 8.0, 4.0, 2.0}};
     //grid.setUniqueBoundaryIds(true); // set and compute unique boundary ids.
     grid.createCartesian(dims, size);
-    grid.loadBalance(1, partition_method);
+    if (partition_method == 1)
+        grid.loadBalance(1, partition_method);
+    else if (partition_method == 2)
+        grid.loadBalance(Dune::EdgeWeightMethod::logTransEdgeWgt, nullptr, nullptr, false, false, 1, partition_method);
 #ifdef HAVE_DUNE_ISTL
     using AttributeSet = Dune::OwnerOverlapCopyAttributeSet::AttributeSet;
 #else
@@ -420,7 +426,10 @@ for (auto partition_method : partition_methods) {
     grid.setUniqueBoundaryIds(true); // set and compute unique boundary ids.
     seqGrid.setUniqueBoundaryIds(true);
     grid.createCartesian(dims, size);
-    grid.loadBalance(1, partition_method);
+    if (partition_method == 1)
+        grid.loadBalance(1, partition_method);
+    else if (partition_method == 2)
+        grid.loadBalance(Dune::EdgeWeightMethod::logTransEdgeWgt, nullptr, nullptr, false, false, 1, partition_method);
     seqGrid.createCartesian(dims, size);
 
     auto idSet = grid.globalIdSet(), seqIdSet = seqGrid.globalIdSet();
@@ -562,8 +571,10 @@ for (auto partition_method : partition_methods) {
     const Dune::CpGrid::GlobalIdSet& unbalanced_gid_set=grid.globalIdSet();
 
     grid.communicate(data, Dune::All_All_Interface, Dune::ForwardCommunication);
-    grid.loadBalance(data, 1, partition_method);
-
+    if (partition_method == 1)
+        grid.loadBalance(data, 1, partition_method);
+    else if (partition_method == 2)
+        grid.loadBalance(data, Dune::EdgeWeightMethod::logTransEdgeWgt, nullptr, true, nullptr, false, false, 1, partition_method, 1.1, false);
     if ( grid.numCells())
     {
         std::array<int,3> ijk;
@@ -736,7 +747,10 @@ for (auto partition_method : partition_methods) {
     typedef Dune::CpGrid::LeafGridView GridView;
     enum{dimWorld = GridView::dimensionworld};
 
-    grid.loadBalance(1, partition_method);
+    if (partition_method == 1)
+        grid.loadBalance(1, partition_method);
+    else if (partition_method == 2)
+        grid.loadBalance(Dune::EdgeWeightMethod::logTransEdgeWgt, nullptr, nullptr, false, false, 1, partition_method);
     auto global_grid = grid;
     global_grid.switchToGlobalView();
 
@@ -809,7 +823,10 @@ for (auto partition_method : partition_methods) {
     typedef GridView::Codim<0>::Iterator ElementIterator;
     typedef typename GridView::IntersectionIterator IntersectionIterator;
 
-    grid.loadBalance(1, partition_method);
+    if (partition_method == 1)
+        grid.loadBalance(1, partition_method);
+    else if (partition_method == 2)
+        grid.loadBalance(Dune::EdgeWeightMethod::logTransEdgeWgt, nullptr, nullptr, false, false, 1, partition_method);
     ElementIterator endEIt = gridView.end<0>();
     for (ElementIterator eIt = gridView.begin<0>(); eIt != endEIt; ++eIt) {
         IntersectionIterator isEndIt = gridView.iend(eIt);


### PR DESCRIPTION
When compiling shared libaries we got linker errors for functions that were defined multiple times.