### PR TITLE
Replace outdated macro (removed in dune 2.10)

### DIFF
--- a/opm/grid/cpgrid/Entity2IndexDataHandle.hpp
+++ b/opm/grid/cpgrid/Entity2IndexDataHandle.hpp
@@ -64,7 +64,7 @@ public:
         : fromGrid_(fromGrid), toGrid_(toGrid), data_(data)
     {}
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 8)
+#if DUNE_VERSION_GTE(DUNE_COMMON, 2, 8)
     bool fixedSize()
     {
         return data_.fixedSize(3, codim);


### PR DESCRIPTION
The macro redefinition already existed in 2.7 so it shouldn't be a problem to change this.

Of course an alternative is to remove the version check altogether