### PR TITLE
Global refinement supported for corner point grids

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -619,7 +619,7 @@ namespace Dune
 
         /// --------------- Auxiliary methods to support Adaptivity (begin) ---------------
         
-        /// @brief Refine each marked element and establish relationships between corners, faces, and cells marked for refinement,
+        /// @brief Refine each marked element and stablish relationships between corners, faces, and cells marked for refinement,
         ///        with the refined corners, refined faces, and refined cells.
         ///
         /// --- Marked elements parameters ---

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -486,8 +486,10 @@ namespace Dune
         /// \brief Access to the LeafIndexSet
         const Traits::LeafIndexSet& leafIndexSet() const;
 
-        /// global refinement
-        void globalRefine (int);
+        /// \brief  Refine the grid refCount times using the default refinement rule.
+        ///         This behaves like marking all elements for refinement and then calling preAdapt, adapt and postAdapt.
+        ///         The state after globalRefine is comparable to the state after postAdapt.
+        void globalRefine (int refCount);
 
         const std::vector<Dune::GeometryType>& geomTypes(const int) const;
 

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -621,7 +621,7 @@ namespace Dune
 
         /// --------------- Auxiliary methods to support Adaptivity (begin) ---------------
         
-        /// @brief Refine each marked element and stablish relationships between corners, faces, and cells marked for refinement,
+        /// @brief Refine each marked element and establish relationships between corners, faces, and cells marked for refinement,
         ///        with the refined corners, refined faces, and refined cells.
         ///
         /// --- Marked elements parameters ---

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1666,13 +1666,13 @@ bool CpGrid::adapt(const std::vector<std::array<int,3>>& cells_per_dim_vec,
     for (int preAdaptLevel = 0; preAdaptLevel < preAdaptMaxLevel +1; ++preAdaptLevel) {
         // Resize with the corresponding amount of cells of the preAdapt level. Deafualt {-1, empty vector} when the cell has no children.
         if ( (*data_[preAdaptLevel]).parent_to_children_cells_.empty()){
-        preAdapt_parent_to_children_cells_vec[preAdaptLevel].resize(data_[preAdaptLevel]->size(0), std::make_pair(-1, std::vector<int>{}));
+            preAdapt_parent_to_children_cells_vec[preAdaptLevel].resize(data_[preAdaptLevel]->size(0), std::make_pair(-1, std::vector<int>{}));
         }
         else {
-        preAdapt_parent_to_children_cells_vec[preAdaptLevel] =  (*data_[preAdaptLevel]).parent_to_children_cells_;
+            preAdapt_parent_to_children_cells_vec[preAdaptLevel] =  (*data_[preAdaptLevel]).parent_to_children_cells_;
         }
         // Resize with the corresponding amount of cell of the preAdapt level. Dafualt -1 when the cell vanished and does not appear on the leaf grid view.
-        // In entry 'level cell index', we store 'leafview cell index', or -1 when the cell vanished. 
+        // In entry 'level cell index', we store 'leafview cell index', or -1 when the cell vanished.
         preAdapt_level_to_leaf_cells_vec[preAdaptLevel].resize(data_[preAdaptLevel]->size(0), -1);
     }
     //
@@ -1868,7 +1868,7 @@ bool CpGrid::adapt(const std::vector<std::array<int,3>>& cells_per_dim_vec,
             data_[preAdaptMaxLevel+1] = refined_grid_ptr_vec[level];
         }
         else {
-        (this-> data_).push_back(refined_grid_ptr_vec[level]);
+            (this-> data_).push_back(refined_grid_ptr_vec[level]);
         }
 
         Dune::cpgrid::DefaultGeometryPolicy&  refinedLevel_geometries = (*data_[refinedLevelGridIdx]).geometry_;

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -930,9 +930,25 @@ const CpGridFamily::Traits::LeafIndexSet& CpGrid::leafIndexSet() const
     return *current_view_data_->index_set_;
 }
 
