### PR TITLE
Local Cartesian Index for level grids

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -122,6 +122,7 @@ if(Boost_VERSION_STRING VERSION_GREATER 1.53)
 	  tests/cpgrid/geometry_test.cpp
 	  tests/cpgrid/grid_lgr_test.cpp
 	  tests/cpgrid/inactiveCell_lgr_test.cpp
+	  tests/cpgrid/lgr_cartesian_idx_test.cpp
 	  tests/cpgrid/lookUpCellCentroid_cpgrid_test.cpp
 	  tests/cpgrid/lookupdataCpGrid_test.cpp
 	  tests/cpgrid/shifted_cart_test.cpp

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1091,8 +1091,9 @@ namespace Dune
         /// @brief Compute for each level grid, a map from the global_cell_[ cell index in level grid ] to the leaf index of the equivalent cell
         ///        on the leaf grid view.
         ///        Notice that cells that vanished and do not appear on the leaf grid view will not be considered.
-        std::vector<std::unordered_map<std::size_t, std::size_t>> mapGlobalCellLevelToLeafIndexSet();
-
+        std::vector<std::unordered_map<std::size_t, std::size_t>> mapGlobalCellLevelToLeafIndexSet() const;
+        
+        std::vector<std::array<std::size_t,2>> mapLeafIndexSetToGlobalCellLevel() const;
 
         /// \brief Size of the overlap on the leaf level
         unsigned int overlapSize(int) const;

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1091,9 +1091,11 @@ namespace Dune
         /// @brief Compute for each level grid, a map from the global_cell_[ cell index in level grid ] to the leaf index of the equivalent cell
         ///        on the leaf grid view.
         ///        Notice that cells that vanished and do not appear on the leaf grid view will not be considered.
-        std::vector<std::unordered_map<std::size_t, std::size_t>> mapGlobalCellLevelToLeafIndexSet() const;
-        
-        std::vector<std::array<std::size_t,2>> mapLeafIndexSetToGlobalCellLevel() const;
+        ///        global_cell_[ cell index in level grid ] coincide with (local) Cartesian Index.
+        std::vector<std::unordered_map<std::size_t, std::size_t>> mapLocalCartesianIndexSetsToLeafIndexSet() const;
+
+        /// @brief Reverse map: from leaf index cell to { level, local/level Cartesian index of the cell }
+        std::vector<std::array<int,2>> mapLeafIndexSetToLocalCartesianIndexSets() const;
 
         /// \brief Size of the overlap on the leaf level
         unsigned int overlapSize(int) const;

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -968,6 +968,11 @@ namespace Dune
         ///        For nested refinement, we lookup the oldest ancestor, from level zero.
         void computeGlobalCellLeafGridViewWithLgrs(std::vector<int>& global_cell_leaf);
 
+        /// @brief Compute for each level grid, a map from the global_cell_[ cell index in level grid ] to the leaf index of the equivalent cell
+        ///        on the leaf grid view.
+        ///        Notice that cells that vanished and do not appear on the leaf grid view will not be considered.
+        void mapGlobalCellLevelToLeafIndexSet();
+
         /// @brief Get the ijk index of a refined corner, given its corner index of a single-cell-refinement.
         ///
         /// Given a single-cell, we refine it in {nx, ny, nz} refined children cells (per direction). Then, this single-cell-refinement

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -968,11 +968,6 @@ namespace Dune
         ///        For nested refinement, we lookup the oldest ancestor, from level zero.
         void computeGlobalCellLeafGridViewWithLgrs(std::vector<int>& global_cell_leaf);
 
-        /// @brief Compute for each level grid, a map from the global_cell_[ cell index in level grid ] to the leaf index of the equivalent cell
-        ///        on the leaf grid view.
-        ///        Notice that cells that vanished and do not appear on the leaf grid view will not be considered.
-        void mapGlobalCellLevelToLeafIndexSet();
-
         /// @brief Get the ijk index of a refined corner, given its corner index of a single-cell-refinement.
         ///
         /// Given a single-cell, we refine it in {nx, ny, nz} refined children cells (per direction). Then, this single-cell-refinement
