### PR TITLE
Prepare OPM for DUNE 2.10

### DIFF
--- a/examples/finitevolume/finitevolume.cc
+++ b/examples/finitevolume/finitevolume.cc
@@ -36,7 +36,7 @@ template<class G>
 void timeloop(const G& grid, double tend)
 {
     // make a mapper for codim 0 entities in the leaf grid
-#if DUNE_VERSION_NEWER(DUNE_GEOMETRY, 2, 8)
+#if DUNE_VERSION_GTE(DUNE_GEOMETRY, 2, 8)
     Dune::MultipleCodimMultipleGeomTypeMapper<typename G::LeafGridView>  mapper(grid.leafGridView(), Dune::mcmgElementLayout());
 #else
     Dune::LeafMultipleCodimMultipleGeomTypeMapper<G> mapper(grid, Dune::mcmgElementLayout());

--- a/opm/grid/common/SubGridPart.hpp
+++ b/opm/grid/common/SubGridPart.hpp
@@ -50,7 +50,7 @@ struct SubGridPartTraits {
     using IntersectionIterator = typename Grid ::Traits ::LeafIntersectionIterator;
 
     /** \brief type of the collective communication */
-    using CollectiveCommunication = typename Grid ::Traits ::CollectiveCommunication;
+    using CollectiveCommunication = typename Grid ::Traits ::Communication;
 
 
     template <class BaseEntityType>

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -945,7 +945,7 @@ struct AttributeDataHandle
           c2e_(cell_to_entity), grid_(grid)
     {}
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 8)
+#if DUNE_VERSION_GTE(DUNE_COMMON, 2, 8)
     bool fixedSize()
 #else
         bool fixedsize()

--- a/opm/grid/cpgrid/Entity2IndexDataHandle.hpp
+++ b/opm/grid/cpgrid/Entity2IndexDataHandle.hpp
@@ -64,7 +64,7 @@ public:
         : fromGrid_(fromGrid), toGrid_(toGrid), data_(data)
     {}
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 8)
+#if DUNE_VERSION_GTE(DUNE_COMMON, 2, 8)
     bool fixedSize()
     {
         return data_.fixedSize(3, codim);

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -120,7 +120,7 @@ public:
 
     typedef int DataType;
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 8)
+#if DUNE_VERSION_GTE(DUNE_COMMON, 2, 8)
     bool fixedSize()
 #else
     bool fixedsize()
@@ -217,7 +217,7 @@ public:
     {}
 
     typedef int DataType;
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 8)
+#if DUNE_VERSION_GTE(DUNE_COMMON, 2, 8)
     bool fixedSize()
 #else
     bool fixedsize()


### PR DESCRIPTION
DUNE_VERSION_NEWER has been removed. Falling back to DUNE_VERSION_GTE which exists since at least DUNE 2.7

Use Dune::Communcation instead of removed Dune::CollectiveCommunication (there since at least DUNE 2.7)l