### PR TITLE
[refactor] Local and global ids taking into account CpGrid with LGRs

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1025,8 +1025,8 @@ namespace Dune
                                            int preAdaptMaxLevel);
 
         void updateCornerHistoryLevels(const std::vector<std::vector<std::array<int,2>>>& cornerInMarkedElemWithEquivRefinedCorner,
-                                       std::map<std::array<int,2>,std::array<int,2>> elemLgrAndElemLgrCorner_to_refinedLevelAndRefinedCorner,
-                                       std::unordered_map<int,std::array<int,2>> adaptedCorner_to_elemLgrAndElemLgrCorner,
+                                       const std::map<std::array<int,2>,std::array<int,2>>& elemLgrAndElemLgrCorner_to_refinedLevelAndRefinedCorner,
+                                       const std::unordered_map<int,std::array<int,2>>& adaptedCorner_to_elemLgrAndElemLgrCorner,
                                        const int& corner_count,
                                        const std::vector<std::array<int,2>>& preAdaptGrid_corner_history,
                                        const int& preAdaptMaxLevel);

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1024,6 +1024,13 @@ namespace Dune
                                            const std::vector<std::array<int,3>>& cells_per_dim_vec,
                                            int preAdaptMaxLevel);
 
+        void updateCornerHistoryLevels(const std::vector<std::vector<std::array<int,2>>>& cornerInMarkedElemWithEquivRefinedCorner,
+                                       std::map<std::array<int,2>,std::array<int,2>> elemLgrAndElemLgrCorner_to_refinedLevelAndRefinedCorner,
+                                       std::unordered_map<int,std::array<int,2>> adaptedCorner_to_elemLgrAndElemLgrCorner,
+                                       const int& corner_count,
+                                       const std::vector<std::array<int,2>>& preAdaptGrid_corner_history,
+                                       const int& preAdaptMaxLevel);
+
         /// @brief Get the ijk index of a refined corner, given its corner index of a single-cell-refinement.
         ///
         /// Given a single-cell, we refine it in {nx, ny, nz} refined children cells (per direction). Then, this single-cell-refinement

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -3331,8 +3331,6 @@ void CpGrid::updateCornerHistoryLevels(const std::vector<std::vector<std::array<
                                        const int& corner_count,
                                        const std::vector<std::array<int,2>>& preAdaptGrid_corner_history,
                                        const int& preAdaptMaxLevel)
