### PR TITLE
Feature/graph of grid

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -125,6 +125,7 @@ if(Boost_VERSION_STRING VERSION_GREATER 1.53)
 	  tests/cpgrid/lookUpCellCentroid_cpgrid_test.cpp
 	  tests/cpgrid/lookupdataCpGrid_test.cpp
 	  tests/cpgrid/shifted_cart_test.cpp
+    tests/test_graphofgrid.cpp
   )
 endif()
 

--- a/opm/grid/GraphOfGrid.cpp
+++ b/opm/grid/GraphOfGrid.cpp
@@ -1,0 +1,111 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#include <config.h>
+
+#include <opm/grid/CpGrid.hpp>
+
+namespace Opm {
+
+
+/// \brief A class storing a graph representation of the grid
+///
+/// Stores the list of all cell global IDs and for each cell
+/// a list of global IDs of its neighbors.
+/// In addition, weights of graph vertices and edges are stored.
+/// 
+/// Features edge contractions, which adds weights of merged vertices
+/// and of edges to every shared neighbor. Intended use is for loadbalancing
+/// to ensure that no well is split between processes.
+template<typename Grid>
+class GraphOfGrid{
+  using WeightType = float;
+
+  struct VertexProperties
+  {
+    WeightType weight = 1;
+    std::map<int,WeightType> edges; // neighbor's global ID and edge's weight
+  };
+
+public:
+  GraphOfGrid (const Grid& grid_)
+    : grid(grid_)
+  {
+    createGraph();
+  }
+
+  /// \brief Number of graph vertices
+  int size () const
+  {
+    return graph.size();
+  }
+
+  /// \brief Number of vertices for given vertex
+  // returns -1 if vertex with such global ID is not in the graph
+  int numEdges (int gID) const
+  {
+    auto pgID = graph.find(gID);
+    if (pgID == graph.end())
+      return -1;
+    else
+      return pgID->second.edges.size();
+  }
+
+private:
+  /// \brief Create a graph representation of the grid
+  void createGraph ();
+
+  const Grid& grid;
+  std::map<int, VertexProperties> graph;
+};
+
+  template<typename Grid>
+  void GraphOfGrid<Grid>::createGraph ()
+  {
+    // load vertices (grid cell IDs) into graph
+    for (auto it=grid.template leafbegin<0>(); it!=grid.template leafend<0>(); ++it)
+    {
+      VertexProperties vertex;
+      // get vertex's global ID
+      int gID = grid.globalIdSet().id(*it); //it->something;
+
+      // iterate over vertex's faces and store neighbors' IDs
+      for (int face_lID=0; face_lID<grid.numCellFaces(gID); ++face_lID)
+      {
+        const int face  = grid.cellFace(gID, face_lID);
+        int otherCell   = grid.faceCell(face, 0);
+        if ( otherCell == gID || otherCell == -1 ) // -1 means no cell, face is at boundary
+        {
+            otherCell = grid.faceCell(face, 1);
+            if ( otherCell == gID || otherCell == -1 )
+                continue;
+        }
+        WeightType weight = 1;
+        vertex.edges.try_emplace(otherCell,weight);
+      }
+
+      graph.try_emplace(gID,vertex);
+    }
+
+  }
+} // namespace Opm

--- a/opm/grid/GraphOfGrid.cpp
+++ b/opm/grid/GraphOfGrid.cpp
@@ -21,19 +21,20 @@
   copyright holders.
 */
 
-#include <config.h>
+#ifndef OPM_GRAPH_OF_GRID_HEADER
+#define OPM_GRAPH_OF_GRID_HEADER
 
+#include <config.h>
 #include <opm/grid/CpGrid.hpp>
 
 namespace Opm {
-
 
 /// \brief A class storing a graph representation of the grid
 ///
 /// Stores the list of all cell global IDs and for each cell
 /// a list of global IDs of its neighbors.
 /// In addition, weights of graph vertices and edges are stored.
-/// 
+///
 /// Features edge contractions, which adds weights of merged vertices
 /// and of edges to every shared neighbor. Intended use is for loadbalancing
 /// to ensure that no well is split between processes.
@@ -60,6 +61,15 @@ public:
   int size () const
   {
     return graph.size();
+  }
+
+  auto begin() const
+  {
+    return graph.begin();
+  }
+  auto end() const
+  {
+    return graph.end();
   }
 
   /// \brief Return properties of vertex of given ID.
@@ -97,32 +107,6 @@ public:
     }
     else
       return pgID->second.edges;
-  }
-  // template<typename ZOLTAN_ID_PTR>
-  using ZOLTAN_ID_PTR = int*;
-  void edgeListMulti (int num_obj,
-                      ZOLTAN_ID_PTR global_ids,
-                      int *num_edges,
-                      ZOLTAN_ID_PTR nbor_global_id,
-                      int *nbor_procs,
-                      float *ewgts,
-                      int *ierr) const
-  {
-    int j=0;
-    for (int i=0; i<num_obj; ++i)
-    {
-      auto pgID = graph.find(global_ids[i]);
-      if (pgID==graph.end())
-        throw "GraphOfGrid::edgeListMulti - vertex ID not found";
-      assert(pgID->size()==num_edges[i]);
-      for (const auto& neighbor : *pgID)
-      {
-        nbor_global_id[j] = neighbor.first;
-        nbor_procs[j] = 0;
-        ewgts[j] = neighbor.second;
-        ++j;
-      }
-    }
   }
 
   /// \brief Contract two vertices
