### PR TITLE
[refactor] LevelCartesianIndexMapper for PolyhedralGrid to eliminate repeated code

### DIFF
--- a/opm/grid/cpgrid/LevelCartesianIndexMapper.hpp
+++ b/opm/grid/cpgrid/LevelCartesianIndexMapper.hpp
@@ -52,7 +52,7 @@ template<>
 class LevelCartesianIndexMapper<Dune::CpGrid>
 {
 public:
-    static const int dimension = 3 ;
+    static constexpr int dimension = 3 ;
 
     explicit LevelCartesianIndexMapper(const Dune::CpGrid& grid) : grid_{ &grid }
     {}

--- a/tests/test_lookupdata_polyhedral.cpp
+++ b/tests/test_lookupdata_polyhedral.cpp
@@ -91,8 +91,6 @@ void lookup_check(const Dune::PolyhedralGrid<3,3>& grid)
 
     std::vector<double> fake_feature_double(grid.size(0), 0.);
     std::iota(fake_feature_double.begin(), fake_feature_double.end(), .5);
-
-    const Opm::LevelCartesianIndexMapper< Dune::PolyhedralGrid<3,3> > levelCartMapp(grid);
     
     const auto leaf_view = grid.leafGridView();
     using GridView = std::remove_cv_t< typename std::remove_reference<decltype(grid.leafGridView())>::type>;
@@ -100,6 +98,7 @@ void lookup_check(const Dune::PolyhedralGrid<3,3>& grid)
     const Opm::LookUpData<Dune::PolyhedralGrid<3,3>, GridView> lookUpData(leaf_view, false);
     // LookUpCartesianData
     const Dune::CartesianIndexMapper<Dune::PolyhedralGrid<3,3>> cartMapper(grid);
+    const Opm::LevelCartesianIndexMapper< Dune::PolyhedralGrid<3,3> > levelCartMapp(cartMapper);
     const Opm::LookUpCartesianData<Dune::PolyhedralGrid<3,3>, GridView> lookUpCartesianData(leaf_view, cartMapper, false);
     // Mapper
     const Dune::MultipleCodimMultipleGeomTypeMapper<GridView> mapper(grid.leafGridView(), Dune::mcmgElementLayout());


### PR DESCRIPTION
Minor change missed to be commented in OPM/opm-grid#793 (declare constrexpr also in the specialized classes).

Refactor specialization for PolyhedralGrid to avoid repetition of code, following the lines of Object Adapter design pattern.  

Not relevant for the Reference Manual.