-//std::vector<std::vector<std::array<int,2>>>& levels_corner_history,
-// std::vector<std::array<int,2>>& leaf_corner_history)
 {
     for (int level = preAdaptMaxLevel+1; level < (this->maxLevel()+1); ++level) {
         data_[level]->corner_history_.resize( data_[level] ->size(3), std::array<int,2>({-1,-1}));

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -3326,8 +3326,8 @@ void CpGrid::updateLeafGridViewGeometries( /* Leaf grid View Corners arguments *
 }
 
 void CpGrid::updateCornerHistoryLevels(const std::vector<std::vector<std::array<int,2>>>& cornerInMarkedElemWithEquivRefinedCorner,
-                                       std::map<std::array<int,2>,std::array<int,2>> elemLgrAndElemLgrCorner_to_refinedLevelAndRefinedCorner,
-                                       std::unordered_map<int,std::array<int,2>> adaptedCorner_to_elemLgrAndElemLgrCorner,
+                                       const std::map<std::array<int,2>,std::array<int,2>>& elemLgrAndElemLgrCorner_to_refinedLevelAndRefinedCorner,
+                                       const std::unordered_map<int,std::array<int,2>>& adaptedCorner_to_elemLgrAndElemLgrCorner,
                                        const int& corner_count,
                                        const std::vector<std::array<int,2>>& preAdaptGrid_corner_history,
                                        const int& preAdaptMaxLevel)
@@ -3340,16 +3340,16 @@ void CpGrid::updateCornerHistoryLevels(const std::vector<std::vector<std::array<
     // corner_history_[ corner equivalent to a corner in a previous level ] = { level where the corner was born, its index in that level grid}.
     for (int corner = 0; corner < static_cast<int>(cornerInMarkedElemWithEquivRefinedCorner.size()); ++corner) {
         if (!cornerInMarkedElemWithEquivRefinedCorner[corner].empty()) {
-            const auto& [refinedLevel, refinedCorner] = elemLgrAndElemLgrCorner_to_refinedLevelAndRefinedCorner[cornerInMarkedElemWithEquivRefinedCorner[corner].back()];
+            const auto& [refinedLevel, refinedCorner] = elemLgrAndElemLgrCorner_to_refinedLevelAndRefinedCorner.at(cornerInMarkedElemWithEquivRefinedCorner[corner].back());
             data_[refinedLevel]->corner_history_[refinedCorner] = preAdaptGrid_corner_history.empty() ? std::array<int,2>{{0, corner}} :  preAdaptGrid_corner_history[corner];
         }
     }
     // corner_history_ leaf grid view
     for ( int leafCorner = 0; leafCorner < corner_count; ++leafCorner){
         data_.back()->corner_history_.resize(corner_count);
-        const auto& [elemLgr, elemLgrCorner] = adaptedCorner_to_elemLgrAndElemLgrCorner[leafCorner];
+        const auto& [elemLgr, elemLgrCorner] = adaptedCorner_to_elemLgrAndElemLgrCorner.at(leafCorner);
         if (elemLgr != -1) {
-            const auto& [refinedLevel, refinedCorner] = elemLgrAndElemLgrCorner_to_refinedLevelAndRefinedCorner[{elemLgr, elemLgrCorner}];
+            const auto& [refinedLevel, refinedCorner] = elemLgrAndElemLgrCorner_to_refinedLevelAndRefinedCorner.at({elemLgr, elemLgrCorner});
             data_.back()->corner_history_[leafCorner] = { refinedLevel, refinedCorner};
         }
         else {

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -3331,14 +3331,11 @@ void CpGrid::updateCornerHistoryLevels(const std::vector<std::vector<std::array<
                                        const int& corner_count,
                                        const std::vector<std::array<int,2>>& preAdaptGrid_corner_history,
                                        const int& preAdaptMaxLevel)
-                                       //std::vector<std::vector<std::array<int,2>>>& levels_corner_history,
-                                       // std::vector<std::array<int,2>>& leaf_corner_history)
+//std::vector<std::vector<std::array<int,2>>>& levels_corner_history,
+// std::vector<std::array<int,2>>& leaf_corner_history)
 {
-    // levels_corners_history.resize((this->maxLevel - preAdaptMaxLevel));
     for (int level = preAdaptMaxLevel+1; level < (this->maxLevel()+1); ++level) {
-        std::cout<< "level: " << level << " preAdaptMaxLevel: " << preAdaptMaxLevel << " data_[level] -> size(3): " << data_[level]->size(3) <<std::endl;
         data_[level]->corner_history_.resize( data_[level] ->size(3), std::array<int,2>({-1,-1}));
-        //  levels_corners_history[level].resize( data_[level] ->size(3), std::array<int,2>({-1,-1}));
     }
     // corner_history_ for levels 0, level 1, ..., preAdapt-maxLevel (maximum level before calling (again) adapt) should be already populated
     // corner_history_[ new corner ] = {-1,-1}
@@ -3346,10 +3343,9 @@ void CpGrid::updateCornerHistoryLevels(const std::vector<std::vector<std::array<
     for (int corner = 0; corner < static_cast<int>(cornerInMarkedElemWithEquivRefinedCorner.size()); ++corner) {
         if (!cornerInMarkedElemWithEquivRefinedCorner[corner].empty()) {
             const auto& [refinedLevel, refinedCorner] = elemLgrAndElemLgrCorner_to_refinedLevelAndRefinedCorner[cornerInMarkedElemWithEquivRefinedCorner[corner].back()];
-                data_[refinedLevel]->corner_history_[refinedCorner] = preAdaptGrid_corner_history.empty() ? std::array<int,2>{{0, corner}} :  preAdaptGrid_corner_history[corner];
-                 std::cout<< "level: " << refinedLevel << " refinedCorner: " << refinedCorner << " corner: " << corner <<std::endl; 
-            }
+            data_[refinedLevel]->corner_history_[refinedCorner] = preAdaptGrid_corner_history.empty() ? std::array<int,2>{{0, corner}} :  preAdaptGrid_corner_history[corner];
         }
+    }
     // corner_history_ leaf grid view
     for ( int leafCorner = 0; leafCorner < corner_count; ++leafCorner){
         data_.back()->corner_history_.resize(corner_count);
@@ -3361,7 +3357,6 @@ void CpGrid::updateCornerHistoryLevels(const std::vector<std::vector<std::array<
         else {
             data_.back()->corner_history_[leafCorner] =  preAdaptGrid_corner_history.empty() ? std::array<int,2>{{0, elemLgrCorner}} : preAdaptGrid_corner_history[elemLgrCorner];
         }
-        std::cout<<"leaf corner: " << leafCorner<<  " level: " <<  data_.back()->corner_history_[leafCorner][0] << " corner: " <<  data_.back()->corner_history_[leafCorner][1] <<std::endl; 
     }
 }
 

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -151,6 +151,8 @@ class CpGridData
     friend class GlobalIdSet;
     friend class HierarchicIterator;
     friend class Dune::cpgrid::IndexSet;
+    friend class Dune::cpgrid::IdSet;
+    friend class Dune::cpgrid::LevelGlobalIdSet;
 
     friend
     void ::markAndAdapt_check(Dune::CpGrid&,
@@ -469,6 +471,27 @@ private:
     std::array<double,3> getAverageArr(const std::vector<std::array<double,3>>& vec) const;
 
 public:
+    /// Add doc/or remove method and replace it with better approach
+    int getGridIdx() const {
+        // Not the nicest way of checking if "this" points at the leaf grid view of a mixed grid (with coarse and refined cells).
+        // 1. When the grid has been refined at least onece, level_data_ptr_ ->size() >1. Therefore, there is a chance of "this" pointing at the leaf grid view.
+        // 2. Unfortunately, level_ is default initialized by 0. This implies, in particular, that if someone wants to check the value of
+        //    "this->level_" when "this" points at the leaf grid view of a grid that has been refined, this value is - unfortunately - equal to 0.
+        // 3. Due to 2. we need an extra bool value to distinguish between the actual level 0 grid and such a leaf grid view (with incorrect level_ == 0). For this
+        //    reason we check if child_to_parent_cells_.empty() [true for actual level 0 grid, false for the leaf grid view].
+        // --- TO BE IMPROVED ---
+        if ((level_data_ptr_ ->size() >1) && (level_ == 0) && (!child_to_parent_cells_.empty())) {
+            return level_data_ptr_->size() -1;
+        }
+        return level_;
+    }
+    /// Add doc/or remove method and replace it with better approach
+    std::vector<std::shared_ptr<Dune::cpgrid::CpGridData>> levelData() const
+    {
+        return *level_data_ptr_;
+    }
+
+
     /// @brief Refine a single cell and return a shared pointer of CpGridData type.
     ///
     /// refineSingleCell() takes a cell and refines it in a chosen amount of cells (per direction); creating the
@@ -814,6 +837,8 @@ private:
     // SUITABLE ONLY FOR LEAFVIEW
     /** Relation between leafview and (possible different) level(s) cell indices. */ // {level, cell index in that level}
     std::vector<std::array<int,2>> leaf_to_level_cells_;
+    /** Corner history. corner_history_[ corner index ] = {level where the corner was born, its index there }, {-1,-1} otherwise. */
+    std::vector<std::array<int,2>> corner_history_;
     // SUITABLE FOR ALL LEVELS INCLUDING LEAFVIEW
     /** Child cells and their parents. Entry is {-1,-1} when cell has no father. */ // {level parent cell, parent cell index}
     std::vector<std::array<int,2>> child_to_parent_cells_;

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -600,6 +600,12 @@ public:
         return *local_id_set_;
     }
 
+    /// Get the global index set.
+    const cpgrid::LevelGlobalIdSet& globalIdSet() const
+    {
+        return *global_id_set_;
+    }
+
     /// The logical cartesian size of the grid.
     /// This function is not part of the Dune grid interface,
     /// and should be used with caution.

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -44,6 +44,12 @@
 #include "PartitionTypeIndicator.hpp"
 #include <opm/grid/cpgrid/DefaultGeometryPolicy.hpp>
 
+// To be able to test local and global ids of vertices
+void refinePatch_and_check(Dune::CpGrid&,
+                           const std::vector<std::array<int,3>>&,
+                           const std::vector<std::array<int,3>>&,
+                           const std::vector<std::array<int,3>>&,
+                           const std::vector<std::string>&);
 
 namespace Dune
 {
@@ -67,6 +73,11 @@ class Entity : public EntityRep<codim>
     friend class GlobalIdSet;
     friend class HierarchicIterator;
     friend class CpGridData;
+    friend void ::refinePatch_and_check(Dune::CpGrid&,
+                                        const std::vector<std::array<int,3>>&,
+                                        const std::vector<std::array<int,3>>&,
+                                        const std::vector<std::array<int,3>>&,
+                                        const std::vector<std::string>&);
 
 public:
     /// @brief

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -588,7 +588,6 @@ Dune::cpgrid::Entity<0> Dune::cpgrid::Entity<codim>::getEquivLevelElem() const
     }
 }
 
-
 template<int codim>
 int Dune::cpgrid::Entity<codim>::getLevelCartesianIdx() const
 {

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -206,10 +206,8 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
         } // end-if-isBlockShape
 
         const auto& grid_view = coarse_grid.leafGridView();
-
         Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LeafGridView> adaptMapper(grid_view, Dune::mcmgElementLayout());
-        const auto& leaf_localIdSet = data.back()->local_id_set_;
-  
+
         for(const auto& element: elements(grid_view)) {
             // postAdapt() has been called, therefore every element gets marked with 0
             BOOST_CHECK( coarse_grid.getMark(element) == 0);
@@ -373,30 +371,25 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
             } // end-preAdaptElements-for-loop
         } // end-startingGridIdx==0
 
