### PR TITLE
Local Cartesian Index for level grids

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -122,6 +122,7 @@ if(Boost_VERSION_STRING VERSION_GREATER 1.53)
 	  tests/cpgrid/geometry_test.cpp
 	  tests/cpgrid/grid_lgr_test.cpp
 	  tests/cpgrid/inactiveCell_lgr_test.cpp
+	  tests/cpgrid/lgr_cartesian_idx_test.cpp
 	  tests/cpgrid/lookUpCellCentroid_cpgrid_test.cpp
 	  tests/cpgrid/lookupdataCpGrid_test.cpp
 	  tests/cpgrid/shifted_cart_test.cpp
@@ -190,6 +191,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/grid/cpgrid/Geometry.hpp
   opm/grid/cpgrid/GlobalIdMapping.hpp
   opm/grid/cpgrid/GridHelpers.hpp
+  opm/grid/cpgrid/LevelCartesianIndexMapper.hpp
   opm/grid/CpGrid.hpp
   opm/grid/cpgrid/Indexsets.hpp
   opm/grid/cpgrid/Intersection.hpp
@@ -202,6 +204,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/grid/cpgrid/PersistentContainer.hpp
   opm/grid/common/CartesianIndexMapper.hpp
   opm/grid/common/GridEnums.hpp
+  opm/grid/common/LevelCartesianIndexMapper.hpp
   opm/grid/common/MetisPartition.hpp
   opm/grid/common/SubGridPart.hpp
   opm/grid/common/ZoltanGraphFunctions.hpp
@@ -217,6 +220,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/grid/polyhedralgrid/gridhelpers.hh
   opm/grid/polyhedralgrid/grid.hh
   opm/grid/polyhedralgrid/gridview.hh
+  opm/grid/polyhedralgrid/levelcartesianindexmapper.hh
   opm/grid/polyhedralgrid.hh
   opm/grid/polyhedralgrid/idset.hh
   opm/grid/polyhedralgrid/indexset.hh

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1091,7 +1091,14 @@ namespace Dune
 
     public:
 
+        /// @brief Compute for each level grid, a map from the global_cell_[ cell index in level grid ] to the leaf index of the equivalent cell
+        ///        on the leaf grid view.
+        ///        Notice that cells that vanished and do not appear on the leaf grid view will not be considered.
+        ///        global_cell_[ cell index in level grid ] coincide with (local) Cartesian Index.
+        std::vector<std::unordered_map<std::size_t, std::size_t>> mapLocalCartesianIndexSetsToLeafIndexSet() const;
 
+        /// @brief Reverse map: from leaf index cell to { level, local/level Cartesian index of the cell }
+        std::vector<std::array<int,2>> mapLeafIndexSetToLocalCartesianIndexSets() const;
 
         /// \brief Size of the overlap on the leaf level
         unsigned int overlapSize(int) const;

--- a/opm/grid/common/CartesianIndexMapper.hpp
+++ b/opm/grid/common/CartesianIndexMapper.hpp
@@ -43,12 +43,6 @@ namespace Dune
             return 0;
         }
 
-        /** \brief return number of cells in the active level zero grid. Only relevant for CpGrid specialization. */
-        int compressedLevelZeroSize() const
-        {
-            return 0;
-        }
-
         /** \brief return index of the cells in the logical Cartesian grid */
         int cartesianIndex( const int /* compressedElementIndex */) const
         {
@@ -57,12 +51,6 @@ namespace Dune
 
         /** \brief return Cartesian coordinate, i.e. IJK, for a given cell */
         void cartesianCoordinate(const int /* compressedElementIndex */, std::array<int,dimension>& /* coords */) const
-        {
-        }
-
-        /** \brief return Cartesian coordinate, i.e. IJK, for a given cell. Only relevant for CpGrid specialization.*/
-        void cartesianCoordinateLevel(const int /* compressedElementIndexOnLevel */,
-                                      std::array<int,dimension>& /* coordsOnLevel */, int /*level*/) const
         {
         }
     };