@@ -1093,6 +1088,10 @@ namespace Dune
 
     public:
 
+        /// @brief Compute for each level grid, a map from the global_cell_[ cell index in level grid ] to the leaf index of the equivalent cell
+        ///        on the leaf grid view.
+        ///        Notice that cells that vanished and do not appear on the leaf grid view will not be considered.
+        std::vector<std::unordered_map<std::size_t, std::size_t>> mapGlobalCellLevelToLeafIndexSet();
 
 
         /// \brief Size of the overlap on the leaf level

--- a/opm/grid/common/CartesianIndexMapper.hpp
+++ b/opm/grid/common/CartesianIndexMapper.hpp
@@ -43,12 +43,6 @@ namespace Dune
             return 0;
         }
 
-        /** \brief return number of cells in the active level zero grid. Only relevant for CpGrid specialization. */
-        int compressedLevelZeroSize() const
-        {
-            return 0;
-        }
-
         /** \brief return index of the cells in the logical Cartesian grid */
         int cartesianIndex( const int /* compressedElementIndex */) const
         {
@@ -60,11 +54,25 @@ namespace Dune
         {
         }
 
+        /// Only relevant for CpGrid specialization.
+        /** \brief return number of cells in the active level zero grid. Only relevant for CpGrid specialization. */
+        int compressedLevelZeroSize() const
+        {
+            return 0;
+        }
+
         /** \brief return Cartesian coordinate, i.e. IJK, for a given cell. Only relevant for CpGrid specialization.*/
         void cartesianCoordinateLevel(const int /* compressedElementIndexOnLevel */,
                                       std::array<int,dimension>& /* coordsOnLevel */, int /*level*/) const
         {
         }
+
+        /** \brief return index of the cells in the logical Cartesian grid, for refined level grids. Only relevant for CpGrid specialization. */
+        int cartesianIndexLevel( const int /* compressedElementIndex */ , const int level) const
+        {
+            return 0;
+        }
+        /// Only relevant for CpGrid specialization. END
     };
 
 } // end namespace Opm

--- a/opm/grid/cpgrid/CartesianIndexMapper.hpp
+++ b/opm/grid/cpgrid/CartesianIndexMapper.hpp
@@ -50,11 +50,6 @@ namespace Dune
             return grid_.globalCell().size();
         }
 
-        int compressedLevelZeroSize() const
-        {
-            return (*grid_.currentData()[0]).size(0);
-        }
-
         int cartesianIndex( const int compressedElementIndex ) const
         {
             assert(  compressedElementIndex >= 0 && compressedElementIndex < compressedSize() );
@@ -66,13 +61,29 @@ namespace Dune
             grid_.getIJK( compressedElementIndex, coords );
         }
 
+        /// Additional methods realted to LGRs
+        int compressedLevelZeroSize() const
+        {
+            return (*grid_.currentData()[0]).size(0);
+        }
+
+        int cartesianIndexLevel( const int compressedElementIndex, const int level) const
+        {
+            if ((level < 0) || (level > grid_.maxLevel())) {
+                throw std::invalid_argument("Invalid level.\n");
+            }
+            assert(  compressedElementIndex >= 0 && compressedElementIndex <  grid_.currentData()[level]->size(0) );
+            return grid_.currentData()[level]->globalCell()[compressedElementIndex];
+        }
+
         void cartesianCoordinateLevel(const int compressedElementIndexOnLevel, std::array<int,dimension>& coordsOnLevel, int level) const
         {
             if ((level < 0) || (level > grid_.maxLevel())) {
                 throw std::invalid_argument("Invalid level.\n");
             }
-            (*grid_.currentData()[level]).getIJK( compressedElementIndexOnLevel, coordsOnLevel);
+            grid_.currentData()[level]->getIJK( compressedElementIndexOnLevel, coordsOnLevel);
         }
+        /// Additional methods realted to LGRs. END
     };
 
 } // end namespace Opm

--- a/opm/grid/cpgrid/CartesianIndexMapper.hpp
+++ b/opm/grid/cpgrid/CartesianIndexMapper.hpp
@@ -61,7 +61,7 @@ namespace Dune
             grid_.getIJK( compressedElementIndex, coords );
         }
 
