### PR TITLE
Refactor PartitionTypeIndicator to use only Entities.

### DIFF
--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -217,9 +217,9 @@ struct GetRowType<std::vector<E,A> >
 };
 
 PartitionType getPartitionType(const PartitionTypeIndicator& p, const EntityRep<1>& f,
-                               const CpGridData&)
+                               const CpGridData& grid)
 {
-    return p.getPartitionType(f);
+    return p.getPartitionType(Entity<3>(grid, f.index(), f.orientation()));
 }
 
 PartitionType getPartitionType(const PartitionTypeIndicator& p, int i,

--- a/opm/grid/cpgrid/PartitionTypeIndicator.cpp
+++ b/opm/grid/cpgrid/PartitionTypeIndicator.cpp
@@ -9,18 +9,18 @@ namespace Dune
 {
 namespace cpgrid
 {
-PartitionType PartitionTypeIndicator::getPartitionType(const EntityRep<0>& cell_entity) const
+PartitionType PartitionTypeIndicator::getPartitionType(const Entity<0>& cell_entity) const
 {
     if(cell_indicator_.size())
         return PartitionType(cell_indicator_[cell_entity.index()]);
     return InteriorEntity;
 }
 
-PartitionType PartitionTypeIndicator::getPartitionType(const EntityRep<1>& face_entity) const
+PartitionType PartitionTypeIndicator::getPartitionType(const Entity<1>& face_entity) const
 {
     return getFacePartitionType(face_entity.index());
 }
-PartitionType PartitionTypeIndicator::getPartitionType(const EntityRep<3>& point_entity) const
+PartitionType PartitionTypeIndicator::getPartitionType(const Entity<3>& point_entity) const
 {
     return getPointPartitionType(point_entity.index());
 }

--- a/opm/grid/cpgrid/PartitionTypeIndicator.hpp
+++ b/opm/grid/cpgrid/PartitionTypeIndicator.hpp
@@ -57,15 +57,15 @@ public:
     /// Get the partition type of a cell.
     /// \param cell_entity The entity describing the cell
     /// \return The partition type of the cell.
-    PartitionType getPartitionType(const EntityRep<0>& cell_entity) const;
+    PartitionType getPartitionType(const Entity<0>& cell_entity) const;
     /// Get the partition type of a face.
     /// \param face_entity The entity describing the face
     /// \return The partition type of the face.
-    PartitionType getPartitionType(const EntityRep<1>& face_entity) const;
+    PartitionType getPartitionType(const Entity<1>& face_entity) const;
     /// Get the partition type of a point.
     /// \param point_entity The entity describing the point.
     /// \return The partition type of the point.
-    PartitionType getPartitionType(const EntityRep<3>& point_entity) const;
+    PartitionType getPartitionType(const Entity<3>& point_entity) const;
 
 private:
     /// Get the partition type of a face by its index


### PR DESCRIPTION
Those have more information than EnitityRep which might be useful with LGRs/adaptivity.

This WIP as it is just there for demonstration.