--- a/opm/grid/common/LevelCartesianIndexMapper.hpp
+++ b/opm/grid/common/LevelCartesianIndexMapper.hpp
@@ -1,0 +1,88 @@
+//===========================================================================
+//
+// File: LevelCartesianIndexMapper.hpp
+//
+// Created: Tue October 01  11:44:00 2024
+//
+// Author(s): Antonella Ritorto <antonella.ritorto@opm-op.com>
+//
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2024 Equinor ASA.
+
+  This file is part of The Open Porous Media project  (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_LEVELCARTESIANINDEXMAPPER_HEADER
+#define OPM_LEVELCARTESIANINDEXMAPPER_HEADER
+
+#include <array>
+
+namespace Opm
+{
+// Interface class to access the local Cartesian grid of each level grid (when refinement).
+template< class Grid >
+class LevelCartesianIndexMapper
+{
+public:
+    // Dimension of the grid.
+    static const int dimension = Grid :: dimension ;
+
+    // Constructor taking a grid.
+    explicit LevelCartesianIndexMapper( const Grid& )
+    {}
+
+    // Return the number of cells in each direction (Cartesian dimensions) of a local Cartesian grid with level "level"
+    const std::array<int, dimension>& cartesianDimensions(int level) const
+    {
+        static std::array<int, dimension> a;
+        return a;
+    }
+
+    // Return total number of cells in a local Cartesian grid with level "level".
+    int cartesianSize(int level) const
+    {
+        return 0;
+    }
+
+    // Return number of cells in the active local Cartesian grid with level "level".
+    int compressedSize(int level) const
+    {
+        return 0;
+    }
+
+    // Return index of a cell in the local Cartesian grid with level "level".
+    int cartesianIndex( const int /* compressedElementIndex */ , const int level) const
+    {
+        return 0;
+    }
+
+    // Compute Cartesian coordinate, i.e. IJK, for a given cell, on a given local Cartesian grid with level "level".
+    void cartesianCoordinate(const int /* compressedElementIndexOnLevel */,
+                             std::array<int,dimension>& /* coordsOnLevel */,
+                             int /*level*/) const
+    {
+    }
+};
+
+} // end namespace Opm
+#endif

--- a/opm/grid/cpgrid/CartesianIndexMapper.hpp
+++ b/opm/grid/cpgrid/CartesianIndexMapper.hpp
@@ -50,11 +50,6 @@ namespace Dune
             return grid_.globalCell().size();
         }
 
-        int compressedLevelZeroSize() const
-        {
-            return (*grid_.currentData()[0]).size(0);
-        }
-
         int cartesianIndex( const int compressedElementIndex ) const
         {
             assert(  compressedElementIndex >= 0 && compressedElementIndex < compressedSize() );
@@ -64,14 +59,6 @@ namespace Dune
         void cartesianCoordinate(const int compressedElementIndex, std::array<int,dimension>& coords) const
         {
             grid_.getIJK( compressedElementIndex, coords );
-        }
-
-        void cartesianCoordinateLevel(const int compressedElementIndexOnLevel, std::array<int,dimension>& coordsOnLevel, int level) const
-        {
-            if ((level < 0) || (level > grid_.maxLevel())) {
-                throw std::invalid_argument("Invalid level.\n");
-            }
-            (*grid_.currentData()[level]).getIJK( compressedElementIndexOnLevel, coordsOnLevel);
         }
     };
 

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -679,6 +679,26 @@ void CpGrid::computeGlobalCellLeafGridViewWithLgrs(std::vector<int>& global_cell
     }
 }
 