-
-
-        const auto& global_id_set_ptr = coarse_grid.globalIdSet(); //.global_id_set_ptr_;
-        const auto& leaf_globalIdSet = data.back()->global_id_set_;
-
         std::set<int> allIds_set;
         std::vector<int> allIds_vec;
         allIds_vec.reserve(data.back()->size(0) + data.back()->size(3));
         for (const auto& element: elements(grid_view)){
-            const auto& localId = (*leaf_localIdSet).id(element);
-            const auto& globalId = (*leaf_globalIdSet).id(element);
+            const auto& localId = data.back()->localIdSet().id(element);
+            const auto& globalId = data.back()->globalIdSet().id(element);
             // In serial run, local and global id coincide:
             BOOST_CHECK_EQUAL(localId, globalId);
             allIds_set.insert(localId);
             allIds_vec.push_back(localId);
             // Check that the global_id_set_ptr_ has the correct id (id from the level where the entity was born).
-            BOOST_CHECK_EQUAL( global_id_set_ptr.id(element), (*data[element.level()]).local_id_set_ -> id(element.getEquivLevelElem()));
+            BOOST_CHECK_EQUAL( coarse_grid.globalIdSet().id(element), data[element.level()]->localIdSet().id(element.getEquivLevelElem()));
         }
         // Check injectivity of the map local_id_set_ (and, indirectly, global_id_set_) after adding cell ids.
         BOOST_CHECK( allIds_set.size() == allIds_vec.size());
 
         for (const auto& point: vertices(grid_view)){
-            const auto& localId = (*leaf_localIdSet).id(point);
-            const auto& globalId = (*leaf_globalIdSet).id(point);
+            const auto& localId = data.back()->localIdSet().id(point);
+            const auto& globalId = data.back()->globalIdSet().id(point);
             BOOST_CHECK_EQUAL(localId, globalId);
             allIds_set.insert(localId);
             allIds_vec.push_back(localId);
@@ -410,35 +403,47 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
             std::set<int> levelIds_set;
             std::vector<int> levelIds_vec;
             levelIds_vec.reserve(data[level]->size(0) + data[level]->size(3));
-            const auto& level_view = coarse_grid.levelGridView(level);
-            const auto& level_localIdSet = (*data[level]).local_id_set_;
-            const auto& level_globalIdSet = (*data[level]).global_id_set_;
-            const auto& level_indexSet = (*data[level]).index_set_;
 
-            for (const auto& element: elements(level_view)){
-                const auto& localId = (*level_localIdSet).id(element);
-                const auto& globalId = (*level_globalIdSet).id(element);
+            for (const auto& element: elements(coarse_grid.levelGridView(level))){
+                const auto& localId = data[level]->localIdSet().id(element);
+                const auto& globalId = data[level]->globalIdSet().id(element);
                 // In serial run, local and global id coincide:
                 BOOST_CHECK_EQUAL(localId, globalId);
                 levelIds_set.insert(localId);
                 levelIds_vec.push_back(localId);
+                /* // Search in the leaf grid view elements for the element with the same id, if it exists.
+                   if (auto itIsLeaf = std::find_if( elements(coarse_grid.leafGridView()).begin(),
+                   elements(coarse_grid.leafGridView()).end(),
+                   [localId, data](const Dune::cpgrid::Entity<0>& leafElem)
+                   { return (localId == data.back()->localIdSet().id(leafElem)); });
+                   itIsLeaf != elements(coarse_grid.leafGridView()).end()) {
+                   BOOST_CHECK( itIsLeaf->getEquivLevelElem() == element);
+                   }*/
                 if (element.isLeaf()) { // Check that the id of a cell not involved in any further refinement appears on the IdSet of the leaf grid view.
                     BOOST_CHECK( std::find(allIds_set.begin(), allIds_set.end(), localId) != allIds_set.end());
                 }
                 else { // Check that the id of a cell that vanished during refinement does not appear on the IdSet of the leaf grid view.
                     BOOST_CHECK( std::find(allIds_set.begin(), allIds_set.end(), localId) == allIds_set.end());
                 }
-                const auto& idx = (*level_indexSet).index(element);
+                const auto& idx = data[level]->indexSet().index(element);
                 // In serial run, local and global id coincide:
                 BOOST_CHECK_EQUAL(idx, element.index());
             }
 
-            for (const auto& point : vertices(level_view)) {
-                const auto& localId = (*level_localIdSet).id(point);
-                const auto& globalId = (*level_globalIdSet).id(point);
+            for (const auto& point : vertices(coarse_grid.levelGridView(level))) {
+                const auto& localId = data[level]->localIdSet().id(point);
+                const auto& globalId = data[level]->globalIdSet().id(point);
                 BOOST_CHECK_EQUAL(localId, globalId);
                 levelIds_set.insert(localId);
                 levelIds_vec.push_back(localId);
+                // Search in the leaf grid view elements for the element with the same id, if it exists.
+                /*   if (auto itIsLeaf = std::find_if( vertices(coarse_grid.leafGridView()).begin(),
+                                                  vertices(coarse_grid.leafGridView()).end(),
+                                                  [localId, data](const Dune::cpgrid::Entity<3>& leafPoint)
+                                                  { return (localId == data.back()->localIdSet().id(leafPoint)); });
+                    itIsLeaf != vertices(coarse_grid.leafGridView()).end()) {
+                    BOOST_CHECK( (*itIsLeaf).geometry().center() == point.geometry().center() );
+                }*/
             }
             // Check injectivity of the map local_id_set_ (and, indirectly, global_id_set_)
             BOOST_CHECK( levelIds_set.size() == levelIds_vec.size());

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -149,7 +149,6 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
                 const auto& grid_view = coarse_grid.leafGridView();
                 const auto& equiv_grid_view = other_grid.leafGridView();
 
-
                 for(const auto& element: elements(grid_view)) {
                     BOOST_CHECK( element.getOrigin().level() == 0);
                     auto equiv_element_iter = equiv_grid_view.begin<0>();
@@ -396,6 +395,10 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
         }
         // Check injectivity of the map local_id_set_ (and, indirectly, global_id_set_) after adding point ids.
         BOOST_CHECK( allIds_set.size() == allIds_vec.size());
+        // CpGrid supports only elements (cells) and vertices (corners). Total amount of ids for the leaf grid view should coincide
+        // with the total amount of cells and corners on the leaf grid view.
+        BOOST_CHECK( static_cast<int>(allIds_set.size()) == (data.back()->size(0) + data.back()->size(3)));
+        
 
         // Local/Global id sets for level grids (level 0, 1, ..., maxLevel)
         for (int level = 0; level < coarse_grid.maxLevel() +1; ++level)
@@ -451,6 +454,9 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
             }
             // Check injectivity of the map local_id_set_ (and, indirectly, global_id_set_)
             BOOST_CHECK( levelIds_set.size() == levelIds_vec.size());
+            // CpGrid supports only elements (cells) and vertices (corners). Total amount of ids for each level grid should coincide
+            // with the total amount of cells and corners on that level grid.
+            BOOST_CHECK( static_cast<int>(levelIds_set.size()) == (data[level]->size(0) + data[level]->size(3)));
         }
     } // end-if-preAdapt
 }
