### PR TITLE
fixed: zero-initialize array

### DIFF
--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -807,7 +807,7 @@ private:
      * in each pillar. Note that of these some may have no volume
      * and this be inactive.
      */
-    std::array<int, 3>                logical_cartesian_size_;
+    std::array<int, 3>                logical_cartesian_size_{};
     /** @brief vector with the gobal cell index for each cell.
      *
      * Note the size of this container is determined by the


### PR DESCRIPTION
This caused issues for serialization tests with the debug iterator build. Random data cause integer overflow in the getSize method. Granted, those tests probably use classes in states they are not intended to be used, but it's also good to initialize.