+std::vector<std::unordered_map<std::size_t, std::size_t>> CpGrid::mapLocalCartesianIndexSetsToLeafIndexSet() const
+{
+    std::vector<std::unordered_map<std::size_t, std::size_t>> localCartesianIdxSets_to_leafIdx(maxLevel()+1); // Plus level 0
+    for (const auto& element : elements(leafGridView())) {
+        const auto& global_cell_level = currentData()[element.level()]->globalCell()[element.getEquivLevelElem().index()];
+        localCartesianIdxSets_to_leafIdx[element.level()][global_cell_level] = element.index();
+    }
+    return localCartesianIdxSets_to_leafIdx;
+}
+
+std::vector<std::array<int,2>> CpGrid::mapLeafIndexSetToLocalCartesianIndexSets() const
+{
+    std::vector<std::array<int,2>> leafIdx_to_localCartesianIdxSets(currentData().back()->size(0));
+    for (const auto& element : elements(leafGridView())) {
+        const auto& global_cell_level = currentData()[element.level()]->globalCell()[element.getEquivLevelElem().index()];
+        leafIdx_to_localCartesianIdxSets[element.index()] = {element.level(), global_cell_level};
+    }
+    return leafIdx_to_localCartesianIdxSets;
+}
+
 void CpGrid::getIJK(const int c, std::array<int,3>& ijk) const
 {
     current_view_data_->getIJK(c, ijk);

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -308,8 +308,19 @@ public:
         ijk = getIJK(global_cell_[c], logical_cartesian_size_);
     }
 
+    /// Return global_cell_ of any level grid, or the leaf grid view (in presence of refinement).
+    /// global_cell_ has size number of cells present on a process and maps to the underlying Cartesian Grid.
+    ///
+    /// Note: CpGrid::globalCell() returns current_view_data_-> global_cell_ (current_view_data_ points at
+    /// data_.back() or distributed_data_.back(), in general. If the grid has been refined, current_view_data_
+    /// points at the "leaf grid view").
+    const std::vector<int>& globalCell() const
+    {
+        return  global_cell_;
+    }
+
     /// @brief Extract Cartesian index triplet (i,j,k) given an index between 0 and NXxNYxNZ -1
-    ///        where NX, NY, and NZ is the total amoung of cells in each direction x-,y-,and z- respectively.
+    ///    where NX, NY, and NZ is the total amoung of cells in each direction x-,y-,and z- respectively.
     ///
     /// @param [in] idx      Integer between 0 and cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]-1
     /// @param [in] cells_per_dim

--- a/opm/grid/cpgrid/LevelCartesianIndexMapper.hpp
+++ b/opm/grid/cpgrid/LevelCartesianIndexMapper.hpp
@@ -1,0 +1,110 @@
+//===========================================================================
+//
+// File: LevelCartesianIndexMapper.hpp
+//
+// Created: Tue October 01  09:44:00 2024
+//
+// Author(s): Antonella Ritorto <antonella.ritorto@opm-op.com>
+//
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2024 Equinor ASA.
+
+  This file is part of The Open Porous Media project  (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_CPGRIDLEVELCARTESIANINDEXMAPPER_HH
+#define OPM_CPGRIDLEVELCARTESIANINDEXMAPPER_HH
+
+#include <opm/grid/common/LevelCartesianIndexMapper.hpp>
+#include <opm/grid/CpGrid.hpp>
+
+namespace Dune
+{
+class CpGrid;
+}
+
+namespace Opm
+{
+// Interface class to access the local Cartesian grid of each level grid (when refinement).
+// Further documentation in opm/grid/common/LevelCartesianIndexMapper.hpp
+//
+// Specialization for CpGrid
+template<>
+class LevelCartesianIndexMapper<Dune::CpGrid>
+{
+public:
+    static const int dimension = 3 ;
+
+    explicit LevelCartesianIndexMapper(const Dune::CpGrid& grid) : grid_{ &grid }
+    {}
+
+    const std::array<int,3>& cartesianDimensions(int level) const
+    {
+        return grid_->currentData()[level]->logicalCartesianSize();
+    }
+
+    int cartesianSize(int level) const
+    {
+        return computeCartesianSize(level);
+    }
+
+    int compressedSize(int level) const
+    {
+        validLevel(level);
+        return grid_->currentData()[level]->size(0);
+    }
+
+    int cartesianIndex( const int compressedElementIndex, const int level) const
+    {
+        validLevel(level);
+        assert(  compressedElementIndex >= 0 && compressedElementIndex <  grid_->currentData()[level]->size(0) );
+        return grid_->currentData()[level]->globalCell()[compressedElementIndex];
+    }
+
+    void cartesianCoordinate(const int compressedElementIndexOnLevel, std::array<int,dimension>& coordsOnLevel, int level) const
+    {
+        validLevel(level);
+        grid_->currentData()[level]->getIJK( compressedElementIndexOnLevel, coordsOnLevel);
+    }
+
+private:
+    const Dune::CpGrid* grid_;
+
+    int computeCartesianSize(int level) const
+    {
+        int size = cartesianDimensions(level)[ 0 ];
+        for( int d=1; d<dimension; ++d )
+            size *= cartesianDimensions(level)[ d ];
+        return size;
+    }
+
+    void validLevel(int level) const
+    {
+        if ((level < 0) || (level > grid_->maxLevel())) {
+            throw std::invalid_argument("Invalid level.\n");
+        }
+    }
+};
+
+}
+
+#endif

--- a/opm/grid/polyhedralgrid/cartesianindexmapper.hh
+++ b/opm/grid/polyhedralgrid/cartesianindexmapper.hh
@@ -31,7 +31,7 @@ namespace Dune
 
         const std::array<int, dimension>& cartesianDimensions() const
         {
-          return grid_.logicalCartesianSize();
+            return grid_.logicalCartesianSize();
         }
 
         int cartesianSize() const
@@ -40,12 +40,6 @@ namespace Dune
         }
 
         int compressedSize() const
