### PR TITLE
Fix the id sets for LGRs and reactivate tests.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -112,15 +112,15 @@ list (APPEND TEST_SOURCE_FILES
 
 if(Boost_VERSION_STRING VERSION_GREATER 1.53)
 	list(APPEND TEST_SOURCE_FILES
-#	  tests/cpgrid/adapt_cpgrid_test.cpp
+	  tests/cpgrid/adapt_cpgrid_test.cpp
 	  tests/cpgrid/avoidNNCinLGRs_test.cpp
 	  tests/cpgrid/avoidNNCinLGRsCpGrid_test.cpp
 	  tests/cpgrid/cuboidShape_test.cpp
 	  tests/cpgrid/disjointPatches_test.cpp
 	  tests/cpgrid/eclCentroid_test.cpp
 	  tests/cpgrid/geometry_test.cpp
-#	  tests/cpgrid/grid_lgr_test.cpp
-#	  tests/cpgrid/inactiveCell_lgr_test.cpp
+	  tests/cpgrid/grid_lgr_test.cpp
+	  tests/cpgrid/inactiveCell_lgr_test.cpp
 	  tests/cpgrid/lookUpCellCentroid_cpgrid_test.cpp
 	  tests/cpgrid/lookupdataCpGrid_test.cpp
 	  tests/cpgrid/shifted_cart_test.cpp

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1916,7 +1916,6 @@ bool CpGrid::adapt(const std::vector<std::array<int,3>>& cells_per_dim_vec,
         (*data_[refinedLevelGridIdx]).global_cell_.swap(refined_global_cell_vec[level]);
         (*data_[refinedLevelGridIdx]).index_set_ = std::make_unique<cpgrid::IndexSet>(data_[refinedLevelGridIdx]->size(0),
                                                                                       data_[refinedLevelGridIdx]->size(3));
-        (*data_[refinedLevelGridIdx]).local_id_set_ = std::make_shared<const cpgrid::IdSet>(*data_[refinedLevelGridIdx]);
         // Determine the amount of cells per direction, per parent cell, of the corresponding LGR.
         (*data_[refinedLevelGridIdx]).cells_per_dim_ = cells_per_dim_vec[level];
         // TO DO: This new code for refinement do not assume Cartesian Shape. How does logical_cartesian_size_ should be defined then?
@@ -1949,7 +1948,6 @@ bool CpGrid::adapt(const std::vector<std::array<int,3>>& cells_per_dim_vec,
     (*data_[levels + preAdaptMaxLevel +1]).global_cell_.swap(adapted_global_cell);
     (*data_[levels + preAdaptMaxLevel +1]).index_set_ = std::make_unique<cpgrid::IndexSet>(data_[levels + preAdaptMaxLevel +1]->size(0),
                                                                                            data_[levels + preAdaptMaxLevel +1]->size(3));
-    (*data_[levels + preAdaptMaxLevel +1]).local_id_set_ = std::make_shared<const cpgrid::IdSet>(*data_[levels + preAdaptMaxLevel +1]);
     (*data_[levels + preAdaptMaxLevel +1]).logical_cartesian_size_ =  (*data_[0]).logical_cartesian_size_;
 
     // Update the leaf grid view


### PR DESCRIPTION
This is a follow up of #741 and completes the fix of the parallel regression and restores the state for LGRs.

To accomplish this we again ask the local id set for the global id in a sequential run. To do this correctly with multiple levels we need to make sure that we use the full entity as we need level information. 

In #741 we used the EntityRep which made our tests of ids for higher levels fail as points on finer levels that also appeared on lower ones suddenly had different ids. In addition we needed to make sure that the id_ pointer of the global id set actually pointed to the correct local id set. This is guaranteed by the CpGridData constructor and we should never reset the local_id_set_ member of CpGridData as this breaks the guarantee (unless we also reset global_id_set_).