### PR TITLE
[fix] Omit fmt::format usage.

### DIFF
--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -58,6 +58,7 @@
 #include <iostream>
 #include <initializer_list>
 #include <set>
+#include <string>
 #include <utility>
 
 namespace Dune

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -53,8 +53,6 @@
 #include <opm/grid/RepairZCORN.hpp>
 #include <opm/grid/utility/StopWatch.hpp>
 
-#include <fmt/format.h>
-
 #include <cstddef>
 #include <fstream>
 #include <iostream>
@@ -314,9 +312,8 @@ namespace cpgrid
                 }
             }
 
-            Opm::OpmLog::info(fmt::format("{} pinch-out connection{} generated",
-                                          nnc_cells[PinchNNC].size(),
-                                          (nnc_cells[PinchNNC].size() != 1)? "s" : ""));
+            auto suffix = (nnc_cells[PinchNNC].size() != 1)? "s" : "";
+            Opm::OpmLog::info(std::to_string(nnc_cells.size()) + " pinch-out connection"+suffix+" generated");
 
             // Add explicit NNCs.
             const auto& nncs = ecl_state->getInputNNC();

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -313,8 +313,8 @@ namespace cpgrid
                 }
             }
 
-            auto suffix = (nnc_cells[PinchNNC].size() != 1)? "s" : "";
-            Opm::OpmLog::info(std::to_string(nnc_cells.size()) + " pinch-out connection"+suffix+" generated");
+            auto suffix = std::string{(nnc_cells[PinchNNC].size() != 1)? "s" : ""};
+            Opm::OpmLog::info(std::to_string(nnc_cells.size()) + " pinch-out connection" + suffix + " generated");
 
             // Add explicit NNCs.
             const auto& nncs = ecl_state->getInputNNC();


### PR DESCRIPTION
We do not require that package for building.
In the long run we should make the one in opm-common available, though.

For the time being this is better than #768 

I apologize for the fallout from #767