-        {
-            return grid_.size( 0 );
-        }
-
-        // Only for unifying calls with CartesianIndexMapper<CpGrid> where levels are relevant.
-        int compressedLevelZeroSize() const
         {
             return grid_.size( 0 );
         }
@@ -71,15 +65,6 @@ namespace Dune
           }
           else
               coords[ 0 ] = gc ;
-        }
-
-        // Only for unifying calls with CartesianIndexMapper<CpGrid> where levels are relevant.
-        void cartesianCoordinateLevel(const int compressedElementIndexOnLevel, std::array<int,dimension>& coordsOnLevel, int level) const
-        {
-            if (level) {
-                throw std::invalid_argument("Invalid level.\n");
-            }
-            cartesianCoordinate(compressedElementIndexOnLevel, coordsOnLevel);
         }
     };
 

--- a/opm/grid/polyhedralgrid/levelcartesianindexmapper.hh
+++ b/opm/grid/polyhedralgrid/levelcartesianindexmapper.hh
@@ -1,0 +1,130 @@
+//===========================================================================
+//
+// File: levelcartesianindexmapper.hh
+//
+// Created: Tue October 01  09:44:00 2024
+//
+// Author(s): Antonella Ritorto <antonella.ritorto@opm-op.com>
+//
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2024 Equinor ASA.
+
+  This file is part of The Open Porous Media project  (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_POLYHEDRALGRIDLEVELCARTESIANINDEXMAPPER_HH
+#define OPM_POLYHEDRALGRIDLEVELCARTESIANINDEXMAPPER_HH
+
+#include <opm/grid/common/LevelCartesianIndexMapper.hpp>
+#include <opm/grid/polyhedralgrid.hh>
+
+
+namespace Dune
+{
+template<int dim, int dimworld, typename coord_t>
+class PolyhedralGrid;
+
+}
+
+namespace Opm
+{
+// Interface class to access the local Cartesian grid of each level grid (when refinement).
+// Further documentation in opm/grid/common/LevelCartesianIndexMapper.hpp
+//
+// Specialization for PolyhedralGrid
+template<int dim, int dimworld, typename coord_t>
+class LevelCartesianIndexMapper<Dune::PolyhedralGrid< dim, dimworld, coord_t >>
+{
+    typedef Dune::PolyhedralGrid< dim, dimworld, coord_t >  Grid;
+public:
+    static const int dimension = 3 ;
+
+    explicit LevelCartesianIndexMapper(const Grid& grid) : grid_{ &grid }
+    {}
+
+    const std::array<int,3>& cartesianDimensions(int level) const
+    {
+        throwIfLevelPositive(level);
+        return grid_->logicalCartesianSize();
+    }
+
+    int cartesianSize(int level) const
+    {
+        throwIfLevelPositive(level);
+        return computeCartesianSize(0);
+    }
+
+    int compressedSize(int level) const
+    {
+        throwIfLevelPositive(level);
+        return grid_->size(0);
+    }
+
+    int cartesianIndex( const int compressedElementIndex, const int level) const
+    {
+        throwIfLevelPositive(level);
+        assert( compressedElementIndex >= 0 && compressedElementIndex < compressedSize(0) );
+        return grid_->globalCell()[ compressedElementIndex ];
+    }
+
+    void cartesianCoordinate(const int compressedElementIndex, std::array<int,dimension>& coords, int level) const
+    {
+        throwIfLevelPositive(level);
+
+        int gc = cartesianIndex( compressedElementIndex, 0);
+        auto cartesianDimensions = grid_->logicalCartesianSize();
+        if( dimension >=2 )
+        {
+            for( int d=0; d<dimension-2; ++d )
+            {
+                coords[d] = gc % cartesianDimensions[d];  gc /= cartesianDimensions[d];
+            }
+
+            coords[dimension-2] = gc % cartesianDimensions[dimension-2];
+            coords[dimension-1] = gc / cartesianDimensions[dimension-1];
+        }
+        else
+            coords[ 0 ] = gc ;
+    }
+
+private:
+    const Grid* grid_;
+
+    int computeCartesianSize(int level) const
+    {
+        int size = cartesianDimensions(level)[ 0 ];
+        for( int d=1; d<dimension; ++d )
+            size *= cartesianDimensions(level)[ d ];
+        return size;
+    }
+
+    void throwIfLevelPositive(int level) const
+    {
+        if (level) {
+            throw std::invalid_argument("Invalid level.\n");
+        }
+    }
+};
+
+}
+
+#endif

--- a/tests/cpgrid/lgr_cartesian_idx_test.cpp
+++ b/tests/cpgrid/lgr_cartesian_idx_test.cpp
@@ -1,0 +1,232 @@
+//===========================================================================
+//
+// File: lgr_cartesian_idx_test.cpp
+//
+// Created: Sep 26 2024 09:15
+//
+// Author(s): Antonella Ritorto   <antonella.ritorto@opm-op.com>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+/*
+  Copyright 2024 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#define BOOST_TEST_MODULE LGRTests
+#include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
+#include <opm/grid/CpGrid.hpp>
+#include <opm/grid/cpgrid/CpGridData.hpp>
+#include <opm/grid/cpgrid/DefaultGeometryPolicy.hpp>
+#include <opm/grid/cpgrid/Entity.hpp>
+#include <opm/grid/cpgrid/EntityRep.hpp>
+#include <opm/grid/cpgrid/Geometry.hpp>
+#include <opm/grid/cpgrid/LevelCartesianIndexMapper.hpp>
+#include <opm/grid/LookUpData.hh>
+
+#include <dune/common/version.hh>
+#include <dune/grid/common/mcmgmapper.hh>
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Parser/Parser.hpp>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+
+#include <cassert>
+#include <sstream>
+#include <iostream>
+#include <cstdlib>
+#include <cmath>
+#include <map>
+
+struct Fixture
+{
+    Fixture()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        Dune::MPIHelper::instance(m_argc, m_argv);
+        Opm::OpmLog::setupSimpleDefaultLogging();
+    }
+
+    static int rank()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        return Dune::MPIHelper::instance(m_argc, m_argv).rank();
+    }
+};
+
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+void checkGlobalCellLgr(Dune::CpGrid& grid)
+{
+    const Dune::CartesianIndexMapper<Dune::CpGrid> mapper{grid};
+
+    const Opm::LevelCartesianIndexMapper<Dune::CpGrid> levelCartMapp(grid);
+
+    for (const auto& element : elements(grid.leafGridView()))
+    {
+        // How to get the Cartesian Index of a cell on the leaf grid view.
+        // 1. The "default" Cartesian Index of a cell on the leaf (which is a mixed grid with coarse and refined cells) is equal to the Cartesian Index of:
+        //    (a) the equivalent cell in level zero (same center and volume, cell not involved in any refinement).
+        //    (b) the parent cell in level zero when the leaf cell is a refined one (it has a equivalent cell that belongs to a refined level grid).
+        //    This default Cartesian Index for leaf cells coincide with the globalCell values.
+        const auto& cartesian_idx_from_leaf_elem =  mapper.cartesianIndex( element.index() );
+        const auto& global_cell_idx_leaf = grid.globalCell()[element.index()]; // parent cell index when the cell is a refined one.
+        BOOST_CHECK_EQUAL(cartesian_idx_from_leaf_elem, global_cell_idx_leaf);
+        // global_ijk represents the ijk values of the equivalent cell on the level zero, or parent cell if the leaf cell is a refined one.
+        // Notice that all the refined cells of a same parent cell will get the same global_cell_ value and the same global_ijk (since they
+        // inherit the parent cell value).
+        std::array<int,3> global_ijk = {0,0,0};
+        mapper.cartesianCoordinate( element.index(), global_ijk);
+
+        // How to get the Level Cartesian Index of a cell on the leaf grid view.
+        // Each LGR can be seen as a Cartesian Grid itself, with its own (local) logical_cartesian_size and its own (local) Cartesian indices.
+        // Given a leaf cell, via the CartesianIndexMapper and its method cartesianIndexLevel(...), we get the local-Cartesian-index.
+        const auto& cartesian_idx_from_level_elem =  levelCartMapp.cartesianIndex( element.getEquivLevelElem().index(), element.level() );
+        const auto& global_cell_idx_level = grid.currentData()[element.level()]->globalCell()[element.getEquivLevelElem().index()];
+        BOOST_CHECK_EQUAL(cartesian_idx_from_level_elem, global_cell_idx_level);
+        // local_ijk represents the ijk values of the equivalent cell on the level its was born.
+        std::array<int,3> local_ijk = {0,0,0};
+        levelCartMapp.cartesianCoordinate( element.getEquivLevelElem().index(), local_ijk, element.level() );
+
+        // For leaf cells that were not involved in any refinement, global_ijk and local_ijk must coincide.
+        if(element.level()==0)
+        {
+            BOOST_CHECK_EQUAL( global_ijk[0], local_ijk[0]);
+            BOOST_CHECK_EQUAL( global_ijk[1], local_ijk[1]);
+            BOOST_CHECK_EQUAL( global_ijk[2], local_ijk[2]);
+        }
+    }
+
+    const auto& localCartesianIdxSets_to_leafIdx = grid.mapLocalCartesianIndexSetsToLeafIndexSet();
+    const auto& leafIdx_to_localCartesianIdxSets = grid.mapLeafIndexSetToLocalCartesianIndexSets();
+    
+    for (int level = 0; level < grid.maxLevel(); ++level)
+    {
+        for (const auto& element : elements(grid.levelGridView(level)))
+        {
+            const auto& global_cell_level = grid.currentData()[element.level()]->globalCell()[element.index()];
+            if(element.isLeaf()) {
+                const auto& leaf_idx = localCartesianIdxSets_to_leafIdx[element.level()].at(global_cell_level);
+                BOOST_CHECK_EQUAL( leafIdx_to_localCartesianIdxSets[leaf_idx][0], element.level());
+                BOOST_CHECK_EQUAL( leafIdx_to_localCartesianIdxSets[leaf_idx][1], global_cell_level);
+            }
+            else {
+                BOOST_CHECK_THROW( localCartesianIdxSets_to_leafIdx[element.level()].at(global_cell_level), std::out_of_range);
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(refine_one_cell)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    grid.createCartesian(grid_dim, cell_sizes);
+
+    const std::array<int, 3> cells_per_dim = {2,2,2};
+    const std::array<int, 3> startIJK = {1,0,1};
+    const std::array<int, 3> endIJK = {2,1,2};// Single Cell! (with index 13 in level zero grid), LGR dimensions 2x2x2
+    const std::string lgr_name = {"LGR1"};
+    grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+
+    checkGlobalCellLgr(grid);
+}
+
+BOOST_AUTO_TEST_CASE(three_lgrs)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    grid.createCartesian(grid_dim, cell_sizes);
+
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}, {4,4,4}};
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,2}, {3,2,2}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,1,1}, {1,1,3}, {4,3,3}};
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3"};
+    grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+
+    checkGlobalCellLgr(grid);
+}
+
+BOOST_AUTO_TEST_CASE(inactiveCells_in_lgrs)
+{
+
+    const std::string deckString =
+        R"( RUNSPEC
+        DIMENS
+        1  1  5 /
+        GRID
+        COORD
+        0 0 0
+        0 0 1
+        1 0 0
+        1 0 1
+        0 1 0
+        0 1 1
+        1 1 0
+        1 1 1
+        /
+        ZCORN
+        4*0
+        8*1
+        8*2
+        8*3
+        8*4
+        4*5
+        /
+        ACTNUM
+        0
+        1
+        1
+        1
+        0
+        /
+        PORO
+        5*0.15
+        /)";
+
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}};
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,3}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{1,1,2}, {1,1,5}};
+    // LGR1 cell indices = {0,1}, LGR2 cell indices = {3,4}.
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2"};
+
+    Opm::Parser parser;
+    const auto deck = parser.parseString(deckString);
+    Opm::EclipseState es(deck);
+
+    Dune::CpGrid grid;
+    grid.processEclipseFormat(&es.getInputGrid(), &es, false, false, false);
+
+    grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+    
+    checkGlobalCellLgr(grid);
+}