-void CpGrid::globalRefine (int)
+void CpGrid::globalRefine (int refCount)
 {
-    std::cout << "Warning: Global refinement not implemented, yet." << std::endl;
+    assert(refCount>-1);
+    // Throw if the grid has been already partially refined, i.e., there exist coarse cells with more than 6 faces.
+    // This is the case when a coarse cell has not been marked for refinement, but at least one of its neighboring cells
+    // got refined. Therefore, the coarse face that they share got replaced by refined-faces.
+    // if ((data_.size()>1) && )
+    if (refCount>0) {
+        for (int refinedLevel = 0; refinedLevel < refCount; ++refinedLevel) {
+            // Mark all the elements of the current leaf grid view for refinement
+            const auto& grid_view = this-> leafGridView();
+            for(const auto& element: elements(grid_view)) {
+                mark(1, element);
+            }
+            preAdapt();
+            adapt();
+            postAdapt();
+        }
+    }
 }
 
 const std::vector< Dune :: GeometryType >& CpGrid::geomTypes( const int codim ) const

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1649,7 +1649,12 @@ bool CpGrid::adapt(const std::vector<std::array<int,3>>& cells_per_dim_vec,
     std::vector<std::vector<int>> preAdapt_level_to_leaf_cells_vec(preAdaptMaxLevel +1);
     for (int preAdaptLevel = 0; preAdaptLevel < preAdaptMaxLevel +1; ++preAdaptLevel) {
         // Resize with the corresponding amount of cells of the preAdapt level. Deafualt {-1, empty vector} when the cell has no children.
+        if ( (*data_[preAdaptLevel]).parent_to_children_cells_.empty()){
         preAdapt_parent_to_children_cells_vec[preAdaptLevel].resize(data_[preAdaptLevel]->size(0), std::make_pair(-1, std::vector<int>{}));
+        }
+        else {
+        preAdapt_parent_to_children_cells_vec[preAdaptLevel] =  (*data_[preAdaptLevel]).parent_to_children_cells_;
+        }
         // Resize with the corresponding amount of cell of the preAdapt level. Dafualt -1 when the cell vanished and does not appear on the leaf grid view.
         // In entry 'level cell index', we store 'leafview cell index', or -1 when the cell vanished. 
         preAdapt_level_to_leaf_cells_vec[preAdaptLevel].resize(data_[preAdaptLevel]->size(0), -1);
@@ -1675,10 +1680,10 @@ bool CpGrid::adapt(const std::vector<std::array<int,3>>& cells_per_dim_vec,
                                             /* Additional parameters */
                                             cells_per_dim_vec);
 
-    // Update/define parent_to_children_cells_ and level_to_leaf_cells_ for all the existing level grids (level 0, 1, ..., preAdaptMaxLevel), before this call of adapt. 
-    for (int preAdaptLevel = 0; preAdaptLevel < preAdaptMaxLevel +1; ++preAdaptLevel) { 
-        (*data_[preAdaptLevel]).parent_to_children_cells_ = preAdapt_parent_to_children_cells_vec[preAdaptLevel];     
-        (*data_[preAdaptLevel]).level_to_leaf_cells_ =  preAdapt_level_to_leaf_cells_vec[preAdaptLevel]; 
+    // Update/define parent_to_children_cells_ and level_to_leaf_cells_ for all the existing level grids (level 0, 1, ..., preAdaptMaxLevel), before this call of adapt.
+    for (int preAdaptLevel = 0; preAdaptLevel < preAdaptMaxLevel +1; ++preAdaptLevel) {
+        (*data_[preAdaptLevel]).parent_to_children_cells_ = preAdapt_parent_to_children_cells_vec[preAdaptLevel];
+        (*data_[preAdaptLevel]).level_to_leaf_cells_ =  preAdapt_level_to_leaf_cells_vec[preAdaptLevel];
     }
 
     // -- Child-parent relations --
@@ -1801,6 +1806,38 @@ bool CpGrid::adapt(const std::vector<std::array<int,3>>& cells_per_dim_vec,
                                     cornerInMarkedElemWithEquivRefinedCorner,
                                     cells_per_dim_vec);
 
+    std::vector<int> adapted_global_cell(cell_count, 0);
+    updateLeafGridViewGeometries( /* Leaf grid View Corners arguments */
+                                  adapted_corners,
+                                  corner_count,
+                                  /* Leaf grid View Faces arguments */
+                                  adapted_faces,
+                                  mutable_face_tags,
+                                  mutable_face_normals,
+                                  adapted_face_to_point,
+                                  face_count,
+                                  /* Leaf grid View Cells argumemts  */
+                                  adapted_cells,
+                                  adapted_cell_to_point,
+                                  adapted_global_cell,
+                                  cell_count,
+                                  adapted_cell_to_face,
+                                  adapted_face_to_cell,
+                                  /* Auxiliary arguments */
+                                  adaptedCorner_to_elemLgrAndElemLgrCorner,
+                                  adaptedFace_to_elemLgrAndElemLgrFace,
+                                  adaptedCell_to_elemLgrAndElemLgrCell,
+                                  elemLgrAndElemLgrFace_to_adaptedFace,
+                                  faceInMarkedElemAndRefinedFaces,
+                                  adapted_geometries,
+                                  elemLgrAndElemLgrCorner_to_adaptedCorner,
+                                  vanishedRefinedCorner_to_itsLastAppearance,
+                                  markedElem_to_itsLgr,
+                                  assignRefinedLevel,
+                                  markedElemAndEquivRefinedCorn_to_corner,
+                                  cornerInMarkedElemWithEquivRefinedCorner,
+                                  cells_per_dim_vec,
+                                  preAdaptMaxLevel);
 
     for (int level = 0; level < levels; ++level) {
         const int refinedLevelGridIdx = level + preAdaptMaxLevel +1;
@@ -1811,7 +1848,12 @@ bool CpGrid::adapt(const std::vector<std::array<int,3>>& cells_per_dim_vec,
         refined_grid_ptr_vec[level] = std::make_shared<Dune::cpgrid::CpGridData>(refined_data_vec[level]);
 #endif
         // Store refined grid
+        if ((level == 0) && (preAdaptMaxLevel>0)) { // Overwrite the leaf-grid-view with the first new-refined-level-grid
+            data_[preAdaptMaxLevel+1] = refined_grid_ptr_vec[level];
+        }
+        else {
         (this-> data_).push_back(refined_grid_ptr_vec[level]);
+        }
 
         Dune::cpgrid::DefaultGeometryPolicy&  refinedLevel_geometries = (*data_[refinedLevelGridIdx]).geometry_;
         // Mutable containers for adapted corners, faces, cells, face tags, and face normals.
@@ -1874,43 +1916,10 @@ bool CpGrid::adapt(const std::vector<std::array<int,3>>& cells_per_dim_vec,
         // { (# marked elemnts)x cells_per_dim_vec[level][0], cells_per_dim_vec[level][1], cells_per_dim_vec[level][2]}.
         /** To do: how the definition of refined level grids logical_cartesian_size_ affects LookUpData class (and LookUpCartesianData)*/
     }
-
-    std::vector<int> adapted_global_cell(cell_count, 0);
-    updateLeafGridViewGeometries( /* Leaf grid View Corners arguments */
-                                  adapted_corners,
-                                  corner_count,
-                                  /* Leaf grid View Faces arguments */
-                                  adapted_faces,
-                                  mutable_face_tags,
-                                  mutable_face_normals,
-                                  adapted_face_to_point,
-                                  face_count,
-                                  /* Leaf grid View Cells argumemts  */
-                                  adapted_cells,
-                                  adapted_cell_to_point,
-                                  adapted_global_cell,
-                                  cell_count,
-                                  adapted_cell_to_face,
-                                  adapted_face_to_cell,
-                                  /* Auxiliary arguments */
-                                  adaptedCorner_to_elemLgrAndElemLgrCorner,
-                                  adaptedFace_to_elemLgrAndElemLgrFace,
-                                  adaptedCell_to_elemLgrAndElemLgrCell,
-                                  elemLgrAndElemLgrFace_to_adaptedFace,
-                                  faceInMarkedElemAndRefinedFaces,
-                                  adapted_geometries,
-                                  elemLgrAndElemLgrCorner_to_adaptedCorner,
-                                  vanishedRefinedCorner_to_itsLastAppearance,
-                                  markedElem_to_itsLgr,
-                                  assignRefinedLevel,
-                                  markedElemAndEquivRefinedCorn_to_corner,
-                                  cornerInMarkedElemWithEquivRefinedCorner,
-                                  cells_per_dim_vec,
-                                  preAdaptMaxLevel);
-
-
+    
     // Store adapted grid
     (this-> data_).push_back(adaptedGrid_ptr);
+
     // Further Adapted  grid Attributes
     (*data_[levels + preAdaptMaxLevel +1]).child_to_parent_cells_ = adapted_child_to_parent_cells;
     (*data_[levels + preAdaptMaxLevel +1]).cell_to_idxInParentCell_ = adapted_cell_to_idxInParentCell;
@@ -1970,7 +1979,7 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
             OPM_THROW_NOLOG(std::logic_error, "Adding LGRs to a distributed grid is not supported, yet.");
         }
     }
-    if (startIJK_vec.size() > 0) {
+    if (startIJK_vec.size() > 1) {
         bool notAllowedYet = false;
         for (int level = 0; level < static_cast<int>(startIJK_vec.size()); ++level) {
             for (int otherLevel = level+1; otherLevel < static_cast<int>(startIJK_vec.size()); ++otherLevel) {
@@ -2075,7 +2084,7 @@ void CpGrid::refineAndProvideMarkedRefinedRelations( /* Marked elements paramete
                                                      std::map<std::array<int,2>,std::array<int,2>>& refinedLevelAndRefinedCell_to_elemLgrAndElemLgrCell,
                                                      std::vector<int>& refined_cell_count_vec,
                                                      const std::vector<int>& assignRefinedLevel,
-                                                     std::vector<std::vector<std::tuple<int,std::vector<int>>>>& refined_parent_to_children_cells_vec,
+                                                     std::vector<std::vector<std::tuple<int,std::vector<int>>>>& preAdapt_parent_to_children_cells_vec,
                                                      /* Adapted cells parameters */
                                                      std::map<std::array<int,2>,int>& elemLgrAndElemLgrCell_to_adaptedCell,
                                                      std::unordered_map<int,std::array<int,2>>& adaptedCell_to_elemLgrAndElemLgrCell,
@@ -2130,7 +2139,7 @@ void CpGrid::refineAndProvideMarkedRefinedRelations( /* Marked elements paramete
                 refined_cell_count_vec[shiftedLevel] +=1;
 
             }
-            refined_parent_to_children_cells_vec[element.level()][element.getEquivLevelElem().index()] = std::make_pair( markedElemLevel, refinedChildrenList);
+            preAdapt_parent_to_children_cells_vec[element.level()][element.getEquivLevelElem().index()] = std::make_pair( markedElemLevel, refinedChildrenList);
             for (const auto& [markedCorner, lgrEquivCorner] : parentCorners_to_equivalentRefinedCorners) {
                 cornerInMarkedElemWithEquivRefinedCorner[markedCorner].push_back({elemIdx, lgrEquivCorner});
                 markedElemAndEquivRefinedCorn_to_corner[ {elemIdx, lgrEquivCorner}] = markedCorner;
@@ -2408,13 +2417,13 @@ void CpGrid::identifyRefinedCornersPerLevel(std::map<std::array<int,2>,std::arra
     } // end-elem-for-loop
 }
 
-void  CpGrid::identifyRefinedFacesPerLevel(std::map<std::array<int,2>,std::array<int,2>>& elemLgrAndElemLgrFace_to_refinedLevelAndRefinedFace,
-                                           std::map<std::array<int,2>,std::array<int,2>>& refinedLevelAndRefinedFace_to_elemLgrAndElemLgrFace,
-                                           std::vector<int>& refined_face_count_vec,
-                                           const std::vector<std::shared_ptr<Dune::cpgrid::CpGridData>>& markedElem_to_itsLgr,
-                                           const std::vector<int>& assignRefinedLevel,
-                                           const std::vector<std::vector<std::pair<int, std::vector<int>>>>& faceInMarkedElemAndRefinedFaces,
-                                           const std::vector<std::array<int,3>>& cells_per_dim_vec)
+void CpGrid::identifyRefinedFacesPerLevel(std::map<std::array<int,2>,std::array<int,2>>& elemLgrAndElemLgrFace_to_refinedLevelAndRefinedFace,
+                                          std::map<std::array<int,2>,std::array<int,2>>& refinedLevelAndRefinedFace_to_elemLgrAndElemLgrFace,
+                                          std::vector<int>& refined_face_count_vec,
+                                          const std::vector<std::shared_ptr<Dune::cpgrid::CpGridData>>& markedElem_to_itsLgr,
+                                          const std::vector<int>& assignRefinedLevel,
+                                          const std::vector<std::vector<std::pair<int, std::vector<int>>>>& faceInMarkedElemAndRefinedFaces,
+                                          const std::vector<std::array<int,3>>& cells_per_dim_vec)
 {
     // Step 1. Add the LGR faces, for each LGR
     for (int elem = 0; elem < current_view_data_->size(0); ++elem) {
@@ -2494,7 +2503,6 @@ void CpGrid::identifyLeafGridCorners(std::map<std::array<int,2>,int>& elemLgrAnd
             //       Since the container is a map, the lgr and the lgr corner index correspond to the last
             //       appearance of the marked corner (from level 0).
             const auto& [lastAppearanceLgr, lastAppearanceLgrCorner] = cornerInMarkedElemWithEquivRefinedCorner[corner].back();
-
             // Build the relationships between adapted corner and level corner, for future search due topology aspects.
             elemLgrAndElemLgrCorner_to_adaptedCorner[{lastAppearanceLgr, lastAppearanceLgrCorner}] = corner_count;
             adaptedCorner_to_elemLgrAndElemLgrCorner[corner_count] = {lastAppearanceLgr, lastAppearanceLgrCorner};
@@ -2614,13 +2622,13 @@ void CpGrid::identifyLeafGridCorners(std::map<std::array<int,2>,int>& elemLgrAnd
     } // end-elem-for-loop
 }
 
-void  CpGrid::identifyLeafGridFaces(std::map<std::array<int,2>,int>& elemLgrAndElemLgrFace_to_adaptedFace,
-                                    std::unordered_map<int,std::array<int,2>>& adaptedFace_to_elemLgrAndElemLgrFace,
-                                    int& face_count,
-                                    const std::vector<std::shared_ptr<Dune::cpgrid::CpGridData>>& markedElem_to_itsLgr,
-                                    const std::vector<int>& assignRefinedLevel,
-                                    const std::vector<std::vector<std::pair<int, std::vector<int>>>>& faceInMarkedElemAndRefinedFaces,
-                                    const std::vector<std::array<int,3>>& cells_per_dim_vec)
+void CpGrid::identifyLeafGridFaces(std::map<std::array<int,2>,int>& elemLgrAndElemLgrFace_to_adaptedFace,
+                                   std::unordered_map<int,std::array<int,2>>& adaptedFace_to_elemLgrAndElemLgrFace,
+                                   int& face_count,
+                                   const std::vector<std::shared_ptr<Dune::cpgrid::CpGridData>>& markedElem_to_itsLgr,
+                                   const std::vector<int>& assignRefinedLevel,
+                                   const std::vector<std::vector<std::pair<int, std::vector<int>>>>& faceInMarkedElemAndRefinedFaces,
+                                   const std::vector<std::array<int,3>>& cells_per_dim_vec)
 {
     // Step 1. Add the LGR faces, for each LGR
     for (int elem = 0; elem < current_view_data_->size(0); ++elem) {
@@ -3051,8 +3059,11 @@ void CpGrid::populateRefinedCells(std::vector<Dune::cpgrid::EntityVariableBase<c
             // Auxiliary cell_to_face
             std::vector<cpgrid::EntityRep<1>> aux_refined_cell_to_face;
 
-            refined_global_cell_vec[shiftedLevel][cell] = cell; // current_view_data_ -> global_cell_[elemLgr]; instead?
-            assert( markedElem_to_itsLgr[elemLgr]!=nullptr);
+            // To supoort the simulation of a mixed grid (coarse and refined cells), global_cell_ values of refined-level-grids
+            // is a vector of consecutive indices from 0 to total cells on the level-grid. In case we want to modify this, take into
+            // account that LookUpData and LookUpCartesianData will be affected, therefore, code in opm-simulators related to
+            // searching for field features when the grid has LGRs will be affected as well.
+            refined_global_cell_vec[shiftedLevel][cell] = (preAdaptMaxLevel>0) ? current_view_data_ -> global_cell_[elemLgr] : cell;
             // Get pre-adapt corners of the cell that will be replaced with leaf view ones.
             const auto& preAdapt_cell_to_point = markedElem_to_itsLgr[elemLgr]->cell_to_point_[elemLgrCell];
             // Get pre-adapt faces of the cell that will be replaced with leaf view ones.

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -464,10 +464,10 @@ BOOST_AUTO_TEST_CASE(globalRefinement_calling_globalRefine)
 BOOST_AUTO_TEST_CASE(calling_globalRefine_with_2)
 {
     // Create a grid
-    Dune::CpGrid coarse_grid;
+    Dune::CpGrid equiv_fine_grid;
     const std::array<double, 3> cell_sizes = {0.5, 0.5, 0.5};
     const std::array<int, 3> grid_dim = {8,6,6};
-    coarse_grid.createCartesian(grid_dim, cell_sizes);
+    equiv_fine_grid.createCartesian(grid_dim, cell_sizes);
 
     std::vector<int> markedCells(288);
     std::iota(markedCells.begin(), markedCells.end(), 0);
@@ -482,16 +482,16 @@ BOOST_AUTO_TEST_CASE(calling_globalRefine_with_2)
     const std::array<int, 3> cells_per_dim = {2,2,2};
 
     // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, /*isBlockShape*/false, /*hasBeenRefinedAtLeastOnce*/false, /*isGlobalRefinement*/true);
+    markAndAdapt_check(equiv_fine_grid, cells_per_dim, markedCells, other_grid, /*isBlockShape*/false, /*hasBeenRefinedAtLeastOnce*/false, /*isGlobalRefinement*/true);
 }
 
 BOOST_AUTO_TEST_CASE(calling_globalRefine_with_3)
 {
     // Create a grid
-    Dune::CpGrid coarse_grid;
+    Dune::CpGrid equiv_fine_grid;
     const std::array<double, 3> cell_sizes = {0.25, 0.25, 0.25};
     const std::array<int, 3> grid_dim = {16,12,12};
-    coarse_grid.createCartesian(grid_dim, cell_sizes);
+    equiv_fine_grid.createCartesian(grid_dim, cell_sizes);
 
     std::vector<int> markedCells(2304);
     std::iota(markedCells.begin(), markedCells.end(), 0);
@@ -506,7 +506,35 @@ BOOST_AUTO_TEST_CASE(calling_globalRefine_with_3)
     const std::array<int, 3> cells_per_dim = {2,2,2};
 
     // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, /*isBlockShape*/false, /*hasBeenRefinedAtLeastOnce*/false, /*isGlobalRefinement*/true);
+    markAndAdapt_check(equiv_fine_grid, cells_per_dim, markedCells, other_grid, /*isBlockShape*/false, /*hasBeenRefinedAtLeastOnce*/false, /*isGlobalRefinement*/true);
+}
+
+BOOST_AUTO_TEST_CASE(throw_globalRefine_with_negative_int)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {0.25, 0.25, 0.25};
+    const std::array<int, 3> grid_dim = {16,12,12};
+    grid.createCartesian(grid_dim, cell_sizes);
+
+    BOOST_CHECK_THROW(grid.globalRefine(-5), std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE(throw_globalRefine_of_mixed_grid)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    grid.createCartesian(grid_dim, cell_sizes);
+
+    const std::array<int, 3> cells_per_dim = {2,2,2};
+    const std::array<int, 3> startIJK = {2,0,0};
+    const std::array<int, 3> endIJK = {4,1,1};  // -> marked elements 2 and 3
+    const std::string lgr_name = {"LGR1"};
+    grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+
+    BOOST_CHECK_THROW(grid.globalRefine(1), std::logic_error);
 }
 
 BOOST_AUTO_TEST_CASE(mark2consequtiveCells)
@@ -567,7 +595,6 @@ BOOST_AUTO_TEST_CASE(markNonBlockShapeCells)
     markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, /*isBlockShape*/false, /*hasBeenRefinedAtLeastOnce*/false, /*isGlobalRefinement*/false);
 }
 
-
 BOOST_AUTO_TEST_CASE(markNonBlockShapeCells_II)
 {
     // Create a grid
@@ -579,7 +606,6 @@ BOOST_AUTO_TEST_CASE(markNonBlockShapeCells_II)
     coarse_grid.createCartesian(grid_dim, cell_sizes);
     markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, /*isBlockShape*/false, /*hasBeenRefinedAtLeastOnce*/false, /*isGlobalRefinement*/false);
 }
-
 
 BOOST_AUTO_TEST_CASE(markNonBlockCells_compareAdapt)
 {

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -100,12 +100,12 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
     bool preAdapt = coarse_grid.preAdapt();
     const auto& data = coarse_grid.chooseData();
     if(preAdapt) {
-        coarse_grid.adapt({cells_per_dim}, assignRefinedLevel, {"LGR"});
+        coarse_grid.adapt({cells_per_dim}, assignRefinedLevel, {"LGR"+std::to_string(coarse_grid.maxLevel() +1)});
         coarse_grid.postAdapt();
-        BOOST_CHECK(static_cast<int>(data.size()) == startingGridIdx+3);
-        const auto& adapted_leaf = *data[startingGridIdx+2];
-
-        if(isBlockShape) {
+        BOOST_CHECK(static_cast<int>(data.size()) == coarse_grid.maxLevel() +2);
+        const auto& leafGridIdx = coarse_grid.maxLevel() +1;
+        const auto& adapted_leaf = *data[leafGridIdx];
+        if(isBlockShape) { // For a mixed grid that gets refined a second time, isBlockShape == false, even though the marked elements form a block.
             const auto& blockRefinement_data = other_grid.chooseData();
             const auto& blockRefinement_leaf = *blockRefinement_data.back();
 
@@ -119,10 +119,9 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
             BOOST_CHECK_EQUAL(adapted_leaf.cell_to_face_.size(), blockRefinement_leaf.cell_to_face_.size());
             BOOST_CHECK_EQUAL(coarse_grid.size(3), other_grid.size(3));
             BOOST_CHECK_EQUAL(coarse_grid.size(0), other_grid.size(0));
-            if(!hasBeenRefinedAtLeastOnce) {
-                BOOST_CHECK_EQUAL(coarse_grid.size(1,0), other_grid.size(1,0)); // equal amount of cells in level 1
-                BOOST_CHECK_EQUAL(coarse_grid.size(1,3), other_grid.size(1,3)); // equal amount of corners in level 1
-            }
+            BOOST_CHECK_EQUAL(coarse_grid.size(1,0), other_grid.size(1,0)); // equal amount of cells in level 1
+            BOOST_CHECK_EQUAL(coarse_grid.size(1,3), other_grid.size(1,3)); // equal amount of corners in level 1
+
 
             for(const auto& point: adapted_leaf.geomVector<3>()){
                 auto equiv_point_iter = blockRefinement_leaf.geomVector<3>().begin();
@@ -208,14 +207,8 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
 
         const auto& grid_view = coarse_grid.leafGridView();
 
-        const auto& preAdapt_view = coarse_grid.levelGridView(startingGridIdx);
-        // Note: preAdapt grid in level "startingGridIdx"
-        //       refined grid in level  "startingGridIdx+1"
-        //       adapted grid in level  "startingGridIdx+2"
         Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LeafGridView> adaptMapper(grid_view, Dune::mcmgElementLayout());
-        Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LevelGridView> preAdaptMapper(preAdapt_view, Dune::mcmgElementLayout());
         const auto& adapt_idSet = adapted_leaf.local_id_set_;
-        const auto& preAdapt_idSet = (*data[startingGridIdx+1]).local_id_set_;
 
         for(const auto& element: elements(grid_view)) {
             // postAdapt() has been called, therefore every element gets marked with 0
@@ -237,32 +230,46 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
                 BOOST_CHECK( element.isNew() == true);
                 BOOST_CHECK_CLOSE(element.geometryInFather().volume(), 1./(cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]), 1e-6);
                 if (hasBeenRefinedAtLeastOnce){
-                    BOOST_CHECK(element.father().level() <= startingGridIdx); // Remove? Not that useful...
+                    BOOST_CHECK(element.father().level() <= startingGridIdx);
                     BOOST_CHECK( element.getOrigin().level() <= startingGridIdx);
+                    BOOST_CHECK( data[element.father().level()] ->mark_[element.father().index()] == 1);
                 }
                 else {
                     BOOST_CHECK(element.father().level() == 0);
-                    BOOST_CHECK( element.getOrigin().level() == 0);  // To do: check Entity::getOrigin()
+                    BOOST_CHECK( element.getOrigin().level() == 0);
+                    BOOST_CHECK_EQUAL( (std::find(markedCells.begin(), markedCells.end(), element.father().index()) == markedCells.end()), false);
                 }
-                BOOST_CHECK_EQUAL( (std::find(markedCells.begin(), markedCells.end(), element.father().index()) == markedCells.end()), false);
                 BOOST_CHECK(child_to_parent[0] != -1);
-                BOOST_CHECK_EQUAL( child_to_parent[0] == startingGridIdx, true);
+                BOOST_CHECK_EQUAL( child_to_parent[0], element.father().level());
                 BOOST_CHECK_EQUAL( child_to_parent[1], element.father().index());
                 BOOST_CHECK( element.father() == element.getOrigin());
-                BOOST_CHECK(  ( adapted_leaf.global_cell_[element.index()]) == (data[startingGridIdx]->global_cell_[element.getOrigin().index()]) );
-                BOOST_CHECK( std::get<0>(data[startingGridIdx]->parent_to_children_cells_[child_to_parent[1]]) == element.level());
+
+                const auto& auxLevel = (element.father().level() == 0) ? element.getOrigin().level() : element.getLevelElem().level();
+                const auto& auxLevelIdx = (element.father().level() == 0) ? element.getOrigin().index() : element.getLevelElem().index();
+                BOOST_CHECK(  ( adapted_leaf.global_cell_[element.index()]) == (data[auxLevel]->global_cell_[auxLevelIdx]) );
+
+                BOOST_CHECK( std::get<0>(data[element.father().level()]->parent_to_children_cells_[element.father().index()]) == element.level());
                 // Check amount of children cells of the parent cell
-                BOOST_CHECK_EQUAL(std::get<1>(data[startingGridIdx]->parent_to_children_cells_[child_to_parent[1]]).size(),
-                                  cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]);
-                BOOST_CHECK( element.father().isLeaf() == false);
+                BOOST_CHECK_EQUAL(std::get<1>(data[element.father().level()]->parent_to_children_cells_[child_to_parent[1]]).size(),
+                                  (*data[element.level()]).cells_per_dim_[0]*(*data[element.level()]).cells_per_dim_[1]*(*data[element.level()]).cells_per_dim_[2]);
+                if(!hasBeenRefinedAtLeastOnce)
+                {
+                    BOOST_CHECK( element.father().isLeaf() == false);
+                }
                 BOOST_CHECK( (element.level() > 0) || (element.level() < coarse_grid.maxLevel() +1));
                 BOOST_CHECK( level_cellIdx[0] == element.level());
                 //
                 const auto& id = (*adapt_idSet).id(element);
-                const auto& parent_id = (*preAdapt_idSet).id(element.father());
+                BOOST_CHECK(element.index() == id);
+                BOOST_CHECK(element.index() == adaptMapper.index(element));
+                //
+                const auto& parent_id = (*(data[element.father().level()]->local_id_set_)).id(element.father());
                 BOOST_CHECK(element.index() == id);
                 BOOST_CHECK(element.index() == adaptMapper.index(element));
                 BOOST_CHECK(element.father().index() == parent_id);
+                /** Not ideal to define this for each element. Remove?*/
+                const auto& preAdapt_view = coarse_grid.levelGridView(element.father().level());
+                Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LevelGridView> preAdaptMapper(preAdapt_view, Dune::mcmgElementLayout());
                 BOOST_CHECK(element.father().index() == preAdaptMapper.index(element.father()));
             }
             else{
@@ -271,8 +278,8 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
                 BOOST_CHECK_EQUAL(child_to_parent[0], -1);
                 BOOST_CHECK_EQUAL(child_to_parent[1], -1);
                 if (hasBeenRefinedAtLeastOnce){
-                    BOOST_CHECK( level_cellIdx[0] == startingGridIdx); // Equal when the grid has been refined only once. Remove this check?
-                    BOOST_CHECK( element.level() == startingGridIdx);
+                    BOOST_CHECK( level_cellIdx[0] == element.level());
+                    BOOST_CHECK( element.level() <= startingGridIdx);
                     BOOST_CHECK( element.getOrigin().level() <= startingGridIdx);
                 }
                 else  {
@@ -280,8 +287,8 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
                     BOOST_CHECK( element.level() == 0);
                     BOOST_CHECK( element.getOrigin().level() == 0);
                 }
-                BOOST_CHECK( std::get<0>(data[startingGridIdx]-> parent_to_children_cells_[level_cellIdx[1]]) == -1);
-                BOOST_CHECK( std::get<1>(data[startingGridIdx]->parent_to_children_cells_[level_cellIdx[1]]).empty());
+                BOOST_CHECK( std::get<0>(data[element.level()]-> parent_to_children_cells_[level_cellIdx[1]]) == -1);
+                BOOST_CHECK( std::get<1>(data[element.level()]->parent_to_children_cells_[level_cellIdx[1]]).empty());
                 // Get index of the cell in level 0
                 const auto& entityOldIdx =   adapted_leaf.leaf_to_level_cells_[element.index()][1];
                 BOOST_CHECK( element.getOrigin().index() == entityOldIdx);
@@ -291,68 +298,74 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
             BOOST_CHECK( element.mightVanish() == false); // marks get rewrtitten and set to 0 via postAdapt call
         } // end-element-for-loop
 
-        // Some checks on the preAdapt grid
-        for(const auto& element: elements(preAdapt_view)) {
-            if (!hasBeenRefinedAtLeastOnce){
+
+
+        if (startingGridIdx == 0) {
+            const auto& preAdapt_view = coarse_grid.levelGridView(startingGridIdx);
+            Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LevelGridView> preAdaptMapper(preAdapt_view, Dune::mcmgElementLayout());
+            //  const auto& preAdapt_idSet = (*data[startingGridIdx+1]).local_id_set_;
+            // Some checks on the preAdapt grid
+            for(const auto& element: elements(preAdapt_view)) {
+
                 BOOST_CHECK( element.hasFather() == false);
                 BOOST_CHECK_THROW(element.father(), std::logic_error);
                 BOOST_CHECK_THROW(element.geometryInFather(), std::logic_error);
                 BOOST_CHECK( element.getOrigin() ==  element);
                 BOOST_CHECK( element.getOrigin().level() == startingGridIdx);
                 BOOST_CHECK( element.isNew() == false);
-            }
-            auto it = element.hbegin(coarse_grid.maxLevel()); // With element.level(), fails
-            auto endIt = element.hend(coarse_grid.maxLevel());
-            const auto& [lgr, childrenList] = (*data[startingGridIdx]).parent_to_children_cells_[element.index()];
-            if (std::find(markedCells.begin(), markedCells.end(), element.index()) == markedCells.end()){
-                BOOST_CHECK_EQUAL(lgr, -1);
-                BOOST_CHECK(childrenList.empty());
-                BOOST_CHECK( element.isLeaf() == true);
-                // If it == endIt, then entity.isLeaf() true (when dristibuted_data_ is empty)
-                BOOST_CHECK( it == endIt);
-                BOOST_CHECK( element.mightVanish() == false);
-            }
-            else{
-                BOOST_CHECK(lgr != -1);
-                BOOST_CHECK(static_cast<int>(childrenList.size()) == cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]);
-                // If it != endIt, then entity.isLeaf() false (when dristibuted_data_ is empty)
-                BOOST_CHECK_EQUAL( it == endIt, false);
-                BOOST_CHECK( element.mightVanish() == true);
-                BOOST_CHECK( element.isNew() == false);
-                BOOST_CHECK_EQUAL( element.isLeaf(), false); // parent cells do not appear in the LeafView
-                // Auxiliary int to check amount of children
-                double referenceElemOneParent_volume = 0.;
-                std::array<double,3> referenceElem_entity_center = {0.,0.,0.}; // Expected {.5,.5,.5}
-                for (const auto& child : childrenList) {
-                    BOOST_CHECK( child != -1);
-                    BOOST_CHECK( data[startingGridIdx+1]-> child_to_parent_cells_[child][0] == startingGridIdx);  //
-                    BOOST_CHECK( data[startingGridIdx+1]-> child_to_parent_cells_[child][1] == element.index());
+                auto it = element.hbegin(coarse_grid.maxLevel()); // With element.level(), fails
+                auto endIt = element.hend(coarse_grid.maxLevel());
+                const auto& [lgr, childrenList] = (*data[startingGridIdx]).parent_to_children_cells_[element.index()];
+                if (std::find(markedCells.begin(), markedCells.end(), element.index()) == markedCells.end()){
+                    BOOST_CHECK_EQUAL(lgr, -1);
+                    BOOST_CHECK(childrenList.empty());
+                    BOOST_CHECK( element.isLeaf() == true);
+                    // If it == endIt, then entity.isLeaf() true (when dristibuted_data_ is empty)
+                    BOOST_CHECK( it == endIt);
+                    BOOST_CHECK( element.mightVanish() == false);
+                }
+                else{
+                    BOOST_CHECK(lgr != -1);
+                    BOOST_CHECK(static_cast<int>(childrenList.size()) == cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]);
+                    // If it != endIt, then entity.isLeaf() false (when dristibuted_data_ is empty)
+                    BOOST_CHECK_EQUAL( it == endIt, false);
+                    BOOST_CHECK( element.mightVanish() == true);
+                    BOOST_CHECK( element.isNew() == false);
+                    BOOST_CHECK_EQUAL( element.isLeaf(), false); // parent cells do not appear in the LeafView
 
-                    const auto& childElem =  Dune::cpgrid::Entity<0>(*data[startingGridIdx+1], child, true);
-                    BOOST_CHECK(childElem.hasFather() == true);
-                    BOOST_CHECK(childElem.level() == lgr);
-                    referenceElemOneParent_volume += childElem.geometryInFather().volume();
-                    for (int c = 0; c < 3; ++c)  {
-                        referenceElem_entity_center[c] += (childElem.geometryInFather().center())[c];
+                    // Auxiliary int to check amount of children
+                    double referenceElemOneParent_volume = 0.;
+                    std::array<double,3> referenceElem_entity_center = {0.,0.,0.}; // Expected {.5,.5,.5}
+                    for (const auto& child : childrenList) {
+                        BOOST_CHECK( child != -1);
+                        BOOST_CHECK( data[startingGridIdx+1]-> child_to_parent_cells_[child][0] == startingGridIdx);  //
+                        BOOST_CHECK( data[startingGridIdx+1]-> child_to_parent_cells_[child][1] == element.index());
+
+                        const auto& childElem =  Dune::cpgrid::Entity<0>(*data[startingGridIdx+1], child, true);
+                        BOOST_CHECK(childElem.hasFather() == true);
+                        BOOST_CHECK(childElem.level() == lgr);
+                        referenceElemOneParent_volume += childElem.geometryInFather().volume();
+                        for (int c = 0; c < 3; ++c)  {
+                            referenceElem_entity_center[c] += (childElem.geometryInFather().center())[c];
+                        }
                     }
-                }
-                /// Auxiliary int to check amount of children
-                double referenceElemOneParent_volume_it = 0.;
-                std::array<double,3> referenceElem_entity_center_it = {0.,0.,0.}; // Expected {.5,.5,.5}
-                for (; it != endIt; ++it)
-                {
-                    BOOST_CHECK(it ->hasFather() == true);
-                    BOOST_CHECK(it ->level() == lgr);
-                    referenceElemOneParent_volume_it += it-> geometryInFather().volume();
-                    for (int c = 0; c < 3; ++c)
+                    /// Auxiliary int to check amount of children
+                    double referenceElemOneParent_volume_it = 0.;
+                    std::array<double,3> referenceElem_entity_center_it = {0.,0.,0.}; // Expected {.5,.5,.5}
+                    for (; it != endIt; ++it)
                     {
-                        referenceElem_entity_center_it[c] += (it-> geometryInFather().center())[c];
+                        BOOST_CHECK(it ->hasFather() == true);
+                        BOOST_CHECK(it ->level() == lgr);
+                        referenceElemOneParent_volume_it += it-> geometryInFather().volume();
+                        for (int c = 0; c < 3; ++c)
+                        {
+                            referenceElem_entity_center_it[c] += (it-> geometryInFather().center())[c];
+                        }
                     }
-                }
-                for (int c = 0; c < 3; ++c) {
-                    referenceElem_entity_center[c] /= cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2];
-                    referenceElem_entity_center_it[c] /= cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2];
-                }
+                    for (int c = 0; c < 3; ++c) {
+                        referenceElem_entity_center[c] /= cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2];
+                        referenceElem_entity_center_it[c] /= cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2];
+                    }
                 BOOST_CHECK_CLOSE(referenceElemOneParent_volume, 1, 1e-13);
                 BOOST_CHECK_CLOSE(referenceElem_entity_center[0], .5, 1e-13);
                 BOOST_CHECK_CLOSE(referenceElem_entity_center[1], .5, 1e-13);
@@ -362,9 +375,10 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
                 BOOST_CHECK_CLOSE(referenceElem_entity_center_it[0], .5, 1e-13);
                 BOOST_CHECK_CLOSE(referenceElem_entity_center_it[1], .5, 1e-13);
                 BOOST_CHECK_CLOSE(referenceElem_entity_center_it[2], .5, 1e-13);
-            }
-            BOOST_CHECK( element.level() == 0);
-        } // end-preAdaptElements-for-loop
+                }
+                BOOST_CHECK( element.level() == 0);
+            } // end-preAdaptElements-for-loop
+        } // end-startingGridIdx==0
     } // end-if-preAdapt
 }
 
