### PR TITLE
Use UTF-8 instead of ISO-LATIN-1.

### DIFF
--- a/tests/cpgrid/entityrep_test.cpp
+++ b/tests/cpgrid/entityrep_test.cpp
@@ -5,7 +5,7 @@
 // Created: Wed Aug 26 11:15:48 2009
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
-//            Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            BÃ¥rd Skaflestad     <bard.skaflestad@sintef.no>
 //
 // $Date$
 //

--- a/tests/cpgrid/orientedentitytable_test.cpp
+++ b/tests/cpgrid/orientedentitytable_test.cpp
@@ -5,7 +5,7 @@
 // Created: Wed Aug 26 11:17:20 2009
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
-//            Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            BÃ¥rd Skaflestad     <bard.skaflestad@sintef.no>
 //
 // $Date$
 //


### PR DESCRIPTION
Fixes a compile warning for me. Github shows both as equal, but in the terminal I see this:
```diff
diff --git a/tests/cpgrid/entityrep_test.cpp b/tests/cpgrid/entityrep_test.cpp
index 21b3056c..0a3794b3 100644
--- a/tests/cpgrid/entityrep_test.cpp
+++ b/tests/cpgrid/entityrep_test.cpp
@@ -5,7 +5,7 @@
 // Created: Wed Aug 26 11:15:48 2009
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
-//            B<E5>rd Skaflestad     <bard.skaflestad@sintef.no>
+//            Bård Skaflestad     <bard.skaflestad@sintef.no>
 //
 // $Date$
 //
diff --git a/tests/cpgrid/orientedentitytable_test.cpp b/tests/cpgrid/orientedentitytable_test.cpp
index 2393dfcb..88ee002a 100644
--- a/tests/cpgrid/orientedentitytable_test.cpp
+++ b/tests/cpgrid/orientedentitytable_test.cpp
@@ -5,7 +5,7 @@
 // Created: Wed Aug 26 11:17:20 2009
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
-//            B<E5>rd Skaflestad     <bard.skaflestad@sintef.no>
+//            Bård Skaflestad     <bard.skaflestad@sintef.no>
 //
 // $Date$
 //
```
Note the "B<E5>rd" in the master branch.