-        /// Additional methods realted to LGRs
+        /// Additional methods related to LGRs
         int compressedLevelZeroSize() const
         {
             return (*grid_.currentData()[0]).size(0);
@@ -83,7 +83,7 @@ namespace Dune
             }
             grid_.currentData()[level]->getIJK( compressedElementIndexOnLevel, coordsOnLevel);
         }
-        /// Additional methods realted to LGRs. END
+        /// Additional methods related to LGRs. END
     };
 
 } // end namespace Opm

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -679,12 +679,14 @@ void CpGrid::computeGlobalCellLeafGridViewWithLgrs(std::vector<int>& global_cell
     }
 }
 
-void CpGrid::mapGlobalCellLevelToLeafIndexSet()
+std::vector<std::unordered_map<std::size_t, std::size_t>> CpGrid::mapGlobalCellLevelToLeafIndexSet()
 {
+    std::vector<std::unordered_map<std::size_t, std::size_t>> globalCellLevels_to_leafIdx(maxLevel()+1); // Plus level 0
     for (const auto& element : elements(leafGridView())) {
         const auto& global_cell_level = currentData()[element.level()]->globalCell()[element.getEquivLevelElem().index()];
-        (*currentData()[element.level()]).globalCellLevel_to_leafIdx_[global_cell_level] = element.index();
+        globalCellLevels_to_leafIdx[element.level()][global_cell_level] = element.index();
     }
+    return globalCellLevels_to_leafIdx;
 }
 
 void CpGrid::getIJK(const int c, std::array<int,3>& ijk) const

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -679,6 +679,14 @@ void CpGrid::computeGlobalCellLeafGridViewWithLgrs(std::vector<int>& global_cell
     }
 }
 