@@ -536,7 +542,6 @@ BOOST_AUTO_TEST_CASE(globalRefinement_calling_globalRefine)
     // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
     markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, false, false, true);
 }
-
 
 BOOST_AUTO_TEST_CASE(calling_globalRefine_with_2)
 {

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -411,14 +411,16 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
                 BOOST_CHECK_EQUAL(localId, globalId);
                 levelIds_set.insert(localId);
                 levelIds_vec.push_back(localId);
-                /* // Search in the leaf grid view elements for the element with the same id, if it exists.
-                   if (auto itIsLeaf = std::find_if( elements(coarse_grid.leafGridView()).begin(),
-                   elements(coarse_grid.leafGridView()).end(),
-                   [localId, data](const Dune::cpgrid::Entity<0>& leafElem)
-                   { return (localId == data.back()->localIdSet().id(leafElem)); });
-                   itIsLeaf != elements(coarse_grid.leafGridView()).end()) {
-                   BOOST_CHECK( itIsLeaf->getEquivLevelElem() == element);
-                   }*/
+                // The following check is commented even though all the test cases pass it. However, runnning this file
+                // with it (uncommented) takes ~2.5 minutes.
+                // Search in the leaf grid view elements for the element with the same id, if it exists.
+                /*if (auto itIsLeaf = std::find_if( elements(coarse_grid.leafGridView()).begin(),
+                  elements(coarse_grid.leafGridView()).end(),
+                  [localId, data](const Dune::cpgrid::Entity<0>& leafElem)
+                  { return (localId == data.back()->localIdSet().id(leafElem)); });
+                  itIsLeaf != elements(coarse_grid.leafGridView()).end()) {
+                  BOOST_CHECK( itIsLeaf->getEquivLevelElem() == element);
+                  }*/
                 if (element.isLeaf()) { // Check that the id of a cell not involved in any further refinement appears on the IdSet of the leaf grid view.
                     BOOST_CHECK( std::find(allIds_set.begin(), allIds_set.end(), localId) != allIds_set.end());
                 }
@@ -436,19 +438,20 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
                 BOOST_CHECK_EQUAL(localId, globalId);
                 levelIds_set.insert(localId);
                 levelIds_vec.push_back(localId);
-                // Search in the leaf grid view elements for the element with the same id, if it exists.
-                /*   if (auto itIsLeaf = std::find_if( vertices(coarse_grid.leafGridView()).begin(),
-                                                  vertices(coarse_grid.leafGridView()).end(),
-                                                  [localId, data](const Dune::cpgrid::Entity<3>& leafPoint)
-                                                  { return (localId == data.back()->localIdSet().id(leafPoint)); });
-                    itIsLeaf != vertices(coarse_grid.leafGridView()).end()) {
-                    BOOST_CHECK( (*itIsLeaf).geometry().center() == point.geometry().center() );
-                }*/
+                // The following check is commented even though all the test cases pass it. However, runnning this file
+                // with it (uncommented) takes ~2.5 minutes.
+                /* // Search in the leaf grid view elements for the element with the same id, if it exists.
+                   if (auto itIsLeaf = std::find_if( vertices(coarse_grid.leafGridView()).begin(),
+                   vertices(coarse_grid.leafGridView()).end(),
+                   [localId, data](const Dune::cpgrid::Entity<3>& leafPoint)
+                   { return (localId == data.back()->localIdSet().id(leafPoint)); });
+                   itIsLeaf != vertices(coarse_grid.leafGridView()).end()) {
+                   BOOST_CHECK( (*itIsLeaf).geometry().center() == point.geometry().center() );
+                   }*/
             }
             // Check injectivity of the map local_id_set_ (and, indirectly, global_id_set_)
             BOOST_CHECK( levelIds_set.size() == levelIds_vec.size());
         }
-
     } // end-if-preAdapt
 }
 
@@ -461,7 +464,8 @@ BOOST_AUTO_TEST_CASE(doNothing)
     const std::array<int, 3> cells_per_dim = {2,2,2};
     std::vector<int> markedCells;
     coarse_grid.createCartesian(grid_dim, cell_sizes);
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, /*isBlockShape*/true, /*hasBeenRefinedAtLeastOnce*/false, /*isGlobalRefinement*/true);
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, true, false, true);
 }
 
 BOOST_AUTO_TEST_CASE(globalRefinement)
@@ -485,7 +489,8 @@ BOOST_AUTO_TEST_CASE(globalRefinement)
     other_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
 
     // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, /*isBlockShape*/false, /*hasBeenRefinedAtLeastOnce*/false, /*isGlobalRefinement*/true);
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, false, false, true);
 }
 
 