--- a/tests/cpgrid/lookupdataCpGrid_test.cpp
+++ b/tests/cpgrid/lookupdataCpGrid_test.cpp
@@ -40,6 +40,7 @@
 #include <boost/test/tools/floating_point_comparison.hpp>
 #endif
 #include <opm/grid/CpGrid.hpp>
+#include <opm/grid/cpgrid/LevelCartesianIndexMapper.hpp>
 #include <opm/grid/LookUpData.hh>
 
 #include <dune/grid/common/mcmgmapper.hh>
@@ -94,6 +95,7 @@ void lookup_check(const Dune::CpGrid& grid)
         }
     }
 
+    const Opm::LevelCartesianIndexMapper<Dune::CpGrid> levelCartMapp(grid);
 
     // LookUpData
     const auto& leaf_view = grid.leafGridView();
@@ -146,12 +148,12 @@ void lookup_check(const Dune::CpGrid& grid)
         std::array<int,3> ijk;
         cartMapper.cartesianCoordinate(elem.index(), ijk); // this ijk corresponds to the parent/equivalent cell in level 0.
         std::array<int,3> ijkLevel0;
-        cartMapper.cartesianCoordinateLevel(elem.getOrigin().index(), ijkLevel0, 0);
+        levelCartMapp.cartesianCoordinate(elem.getOrigin().index(), ijkLevel0, 0);
         BOOST_CHECK(ijk == ijkLevel0);
         // Throw for level < 0 or level > maxLevel()
         std::array<int,3> ijkThrow;