+void CpGrid::mapGlobalCellLevelToLeafIndexSet()
+{
+    for (const auto& element : elements(leafGridView())) {
+        const auto& global_cell_level = currentData()[element.level()]->globalCell()[element.getEquivLevelElem().index()];
+        (*currentData()[element.level()]).globalCellLevel_to_leafIdx_[global_cell_level] = element.index();
+    }
+}
+
 void CpGrid::getIJK(const int c, std::array<int,3>& ijk) const
 {
     current_view_data_->getIJK(c, ijk);
@@ -1995,6 +2003,8 @@ bool CpGrid::adapt(const std::vector<std::array<int,3>>& cells_per_dim_vec,
     std::vector<int> global_cell_leaf( data[levels + preAdaptMaxLevel +1]->size(0));
     computeGlobalCellLeafGridViewWithLgrs(global_cell_leaf);
     (*data[levels + preAdaptMaxLevel +1]).global_cell_.swap(global_cell_leaf);
+
+    mapGlobalCellLevelToLeafIndexSet();
 
     updateCornerHistoryLevels(cornerInMarkedElemWithEquivRefinedCorner,
                               elemLgrAndElemLgrCorner_to_refinedLevelAndRefinedCorner,

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -679,26 +679,25 @@ void CpGrid::computeGlobalCellLeafGridViewWithLgrs(std::vector<int>& global_cell
     }
 }
 
-std::vector<std::unordered_map<std::size_t, std::size_t>> CpGrid::mapGlobalCellLevelToLeafIndexSet() const
+std::vector<std::unordered_map<std::size_t, std::size_t>> CpGrid::mapLocalCartesianIndexSetsToLeafIndexSet() const
 {
-    std::vector<std::unordered_map<std::size_t, std::size_t>> globalCellLevels_to_leafIdx(maxLevel()+1); // Plus level 0
+    std::vector<std::unordered_map<std::size_t, std::size_t>> localCartesianIdxSets_to_leafIdx(maxLevel()+1); // Plus level 0
     for (const auto& element : elements(leafGridView())) {
         const auto& global_cell_level = currentData()[element.level()]->globalCell()[element.getEquivLevelElem().index()];
-        globalCellLevels_to_leafIdx[element.level()][global_cell_level] = element.index();
+        localCartesianIdxSets_to_leafIdx[element.level()][global_cell_level] = element.index();
     }
-    return globalCellLevels_to_leafIdx;
+    return localCartesianIdxSets_to_leafIdx;
 }
 
-std::vector<std::array<std::size_t,2>> CpGrid::mapLeafIndexSetToGlobalCellLevel() const 
+std::vector<std::array<int,2>> CpGrid::mapLeafIndexSetToLocalCartesianIndexSets() const
 {
-    std::vector<std::array<std::size_t,2>> leafIdx_to_globalCellLevel(currentData().back()->size(0));
+    std::vector<std::array<int,2>> leafIdx_to_localCartesianIdxSets(currentData().back()->size(0));
     for (const auto& element : elements(leafGridView())) {
         const auto& global_cell_level = currentData()[element.level()]->globalCell()[element.getEquivLevelElem().index()];
-        leafIdx_to_globalCellLevel[element.index()] = {element.level(), global_cell_level};
+        leafIdx_to_localCartesianIdxSets[element.index()] = {element.level(), global_cell_level};
     }
-    return leafIdx_to_globalCellLevel;
+    return leafIdx_to_localCartesianIdxSets;
 }
-
 
 void CpGrid::getIJK(const int c, std::array<int,3>& ijk) const
 {
@@ -2017,7 +2016,7 @@ bool CpGrid::adapt(const std::vector<std::array<int,3>>& cells_per_dim_vec,
     computeGlobalCellLeafGridViewWithLgrs(global_cell_leaf);
     (*data[levels + preAdaptMaxLevel +1]).global_cell_.swap(global_cell_leaf);
 
-    mapGlobalCellLevelToLeafIndexSet();
+    mapLocalCartesianIndexSetsToLeafIndexSet();
 
     updateCornerHistoryLevels(cornerInMarkedElemWithEquivRefinedCorner,
                               elemLgrAndElemLgrCorner_to_refinedLevelAndRefinedCorner,

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -679,7 +679,7 @@ void CpGrid::computeGlobalCellLeafGridViewWithLgrs(std::vector<int>& global_cell
     }
 }
 
-std::vector<std::unordered_map<std::size_t, std::size_t>> CpGrid::mapGlobalCellLevelToLeafIndexSet()
+std::vector<std::unordered_map<std::size_t, std::size_t>> CpGrid::mapGlobalCellLevelToLeafIndexSet() const
 {
     std::vector<std::unordered_map<std::size_t, std::size_t>> globalCellLevels_to_leafIdx(maxLevel()+1); // Plus level 0
     for (const auto& element : elements(leafGridView())) {
@@ -688,6 +688,17 @@ std::vector<std::unordered_map<std::size_t, std::size_t>> CpGrid::mapGlobalCellL
     }
     return globalCellLevels_to_leafIdx;
 }
+
+std::vector<std::array<std::size_t,2>> CpGrid::mapLeafIndexSetToGlobalCellLevel() const 
+{
+    std::vector<std::array<std::size_t,2>> leafIdx_to_globalCellLevel(currentData().back()->size(0));
+    for (const auto& element : elements(leafGridView())) {
+        const auto& global_cell_level = currentData()[element.level()]->globalCell()[element.getEquivLevelElem().index()];
+        leafIdx_to_globalCellLevel[element.index()] = {element.level(), global_cell_level};
+    }
+    return leafIdx_to_globalCellLevel;
+}
+
 
 void CpGrid::getIJK(const int c, std::array<int,3>& ijk) const
 {

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -632,16 +632,6 @@ public:
         return logical_cartesian_size_;
     }
 
-    /// Get map from global_cell_ to leaf index set
-    ///
-    /// Only relevant for CpGrid with LGRs. The maps of
-    /// all refined level grids is defined in CpGrid::adapt(/*..*/),
-    /// via CpGrid::mapGlobalCellLevelToLeafIndexSet().
-    const std::unordered_map<int,int>& getGlobalCellLevelToLeafIndexSet() const
-    {
-        return globalCellLevel_to_leafIdx_;
-    }
-
     /// \brief Redistribute a global grid.
     ///
     /// The whole grid must be available on all processors.

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -306,8 +306,13 @@ public:
         ijk = getIJK(global_cell_[c], logical_cartesian_size_);
     }
 
+    const std::vector<int>& globalCell() const
+    {
+        return  global_cell_;
+    }
+
     /// @brief Extract Cartesian index triplet (i,j,k) given an index between 0 and NXxNYxNZ -1
-    ///        where NX, NY, and NZ is the total amoung of cells in each direction x-,y-,and z- respectively.
+    ///    where NX, NY, and NZ is the total amoung of cells in each direction x-,y-,and z- respectively.
     ///
     /// @param [in] idx      Integer between 0 and cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]-1
     /// @param [in] cells_per_dim
@@ -625,6 +630,16 @@ public:
     const std::array<int, 3>& logicalCartesianSize() const
     {
         return logical_cartesian_size_;
+    }
+
+    /// Get map from global_cell_ to leaf index set
+    ///
+    /// Only relevant for CpGrid with LGRs. The maps of
+    /// all refined level grids is defined in CpGrid::adapt(/*..*/),
+    /// via CpGrid::mapGlobalCellLevelToLeafIndexSet().
+    const std::unordered_map<int,int>& getGlobalCellLevelToLeafIndexSet() const
+    {
+        return globalCellLevel_to_leafIdx_;
     }
 
     /// \brief Redistribute a global grid.

--- a/opm/grid/polyhedralgrid/cartesianindexmapper.hh
+++ b/opm/grid/polyhedralgrid/cartesianindexmapper.hh
@@ -31,7 +31,7 @@ namespace Dune
 
         const std::array<int, dimension>& cartesianDimensions() const
         {
-          return grid_.logicalCartesianSize();
+            return grid_.logicalCartesianSize();
         }
 
         int cartesianSize() const
@@ -40,12 +40,6 @@ namespace Dune
         }
 
         int compressedSize() const
-        {
-            return grid_.size( 0 );
-        }
-
-        // Only for unifying calls with CartesianIndexMapper<CpGrid> where levels are relevant.
-        int compressedLevelZeroSize() const
         {
             return grid_.size( 0 );
         }
@@ -73,6 +67,19 @@ namespace Dune
               coords[ 0 ] = gc ;
         }
 
+        // Only for unifying calls with CartesianIndexMapper<CpGrid> where levels are relevant.
+        int compressedLevelZeroSize() const
+        {
+            return grid_.size( 0 );
+        }
+        // Only for unifying calls with CartesianIndexMapper<CpGrid> where levels are relevant.
+        int cartesianIndexLevel( const int compressedElementIndex, const int level ) const
+        {
+            if (level) {
+                throw std::invalid_argument("Invalid level.\n");
+            }
+            return cartesianIndex(compressedElementIndex);
+        }
         // Only for unifying calls with CartesianIndexMapper<CpGrid> where levels are relevant.
         void cartesianCoordinateLevel(const int compressedElementIndexOnLevel, std::array<int,dimension>& coordsOnLevel, int level) const
         {

--- a/tests/cpgrid/lgr_cartesian_idx_test.cpp
+++ b/tests/cpgrid/lgr_cartesian_idx_test.cpp
@@ -47,7 +47,11 @@
 #include <opm/grid/cpgrid/Geometry.hpp>
 #include <opm/grid/LookUpData.hh>
 
+#include <dune/common/version.hh>
 #include <dune/grid/common/mcmgmapper.hh>
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Parser/Parser.hpp>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 
 #include <cassert>
 #include <sstream>
@@ -122,14 +126,14 @@ void checkGlobalCellLgr(Dune::CpGrid& grid)
     {
         for (const auto& element : elements(grid.levelGridView(level)))
         {
+            const auto& global_cell_level = grid.currentData()[element.level()]->globalCell()[element.index()];
             if(element.isLeaf()) {
-                const auto& global_cell_level = grid.currentData()[element.level()]->globalCell()[element.index()];
                 const auto& leaf_idx = localCartesianIdxSets_to_leafIdx[element.level()].at(global_cell_level);
                 BOOST_CHECK_EQUAL( leafIdx_to_localCartesianIdxSets[leaf_idx][0], element.level());
                 BOOST_CHECK_EQUAL( leafIdx_to_localCartesianIdxSets[leaf_idx][1], global_cell_level);
             }
             else {
-                BOOST_CHECK_THROW( localCartesianIdxSets_to_leafIdx[element.level()].at(element.index()), std::out_of_range);
+                BOOST_CHECK_THROW( localCartesianIdxSets_to_leafIdx[element.level()].at(global_cell_level), std::out_of_range);
             }
         }
     }
@@ -166,5 +170,60 @@ BOOST_AUTO_TEST_CASE(three_lgrs)
     const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
     grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
 
+    checkGlobalCellLgr(grid);
+}
+
+BOOST_AUTO_TEST_CASE(inactiveCells_in_lgrs)
+{
+
+    const std::string deckString =
+        R"( RUNSPEC
+        DIMENS
+        1  1  5 /
+        GRID
+        COORD
+        0 0 0
+        0 0 1
+        1 0 0
+        1 0 1
+        0 1 0
+        0 1 1
+        1 1 0
+        1 1 1
+        /
+        ZCORN
+        4*0
+        8*1
+        8*2
+        8*3
+        8*4
+        4*5
+        /
+        ACTNUM
+        0
+        1
+        1
+        1
+        0
+        /
+        PORO
+        5*0.15
+        /)";
+
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}};
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,3}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{1,1,2}, {1,1,5}};
+    // LGR1 cell indices = {0,1}, LGR2 cell indices = {3,4}.
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2"};
+
+    Opm::Parser parser;
+    const auto deck = parser.parseString(deckString);
+    Opm::EclipseState es(deck);
+
+    Dune::CpGrid grid;
+    grid.processEclipseFormat(&es.getInputGrid(), &es, false, false, false);
+
+    grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+    
     checkGlobalCellLgr(grid);
 }

