### PR TITLE
Fix Non-Zoltan/Non-Metis Build Configurations

### DIFF
--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -28,11 +28,13 @@
 #include <dune/grid/common/mcmgmapper.hh>
 
 #if defined(HAVE_ZOLTAN) && defined(HAVE_METIS)
-int partition_methods[] = {1,2};
+const int partition_methods[] = {1,2};
 #elif defined (HAVE_ZOLTAN)
-int partition_methods[] = {1};
+const int partition_methods[] = {1};
 #elif defined (HAVE_METIS)
-int partition_methods[] = {2};
+const int partition_methods[] = {2};
+#else  // !HAVE_ZOLTAN && !HAVE_METIS
+const int partition_methods[] = {0};
 #endif
 
 #if HAVE_MPI


### PR DESCRIPTION
The `partition_methods` object must also be defined in builds that have neither Zoltan nor Metis.  This will typically happen only for very spartan sequential builds.

While here, also mark the object as `const` to prevent inadvertent changes.