-        BOOST_CHECK_THROW(cartMapper.cartesianCoordinateLevel(elem.index(), ijkThrow, -3), std::invalid_argument);
-        BOOST_CHECK_THROW(cartMapper.cartesianCoordinateLevel(elem.index(), ijkThrow, grid.maxLevel() + 1), std::invalid_argument);
+        BOOST_CHECK_THROW(levelCartMapp.cartesianCoordinate(elem.index(), ijkThrow, -3), std::invalid_argument);
+        BOOST_CHECK_THROW(levelCartMapp.cartesianCoordinate(elem.index(), ijkThrow, grid.maxLevel() + 1), std::invalid_argument);
         // Checks related to LGR field properties
         if (elem.level())
         {
@@ -168,7 +170,7 @@ void lookup_check(const Dune::CpGrid& grid)
             std::array<int,3> ijkLevelGrid;
             (*data[elem.level()]).getIJK(idxOnLevel, ijkLevelGrid);
             std::array<int,3> ijkLevel;
-            cartMapper.cartesianCoordinateLevel(idxOnLevel, ijkLevel, elem.level());
+            levelCartMapp.cartesianCoordinate(idxOnLevel, ijkLevel, elem.level());
             BOOST_CHECK( ijkLevelGrid == ijkLevel);
         }
         // Extra checks related to ElemMapper