--- a/tests/cpgrid/lgr_cartesian_idx_test.cpp
+++ b/tests/cpgrid/lgr_cartesian_idx_test.cpp
@@ -1,0 +1,166 @@
+//===========================================================================
+//
+// File: lgr_cartesian_idx_test.cpp
+//
+// Created: Sep 26 2024 09:15
+//
+// Author(s): Antonella Ritorto   <antonella.ritorto@opm-op.com>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+/*
+  Copyright 2024 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#define BOOST_TEST_MODULE LGRTests
+#include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
+#include <opm/grid/CpGrid.hpp>
+#include <opm/grid/cpgrid/CpGridData.hpp>
+#include <opm/grid/cpgrid/DefaultGeometryPolicy.hpp>
+#include <opm/grid/cpgrid/Entity.hpp>
+#include <opm/grid/cpgrid/EntityRep.hpp>
+#include <opm/grid/cpgrid/Geometry.hpp>
+#include <opm/grid/LookUpData.hh>
+
+#include <dune/grid/common/mcmgmapper.hh>
+
+#include <cassert>
+#include <sstream>
+#include <iostream>
+#include <cstdlib>
+#include <cmath>
+#include <map>
+
+struct Fixture
+{
+    Fixture()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        Dune::MPIHelper::instance(m_argc, m_argv);
+        Opm::OpmLog::setupSimpleDefaultLogging();
+    }
+
+    static int rank()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        return Dune::MPIHelper::instance(m_argc, m_argv).rank();
+    }
+};
+
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+void checkGlobalCellLgr(Dune::CpGrid& grid)
+{
+    const Dune::CartesianIndexMapper<Dune::CpGrid> mapper{grid};
+
+    for (const auto& element : elements(grid.leafGridView()))
+    {
+        // How to get the Cartesian Index of a cell on the leaf grid view.
+        // 1. The "default" Cartesian Index of a cell on the leaf (which is a mixed grid with coarse and refined cells) is equal to the Cartesian Index of:
+        //    (a) the equivalent cell in level zero (same center and volume, cell not involved in any refinement).
+        //    (b) the parent cell in level zero when the leaf cell is a refined one (it has a equivalent cell that belongs to a refined level grid).
+        //    This default Cartesian Index for leaf cells coincide with the globalCell values.
+        const auto& cartesian_idx_from_leaf_elem =  mapper.cartesianIndex( element.index() );
+        const auto& global_cell_idx_leaf = grid.globalCell()[element.index()]; // parent cell index when the cell is a refined one.
+        BOOST_CHECK_EQUAL(cartesian_idx_from_leaf_elem, global_cell_idx_leaf);
+        // global_ijk represents the ijk values of the equivalent cell on the level zero, or parent cell if the leaf cell is a refined one.
+        // Notice that all the refined cells of a same parent cell will get the same global_cell_ value and the same global_ijk (since they
+        // inherit the parent cell value).
+        std::array<int,3> global_ijk = {0,0,0};
+        mapper.cartesianCoordinate( element.index(), global_ijk);
+
+        // How to get the Level Cartesian Index of a cell on the leaf grid view.
+        // Each LGR can be seen as a Cartesian Grid itself, with its own (local) logical_cartesian_size and its own (local) Cartesian indices.
+        // Given a leaf cell, via the CartesianIndexMapper and its method cartesianIndexLevel(...), we get the local-Cartesian-index.
+        const auto& cartesian_idx_from_level_elem =  mapper.cartesianIndexLevel( element.getEquivLevelElem().index(), element.level() );
+        const auto& global_cell_idx_level = grid.currentData()[element.level()]->globalCell()[element.getEquivLevelElem().index()];
+        BOOST_CHECK_EQUAL(cartesian_idx_from_level_elem, global_cell_idx_level);
+        // local_ijk represents the ijk values of the equivalent cell on the level its was born.
+        std::array<int,3> local_ijk = {0,0,0};
+        mapper.cartesianCoordinateLevel( element.getEquivLevelElem().index(), local_ijk, element.level() );
+
+        // For leaf cells that were not involved in any refinement, global_ijk and local_ijk must coincide.
+        if(element.level()==0)
+        {
+            BOOST_CHECK_EQUAL( global_ijk[0], local_ijk[0]);
+            BOOST_CHECK_EQUAL( global_ijk[1], local_ijk[1]);
+            BOOST_CHECK_EQUAL( global_ijk[2], local_ijk[2]);
+        }
+    }
+    
+    for (int level = 0; level < grid.maxLevel(); ++level)
+    {
+        const auto& globalCellLevel_to_leafIdx = grid.currentData()[level]->getGlobalCellLevelToLeafIndexSet();
+        for (const auto& element : elements(grid.levelGridView(level)))
+        {
+            if(element.isLeaf()) {
+                const auto& global_cell_level = grid.currentData()[element.level()]->globalCell()[element.index()];
+                globalCellLevel_to_leafIdx.at(global_cell_level);
+            }
+            else {
+                BOOST_CHECK_THROW( globalCellLevel_to_leafIdx.at(element.index()), std::out_of_range);
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(refine_one_cell)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    grid.createCartesian(grid_dim, cell_sizes);
+
+    const std::array<int, 3> cells_per_dim = {2,2,2};
+    const std::array<int, 3> startIJK = {1,0,1};
+    const std::array<int, 3> endIJK = {2,1,2};// Single Cell! (with index 13 in level zero grid), LGR dimensions 2x2x2
+    const std::string lgr_name = {"LGR1"};
+    grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+
+    checkGlobalCellLgr(grid);
+}
+
+BOOST_AUTO_TEST_CASE(three_lgrs)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    grid.createCartesian(grid_dim, cell_sizes);
+
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}, {4,4,4}};
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,2}, {3,2,2}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {1,1,3}, {4,3,3}};
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
+    grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+
+    checkGlobalCellLgr(grid);
+}