@@ -505,7 +510,8 @@ BOOST_AUTO_TEST_CASE(doNothing_calling_globalRefine)
     other_grid.globalRefine(0);
 
     // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, /*isBlockShape*/true, /*hasBeenRefinedAtLeastOnce*/false, /*isGlobalRefinement*/true);
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, true, false, true);
 }
 
 BOOST_AUTO_TEST_CASE(globalRefinement_calling_globalRefine)
@@ -527,7 +533,8 @@ BOOST_AUTO_TEST_CASE(globalRefinement_calling_globalRefine)
     const std::array<int, 3> cells_per_dim = {2,2,2};
 
     // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, /*isBlockShape*/false, /*hasBeenRefinedAtLeastOnce*/false, /*isGlobalRefinement*/true);
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, false, false, true);
 }
 
 
@@ -552,7 +559,8 @@ BOOST_AUTO_TEST_CASE(calling_globalRefine_with_2)
     const std::array<int, 3> cells_per_dim = {2,2,2};
 
     // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
-    markAndAdapt_check(equiv_fine_grid, cells_per_dim, markedCells, other_grid, /*isBlockShape*/false, /*hasBeenRefinedAtLeastOnce*/false, /*isGlobalRefinement*/true);
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(equiv_fine_grid, cells_per_dim, markedCells, other_grid, false, false, true);
 }
 
 BOOST_AUTO_TEST_CASE(calling_globalRefine_with_3)
@@ -576,7 +584,8 @@ BOOST_AUTO_TEST_CASE(calling_globalRefine_with_3)
     const std::array<int, 3> cells_per_dim = {2,2,2};
 
     // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
-    markAndAdapt_check(equiv_fine_grid, cells_per_dim, markedCells, other_grid, /*isBlockShape*/false, /*hasBeenRefinedAtLeastOnce*/false, /*isGlobalRefinement*/true);
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(equiv_fine_grid, cells_per_dim, markedCells, other_grid, false, false, true);
 }
 
 BOOST_AUTO_TEST_CASE(throw_globalRefine_with_negative_int)
@@ -627,7 +636,8 @@ BOOST_AUTO_TEST_CASE(mark2consequtiveCells)
     other_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
 
     std::vector<int> markedCells = {2,3};
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, /*isBlockShape*/true, /*hasBeenRefinedAtLeastOnce*/false, /*isGlobalRefinement*/false);
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, true, false, false);
 }
 
 BOOST_AUTO_TEST_CASE(mark2InteriorConsequtiveCells)
@@ -650,7 +660,8 @@ BOOST_AUTO_TEST_CASE(mark2InteriorConsequtiveCells)
     other_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
 
     std::vector<int> markedCells = {17,18};
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, /*isBlockShape*/true, /*hasBeenRefinedAtLeastOnce*/false, /*isGlobalRefinement*/false);
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, true, false, false);
 }
 
 BOOST_AUTO_TEST_CASE(markNonBlockShapeCells)
@@ -662,7 +673,8 @@ BOOST_AUTO_TEST_CASE(markNonBlockShapeCells)
     const std::array<int, 3> cells_per_dim = {2,2,2};
     std::vector<int> markedCells = {0}; //,1,2,5,13};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, /*isBlockShape*/false, /*hasBeenRefinedAtLeastOnce*/false, /*isGlobalRefinement*/false);
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, false, false);
 }
 
 BOOST_AUTO_TEST_CASE(markNonBlockShapeCells_II)
@@ -674,7 +686,8 @@ BOOST_AUTO_TEST_CASE(markNonBlockShapeCells_II)
     const std::array<int, 3> cells_per_dim = {2,3,4};
     std::vector<int> markedCells = {1,4,6,9,17,22,28,32,33};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, /*isBlockShape*/false, /*hasBeenRefinedAtLeastOnce*/false, /*isGlobalRefinement*/false);
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, false, false);
 }
 
 BOOST_AUTO_TEST_CASE(markNonBlockCells_compareAdapt)
@@ -699,7 +712,8 @@ BOOST_AUTO_TEST_CASE(markNonBlockCells_compareAdapt)
     other_grid.adapt();
     other_grid.postAdapt();
 
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, /*isBlockShape*/false, /*hasBeenRefinedAtLeastOnce*/false, /*isGlobalRefinement*/false);
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, false, false, false);
 }
 
 BOOST_AUTO_TEST_CASE(callAdaptMultipleTimes)
@@ -747,7 +761,8 @@ BOOST_AUTO_TEST_CASE(callAdaptMultipleTimes)
     other_grid.adapt();
     other_grid.postAdapt();
 
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, /*isBlockShape*/false, /*hasBeenRefinedAtLeastOnce*/false, /*isGlobalRefinement*/false);
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, false, false, false);
 }
 
 BOOST_AUTO_TEST_CASE(refineCoarseCells_in_mixedGrid) {
@@ -765,7 +780,8 @@ BOOST_AUTO_TEST_CASE(refineCoarseCells_in_mixedGrid) {
     coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
 
     std::vector<int> markedCells = {0,1,11,15}; // coarse cells (in level 0 grid, this cell has index 8)
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, /*isBlockShape*/false, /*hasBeenRefinedAtLeastOnce*/true, /*isGlobalRefinement*/false);
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, true, false);
 }
 
 BOOST_AUTO_TEST_CASE(refineInteriorRefinedCells_in_mixedGrid) {
@@ -786,7 +802,8 @@ BOOST_AUTO_TEST_CASE(refineInteriorRefinedCells_in_mixedGrid) {
     // Cells 30, 31, 56, and 57 are refined cells, located in the interior of the refined-level-grid-1 (lgr 1 / level 1).
     // Therefore, cell_to_face_ for all of them has size 6. (Their faces have all 2 refined neigboring cells - (not one coarse cell, and one refined)).
     std::vector<int> markedCells = {30,31, 56,57};
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, /*isBlockShape*/false, /*hasBeenRefinedAtLeastOnce*/true, /*isGlobalRefinement*/false);
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, true, false);
 }
 
 
@@ -810,9 +827,9 @@ BOOST_AUTO_TEST_CASE(refineMixedCells_in_mixedGrid) {
     // - Cells 0,1,2,12, and 15 are coarse cells, not touching the boundary of the LGR1 (cells 12 and 15 do share corners with LGR1 but do not share
     // any face. Therefore, the faces of cells 0,1,2,12,and 15 have all 1 or 2 neighboring coarse cells).
     std::vector<int> markedCells = {0,1,2,12,15,30,31,56,57};
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, /*isBlockShape*/false, /*hasBeenRefinedAtLeastOnce*/true, /*isGlobalRefinement*/false);
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, true, false);
 }