--- a/tests/test_lookupdata_polyhedral.cpp
+++ b/tests/test_lookupdata_polyhedral.cpp
@@ -47,6 +47,7 @@
 #include <dune/grid/io/file/vtk/vtkwriter.hh>
 #include <opm/grid/cpgrid/dgfparser.hh>
 #include <opm/grid/polyhedralgrid/dgfparser.hh>
+#include <opm/grid/polyhedralgrid/levelcartesianindexmapper.hh>
 #include <dune/grid/common/mcmgmapper.hh>
 
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
@@ -91,6 +92,8 @@ void lookup_check(const Dune::PolyhedralGrid<3,3>& grid)
     std::vector<double> fake_feature_double(grid.size(0), 0.);
     std::iota(fake_feature_double.begin(), fake_feature_double.end(), .5);
 
+    const Opm::LevelCartesianIndexMapper< Dune::PolyhedralGrid<3,3> > levelCartMapp(grid);
+    
     const auto leaf_view = grid.leafGridView();
     using GridView = std::remove_cv_t< typename std::remove_reference<decltype(grid.leafGridView())>::type>;
     // LookUpData
@@ -134,12 +137,12 @@ void lookup_check(const Dune::PolyhedralGrid<3,3>& grid)
         std::array<int,3> ijk;
         cartMapper.cartesianCoordinate(idx, ijk);
         std::array<int,3> ijkLevel;