--- a/tests/cpgrid/lgr_cartesian_idx_test.cpp
+++ b/tests/cpgrid/lgr_cartesian_idx_test.cpp
@@ -117,15 +117,15 @@ void checkGlobalCellLgr(Dune::CpGrid& grid)
     
     for (int level = 0; level < grid.maxLevel(); ++level)
     {
-        const auto& globalCellLevel_to_leafIdx = grid.currentData()[level]->getGlobalCellLevelToLeafIndexSet();
+        const auto& globalCellLevel_to_leafIdx = grid.mapGlobalCellLevelToLeafIndexSet();
         for (const auto& element : elements(grid.levelGridView(level)))
         {
             if(element.isLeaf()) {
                 const auto& global_cell_level = grid.currentData()[element.level()]->globalCell()[element.index()];
-                globalCellLevel_to_leafIdx.at(global_cell_level);
+                globalCellLevel_to_leafIdx[element.level()].at(global_cell_level);
             }
             else {
-                BOOST_CHECK_THROW( globalCellLevel_to_leafIdx.at(element.index()), std::out_of_range);
+                BOOST_CHECK_THROW( globalCellLevel_to_leafIdx[element.level()].at(element.index()), std::out_of_range);
             }
         }
     }

--- a/tests/cpgrid/lgr_cartesian_idx_test.cpp
+++ b/tests/cpgrid/lgr_cartesian_idx_test.cpp
@@ -114,15 +114,19 @@ void checkGlobalCellLgr(Dune::CpGrid& grid)
             BOOST_CHECK_EQUAL( global_ijk[2], local_ijk[2]);
         }
     }