-
 
 
 BOOST_AUTO_TEST_CASE(refineMixedCells_in_multiLevelGrid) {
@@ -835,7 +852,8 @@ BOOST_AUTO_TEST_CASE(refineMixedCells_in_multiLevelGrid) {
     // - Cells 0,1,2,12, and 15 are coarse cells, not touching the boundary of the LGR1 (cells 12 and 15 do share corners with LGR1 but do not share
     // any face. Therefore, the faces of cells 0,1,2,12,and 15 have all 1 or 2 neighboring coarse cells).
     std::vector<int> markedCells = {0,1,2,12,15,30,31,56,57};
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, /*isBlockShape*/false, /*hasBeenRefinedAtLeastOnce*/true, /*isGlobalRefinement*/false);
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, true, false);
 }
 
 
@@ -861,7 +879,8 @@ BOOST_AUTO_TEST_CASE(refineMixedCells_in_mixedGrid_II)
     // - Cells 50,59,68 are refined cells, children of {level 0, cell index 18}, forming a collum.
     // Cells 25 and 50, 34 and 59, 43 and 68, share a face (the collums are next to each other).
     std::vector<int> markedCells = {25,34,43,50,59,68, 72, 84};
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, /*isBlockShape*/true, /*hasBeenRefinedAtLeastOnce*/true, /*isGlobalRefinement*/false);
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, true, true, false);
 }
 
 BOOST_AUTO_TEST_CASE(cellTouchesLgrBoundary_throw)
@@ -883,8 +902,6 @@ BOOST_AUTO_TEST_CASE(cellTouchesLgrBoundary_throw)
     // - Coarse cells touching the LGR1 on its boundary.
     // Cell 5, 14, 16, 71, 73, and 82, touching the bottom, front, left, right, back, and the top of LGR1, respectively.
     std::vector<int> markedCells = {5,14,16,71,73,82};
-    BOOST_CHECK_THROW(markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid,
-                                         /*isBlockShape*/true,
-                                         /*hasBeenRefinedAtLeastOnce*/true,
-                                         /*isGlobalRefinement*/false), std::logic_error);
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    BOOST_CHECK_THROW(markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, true, true, false), std::logic_error);
 }

--- a/tests/cpgrid/grid_lgr_test.cpp
+++ b/tests/cpgrid/grid_lgr_test.cpp
@@ -467,44 +467,45 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
 
         std::vector<int> leaf_to_parent_cell; // To store parent cell index, when leaf cell has a parent. Empty entry otherwise.
         leaf_to_parent_cell.resize(data[startIJK_vec.size()+1]-> size(0)); // Correct size.
-        //
-        const auto& leaf_view = coarse_grid.leafGridView();
-        const auto& level0_view = coarse_grid.levelGridView(0);
 
-        Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LeafGridView> leafMapper(leaf_view, Dune::mcmgElementLayout());
-        Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LevelGridView> level0Mapper(level0_view, Dune::mcmgElementLayout());
+        Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LeafGridView> leafMapper(coarse_grid.leafGridView(), Dune::mcmgElementLayout());
+        Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LevelGridView> level0Mapper(coarse_grid.levelGridView(0), Dune::mcmgElementLayout());
 
-        const auto& leaf_idSet = (*data[startIJK_vec.size()+1]).local_id_set_;
-        const auto& leaf_globalIdSet = (*data[startIJK_vec.size()+1]).global_id_set_;
-        const auto& level0_idSet = (*data[0]).local_id_set_;
-
-
-        const auto& global_id_set_ptr = coarse_grid.global_id_set_ptr_;
+        for (const auto& element: elements(coarse_grid.leafGridView())){
+            BOOST_CHECK( ((element.level() >= 0) || (element.level() < static_cast<int>(startIJK_vec.size()) +1)));
+            if (element.hasFather()) { // leaf_cell has a father!
+                leaf_to_parent_cell[leafMapper.index(element)] = level0Mapper.index(element.father());
+                const auto& parent_id = data[0]->localIdSet().id(element.father());
+                BOOST_CHECK(element.index() == leafMapper.index(element));
+                BOOST_CHECK(element.father().index() == leaf_to_parent_cell[element.index()]);
+                BOOST_CHECK(element.father().index() == parent_id);
+                BOOST_CHECK(element.father().index() == level0Mapper.index(element.father()));
+            }
+        }
 
         std::set<int> allIds_set;
         std::vector<int> allIds_vec;
         allIds_vec.reserve(data.back()->size(0) + data.back()->size(3));
