### PR TITLE
[refactor/clean-up] Partition type for cell [refactor] and face [new] to support LGRs on distributed grid

### DIFF
--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -2199,10 +2199,10 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
 
         for (std::size_t level = 0; level < cells_per_dim_vec.size()+1; ++level) {
             for(const auto& element : elements(levelGridView(level))) {
-                if (element.partitionTypeWhenLgrs(globalActiveLgrs) == InteriorEntity) {
+                if (element.partitionType() == InteriorEntity) {
                     ++local_owned_cells_per_level[level];
                 }
-                if (element.partitionTypeWhenLgrs(globalActiveLgrs) == OverlapEntity) {
+                if (element.partitionType() == OverlapEntity) {
                     ++local_overlap_cells_per_level[level];
                 }
             }
@@ -2294,7 +2294,7 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
                 }
             }
             for(const auto& element : elements(levelGridView(level))) {
-                if (element.partitionTypeWhenLgrs(globalActiveLgrs) == InteriorEntity) {
+                if (element.partitionType() == InteriorEntity) {
                     localToGlobal_owned_cells_per_level[level-1][element.index()] = globalIdCell;
                     ++globalIdCell;
                 }
@@ -2378,13 +2378,13 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
         leaf_index_set.beginResize();
 
         for(const auto& element : elements(leafGridView())) {
-            const auto& elemPartitionType = element.getEquivLevelElem().partitionTypeWhenLgrs(globalActiveLgrs);
+            const auto& elemPartitionType = element.getEquivLevelElem().partitionType();
             if ( elemPartitionType == InteriorEntity) {
                 // Check if it has an overlap neighbor
                 bool isFullyInterior = true;
                 for (const auto& intersection : intersections(leafGridView(), element)) {
                     if ( intersection.neighbor() ) {
-                        const auto& neighborPartitionType = intersection.outside().getEquivLevelElem().partitionTypeWhenLgrs(globalActiveLgrs);
+                        const auto& neighborPartitionType = intersection.outside().getEquivLevelElem().partitionType();
                         // To help detection of fully interior cells, i.e., without overlap neighbors
                         if (neighborPartitionType == OverlapEntity )  {
                             isFullyInterior = false;

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -183,13 +183,10 @@ public:
 
     /// @brief In serial run, the only partitionType() is InteriorEntity.
     ///        Only needed when distributed_data_ is not empty.
-    PartitionType partitionType() const;
-
-    /// @brief For parallel run, the entity - for now - does not see the CpGrid therefore we pass a bool to make
-    ///        the entity aware of the fact the the grid has been distributed.
-    ///        Each cell inherits the partition type of its origin (either parent cell or equivalent cell in level 0).
+    ///        In parallel run, the entity each cell inherits the partition type of its origin
+    ///        (either parent cell or equivalent cell in level 0).
     ///        Only needed when distributed_data_ is not empty.
-    PartitionType partitionTypeWhenLgrs(bool) const;
+    PartitionType partitionType() const;
 
     /// @brief Return marker object (GeometryType object) representing the reference element of the entity.
     ///        Currently, cube type for all entities (cells and vertices).
@@ -362,11 +359,6 @@ PartitionType Entity<codim>::partitionType() const
     return pgrid_->partition_type_indicator_->getPartitionType(*this);
 }
 
-template <int codim>
-PartitionType Entity<codim>::partitionTypeWhenLgrs(bool lgrsOnDistributedGrid) const
-{
-    return pgrid_->partition_type_indicator_->getPartitionTypeWhenLgrs(*this, lgrsOnDistributedGrid);
-}
 } // namespace cpgrid
 } // namespace Dune
 

--- a/opm/grid/cpgrid/PartitionTypeIndicator.cpp
+++ b/opm/grid/cpgrid/PartitionTypeIndicator.cpp
@@ -9,21 +9,13 @@ namespace Dune
 {
 namespace cpgrid
 {
-PartitionType PartitionTypeIndicator::getPartitionType(const EntityRep<0>& cell_entity) const
+PartitionType PartitionTypeIndicator::getPartitionType(const Entity<0>& cell_entity) const
 {
     if(cell_indicator_.size())
         return PartitionType(cell_indicator_[cell_entity.index()]);
-    return InteriorEntity;
-}
-
-PartitionType PartitionTypeIndicator::getPartitionTypeWhenLgrs(const Entity<0>& cell_entity, bool lgrsOnDistributedGrid) const
-{
-    if(cell_indicator_.size())
-        return PartitionType(cell_indicator_[cell_entity.index()]);
-    // Assuming grid has been distributed and some LGRs have been added afterwards.
-    // For level 0, it's defined. For other levels, the refined cell inherits its father
-    // attribute.
-    if((grid_data_->level_data_ptr_->size()>1) && lgrsOnDistributedGrid) {
+    // When level zero grid has been distributed and some LGRs have been added afterwards, refined cells
+    // inherit its parent cell attribute.
+    if (grid_data_->level_ >0) { // level_ > 0 only for refined level grids.
         return PartitionType(grid_data_->level_data_ptr_->front()->partition_type_indicator_->getPartitionType(cell_entity.getOrigin()));
     }
     return InteriorEntity;

--- a/opm/grid/cpgrid/PartitionTypeIndicator.hpp
+++ b/opm/grid/cpgrid/PartitionTypeIndicator.hpp
@@ -55,14 +55,11 @@ public:
     : grid_data_(&data)
     {}
     /// Get the partition type of a cell.
+    /// Distributed level zero grid, added LGRs afterwards: When the cell belongs to a refined level grid, partition type
+    /// is inherited from its parent cell from level zero.
     /// \param cell_entity The entity describing the cell
     /// \return The partition type of the cell.
-    PartitionType getPartitionType(const EntityRep<0>& cell_entity) const;
-    /// Get the partition type of a cell on a grid that has been distributed, and refined afterwards.
-    /// \param cell_entity The entity describing the cell (Entity::getOrigin() invoked, therefore EntityRep<0> not enough)
-    /// \param lgrsOnDistributedGrid
-    /// \return The partition type of the cell.
-    PartitionType getPartitionTypeWhenLgrs(const Entity<0>& cell_entity, bool lgrsOnDistributedGrid) const;
+    PartitionType getPartitionType(const Entity<0>& cell_entity) const;
     /// Get the partition type of a face.
     /// \param face_entity The entity describing the face
     /// \return The partition type of the face.

--- a/tests/cpgrid/addLgrsOnDistributedGrid_test.cpp
+++ b/tests/cpgrid/addLgrsOnDistributedGrid_test.cpp
@@ -366,7 +366,7 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
     localInteriorCellIds_vec.reserve(data.back()->size(0)); // more than actually needed since only care about interior cells
     int local_interior_cells_count = 0;
     for (const auto& element: elements(coarse_grid.leafGridView())) {
-         const auto& elemPartitionType = element.getEquivLevelElem().partitionTypeWhenLgrs(true);
+         const auto& elemPartitionType = element.getEquivLevelElem().partitionType();
          if ( elemPartitionType == Dune::InteriorEntity) {
             localInteriorCellIds_vec.push_back(data.back()->globalIdSet().id(element));
             ++local_interior_cells_count;


### PR DESCRIPTION
Refactor getPartitionType(...) to take into account LGRs., as well as improves on cleaning code and avoiding duplication. 
New/refactor: getFacePartitionType(...)  has been refactor to take into account refined level grids. 

Not relevant for the Reference Manual. 