+
+    const auto& localCartesianIdxSets_to_leafIdx = grid.mapLocalCartesianIndexSetsToLeafIndexSet();
+    const auto& leafIdx_to_localCartesianIdxSets = grid.mapLeafIndexSetToLocalCartesianIndexSets();
     
     for (int level = 0; level < grid.maxLevel(); ++level)
     {
-        const auto& localCartesianIdxSets_to_leafIdx = grid.mapLocalCartesianIndexSetsToLeafIndexSet();
         for (const auto& element : elements(grid.levelGridView(level)))
         {
             if(element.isLeaf()) {
                 const auto& global_cell_level = grid.currentData()[element.level()]->globalCell()[element.index()];
-                localCartesianIdxSets_to_leafIdx[element.level()].at(global_cell_level);
+                const auto& leaf_idx = localCartesianIdxSets_to_leafIdx[element.level()].at(global_cell_level);
+                BOOST_CHECK_EQUAL( leafIdx_to_localCartesianIdxSets[leaf_idx][0], element.level());
+                BOOST_CHECK_EQUAL( leafIdx_to_localCartesianIdxSets[leaf_idx][1], global_cell_level);
             }
             else {
                 BOOST_CHECK_THROW( localCartesianIdxSets_to_leafIdx[element.level()].at(element.index()), std::out_of_range);

--- a/tests/cpgrid/lgr_cartesian_idx_test.cpp
+++ b/tests/cpgrid/lgr_cartesian_idx_test.cpp
@@ -117,15 +117,15 @@ void checkGlobalCellLgr(Dune::CpGrid& grid)
     
     for (int level = 0; level < grid.maxLevel(); ++level)
     {
-        const auto& globalCellLevel_to_leafIdx = grid.mapGlobalCellLevelToLeafIndexSet();
+        const auto& localCartesianIdxSets_to_leafIdx = grid.mapLocalCartesianIndexSetsToLeafIndexSet();
         for (const auto& element : elements(grid.levelGridView(level)))
         {
             if(element.isLeaf()) {
                 const auto& global_cell_level = grid.currentData()[element.level()]->globalCell()[element.index()];
-                globalCellLevel_to_leafIdx[element.level()].at(global_cell_level);
+                localCartesianIdxSets_to_leafIdx[element.level()].at(global_cell_level);
             }
             else {
-                BOOST_CHECK_THROW( globalCellLevel_to_leafIdx[element.level()].at(element.index()), std::out_of_range);
+                BOOST_CHECK_THROW( localCartesianIdxSets_to_leafIdx[element.level()].at(element.index()), std::out_of_range);
             }
         }
     }


### PR DESCRIPTION
For each level grid, a map is created from global cell values (from that level), to leaf index set. 
To this aim, CartesianIndexMapper has been extended - due to local Cartesian Index for each LGR for CpGrid,  therefore the specializations for all grids have been adapted too (CpGrid, PolyhedralGrid, and in a separately PR, AluGrid OPM/opm-simulators#5633).

Based on OPM/opm-grid#762 (which has been merged)

Not relevant for the Reference Manual