@@ -216,3 +200,5 @@ private:
   }
 
 } // namespace Opm
+
+#endif // OPM_GRAPH_OF_GRID_HEADER

--- a/opm/grid/GraphOfGridWrappers.cpp
+++ b/opm/grid/GraphOfGridWrappers.cpp
@@ -128,8 +128,8 @@ namespace Opm {
       if ((int)eList.size()!=numEdges[i])
       {
         std::cerr << "getGraphOfGridEdgeList error: Edge number disagreement"
-                  << " between Zoltan and Graph for vertex with ID " << gIDs[i]
-                  << std::endl;
+                  << " between Zoltan (" << numEdges[i] << ") and Graph ("
+                  << eList.size() << ") for vertex with ID " << gIDs[i] << std::endl;
         *err = ZOLTAN_FATAL;
         return;
       }
@@ -147,20 +147,11 @@ namespace Opm {
   // Wells:
   /// \brief Adds well to the GraphOfGrid
   /// Adding the well contracts vertices of the well into one vertex.
-  void addFutureConnectionWell (GraphOfGrid<Dune::CpGrid>& gog, const std::unordered_map<std::string, std::set<int>>& wells)
+  void addFutureConnectionWells (GraphOfGrid<Dune::CpGrid>& gog,
+     const std::unordered_map<std::string, std::set<int>>& wells)
   {
     for (const auto& w : wells)
-    {
-      if (w.second.size()>0)
-      {
-        int minID = *(w.second.begin());
-        for (const auto& e : w.second)
-        {
-          gog.contractVertices(minID,e);
-          minID = std::min(minID,e);
-        }
-      }
-    }
+      gog.addWell(w.second);
   }
 
 } // end namespace Opm

--- a/opm/grid/GraphOfGridWrappers.cpp
+++ b/opm/grid/GraphOfGridWrappers.cpp
@@ -1,0 +1,166 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#include <opm/grid/GraphOfGrid.cpp>
+
+namespace Opm {
+/*
+  This file contains wrappers for GraphOfGrid that satisfy interface
+  requirements of graph partitioners like Zoltan and (TODO!) Metis.
+
+  Additionally, parsing wells is done here.
+*/
+  #define ZOLTAN_OK 1
+  #define ZOLTAN_FATAL 0
+  namespace {
+    using ZOLTAN_ID_PTR = int*;
+  }
+  /// \brief callback ftion for ZOLTAN_NUM_OBJ_FN
+  /// returns the number of vertices in the graph
+  int getGraphOfGridNumVertices(void* pGraph, int *err)
+  {
+    const GraphOfGrid<Dune::CpGrid>&  gog = *static_cast<const GraphOfGrid<Dune::CpGrid>*>(pGraph);
+    int size = gog.size();
+    *err = ZOLTAN_OK;
+    return size;
+  }
+
+  /// \brief callback ftion for ZOLTAN_OBJ_LIST_FN
+  /// fills the vector gIDs with vertex global IDs
+  ///  and the vector objWeights with their weights
+  void getGraphOfGridVerticesList(void* pGraph,
+                                  int dimGlobalID,
+                                  [[maybe_unused]] int dimLocalID,
+                                  ZOLTAN_ID_PTR gIDs,
+                                  [[maybe_unused]] ZOLTAN_ID_PTR lIDs,
+                                  int weightDim,
+                                  float *objWeights,
+                                  int *err)
+  {
+    assert(dimGlobalID==1); // ID is a single int
+    assert(weightDim==1); // vertex weight is a single float
+    const GraphOfGrid<Dune::CpGrid>& gog = *static_cast<const GraphOfGrid<Dune::CpGrid>*>(pGraph);
+    int i=0;
+    for (const auto& v : gog)
+    {
+      gIDs[i] = v.first;
+      // lIDs are left unused
+      objWeights[i] = v.second.weight;
+      ++i;
+    }
+    *err = ZOLTAN_OK;
+  }
+
+  /// \brief callback ftion for ZOLTAN_NUM_EDGES_MULTI_FN
+  /// takes the list of global IDs (gIDs) and fills (consecutively)
+  /// vector numEdges with the number of their edges
+  void getGraphOfGridNumEdges(void *pGraph,
+                              int dimGlobalID,
+                              [[maybe_unused]] int dimLocalID,
+                              int numCells,
+                              ZOLTAN_ID_PTR gIDs,
+                              [[maybe_unused]] ZOLTAN_ID_PTR lIDs,
+                              int *numEdges,
+                              int *err)
+  {
+    assert(dimGlobalID==1); // ID is a single int
+    const GraphOfGrid<Dune::CpGrid>& gog = *static_cast<const GraphOfGrid<Dune::CpGrid>*>(pGraph);
+    for (int i=0; i<numCells; ++i)
+    {
+      int nE = gog.numEdges(gIDs[i]);
+      if (nE== -1)
+      {
+        std::cerr << "getGraphOfGridNumEdges error: Vertex with ID "
+                  << gIDs[i] << " is not in graph." << std::endl;
+        *err = ZOLTAN_FATAL;
+        return;
+      }
+      numEdges[i] = nE;
+    }
+    *err = ZOLTAN_OK;
+  }
+
+  /// \brief callback ftion for ZOLTAN_EDGE_LIST_MULTI_FN
+  /// takes the list of global IDs (gIDs) and fills (consecutively):
+  /// vector nborGIDs with the list of neighbors (all into 1 vector),
+  /// vector nborProc with neighbors' process numbers,
+  /// vector edgeWeights with edge weights.
+  /// The vector numEdges provides the number of edges for each gID
+  void getGraphOfGridEdgeList(void *pGraph, int dimGlobalID,
+                              [[maybe_unused]] int dimLocalID,
+                              int numCells,
+                              ZOLTAN_ID_PTR gIDs,
+                              [[maybe_unused]] ZOLTAN_ID_PTR lIDs,
+                              int *numEdges,
+                              ZOLTAN_ID_PTR nborGIDs,
+                              int *nborProc,
+                              int weightDim,
+                              float *edgeWeights,
+                              int *err)
+  {
+    assert(dimGlobalID==1); // ID is a single int
+    assert(weightDim==1); // edge weight is a single float
+    const GraphOfGrid<Dune::CpGrid>&  gog = *static_cast<const GraphOfGrid<Dune::CpGrid>*>(pGraph);
+    int id=0;
+    for (int i=0; i<numCells; ++i)
+    {
+      auto eList = gog.edgeList(gIDs[i]);
+      if ((int)eList.size()!=numEdges[i])
+      {
+        std::cerr << "getGraphOfGridEdgeList error: Edge number disagreement"
+                  << " between Zoltan and Graph for vertex with ID " << gIDs[i]
+                  << std::endl;
+        *err = ZOLTAN_FATAL;
+        return;
+      }
+      for (const auto& e : eList)
+      {
+        nborGIDs[id]= e.first;
+        nborProc[id]= gog.getVertex(e.first).nproc;
+        edgeWeights[id]= e.second;
+        ++id;
+      }
+    }
+    *err = ZOLTAN_OK;
+  }
+
+  // Wells:
+  /// \brief Adds well to the GraphOfGrid
+  /// Adding the well contracts vertices of the well into one vertex.
+  void addFutureConnectionWell (GraphOfGrid<Dune::CpGrid>& gog, const std::unordered_map<std::string, std::set<int>>& wells)
+  {
+    for (const auto& w : wells)
+    {
+      if (w.second.size()>0)
+      {
+        int minID = *(w.second.begin());
+        for (const auto& e : w.second)
+        {
+          gog.contractVertices(minID,e);
+          minID = std::min(minID,e);
+        }
+      }
+    }
+  }
+
+} // end namespace Opm

--- a/opm/grid/GraphOfGridWrappers.cpp
+++ b/opm/grid/GraphOfGridWrappers.cpp
@@ -21,6 +21,7 @@
   copyright holders.
 */
 
+#include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/grid/GraphOfGrid.cpp>
 
 namespace Opm {
@@ -90,8 +91,9 @@ namespace Opm {
       int nE = gog.numEdges(gIDs[i]);
       if (nE== -1)
       {
-        std::cerr << "getGraphOfGridNumEdges error: Vertex with ID "
-                  << gIDs[i] << " is not in graph." << std::endl;
+        std::ostringstream ostr;
+        ostr << "getGraphOfGridNumEdges error: Vertex with ID " << gIDs[i] << " is not in graph.";
+        OpmLog::error(ostr.str());
         *err = ZOLTAN_FATAL;
         return;
       }
@@ -127,9 +129,11 @@ namespace Opm {
       auto eList = gog.edgeList(gIDs[i]);
       if ((int)eList.size()!=numEdges[i])
       {
-        std::cerr << "getGraphOfGridEdgeList error: Edge number disagreement"
-                  << " between Zoltan (" << numEdges[i] << ") and Graph ("
-                  << eList.size() << ") for vertex with ID " << gIDs[i] << std::endl;
+        std::ostringstream ostr;
+        ostr << "getGraphOfGridEdgeList error: Edge number disagreement"
+             << " between Zoltan (" << numEdges[i] << ") and Graph ("
+             << eList.size() << ") for vertex with ID " << gIDs[i] << std::endl;
+        OpmLog::error(ostr.str());
         *err = ZOLTAN_FATAL;
         return;
       }

--- a/tests/test_graphofgrid.cpp
+++ b/tests/test_graphofgrid.cpp
@@ -9,6 +9,7 @@
 
 #include <opm/grid/GraphOfGrid.cpp>
 
+// basic test to check if the graph was constructed correctly
 BOOST_AUTO_TEST_CASE(SimpleGraph)
 {
 	Dune::CpGrid grid;
@@ -25,9 +26,13 @@ BOOST_AUTO_TEST_CASE(SimpleGraph)
 	BOOST_REQUIRE(edgeL[0]==1.);
 	BOOST_REQUIRE(edgeL[3]==1.);
 	BOOST_REQUIRE(edgeL[6]==1.);
-	BOOST_REQUIRE(edgeL[4]==0.); // not a neighbor (beware! size got increased)
+	BOOST_REQUIRE(edgeL[4]==0.); // not a neighbor (edgeL's size increased)
+
+	edgeL = gog.edgeList(10); // vertex 10 is not in the graph
+	BOOST_REQUIRE(edgeL.size()==0);
 }
 
+// test vertex contraction on a simple graph
 BOOST_AUTO_TEST_CASE(SimpleGraphWithVertexContraction)
 {
 	Dune::CpGrid grid;
@@ -41,8 +46,8 @@ BOOST_AUTO_TEST_CASE(SimpleGraphWithVertexContraction)
 	BOOST_REQUIRE(gog.size()==7);
 	edgeL = gog.edgeList(0);
 	BOOST_REQUIRE(edgeL.size()==4);
-	BOOST_REQUIRE(edgeL[2]==1);
-	BOOST_REQUIRE(edgeL[3]==1);
+	BOOST_REQUIRE(edgeL[2]==1); // neighbor of 0
+	BOOST_REQUIRE(edgeL[3]==1); // neighbor of 1
 
 	gog.contractVertices(0,2);
 	BOOST_REQUIRE(gog.size()==6);
@@ -60,10 +65,6 @@ BOOST_AUTO_TEST_CASE(SimpleGraphWithVertexContraction)
 	BOOST_REQUIRE(v5e==gog.edgeList(6)); // 5 and 6 have the same neighbors (1, 2 got merged)
 	BOOST_REQUIRE(v5e!=gog.edgeList(7));
 
-	auto it = gog.begin();
-	BOOST_REQUIRE(it->first==0); // gID are ordered, 0 is first
-	++it;
-	BOOST_REQUIRE(it->first==3); // 1, 2 got merged, 3 is next
 }
 
 #include <opm/grid/GraphOfGridWrappers.cpp>
@@ -85,21 +86,23 @@ BOOST_AUTO_TEST_CASE(WrapperForZoltan)
     float objWeights[nVer];
     getGraphOfGridVerticesList(&gog, 1, 1, gIDs, lIDs, 1, objWeights, &err);
     BOOST_REQUIRE(err==ZOLTAN_OK);
-    BOOST_REQUIRE(gIDs[6]==6);
-    BOOST_REQUIRE(gIDs[59]==59);
-    BOOST_REQUIRE(objWeights[18]==1);
+    BOOST_REQUIRE(objWeights[18]==1); // all weights are 1 at this point
 
     int numEdges[nVer];
     getGraphOfGridNumEdges(&gog, 1, 1, nVer, gIDs, lIDs, numEdges, &err);
     BOOST_REQUIRE(err==ZOLTAN_OK);
-    BOOST_REQUIRE(numEdges[0]==3);
-    BOOST_REQUIRE(numEdges[9]==4);
-    BOOST_REQUIRE(numEdges[37]==5);
-    BOOST_REQUIRE(numEdges[26]==6);
-
     int nEdges=0;
     for (int i=0; i<nVer; ++i)
+    {
+    	switch (gIDs[i])
+    	{
+		    case 0:  BOOST_REQUIRE(numEdges[i]==3); break;
+		    case 9:  BOOST_REQUIRE(numEdges[i]==4); break;
+		    case 37: BOOST_REQUIRE(numEdges[i]==5); break;
+		    case 26: BOOST_REQUIRE(numEdges[i]==6); break;
+		}
     	nEdges += numEdges[i];
+    }
     BOOST_REQUIRE(nEdges==266);
 
     int nborGIDs[nEdges];
@@ -111,12 +114,12 @@ BOOST_AUTO_TEST_CASE(WrapperForZoltan)
     BOOST_REQUIRE(edgeWeights[203]==1.); // all are 1., no vertices were contracted
 
     numEdges[16] = 8;
-    std::cerr << "Expecting an error message from getGraphOfGridEdgeList, the vertex 16 has a wrong number of edges." <<std::endl;
+    std::cerr << "Expecting an error message from getGraphOfGridEdgeList, the vertex " << gIDs[16] << " has a wrong number of edges." <<std::endl;
     getGraphOfGridEdgeList(&gog, 1, 1, nVer, gIDs, lIDs, numEdges, nborGIDs, nborProc, 1, edgeWeights, &err);
     BOOST_REQUIRE(err==ZOLTAN_FATAL);
 }
 
-BOOST_AUTO_TEST_CASE(GrapWithWell)
+BOOST_AUTO_TEST_CASE(GraphWithWell)
 {
 	Dune::CpGrid grid;
 	std::array<int,3> dims{5,4,3};
@@ -128,7 +131,7 @@ BOOST_AUTO_TEST_CASE(GrapWithWell)
     	{"shape L on the front face", {5,10,15,35,55} },
     	{"lying 8 on the right face", {20,1,41,22,3,43,24} },
     	{"disconnected vertices", {58,12} } };
-    addFutureConnectionWell(gog,wells);
+    addFutureConnectionWells(gog,wells);
     int err;
     int nVer = getGraphOfGridNumVertices(&gog,&err);
     BOOST_REQUIRE(err==ZOLTAN_OK);
@@ -138,18 +141,137 @@ BOOST_AUTO_TEST_CASE(GrapWithWell)
     float objWeights[nVer];
     getGraphOfGridVerticesList(&gog, 1, 1, gIDs, lIDs, 1, objWeights, &err);
     BOOST_REQUIRE(err=ZOLTAN_OK);
-    BOOST_REQUIRE(gIDs[48]==59); // last ID
-    BOOST_REQUIRE(gIDs[47]==57); // pre-last, 58 was contracted to 12
-    BOOST_REQUIRE(gIDs[4]==5); // 3 was contracted to 1
-    BOOST_REQUIRE(objWeights[1]==7.); // well with 7 vertices
-    BOOST_REQUIRE(objWeights[4]==5.); // well with 5 vertices
-    BOOST_REQUIRE(gIDs[19]==25);
-    BOOST_REQUIRE(objWeights[19]==1.); // ordinary vertex
+    for (int i=0; i<nVer; ++i)
+    {
+    	switch (gIDs[i])
+    	{
+		    case 1:  BOOST_REQUIRE(objWeights[i]==7.); break;
+		    case 5:  BOOST_REQUIRE(objWeights[i]==5.); break;
+		    case 12: BOOST_REQUIRE(objWeights[i]==2.); break;
+		    default: BOOST_REQUIRE(objWeights[i]==1.); // ordinary vertex
+	    }
+    }
+}
 
-	// Well well1("SomeName1",std::array<int>{0,1,2,3,4});
-	// Well well2("SomeName2",std::array<int>{52,32,12});
-	// Well well3("SomeName3",std::array<int>{59,48,37});
-	// Well well4("SomeName4",std::array<int>{37,38,39,34}); // merges with well3
+BOOST_AUTO_TEST_CASE(IntersectingWells)
+{
+	Dune::CpGrid grid;
+	std::array<int,3> dims{5,4,3};
+	std::array<double,3> size{1.,1.,1.};
+	grid.createCartesian(dims,size);
+	Opm::GraphOfGrid gog(grid);
+
+	std::array<std::set<int>,3> wells{std::set<int>{0,1,2,3,4},
+	                                  std::set<int>{52,32,12},
+	                                  std::set<int>{59,48,37}};
+			            // later add  std::set<int>{37,38,39,34},
+			            //                         {2,8} and {2,38}
+	for (const auto& w : wells)
+		gog.addWell(w,false);
+
+    int err;
+    int nVer = getGraphOfGridNumVertices(&gog,&err);
+    BOOST_REQUIRE(err==ZOLTAN_OK);
+    BOOST_REQUIRE(nVer == 52);
+
+	gog.addWell(std::set<int>{37,38,39,34}); // intersects with previous
+    nVer = getGraphOfGridNumVertices(&gog,&err);
+    BOOST_REQUIRE(err==ZOLTAN_OK);
+    BOOST_REQUIRE(nVer == 49);
+
+    gog.addWell(std::set<int>{2,8});
+    nVer = getGraphOfGridNumVertices(&gog,&err);
+    BOOST_REQUIRE(err==ZOLTAN_OK);
+    BOOST_REQUIRE(nVer == 48);
+
+    gog.addWell(std::set<int>{2,38});
+    nVer = getGraphOfGridNumVertices(&gog,&err);
+    BOOST_REQUIRE(err==ZOLTAN_OK);
+    BOOST_REQUIRE(nVer == 47);
+
+    gog.addWell(std::set<int>{8,38});
+    nVer = getGraphOfGridNumVertices(&gog,&err);
+    BOOST_REQUIRE(err==ZOLTAN_OK);
+    BOOST_REQUIRE(nVer == 47);
+
+	int gIDs[nVer], lIDs[0];
+    float objWeights[nVer];
+    getGraphOfGridVerticesList(&gog, 1, 1, gIDs, lIDs, 1, objWeights, &err);
+    BOOST_REQUIRE(err=ZOLTAN_OK);
+
+    for (int i=0; i<nVer; ++i)
+    {
+    	switch (gIDs[i])
+    	{
+		    case 0:  BOOST_REQUIRE(objWeights[i]==12.); break;
+		    case 12: BOOST_REQUIRE(objWeights[i]==3.); break;
+		    default: BOOST_REQUIRE(objWeights[i]==1.); // ordinary vertex
+	    }
+    }
+
+    int nOut = 3;
+    int numEdges[nOut];
+    int gID[nOut]; gID[0]=12; gID[1]=0; gID[2]=54;
+    getGraphOfGridNumEdges(&gog, 1, 1, nOut, gID, lIDs, numEdges, &err);
+    BOOST_REQUIRE(err==ZOLTAN_OK);
+    BOOST_REQUIRE(numEdges[0]==12);
+    BOOST_REQUIRE(numEdges[1]==26);
+    BOOST_REQUIRE(numEdges[2]==3);
+
+    int nEdges = 41;
+    int nborGIDs[nEdges];
+    int nborProc[nEdges];
+    float edgeWeights[nEdges];
+    getGraphOfGridEdgeList(&gog, 1, 1, nOut, gID, lIDs, numEdges, nborGIDs, nborProc, 1, edgeWeights, &err);
+    BOOST_REQUIRE(err==ZOLTAN_OK);
+
+    // neighbors of the well with cells 12, 32, 52
+    int checked = 0;
+    for (int i=0; i<12; ++i)
+    {
+		BOOST_REQUIRE(edgeWeights[i]==1);
+		switch (nborGIDs[i])
+		{
+			case  7: case 11: case 13: case 17:
+			case 27: case 31: case 33: case  0: // 37 is a well with ID 0
+			case 47: case 51: case 53: case 57:
+				++checked;
+		}
+    }
+    BOOST_REQUIRE(checked==12);
+
+    // neighbors of the well with cells 0,1,2,3,4,8,34,37,38,39,48,59
+    checked=0;
+    for (int i=12; i<38; ++i)
+    {
+    	switch (nborGIDs[i])
+    	{
+    		// neighboring two well cells adds up the edge weight
+	    	case 7: case 9: case 28: case 33: case 54: case 58:
+	    		BOOST_REQUIRE(edgeWeights[i]==2.);
+    		    ++checked;
+    		    break;
+	        default: BOOST_REQUIRE(edgeWeights[i]==1.);
+    	}
+    }
+    BOOST_REQUIRE(checked==6);
+    checked=0;
+
+    // neighbors of the cell with global ID 54
+    for (int i=38; i<41; ++i)
+    {
+    	switch (nborGIDs[i])
+    	{
+	    	case 0: // contains cells 34 and 59
+	    		++checked;
+	    		BOOST_REQUIRE(edgeWeights[i]==2.);
+	    		break;
+	    	case 49: case 53:
+	    		++checked;
+	    		BOOST_REQUIRE(edgeWeights[i]==1.);
+    	}
+    }
+    BOOST_REQUIRE(checked==3);
 }
 
 bool

--- a/tests/test_graphofgrid.cpp
+++ b/tests/test_graphofgrid.cpp
@@ -1,0 +1,39 @@
+#include <config.h>
+
+#include <dune/common/version.hh>
+
+#define BOOST_TEST_MODULE GraphRepresentationOfGrid
+#define BOOST_TEST_NO_MAIN
+#include <boost/test/unit_test.hpp>
+#include <opm/grid/CpGrid.hpp>
+
+#include <opm/grid/GraphOfGrid.cpp>
+
+BOOST_AUTO_TEST_CASE(SimpleGraph)
+{
+	Dune::CpGrid grid;
+	std::array<int,3> dims{2,2,2};
+	std::array<double,3> size{2.,2.,2.};
+	grid.createCartesian(dims,size);
+	Opm::GraphOfGrid gog(grid);
+	BOOST_REQUIRE(gog.size()==8); // number of graph vertices
+	BOOST_REQUIRE(gog.numEdges(0)==3); // each vertex has 3 neighbors
+	// vertex 1 and vertex 2 are neighbors
+}
+
+BOOST_AUTO_TEST_CASE(GrapWithWell)
+{
+}
+
+bool
+init_unit_test_func()
+{
+    return true;
+}
+
+int main(int argc, char** argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+    boost::unit_test::unit_test_main(&init_unit_test_func,
+                                     argc, argv);
+}

--- a/tests/test_graphofgrid.cpp
+++ b/tests/test_graphofgrid.cpp
@@ -114,7 +114,9 @@ BOOST_AUTO_TEST_CASE(WrapperForZoltan)
     BOOST_REQUIRE(edgeWeights[203]==1.); // all are 1., no vertices were contracted
 
     numEdges[16] = 8;
-    std::cerr << "Expecting an error message from getGraphOfGridEdgeList, the vertex " << gIDs[16] << " has a wrong number of edges." <<std::endl;
+    std::string message("Expecting an error message from getGraphOfGridEdgeList, the vertex "
+                        + gIDs[16] + std::string(" has a wrong number of edges."));
+    Opm::OpmLog::info(message);
     getGraphOfGridEdgeList(&gog, 1, 1, nVer, gIDs, lIDs, numEdges, nborGIDs, nborProc, 1, edgeWeights, &err);
     BOOST_REQUIRE(err==ZOLTAN_FATAL);
 }

--- a/tests/test_graphofgrid.cpp
+++ b/tests/test_graphofgrid.cpp
@@ -18,7 +18,29 @@ BOOST_AUTO_TEST_CASE(SimpleGraph)
 	Opm::GraphOfGrid gog(grid);
 	BOOST_REQUIRE(gog.size()==8); // number of graph vertices
 	BOOST_REQUIRE(gog.numEdges(0)==3); // each vertex has 3 neighbors
-	// vertex 1 and vertex 2 are neighbors
+	auto edgeL = gog.edgeList(2);
+	BOOST_REQUIRE(edgeL.size()==3); // neighbors of vertex 2 are: 0, 3, 6
+	BOOST_REQUIRE(edgeL[0]==1.);
+	BOOST_REQUIRE(edgeL[3]==1.);
+	BOOST_REQUIRE(edgeL[6]==1.);
+
+	gog.contractVertices(0,1);
+	BOOST_REQUIRE(gog.size()==7);
+	edgeL = gog.edgeList(0);
+	BOOST_REQUIRE(edgeL.size()==4);
+	BOOST_REQUIRE(edgeL[2]==1);
+	BOOST_REQUIRE(edgeL[3]==1);
+	
+	gog.contractVertices(0,2);
+	BOOST_REQUIRE(gog.size()==6);
+	BOOST_REQUIRE(gog.getVertex(0).weight==3.);
+	edgeL = gog.edgeList(0);
+	BOOST_REQUIRE(edgeL.size()==4);
+	BOOST_REQUIRE(edgeL[3]==2);
+	BOOST_REQUIRE(gog.edgeList(3)[0]==2);
+	BOOST_REQUIRE_MESSAGE(gog.getVertex(1).weight==0.,"Implementation detail: \
+		Looking up vertex not present in GraphofGrid gives dummy with weight 0.");
+
 }
 
 BOOST_AUTO_TEST_CASE(GrapWithWell)

