### PR TITLE
changed: avoid use of deprecated Factorial struct

### DIFF
--- a/opm/grid/common/Volumes.hpp
+++ b/opm/grid/common/Volumes.hpp
@@ -107,7 +107,11 @@ namespace Dune
         for (int i = 0; i < Dim; ++i) {
             tmp[i] = a[i+1] - a[i];
         }
+#if DUNE_VERSION_GTE(DUNE_COMMON, 2, 9)
+        return determinantOf(tmp) / double(factorial(Dim));
+#else
         return determinantOf(tmp) / double(Factorial<Dim>::factorial);
+#endif
         // determinant / factorial
     }
 


### PR DESCRIPTION
Quells a warning with clang.

"Use function factorial instead! Will be removed after Dune 2.9"