-        for (const auto& element: elements(leaf_view)){
-            const auto& localId = (*leaf_idSet).id(element);
-            const auto& globalId = (*leaf_globalIdSet).id(element);
+        for (const auto& element: elements(coarse_grid.leafGridView())){
+            const auto& localId = data.back()->localIdSet().id(element);
+            const auto& globalId = data.back()->globalIdSet().id(element);
             // In serial run, local and global id coincide:
             BOOST_CHECK_EQUAL(localId, globalId);
             allIds_set.insert(localId);
             allIds_vec.push_back(localId);
             // Check that the global_id_set_ptr_ has the correct id (id from the level where the entity was born).
-            BOOST_CHECK_EQUAL( global_id_set_ptr->id(element), (*data[element.level()]).local_id_set_ -> id(element.getEquivLevelElem()));
+            BOOST_CHECK_EQUAL( coarse_grid.globalIdSet().id(element), data[element.level()]->localIdSet().id(element.getEquivLevelElem()));
         }
         // Check injectivity of the map local_id_set_ (and, indirectly, global_id_set_) after adding cell ids.
         BOOST_CHECK( allIds_set.size() == allIds_vec.size());
 
-        for (const auto& point: vertices(leaf_view)){
-            const auto& localId = (*leaf_idSet).id(point);
-            const auto& globalId = (*leaf_globalIdSet).id(point);
+        for (const auto& point : vertices(coarse_grid.leafGridView())){
+            const auto& localId = data.back()->localIdSet().id(point);
+            const auto& globalId = data.back()->globalIdSet().id(point);
             BOOST_CHECK_EQUAL(localId, globalId);
             allIds_set.insert(localId);
             allIds_vec.push_back(localId);
             // Check that the global_id_set_ptr_ has the correct id (id from the level where the entity was born).
-            // BOOST_CHECK_EQUAL( global_id_set_ptr->id(point), (*data[point.grid_.getGridIdx()]).local_id_set_ -> id(point.getEquivLevelElem())); - to be done -
         }
         // Check injectivity of the map local_id_set_ (and, indirectly, global_id_set_) after adding point ids.
         BOOST_CHECK( allIds_set.size() == allIds_vec.size());
@@ -515,53 +516,49 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
             std::set<int> levelIds_set;
             std::vector<int> levelIds_vec;
             levelIds_vec.reserve(data[level]->size(0) + data[level]->size(3));
-            const auto& level_view = coarse_grid.levelGridView(level);
-            const auto& level_localIdSet = (*data[level]).local_id_set_;
-            const auto& level_globalIdSet = (*data[level]).global_id_set_;
-            const auto& level_indexSet = (*data[level]).index_set_;
-
-            for (const auto& element: elements(level_view)){
-                const auto& localId = (*level_localIdSet).id(element);
-                const auto& globalId = (*level_globalIdSet).id(element);
+            for (const auto& element: elements(coarse_grid.levelGridView(level))){
+                const auto& localId = data[level]->localIdSet().id(element);
+                const auto& globalId = data[level]->globalIdSet().id(element);
                 // In serial run, local and global id coincide:
                 BOOST_CHECK_EQUAL(localId, globalId);
                 levelIds_set.insert(localId);
                 levelIds_vec.push_back(localId);
+                // Search in the leaf grid view elements for the element with the same id, if it exists.
+                if (auto itIsLeaf = std::find_if( elements(coarse_grid.leafGridView()).begin(),
+                                                  elements(coarse_grid.leafGridView()).end(),
+                                                  [localId, data](const Dune::cpgrid::Entity<0>& leafElem)
+                                                  { return (localId == data.back()->localIdSet().id(leafElem)); });
+                    itIsLeaf != elements(coarse_grid.leafGridView()).end()) {
+                    BOOST_CHECK( itIsLeaf->getEquivLevelElem() == element);
+                }
                 if (element.isLeaf()) { // Check that the id of a cell not involved in any further refinement appears on the IdSet of the leaf grid view.
                     BOOST_CHECK( std::find(allIds_set.begin(), allIds_set.end(), localId) != allIds_set.end());
                 }
                 else { // Check that the id of a cell that vanished during refinement does not appear on the IdSet of the leaf grid view.
                     BOOST_CHECK( std::find(allIds_set.begin(), allIds_set.end(), localId) == allIds_set.end());
                 }
-                const auto& idx = (*level_indexSet).index(element);
+                const auto& idx = data[level]->indexSet().index(element);
                 // In serial run, local and global id coincide:
                 BOOST_CHECK_EQUAL(idx, element.index());
             }
 
-            for (const auto& point : vertices(level_view)) {
-                const auto& localId = (*level_localIdSet).id(point);
-                const auto& globalId = (*level_globalIdSet).id(point);
+            for (const auto& point : vertices(coarse_grid.levelGridView(level))) {
+                const auto& localId = data[level]->localIdSet().id(point);
+                const auto& globalId = data[level]->globalIdSet().id(point);
                 BOOST_CHECK_EQUAL(localId, globalId);
                 levelIds_set.insert(localId);
                 levelIds_vec.push_back(localId);
-                // Currently, isLeaf() for a corner is not defined, so we cannot distinguish between the corners that
-                // might have vanished uring refinement and the ones that appear in the leaf grid view.
-                // BOOST_CHECK( std::find(allPointIds_set.begin(), allPointIds_set.end(), localId) != allPointIds_set.end());
+                // Search in the leaf grid view elements for the element with the same id, if it exists.
+                if (auto itIsLeaf = std::find_if( vertices(coarse_grid.leafGridView()).begin(),
+                                                  vertices(coarse_grid.leafGridView()).end(),
+                                                  [localId, data](const Dune::cpgrid::Entity<3>& leafPoint)
+                                                  { return (localId == data.back()->localIdSet().id(leafPoint)); });
+                    itIsLeaf != vertices(coarse_grid.leafGridView()).end()) {
+                    BOOST_CHECK( (*itIsLeaf).geometry().center() == point.geometry().center() );
+                }
             }
             // Check injectivity of the map local_id_set_ (and, indirectly, global_id_set_)
             BOOST_CHECK( levelIds_set.size() == levelIds_vec.size());
-        }
-
-        for (const auto& element: elements(leaf_view)){
-            BOOST_CHECK( ((element.level() >= 0) || (element.level() < static_cast<int>(startIJK_vec.size()) +1)));
-            if (element.hasFather()) { // leaf_cell has a father!
-                leaf_to_parent_cell[leafMapper.index(element)] = level0Mapper.index(element.father());
-                const auto& parent_id = (*level0_idSet).id(element.father());
-                BOOST_CHECK(element.index() == leafMapper.index(element));
-                BOOST_CHECK(element.father().index() == leaf_to_parent_cell[element.index()]);
-                BOOST_CHECK(element.father().index() == parent_id);
-                BOOST_CHECK(element.father().index() == level0Mapper.index(element.father()));
-            }
         }
     }
     catch (const std::exception& e) {

--- a/tests/cpgrid/inactiveCell_lgr_test.cpp
+++ b/tests/cpgrid/inactiveCell_lgr_test.cpp
@@ -295,28 +295,25 @@ void testInactiveCellsLgrs(const std::string& deckString,
         }
     }
 
-    const auto& global_id_set_ptr = grid.global_id_set_ptr_;
-
     std::set<int> allIds_set;
     std::vector<int> allIds_vec;
     allIds_vec.reserve(data.back()->size(0) + data.back()->size(3));
-    const auto& leaf_view = grid.leafGridView();
-    for (const auto& element: elements(leaf_view)){
-        const auto& localId = data.back()->local_id_set_->id(element);
-        const auto& globalId = data.back()->global_id_set_->id(element);
+    for (const auto& element: elements(grid.leafGridView())){
+        const auto& localId = data.back()->localIdSet().id(element);
+        const auto& globalId = data.back()->globalIdSet().id(element);
         // In serial run, local and global id coincide:
         BOOST_CHECK_EQUAL(localId, globalId);
         allIds_set.insert(localId);
         allIds_vec.push_back(localId);
         // Check that the global_id_set_ptr_ has the correct id (id from the level where the entity was born).
-        BOOST_CHECK_EQUAL( global_id_set_ptr->id(element), (*data[element.level()]).local_id_set_ -> id(element.getEquivLevelElem()));
+        BOOST_CHECK_EQUAL( grid.globalIdSet().id(element), (*data[element.level()]).localIdSet().id(element.getEquivLevelElem()));
     }
     // Check injectivity of the map local_id_set_ (and, indirectly, global_id_set_) after adding cell ids.
     BOOST_CHECK( allIds_set.size() == allIds_vec.size());
 
-    for (const auto& point: vertices(leaf_view)){
-        const auto& localId = data.back()->local_id_set_->id(point);
-        const auto& globalId = data.back()->global_id_set_->id(point);
+    for (const auto& point: vertices(grid.leafGridView())){
+        const auto& localId = data.back()->localIdSet().id(point);
+        const auto& globalId = data.back()->globalIdSet().id(point);
         BOOST_CHECK_EQUAL(localId, globalId);
         allIds_set.insert(localId);
         allIds_vec.push_back(localId);
@@ -330,35 +327,47 @@ void testInactiveCellsLgrs(const std::string& deckString,
         std::set<int> levelIds_set;
         std::vector<int> levelIds_vec;
         levelIds_vec.reserve(data[level]->size(0) + data[level]->size(3));
-        const auto& level_view = grid.levelGridView(level);
-        const auto& level_localIdSet = (*data[level]).local_id_set_;
-        const auto& level_globalIdSet = (*data[level]).global_id_set_;
-        const auto& level_indexSet = (*data[level]).index_set_;
 
-        for (const auto& element: elements(level_view)){
-            const auto& localId = (*level_localIdSet).id(element);
-            const auto& globalId = (*level_globalIdSet).id(element);
+        for (const auto& element: elements(grid.levelGridView(level))){
+            const auto& localId = data[level]->localIdSet().id(element);
+            const auto& globalId = data[level]->globalIdSet().id(element);
             // In serial run, local and global id coincide:
             BOOST_CHECK_EQUAL(localId, globalId);
             levelIds_set.insert(localId);
             levelIds_vec.push_back(localId);
+            // Search in the leaf grid view elements for the element with the same id, if it exists.
+            if (auto itIsLeaf = std::find_if( elements(grid.leafGridView()).begin(),
+                                              elements(grid.leafGridView()).end(),
+                                              [localId, data](const Dune::cpgrid::Entity<0>& leafElem)
+                                              { return (localId == data.back()->localIdSet().id(leafElem)); });
+                itIsLeaf != elements(grid.leafGridView()).end()) {
+                BOOST_CHECK( itIsLeaf->getEquivLevelElem() == element);
+            }
             if (element.isLeaf()) { // Check that the id of a cell not involved in any further refinement appears on the IdSet of the leaf grid view.
                 BOOST_CHECK( std::find(allIds_set.begin(), allIds_set.end(), localId) != allIds_set.end());
             }
             else { // Check that the id of a cell that vanished during refinement does not appear on the IdSet of the leaf grid view.
                 BOOST_CHECK( std::find(allIds_set.begin(), allIds_set.end(), localId) == allIds_set.end());
             }
-            const auto& idx = (*level_indexSet).index(element);
+            const auto& idx = data[level]->indexSet().index(element);
             // In serial run, local and global id coincide:
             BOOST_CHECK_EQUAL(idx, element.index());
         }
 
-        for (const auto& point : vertices(level_view)) {
-            const auto& localId = (*level_localIdSet).id(point);
-            const auto& globalId = (*level_globalIdSet).id(point);
+        for (const auto& point : vertices(grid.levelGridView(level))) {
+            const auto& localId = data[level]->localIdSet().id(point);
+            const auto& globalId = data[level]->globalIdSet().id(point);
             BOOST_CHECK_EQUAL(localId, globalId);
             levelIds_set.insert(localId);
             levelIds_vec.push_back(localId);
+            // Search in the leaf grid view elements for the element with the same id, if it exists.
+            if (auto itIsLeaf = std::find_if( vertices(grid.leafGridView()).begin(),
+                                              vertices(grid.leafGridView()).end(),
+                                              [localId, data](const Dune::cpgrid::Entity<3>& leafPoint)
+                                              { return (localId == data.back()->localIdSet().id(leafPoint)); });
+                itIsLeaf != vertices(grid.leafGridView()).end()) {
+                BOOST_CHECK( (*itIsLeaf).geometry().center() == point.geometry().center());
+            }
         }
         // Check injectivity of the map local_id_set_ (and, indirectly, global_id_set_)
         BOOST_CHECK( levelIds_set.size() == levelIds_vec.size());

--- a/tests/cpgrid/lookupdataCpGrid_test.cpp
+++ b/tests/cpgrid/lookupdataCpGrid_test.cpp
@@ -112,7 +112,7 @@ void lookup_check(const Dune::CpGrid& grid)
     const Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LeafGridView> leafMapper(leaf_view, Dune::mcmgElementLayout());
     const Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LevelGridView> level0Mapper(level0_view, Dune::mcmgElementLayout());
 
-    const auto& leaf_idSet = (*data.back()).localIdSet();
+    // const auto& leaf_idSet = (*data.back()).localIdSet();
     const auto& level0_idSet = (*data[0]).localIdSet();
 
     for (const auto& elem : elements(leaf_view)) {
@@ -177,9 +177,7 @@ void lookup_check(const Dune::CpGrid& grid)
         BOOST_CHECK(featureInElem == level0Mapper.index(elem.getOrigin()) +3);
         BOOST_CHECK(featureInElem == fake_feature[lookUpData.getFieldPropIdx(elem)]);
         if (elem.hasFather()) { // leaf_cell has a father!
-            const auto id = leaf_idSet.id(elem);
             const auto parent_id = level0_idSet.id(elem.father());
-            BOOST_CHECK(elem.index() == id);
             BOOST_CHECK(elem.index() == leafMapper.index(elem));
             BOOST_CHECK(elem.father().index() == featureInElem -3);
             BOOST_CHECK(elem.father().index() == parent_id);

--- a/tests/cpgrid/lookupdataCpGrid_test.cpp
+++ b/tests/cpgrid/lookupdataCpGrid_test.cpp
@@ -111,8 +111,6 @@ void lookup_check(const Dune::CpGrid& grid)
     const auto& level0_view = grid.levelGridView(0);
     const Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LeafGridView> leafMapper(leaf_view, Dune::mcmgElementLayout());
     const Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LevelGridView> level0Mapper(level0_view, Dune::mcmgElementLayout());
-
-    // const auto& leaf_idSet = (*data.back()).localIdSet();
     const auto& level0_idSet = (*data[0]).localIdSet();
 
     for (const auto& elem : elements(leaf_view)) {


### PR DESCRIPTION
Each entity has an unique id along the entire hierarchical grid. This means that an entity appearing in more than one level has exactly the same id in each of those levels. 

This PR refactors the computation of local and global ids to support CpGrids with LGRs.
This PR is not relevant for the update of the reference manual. 

To be improved: avoid, if possible, repetition of code. 