--- a/tests/test_graphofgrid.cpp
+++ b/tests/test_graphofgrid.cpp
@@ -16,35 +16,140 @@ BOOST_AUTO_TEST_CASE(SimpleGraph)
 	std::array<double,3> size{2.,2.,2.};
 	grid.createCartesian(dims,size);
 	Opm::GraphOfGrid gog(grid);
+
 	BOOST_REQUIRE(gog.size()==8); // number of graph vertices
 	BOOST_REQUIRE(gog.numEdges(0)==3); // each vertex has 3 neighbors
+
 	auto edgeL = gog.edgeList(2);
 	BOOST_REQUIRE(edgeL.size()==3); // neighbors of vertex 2 are: 0, 3, 6
 	BOOST_REQUIRE(edgeL[0]==1.);
 	BOOST_REQUIRE(edgeL[3]==1.);
 	BOOST_REQUIRE(edgeL[6]==1.);
+	BOOST_REQUIRE(edgeL[4]==0.); // not a neighbor (beware! size got increased)
+}
 
+BOOST_AUTO_TEST_CASE(SimpleGraphWithVertexContraction)
+{
+	Dune::CpGrid grid;
+	std::array<int,3> dims{2,2,2};
+	std::array<double,3> size{2.,2.,2.};
+	grid.createCartesian(dims,size);
+	Opm::GraphOfGrid gog(grid);
+
+	auto edgeL = gog.edgeList(2);
 	gog.contractVertices(0,1);
 	BOOST_REQUIRE(gog.size()==7);
 	edgeL = gog.edgeList(0);
 	BOOST_REQUIRE(edgeL.size()==4);
 	BOOST_REQUIRE(edgeL[2]==1);
 	BOOST_REQUIRE(edgeL[3]==1);
-	
+
 	gog.contractVertices(0,2);
 	BOOST_REQUIRE(gog.size()==6);
 	BOOST_REQUIRE(gog.getVertex(0).weight==3.);
 	edgeL = gog.edgeList(0);
 	BOOST_REQUIRE(edgeL.size()==4);
 	BOOST_REQUIRE(edgeL[3]==2);
+	BOOST_REQUIRE(gog.edgeList(3).size()==2);
 	BOOST_REQUIRE(gog.edgeList(3)[0]==2);
 	BOOST_REQUIRE_MESSAGE(gog.getVertex(1).weight==0.,"Implementation detail: \
 		Looking up vertex not present in GraphofGrid gives dummy with weight 0.");
 
+    auto v5e = gog.getVertex(5).edges;
+	BOOST_REQUIRE(v5e==gog.edgeList(5));
+	BOOST_REQUIRE(v5e==gog.edgeList(6)); // 5 and 6 have the same neighbors (1, 2 got merged)
+	BOOST_REQUIRE(v5e!=gog.edgeList(7));
+
+	auto it = gog.begin();
+	BOOST_REQUIRE(it->first==0); // gID are ordered, 0 is first
+	++it;
+	BOOST_REQUIRE(it->first==3); // 1, 2 got merged, 3 is next
+}
+
+#include <opm/grid/GraphOfGridWrappers.cpp>
+
+BOOST_AUTO_TEST_CASE(WrapperForZoltan)
+{
+	Dune::CpGrid grid;
+	std::array<int,3> dims{5,4,3};
+	std::array<double,3> size{1.,1.,1.};
+	grid.createCartesian(dims,size);
+	Opm::GraphOfGrid gog(grid);
+
+    int err;
+    int nVer = getGraphOfGridNumVertices(&gog,&err);
+    BOOST_REQUIRE(err==ZOLTAN_OK);
+    BOOST_REQUIRE(nVer == 60);
+
+    int gIDs[nVer], lIDs[0];
+    float objWeights[nVer];
+    getGraphOfGridVerticesList(&gog, 1, 1, gIDs, lIDs, 1, objWeights, &err);
+    BOOST_REQUIRE(err==ZOLTAN_OK);
+    BOOST_REQUIRE(gIDs[6]==6);
+    BOOST_REQUIRE(gIDs[59]==59);
+    BOOST_REQUIRE(objWeights[18]==1);
+
+    int numEdges[nVer];
+    getGraphOfGridNumEdges(&gog, 1, 1, nVer, gIDs, lIDs, numEdges, &err);
+    BOOST_REQUIRE(err==ZOLTAN_OK);
+    BOOST_REQUIRE(numEdges[0]==3);
+    BOOST_REQUIRE(numEdges[9]==4);
+    BOOST_REQUIRE(numEdges[37]==5);
+    BOOST_REQUIRE(numEdges[26]==6);
+
+    int nEdges=0;
+    for (int i=0; i<nVer; ++i)
+    	nEdges += numEdges[i];
+    BOOST_REQUIRE(nEdges==266);
+
+    int nborGIDs[nEdges];
+    int nborProc[nEdges];
+    float edgeWeights[nEdges];
+    getGraphOfGridEdgeList(&gog, 1, 1, nVer, gIDs, lIDs, numEdges, nborGIDs, nborProc, 1, edgeWeights, &err);
+    BOOST_REQUIRE(err==ZOLTAN_OK);
+    BOOST_REQUIRE_MESSAGE(nborProc[145]==0, "Implementation detail: default process in GraphofGrid is 0");
+    BOOST_REQUIRE(edgeWeights[203]==1.); // all are 1., no vertices were contracted
+
+    numEdges[16] = 8;
+    std::cerr << "Expecting an error message from getGraphOfGridEdgeList, the vertex 16 has a wrong number of edges." <<std::endl;
+    getGraphOfGridEdgeList(&gog, 1, 1, nVer, gIDs, lIDs, numEdges, nborGIDs, nborProc, 1, edgeWeights, &err);
+    BOOST_REQUIRE(err==ZOLTAN_FATAL);
 }
 
 BOOST_AUTO_TEST_CASE(GrapWithWell)
 {
+	Dune::CpGrid grid;
+	std::array<int,3> dims{5,4,3};
+	std::array<double,3> size{1.,1.,1.};
+	grid.createCartesian(dims,size);
+	Opm::GraphOfGrid gog(grid);
+
+    std::unordered_map<std::string, std::set<int>> wells{
+    	{"shape L on the front face", {5,10,15,35,55} },
+    	{"lying 8 on the right face", {20,1,41,22,3,43,24} },
+    	{"disconnected vertices", {58,12} } };
+    addFutureConnectionWell(gog,wells);
+    int err;
+    int nVer = getGraphOfGridNumVertices(&gog,&err);
+    BOOST_REQUIRE(err==ZOLTAN_OK);
+    BOOST_REQUIRE(nVer == 49);
+
+	int gIDs[nVer], lIDs[0];
+    float objWeights[nVer];
+    getGraphOfGridVerticesList(&gog, 1, 1, gIDs, lIDs, 1, objWeights, &err);
+    BOOST_REQUIRE(err=ZOLTAN_OK);
+    BOOST_REQUIRE(gIDs[48]==59); // last ID
+    BOOST_REQUIRE(gIDs[47]==57); // pre-last, 58 was contracted to 12
+    BOOST_REQUIRE(gIDs[4]==5); // 3 was contracted to 1
+    BOOST_REQUIRE(objWeights[1]==7.); // well with 7 vertices
+    BOOST_REQUIRE(objWeights[4]==5.); // well with 5 vertices
+    BOOST_REQUIRE(gIDs[19]==25);
+    BOOST_REQUIRE(objWeights[19]==1.); // ordinary vertex
+
+	// Well well1("SomeName1",std::array<int>{0,1,2,3,4});
+	// Well well2("SomeName2",std::array<int>{52,32,12});
+	// Well well3("SomeName3",std::array<int>{59,48,37});
+	// Well well4("SomeName4",std::array<int>{37,38,39,34}); // merges with well3
 }
 
 bool


### PR DESCRIPTION
Graph representation of the grid.
Purpose: Loadbalancing of the grid with wells. Each well is represented with a single vertex in the graph repr. of the grid, therefore no well can be spread over multiple processes.

What is implemented so far:

    GraphofGrid -class that stores the representation. Needs a grid (currently CpGrid) to build the graph. Has functions for searching for cells by their global IDs, adding wells, and vertex contraction.
        Edge weights (transmissibilities) currently start equal to 1, and are possibly added up when contracted vertices have a common neighbor
    wrappers for Zoltan callback functions (not tested with Zoltan yet though)
    unit test for the above

This is #774 reopened due to a github glitch.