@@ -496,67 +510,190 @@ BOOST_AUTO_TEST_CASE(markNonBlockCells_compareAdapt)
     other_grid.preAdapt();
     other_grid.adapt();
     other_grid.postAdapt();
-    
+
     markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, false, false, false);
 }
 
-/*BOOST_AUTO_TEST_CASE(adaptFromAMixedGrid)
-  {
-  // Create a grid
-  Dune::CpGrid coarse_grid;
-  const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-  const std::array<int, 3> grid_dim = {4,3,3};
-  const std::array<int, 3> cells_per_dim = {2,2,2};
-  coarse_grid.createCartesian(grid_dim, cell_sizes);
+BOOST_AUTO_TEST_CASE(callAdaptMultipleTimes)
+{
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+
+    const std::array<int, 3> cells_per_dim = {2,2,2};
+    std::vector<int> markedCells1 = {1,4,6};
+    std::vector<int> markedCells2 = {38, 43}; // Equivalent cells to level 0 cells with indices {17,22};
+    std::vector<int> markedCells3 = {63, 67}; // Equivalent cells to level 0 cells with indices {28,32};
+
+    std::vector<int> markedCells = {1,4,6,17,22,28,32};
+
+    // Create a grid
+    Dune::CpGrid other_grid;
+    other_grid.createCartesian(grid_dim, cell_sizes);
+    for (const auto& elemIdx : markedCells1)
+    {
+        const auto& elem =  Dune::cpgrid::Entity<0>(*(other_grid.chooseData()[0]), elemIdx, true);
+        other_grid.mark(1, elem);
+    }
+    other_grid.preAdapt();
+    other_grid.adapt();
+    other_grid.postAdapt();
+
+    for (const auto& elemIdx : markedCells2)
+    {
+        const auto& elem =  Dune::cpgrid::Entity<0>(*(other_grid.chooseData().back()), elemIdx, true);
+        other_grid.mark(1, elem);
+    }
+    other_grid.preAdapt();
+    other_grid.adapt();
+    other_grid.postAdapt();
+
+    for (const auto& elemIdx : markedCells3)
+    {
+        const auto& elem =  Dune::cpgrid::Entity<0>(*(other_grid.chooseData().back()), elemIdx, true);
+        other_grid.mark(1, elem);
+    }
+    other_grid.preAdapt();
+    other_grid.adapt();
+    other_grid.postAdapt();
+
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, false, false, false);
+}
+
+BOOST_AUTO_TEST_CASE(refineCoarseCells_in_mixedGrid) {
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {2,2,2};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+
+    // LGR1 marked element with elemIdx = 3, refined into 8 children cells with leaf indices 3,...,10.
+    const std::array<int, 3> startIJK = {3,0,0};
+    const std::array<int, 3> endIJK = {4,1,1};
+    const std::string lgr_name = {"LGR1"};
+    coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+
+    std::vector<int> markedCells = {0,1,11,15}; // coarse cells (in level 0 grid, this cell has index 8)
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, true, false);
+}
+
+BOOST_AUTO_TEST_CASE(refineInteriorRefinedCells_in_mixedGrid) {
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {3,3,3};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+
+    // LGR1 marked elements with elemIdx = 17 and 18, refined into 27 children cells each,
+    // with leaf indices 17+0,...,17+26 = 43 (children {level 0, cell index 17}),44,...,70 (children {level 0, cell index 18}).
+    const std::array<int, 3> startIJK = {1,1,1};
+    const std::array<int, 3> endIJK = {3,2,2};
+    const std::string lgr_name = {"LGR1"};
+    coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+
+    // Cells 30, 31, 56, and 57 are refined cells, located in the interior of the refined-level-grid-1 (lgr 1 / level 1).
+    // Therefore, cell_to_face_ for all of them has size 6. (Their faces have all 2 refined neigboring cells - (not one coarse cell, and one refined)).
+    std::vector<int> markedCells = {30,31, 56,57};
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, true, false);
+}
 
 
-  const std::array<int, 3> startIJK = {1,1,1};
-  const std::array<int, 3> endIJK = {3,2,2};  // -> marked elements 17 and 18
-  const std::string lgr_name = {"LGR1"};
-  coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+BOOST_AUTO_TEST_CASE(refineMixedCells_in_mixedGrid) {
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {3,3,3};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
 
-  std::vector<int> markedCells = {0,1}; // coarse cells
-  markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, true, true, false);
-  }
+    // LGR1 marked elements with elemIdx = 17 and 18, refined into 27 children cells each,
+    // with leaf indices 17+0,...,17+26 = 43 (children {level 0, cell index 17}),44,...,70 (children {level 0, cell index 18}).
+    const std::array<int, 3> startIJK = {1,1,1};
+    const std::array<int, 3> endIJK = {3,2,2};
+    const std::string lgr_name = {"LGR1"};
+    coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
 
-  BOOST_AUTO_TEST_CASE(adaptFromAMixedGridRefinedCell)
-  {
-  // Create a grid
-  Dune::CpGrid coarse_grid;
-  const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-  const std::array<int, 3> grid_dim = {4,3,3};
-  const std::array<int, 3> cells_per_dim = {2,2,2};
-  coarse_grid.createCartesian(grid_dim, cell_sizes);
-
-
-  const std::array<int, 3> startIJK = {1,1,1};
-  const std::array<int, 3> endIJK = {3,2,2};  // -> marked elements 17 and 18
-  const std::string lgr_name = {"LGR1"};
-  coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
-
-  std::vector<int> markedCells = {34}; // {34, 35} refined cells (with parent cell 17) -> check conversion of corners between neighboring lgrs definition!
-  // Error:  Cannot convert corner index from one LGR to its neighboring LGR
-  // 42 refined cell with parent cell 18.
-  markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, true, true, false);
-  }
+    // - Cells 30, 31, 56, and 57 are refined cells, located in the interior of the refined-level-grid-1 (lgr 1 / level 1).
+    // Therefore, cell_to_face_ for all of them has size 6. (Their faces have all 2 refined neigboring cells - (not one coarse cell, and one refined)).
+    // - Cells 0,1,2,12, and 15 are coarse cells, not touching the boundary of the LGR1 (cells 12 and 15 do share corners with LGR1 but do not share
+    // any face. Therefore, the faces of cells 0,1,2,12,and 15 have all 1 or 2 neighboring coarse cells).
+    std::vector<int> markedCells = {0,1,2,12,15,30,31,56,57};
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, true, false);
+}
 
 
-  BOOST_AUTO_TEST_CASE(adaptFromAMixedGridMixedCells)
-  {
-  // Create a grid
-  Dune::CpGrid coarse_grid;
-  const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-  const std::array<int, 3> grid_dim = {4,3,3};
-  const std::array<int, 3> cells_per_dim = {2,2,2};
-  coarse_grid.createCartesian(grid_dim, cell_sizes);
+
+BOOST_AUTO_TEST_CASE(refineMixedCells_in_multiLevelGrid) {
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {3,3,3};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+
+    // LGR1: element with elemIdx = 17, refined into 27 children cells with leaf indices 17+0,...,17+26 = 43 (children {level 0, cell index 17}).
+    // LGR2: element with elemIdx = 18, refined into 27 children cells with leaf indices 44,...,70 (children {level 0, cell index 18}).
+    const std::vector<std::array<int, 3>> startIJK_vec = {{1,1,1}, {2,1,1}};
+    const std::vector<std::array<int, 3>> endIJK_vec = {{2,2,2}, {3,2,2}};
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2"};
+    coarse_grid.addLgrsUpdateLeafView({cells_per_dim, cells_per_dim}, startIJK_vec, endIJK_vec, lgr_name_vec);
+
+    // - Cells 30, 31, 56, and 57 are refined cells, located in the interior of the refined-level-grid-1 (lgr 1 / level 1).
+    // Therefore, cell_to_face_ for all of them has size 6. (Their faces have all 2 refined neigboring cells - (not one coarse cell, and one refined)).
+    // - Cells 0,1,2,12, and 15 are coarse cells, not touching the boundary of the LGR1 (cells 12 and 15 do share corners with LGR1 but do not share
+    // any face. Therefore, the faces of cells 0,1,2,12,and 15 have all 1 or 2 neighboring coarse cells).
+    std::vector<int> markedCells = {0,1,2,12,15,30,31,56,57};
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, true, false);
+}
 
 
-  const std::array<int, 3> startIJK = {1,1,1};
-  const std::array<int, 3> endIJK = {3,2,2};  // -> marked elements 17 and 18
-  const std::string lgr_name = {"LGR1"};
-  coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+BOOST_AUTO_TEST_CASE(refineMixedCells_in_mixedGrid_II)
+{
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {3,3,3};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
 
-  std::vector<int> markedCells = {2,3,34}; // {34, 41} refined cells (with parent cell 17),
-  // 42, 49 refined cell with parent cell 18-> check conversion of corners between neighboring lgrs definition!
-  markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, true, false);
-  }*/
+    // LGR1 marked elements with elemIdx = 17 and 18, refined into 27 children cells each,
+    // with leaf indices 17+0,...,17+26 = 43 (children {level 0, cell index 17}),44,...,70 (children {level 0, cell index 18}).
+    const std::array<int, 3> startIJK = {1,1,1};
+    const std::array<int, 3> endIJK = {3,2,2};
+    const std::string lgr_name = {"LGR1"};
+    coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+
+    // - Cells 72 (in level 0 with cell index 20) and 84 (in level 0 with cell index 32) are coarse cells,
+    // sharing one K_FACE, that do not share faces with LGR1 (they do share corners).
+    // - Cells 25,34,43 are refined cells, children of {level 0, cell index 17}, forming a collum.
+    // - Cells 50,59,68 are refined cells, children of {level 0, cell index 18}, forming a collum.
+    // Cells 25 and 50, 34 and 59, 43 and 68, share a face (the collums are next to each other).
+    std::vector<int> markedCells = {25,34,43,50,59,68, 72, 84};
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, true, true, false);
+}
+
+BOOST_AUTO_TEST_CASE(cellTouchesLgrBoundary_throw)
+{
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {3,3,3};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
+
+    // LGR1 marked elements with elemIdx = 17 and 18, refined into 27 children cells each,
+    // with leaf indices 17+0,...,17+26 = 43 (children {level 0, cell index 17}),44,...,70 (children {level 0, cell index 18}).
+    const std::array<int, 3> startIJK = {1,1,1};
+    const std::array<int, 3> endIJK = {3,2,2};
+    const std::string lgr_name = {"LGR1"};
+    coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+
+    // - Coarse cells touching the LGR1 on its boundary.
+    // Cell 5, 14, 16, 71, 73, and 82, touching the bottom, front, left, right, back, and the top of LGR1, respectively.
+    std::vector<int> markedCells = {5,14,16,71,73,82};
+    BOOST_CHECK_THROW(markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, true, true, false), std::logic_error);
+}


### PR DESCRIPTION
This PR 
1. extends the support of DUNE-Grid interface for CpGrid (corner point grids), defining (and testing) CpGrid::globalRefine(int). The default refinement is to divide each cell into 8 refined cells ( 2 refined cells in each direction: x,-y-, and z-axis).
2. is based on OPM/opm-grid#731, therefore, it should be merged after it. 
3. does not affect the update of the OPM reference-manual. 