-        cartMapper.cartesianCoordinateLevel(idx, ijkLevel, 0);
+        levelCartMapp.cartesianCoordinate(idx, ijkLevel, 0);
         BOOST_CHECK(ijk == ijkLevel);
         // Throw for level > 0 (Local grid refinement not supported for Polyhedral Grid)
         std::array<int,3> ijkThrow;
-        BOOST_CHECK_THROW(cartMapper.cartesianCoordinateLevel(idx, ijkThrow, 4), std::invalid_argument);
-        BOOST_CHECK_THROW(cartMapper.cartesianCoordinateLevel(idx, ijkThrow, -3), std::invalid_argument);
+        BOOST_CHECK_THROW(levelCartMapp.cartesianCoordinate(idx, ijkThrow, 4), std::invalid_argument);
+        BOOST_CHECK_THROW(levelCartMapp.cartesianCoordinate(idx, ijkThrow, -3), std::invalid_argument);
     }
 }
 


### PR DESCRIPTION
Based on OPM/opm-grid#765

Improvement of OPM/opm-grid#765 since it removes the non-DUNE methods added in CartesianIndexMapper. 

Create a template class LevelCartesianIndexMapper. It mimics the Dune::CartesianIndexMapper class. Difference: methods have "int level" as a function parameter. 
Specialization for CpGrid and PolyhedralGrid are added accordingly. 

PR OPM/opm-simulators#5649 deals with the AluGrid specialization. Additionally, it refactors the code where those non-DUNE methods were used (RelpermDiagnostics).

Not relevant for the Reference Manual. 
