### PR TITLE
Point ids for refined grids and addLgrsUpdateLeafGridView refactorization

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -202,6 +202,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/grid/LookUpData.hh
   opm/grid/cpgrid/OrientedEntityTable.hpp
   opm/grid/cpgrid/ParentToChildrenCellGlobalIdHandle.hpp
+	opm/grid/cpgrid/ParentToChildCellToPointGlobalIdHandle.hpp
   opm/grid/cpgrid/PartitionIteratorRule.hpp
   opm/grid/cpgrid/PartitionTypeIndicator.hpp
   opm/grid/cpgrid/PersistentContainer.hpp

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -2239,6 +2239,41 @@ void CpGridData::validStartEndIJKs(const std::vector<std::array<int,3>>& startIJ
     }
 }
 
+bool CpGridData::compatibleSubdivisions(const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                        const std::vector<std::array<int,3>>& startIJK_vec,
+                                        const std::vector<std::array<int,3>>& endIJK_vec) const
+{
+    bool compatibleSubdivisions = true;
+    if (startIJK_vec.size() > 1) {
+        bool notAllowedYet = false;
+        for (std::size_t level = 0; level < startIJK_vec.size(); ++level) {
+            for (std::size_t otherLevel = level+1; otherLevel < startIJK_vec.size(); ++otherLevel) {
+                const auto& sharedFaceTag = this-> sharedFaceTag({startIJK_vec[level], startIJK_vec[otherLevel]}, {endIJK_vec[level],endIJK_vec[otherLevel]});
+                if(sharedFaceTag == -1){
+                    break; // Go to the next "other patch"
+                }
+                if (sharedFaceTag == 0 ) {
+                    notAllowedYet = notAllowedYet ||
+                        ((cells_per_dim_vec[level][1] != cells_per_dim_vec[otherLevel][1]) || (cells_per_dim_vec[level][2] != cells_per_dim_vec[otherLevel][2]));
+                }
+                if (sharedFaceTag == 1) {
+                    notAllowedYet = notAllowedYet ||
+                        ((cells_per_dim_vec[level][0] != cells_per_dim_vec[otherLevel][0]) || (cells_per_dim_vec[level][2] != cells_per_dim_vec[otherLevel][2]));
+                }
+                if (sharedFaceTag == 2) {
+                    notAllowedYet = notAllowedYet ||
+                        ((cells_per_dim_vec[level][0] != cells_per_dim_vec[otherLevel][0]) || (cells_per_dim_vec[level][1] != cells_per_dim_vec[otherLevel][1]));
+                }
+                if (notAllowedYet){
+                    compatibleSubdivisions = false;
+                    break;
+                }
+            } // end-otherLevel-for-loop
+        } // end-level-for-loop
+    }// end-if-patchesShareFace
+    return compatibleSubdivisions;
+}
+
 Geometry<3,3> CpGridData::cellifyPatch(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK,
                                        const std::vector<int>& patch_cells,
                                        DefaultGeometryPolicy& cellifiedPatch_geometry,

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -364,9 +364,9 @@ public:
     /// @brief Check startIJK and endIJK of each patch of cells to be refined are valid, i.e.
     ///        startIJK and endIJK vectors have the same size and, startIJK < endIJK coordenate by coordenate.
     ///
-    /// @param [in]  startIJK_vec  Vector of Cartesian triplet indices where each patch starts.
-    /// @param [in]  endIJK_vec    Vector of Cartesian triplet indices where each patch ends.
-    ///                            Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
+    /// @param [in]  startIJK_vec       Vector of Cartesian triplet indices where each patch starts.
+    /// @param [in]  endIJK_vec         Vector of Cartesian triplet indices where each patch ends.
+    ///                                 Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
     void validStartEndIJKs(const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
 
     /// @brief Check that every cell to be refined has cuboid shape.
@@ -412,6 +412,25 @@ public:
     void postAdapt();
 
 private:
+    /// @brief Check compatibility of number of subdivisions of neighboring LGRs.
+    ///
+    /// Check shared faces on boundaries of LGRs. Not optimal since the code below does not take into account
+    /// active/inactive cells, instead, relies on "ijk-computations".
+    ///
+    /// @param [in]  cells_per_dim_vec    Vector of expected subdivisions per cell, per direction, in each LGR.
+    /// @param [in]  startIJK_vec         Vector of Cartesian triplet indices where each patch starts.
+    /// @param [in]  endIJK_vec           Vector of Cartesian triplet indices where each patch ends.
+    ///                                   Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
+    /// @return True if all block of cells either do not share faces on their boundaries, or they may share faces with compatible
+    ///         subdivisions. Example: block1 and block2 share an I_FACE, then number of subdivisions NY NZ should coincide, i.e.
+    ///         if block1, block2 cells_per_dim values are {NX1, NY1, NZ1}, {NX2, NY2, NZ2}, respectively, then NY1 == NY2 and
+    ///         NZ1 == Nz2.
+    ///         False if at least two blocks share a face and their subdivions are not compatible. In the example above,
+    ///         if NY1 != NY2 or NZ1 != NZ2.
+    bool compatibleSubdivisions(const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                const std::vector<std::array<int,3>>& startIJK_vec,
+                                const std::vector<std::array<int,3>>& endIJK_vec) const;
+
     std::array<Dune::FieldVector<double,3>,8> getReferenceRefinedCorners(int idx_in_parent_cell, const std::array<int,3>& cells_per_dim) const;
 
     /// @brief Compute amount of cells in each direction of a patch of cells. (Cartesian grid required).

--- a/opm/grid/cpgrid/ParentToChildCellToPointGlobalIdHandle.hpp
+++ b/opm/grid/cpgrid/ParentToChildCellToPointGlobalIdHandle.hpp
@@ -1,0 +1,177 @@
+//===========================================================================
+//
+// File: ParentToChildCellToPointGlobalIdHandle.hpp
+//
+// Created: November 19 2024
+//
+// Author(s): Antonella Ritorto <antonella.ritorto@opm-op.com>
+//            Markus Blatt      <markus.blatt@opm-op.com>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2024 Equinor ASA
+  This file is part of The Open Porous Media project  (OPM).
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_PARENTTOCHILDCELLTOPOINTGLOBALIDHANDLE_HEADER
+#define OPM_PARENTTOCHILDCELLTOPOINTGLOBALIDHANDLE_HEADER
+
+#include <opm/grid/common/CommunicationUtils.hpp>
+#include <opm/grid/cpgrid/Entity.hpp>
+
+#include <array>
+#include <tuple>
+#include <vector>
+
+
+namespace
+{
+#if HAVE_MPI
+
+/// \brief Handle for assignment of point global ids of refined cells.
+struct ParentToChildCellToPointGlobalIdHandle {
+    //   - The container used for gather and scatter contains "candidates" point global ids for interior elements of the refined level grids (LGRs).
+    //     Access is done with the local index of its parent cell index and its parent cell list of children.
+    //     level_point_global_ids[ level-1 ][ child_cell_local_index [ corner ] ] = "candidate" point global id,
+    //     when child_cell_local_index belongs to the children_local_index_list:
+    //     parent_to_children_[ element.index() ] =  parent_to_children_[ element.index() ] = { level, children_local_index_list }
+    //     and corner = 0, ...,7.
+    //     To decide which "candidate" point global id wins, we use the rank. The smallest ranks wins,
+    //     i.e., the other non-selected candidates get rewritten with the values from the smallest (winner) rank.
+    //   - In the scatter method, the "winner" rank and the 8 point global ids of each number of children) get rewritten.
+
+    using DataType = int;
+
+    /// \param comm                    Communication
+    /// \param parent_to_children      Map from parent index to all children, and the level they are stored.
+    ///                                parent_to_children_[ element.index() ] = { level, children_list local indices }
+    /// \param level_cell_to_point
+    /// \param level_point_global_ids  A container that for the elements of a level contains all candidate point global ids.
+    /// \param level_winning_ranks
+    /// \param level_point_global_ids
+    ParentToChildCellToPointGlobalIdHandle(const Dune::CpGrid::Communication& comm,
+                                           const std::vector<std::tuple<int, std::vector<int>>>& parent_to_children,
+                                           const std::vector<std::vector<std::array<int,8>>>& level_cell_to_point,
+                                           std::vector<std::vector<DataType>>& level_winning_ranks,
+                                           std::vector<std::vector<DataType>>& level_point_global_ids)
+    : comm_(comm)
+    , parent_to_children_(parent_to_children)
+    , level_cell_to_point_(level_cell_to_point)
+    , level_winning_ranks_(level_winning_ranks)
+    , level_point_global_ids_(level_point_global_ids)
+    {}
+
+    bool fixedSize(std::size_t, std::size_t)
+    {
+        // Not every cell has children. When they have children, the amount might vary.
+        return false;
+    }
+
+    bool contains(std::size_t, std::size_t codim)
+    {
+        // Only communicate values attached to cells.
+        return codim == 0;
+    }
+
+    template <class T> // T = Entity<0>
+    std::size_t size(const T& element)
+    {
+        // Communicate variable size: 1 (rank) + (8* amount of child cells) from an interior parent cell from level zero grid.
+        // Skip values that are not interior, or have no children (in that case, 'invalid' level = -1)
+        const auto& [level, children] = parent_to_children_[element.index()];
+        // [Bug in dune-common] VariableSizeCommunicator will deadlock if a process attempts to send a message of size zero.
+        // This can happen if the size method returns zero for all entities that are shared with another process.
+        // Therefore, when skipping cells without children or for overlap cells, we set the size to 1.
+        if ( (element.partitionType() != Dune::InteriorEntity) || (level == -1))
+            return 1;
+        return 1 + ( 8*children.size()); // rank + 8 "winner" point global ids per child cell
+    }
+
+    // Gather global ids of child cells of a coarse interior parent cell
+    template <class B, class T> // T = Entity<0>
+    void gather(B& buffer, const T& element)
+    {
+        // Skip values that are not interior, or have no children (in that case, 'invalid level' = -1)
+        const auto& [level, children] = parent_to_children_[element.index()];
+        // [Bug in dune-common] VariableSizeCommunicator will deadlock if a process tries to send a message with size zero.
+        // To avoid this, for cells without children or for overlap cells, we set the size to 1 and write a single DataType
+        // value (e.g., '42').
+        if ( (element.partitionType() != Dune::InteriorEntity) || (level==-1)) {
+            buffer.write(42);
+            return;
+        }
+        // Store the children's corner global ids in the buffer when the element is interior and has children.
+        // Write the rank first, for example via the "corner 0" of cell_to_point_ of the first child:
+        // First child: children[0]
+        // First corner of first child:  level_cell_to_point_[ level -1 ][children[0]] [0]
+        buffer.write( comm_.rank() );
+        for (const auto& child : children)
+            for (const auto& corner : level_cell_to_point_[level -1][child])
+                buffer.write(level_point_global_ids_[level-1][corner]);
+    }
+
+    // Scatter global ids of child cells of a coarse overlap parent cell
+    template <class B, class T> // T = Entity<0>
+    void scatter(B& buffer, const T& element, std::size_t size)
+    {
+        const auto& [level, children] = parent_to_children_[element.index()];
+        // Read all values to advance the pointer used by the buffer to the correct index.
+        // (Skip overlap-cells-without-children and interior-cells).
+        if ( ( (element.partitionType() == Dune::OverlapEntity) && (level==-1) ) || (element.partitionType() == Dune::InteriorEntity ) ) {
+            // Read all values to advance the pointer used by the buffer
+            // to the correct index
+            for (std::size_t received_int = 0; received_int < size;  ++received_int) {
+                DataType tmp;
+                buffer.read(tmp);
+            }
+        }
+        else { // Overlap cell with children.
+            // Read and store the values in the correct location directly.
+            // The order of the children is the same on each process.
+            assert(children.size()>0);
+            assert(level>0);
+            // Read and store the values in the correct location directly.
+            DataType tmp_rank;
+            buffer.read(tmp_rank);
+            for (const auto& child : children) {
+                for (const auto& corner : level_cell_to_point_[level -1][child]) {
+                    auto& min_rank = level_winning_ranks_[level-1][corner];
+                    // Rewrite the rank (smaller rank wins)
+                    if (tmp_rank < min_rank) {
+                        min_rank = tmp_rank;
+                        auto& target_entry = level_point_global_ids_[level-1][corner];
+                        buffer.read(target_entry);
+                    } else {
+                        DataType rubbish;
+                        buffer.read(rubbish);
+                    }
+                }
+            }
+        }
+    }
+
+private:
+    const Dune::CpGrid::Communication& comm_;
+    const std::vector<std::tuple<int, std::vector<int>>>& parent_to_children_;
+    const std::vector<std::vector<std::array<int,8>>>& level_cell_to_point_;
+    std::vector<std::vector<DataType>>& level_winning_ranks_;
+    std::vector<std::vector<DataType>>& level_point_global_ids_;
+};
+#endif // HAVE_MPI
+} // namespace
+#endif

--- a/tests/cpgrid/addLgrsOnDistributedGrid_test.cpp
+++ b/tests/cpgrid/addLgrsOnDistributedGrid_test.cpp
@@ -366,29 +366,18 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
         // Check global id is not duplicated for interior cells in each refined level grid.
         std::vector<int> interior_cell_global_ids;
         int local_interior_cell_count = 0;
-        interior_cell_global_ids.reserve(coarse_grid.currentData()[level]->size(0));
+        interior_cell_global_ids.reserve(data[level]->size(0));
+
         for (const auto& element: elements(coarse_grid.levelGridView(level), Dune::Partitions::interior)){
-            interior_cell_global_ids.push_back(coarse_grid.currentData()[level]->globalIdSet().id(element));
+            interior_cell_global_ids.push_back(data[level]->globalIdSet().id(element));
             ++local_interior_cell_count;
         }
+
         auto global_level_interior_cell_count = coarse_grid.comm().sum(local_interior_cell_count);
         auto [all_level_interior_cell_global_ids, displ] = Opm::allGatherv(interior_cell_global_ids, coarse_grid.comm());
         const std::set<int> all_level_interior_cell_global_ids_set(all_level_interior_cell_global_ids.begin(), all_level_interior_cell_global_ids.end());
         BOOST_CHECK( all_level_interior_cell_global_ids.size() == all_level_interior_cell_global_ids_set.size() );
         BOOST_CHECK( global_level_interior_cell_count == static_cast<int>(all_level_interior_cell_global_ids_set.size()) );
-
-        // Check global id is not duplicated for interior points in each refined level grid.
-        std::vector<int> interior_point_global_ids;
-        int local_interior_point_count = 0;
-        interior_point_global_ids.reserve(coarse_grid.currentData()[level]->size(3));
-        for (const auto& point : vertices(coarse_grid.levelGridView(level),  Dune::Partitions::interior)){
-            interior_point_global_ids.push_back(coarse_grid.currentData()[level]->globalIdSet().id(point));
-            ++local_interior_point_count;
-        }
-        auto global_level_interior_point_count = coarse_grid.comm().sum(local_interior_point_count);
-        auto [all_level_interior_point_global_ids, displ_point] = Opm::allGatherv(interior_point_global_ids, coarse_grid.comm());
-        const std::set<int> all_level_interior_point_global_ids_set(all_level_interior_point_global_ids.begin(), all_level_interior_point_global_ids.end());
-        BOOST_CHECK( static_cast<std::size_t>(global_level_interior_point_count)  == all_level_interior_point_global_ids_set.size() );
     }
 
     // Check global id is not duplicated for interior cells
@@ -409,20 +398,9 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
     BOOST_CHECK( static_cast<int>(allGlobalIds_cells.size()) == global_cells_count);
     BOOST_CHECK( allGlobalIds_cells.size() == allGlobalIds_cells_set.size() );
 
-    // Check global id is not duplicated for interior points
-    std::vector<int> localInteriorPointIds_vec;
-    localInteriorPointIds_vec.reserve(data.back()->size(3)); // more than actually needed since only care about interior points
-    int local_interior_points_count = 0;
-    for (const auto& point: vertices(coarse_grid.leafGridView(), Dune::Partitions::interior)) {
-        localInteriorPointIds_vec.push_back(data.back()->globalIdSet().id(point));
-        ++local_interior_points_count;
-    } 
-    auto global_point_count  = coarse_grid.comm().sum(local_interior_points_count);
-    auto [allGlobalIds_points, displ_point] = Opm::allGatherv(localInteriorPointIds_vec, coarse_grid.comm());
-
-    const std::set<int> allGlobalIds_points_set(allGlobalIds_points.begin(), allGlobalIds_points.end());
-    BOOST_CHECK( static_cast<int>(allGlobalIds_points.size()) == global_point_count);
-    BOOST_CHECK( allGlobalIds_points.size() == allGlobalIds_points_set.size() );
+    /** [Bug] Uniqueness of point global ids cannot be checked in general since current code sets overlap layer size equal to 1,
+        which in particular means that cells that share corners or edges (and not faces) with interior cells are not considered/
+        seen by the process. Therefore, depending how the LGRs are distributed, there may be "multiple ids" for the same points.*/
 
     // Local/Global id sets for level grids (level 0, 1, ..., maxLevel). For level grids, local might differ from global id.
     for (int level = 0; level < coarse_grid.maxLevel() +1; ++level)
@@ -520,6 +498,26 @@ BOOST_AUTO_TEST_CASE(threeLgrs)
         // Leaf grid view total amount of cells: 10x8x8 -6 + 32 + 27 + 64 = 757
         refinePatch_and_check(grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
 
+        // Check global id is not duplicated for points for each LGR
+        // LGR1 dim 4x2x4 -> 5x3x5 = 75 points
+        // LGR2 dim 3x3x3 -? 4x4x4 = 64 points
+        // LGR3 dim 4x4x4 -> 5x5x5 = 125 points
+        const std::vector<int>& expected_point_ids_per_lgr = { 75, 64, 125};
+        for (int lgr = 1; lgr < 4; ++lgr) {
+            std::vector<int> local_point_ids;
+            local_point_ids.reserve(expected_point_ids_per_lgr[lgr-1]);
+            for (const auto& element : elements(grid.levelGridView(lgr))) {
+                for (int corner = 0; corner < 8; ++corner)
+                {
+                    const auto& point = element.subEntity<3>(corner);
+                    local_point_ids.push_back(grid.currentData()[lgr]->globalIdSet().id(point));
+                }
+            }
+            auto [all_point_ids, displPoint ] = Opm::allGatherv(local_point_ids, grid.comm());
+            const std::set<int> all_point_ids_set(all_point_ids.begin(), all_point_ids.end());
+            BOOST_CHECK( static_cast<int>(all_point_ids_set.size()) == expected_point_ids_per_lgr[lgr-1]);
+        }
+
         // Check global id is not duplicated for points
         std::vector<int> localPointIds_vec;
         localPointIds_vec.reserve(grid.currentData().back()->size(3));
@@ -567,13 +565,34 @@ BOOST_AUTO_TEST_CASE(atLeastOneLgr_per_process_attempt)
         // LGR4 element indices = 27, 31 in rank 3.Total 16 refined cells, 45 points (45-12 = 33 with new global id).
         grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
 
-        // LGR1 dim 1x2x1 (16 refined cells)
-        // LGR2 dim 1x1x1 (27 refined cells)
-        // LGR3 dim 1x1x1 (64 refined cells)
-        // LGR4 dim 1x2x1 (16 refined cells) 3x5x3
+        // LGR1 dim 2x4x2 (16 refined cells)
+        // LGR2 dim 3x3x3 (27 refined cells)
+        // LGR3 dim 4x4x4 (64 refined cells)
+        // LGR4 dim 2x4x2 (16 refined cells)
         // Total global ids in leaf grid view for cells: 36-(6 marked cells) + 16 + 27 + 64 + 16 = 153
         // Total global ids in leaf grid view for points: 80 + 33 + 56 + 117 + 33 = 319
         refinePatch_and_check(grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+        
+        // Check global id is not duplicated for points for each LGR
+        // LGR1 dim 2x4x2 -> 3x5x3 = 45 points
+        // LGR2 dim 3x3x3 -> 4x4x4 = 64 points
+        // LGR3 dim 4x4x4 -> 5x5x5 = 125 points
+        // LGR4 dim 2x4x2 -> 3x5x3 = 45 points
+        const std::vector<int>& expected_point_ids_per_lgr = { 45, 64, 125, 45};
+        for (int lgr = 1; lgr < 5; ++lgr) {
+            std::vector<int> local_point_ids;
+            local_point_ids.reserve(expected_point_ids_per_lgr[lgr-1]);
+            for (const auto& element : elements(grid.levelGridView(lgr))) {
+                for (int corner = 0; corner < 8; ++corner)
+                {
+                    const auto& point = element.subEntity<3>(corner);
+                    local_point_ids.push_back(grid.currentData()[lgr]->globalIdSet().id(point));
+                }
+            }
+            auto [all_point_ids, displPoint ] = Opm::allGatherv(local_point_ids, grid.comm());
+            const std::set<int> all_point_ids_set(all_point_ids.begin(), all_point_ids.end());
+            BOOST_CHECK( static_cast<int>(all_point_ids_set.size()) == expected_point_ids_per_lgr[lgr-1]);
+        }
 
         // Check global id is not duplicated for points
         std::vector<int> localPointIds_vec;
@@ -584,7 +603,6 @@ BOOST_AUTO_TEST_CASE(atLeastOneLgr_per_process_attempt)
         }
         auto [allGlobalIds_points, displPoint ] = Opm::allGatherv(localPointIds_vec, grid.comm());
         const std::set<int> allGlobalIds_points_set(allGlobalIds_points.begin(), allGlobalIds_points.end());
-
         // Total global ids in leaf grid view for points: 80 + 33 + 56 + 117 + 33 = 319
         BOOST_CHECK( allGlobalIds_points_set.size() == 319 );
     }
@@ -623,6 +641,39 @@ BOOST_AUTO_TEST_CASE(throw_not_fully_interior_lgr)
 
         grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
         refinePatch_and_check(grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+
+        // Check global id is not duplicated for points for each LGR
+        // LGR1 dim 2x4x2 -> 3x5x3 = 45 points
+        // LGR2 dim 3x3x3 -> 4x4x4 = 64 points
+        // LGR3 dim 4x4x4 -> 5x5x5 = 125 points
+        // LGR4 dim 2x4x2 -> 3x5x3 = 45 points
+        const std::vector<int>& expected_point_ids_per_lgr = { 45, 64, 125, 45};
+        for (int lgr = 1; lgr < 5; ++lgr) {
+            std::vector<int> local_point_ids;
+            local_point_ids.reserve(expected_point_ids_per_lgr[lgr-1]);
+            for (const auto& element : elements(grid.levelGridView(lgr))) {
+                for (int corner = 0; corner < 8; ++corner)
+                {
+                    const auto& point = element.subEntity<3>(corner);
+                    local_point_ids.push_back(grid.currentData()[lgr]->globalIdSet().id(point));
+                }
+            }
+            auto [all_point_ids, displPoint ] = Opm::allGatherv(local_point_ids, grid.comm());
+            const std::set<int> all_point_ids_set(all_point_ids.begin(), all_point_ids.end());
+            BOOST_CHECK( static_cast<int>(all_point_ids_set.size()) == expected_point_ids_per_lgr[lgr-1]);
+        }
+
+        // Check global id is not duplicated for points
+        std::vector<int> localPointIds_vec;
+        localPointIds_vec.reserve(grid.currentData().back()->size(3));
+        for (const auto& point : vertices(grid.leafGridView())) {
+            // Notice that all partition type points are pushed back. Selecting only interior points does not bring us to the expected value.
+            localPointIds_vec.push_back(grid.currentData().back()->globalIdSet().id(point));
+        }
+        auto [allGlobalIds_points, displPoint ] = Opm::allGatherv(localPointIds_vec, grid.comm());
+        const std::set<int> allGlobalIds_points_set(allGlobalIds_points.begin(), allGlobalIds_points.end());
+        // Total global ids in leaf grid view for points: 80 + 33 + 56 + 117 + 33 = 319
+        BOOST_CHECK( allGlobalIds_points_set.size() == 319 );
     }
 }
 
@@ -645,9 +696,6 @@ BOOST_AUTO_TEST_CASE(globalRefine2)
 
 BOOST_AUTO_TEST_CASE(distributed_lgr)
 {
-    // Only for testing assignment of new global ids for refined entities (cells and point belonging to
-    // refined level grids).
-
     // Create a grid
     Dune::CpGrid grid;
     const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
@@ -673,19 +721,64 @@ BOOST_AUTO_TEST_CASE(distributed_lgr)
         const std::vector<std::array<int,3>> endIJK_vec = {{3,1,1}};
         const std::vector<std::string> lgr_name_vec = {"LGR1"};
         // LGR1 element indices = 1 (rank 0), 2 (rank 2). Total 16 refined cells, 45 points (45-12 = 33 with new global id).
-        // LGR1 dim 2x1x1 (16 refined cells) (45 points - only 33 new points)
+        // LGR1 dim 4x2x2 (16 refined cells) (45 points - only 33 new points)
 
         grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
         refinePatch_and_check(grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+
+        // Check global id is not duplicated for points for each LGR
+        // LGR1 dim 4x2x2 -> 5x3x3 = 45 points
+        std::vector<int> local_point_ids;
+        local_point_ids.reserve(45); // expected_point_ids in LGR1
+        for (const auto& element : elements(grid.levelGridView(1))) {
+            for (int corner = 0; corner < 8; ++corner)
+            {
+                const auto& point = element.subEntity<3>(corner);
+                local_point_ids.push_back(grid.currentData()[1]->globalIdSet().id(point));
+            }
+        }
+        auto [all_point_ids, displPoint ] = Opm::allGatherv(local_point_ids, grid.comm());
+        const std::set<int> all_point_ids_set(all_point_ids.begin(), all_point_ids.end());
+        // Coarse cells 1 in rank 0 and 2 in rank 2 share an I_FACE where (LGR1_dim[1]+1)*(LGR1_dim[2]+ 1),
+        // here (2 +1)*(2 +1) = 9 points lying on, 4 of them being the 4 corners of the coarse I_FACE shared
+        // by cell 1 and cell 2. Leaving us with 9 - 4 = 5 potential duplicated ids.
+        //
+        // Global cell ids of cells to be refined = {1, 2}
+        // cell 1 = { interior in P0, overlap in P1, overlap in P2, does not exist in P3}
+        // cell 2 = { overlap in P0, does not exist in P1, interior in P2, overlap in P3}
+        // Remark: the LGR is distributed in only two of the four processes, P0 and P2.
+        // - P0 sees the entire LGR.
+        // - P1 does NOT see cell 2, but sees cell 1
+        // - P2 does NOT see the LGR at all.
+        // - P3 does NOT see cell 1, but sees cell 2
+        // P3 creates:
+        //  +5 duplicated ids on {I_FACE, false} cell 2 (seen in P3) [equivalent face: {I_FACE, true} of unseen-in-P3 cell 1]
+        // That means that the "unfortunate" expected point ids count is 45 (desired value) + 5 (duplicated laying on
+        // shared I_FACE) = 50.
+        BOOST_CHECK( static_cast<int>(all_point_ids_set.size()) == 50);
+        
+        /** Current approach avoids duplicated point ids when
+         // 1. the LGR is distributed in P_{i_0}, ..., P_{i_n}, with n+1 < grid.comm().size(),
+         // AND
+         // 2. there is no coarse cell seen by a process P with P != P_{i_j}, j = 0, ..., n.
+         // Otherwise, there will be points with multiple ids.*/ 
+
+        // Check global id is not duplicated for points
+        std::vector<int> localPointIds_vec;
+        localPointIds_vec.reserve(grid.currentData().back()->size(3));
+        for (const auto& point : vertices(grid.leafGridView())) {
+            // Notice that all partition type points are pushed back. Selecting only interior points does not bring us to the expected value.
+            localPointIds_vec.push_back(grid.currentData().back()->globalIdSet().id(point));
+        }
+        auto [allGlobalIds_points, displPointLeaf ] = Opm::allGatherv(localPointIds_vec, grid.comm());
+        const std::set<int> allGlobalIds_points_set(allGlobalIds_points.begin(), allGlobalIds_points.end());
+        // Total global ids in leaf grid view for points: 80 + (45 - 12) + 5 (undesired duplicated ids on shared I_FACE) = 118
+        BOOST_CHECK( allGlobalIds_points_set.size() == 118 );
     }
 }
 
-
 BOOST_AUTO_TEST_CASE(distributed_lgr_II)
 {
-    // Only for testing assignment of new global ids for refined entities (cells and point belonging to
-    // refined level grids).
-
     // Create a grid
     Dune::CpGrid grid;
     const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
@@ -714,14 +807,44 @@ BOOST_AUTO_TEST_CASE(distributed_lgr_II)
 
         grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
         refinePatch_and_check(grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+
+        // Check global id is not duplicated for points for each LGR
+        // LGR1 dim 6x2x2 -> 7x3x3 = 63 points
+        std::vector<int> local_point_ids;
+        local_point_ids.reserve(63); // expected_point_ids in LGR1
+        for (const auto& point : vertices(grid.levelGridView(1))) {
+            local_point_ids.push_back(grid.currentData()[1]->globalIdSet().id(point));
+        }
+        auto [all_point_ids, displPoint ] = Opm::allGatherv(local_point_ids, grid.comm());
+        const std::set<int> all_point_ids_set(all_point_ids.begin(), all_point_ids.end());
+        BOOST_CHECK( static_cast<int>(all_point_ids_set.size()) == 63);
+        // Difference with previous test case:
+        // Global cell ids of cells to be refined = {8, 9, 10}
+        // cell 8 = { interior in P0, does not exist in P1, does not exist in P2, does not exist in P3}
+        // cell 9 = { interior in P0, does not exist in P1, overlap in P2, does not exist in P3}
+        // cell 10 = { overlap in P0, does not exist in P1, interior in P2, does not exist in P3}
+        // Remark: the LGR is distributed only in 2 processes which are the only two processes seeing these cells.
+        // - P0 sees the entire LGR.
+        // - P1 does NOT see the LGR at all.
+        // - P2 does NOT see cell 8, but NO OTHER process sees cell 8 since it's fully inteior of P0.
+        // - P3 does NOT see the LGR at all.
+
+        // Check global id is not duplicated for points
+        std::vector<int> localPointIds_vec;
+        localPointIds_vec.reserve(grid.currentData().back()->size(3));
+        for (const auto& point : vertices(grid.leafGridView())) {
+            // Notice that all partition type points are pushed back. Selecting only interior points does not bring us to the expected value.
+            localPointIds_vec.push_back(grid.currentData().back()->globalIdSet().id(point));
+        }
+        auto [allGlobalIds_points, displPointLeaf ] = Opm::allGatherv(localPointIds_vec, grid.comm());
+        const std::set<int> allGlobalIds_points_set(allGlobalIds_points.begin(), allGlobalIds_points.end());
+        // Total global ids in leaf grid view for points: 80 + (63 - 16) = 127
+        BOOST_CHECK( allGlobalIds_points_set.size() == 127 );
     }
 }
 
 BOOST_AUTO_TEST_CASE(distributed_in_all_ranks_lgr)
 {
-    // Only for testing assignment of new global ids for refined entities (cells and point belonging to
-    // refined level grids).
-
     // Create a grid
     Dune::CpGrid grid;
     const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
@@ -753,6 +876,61 @@ BOOST_AUTO_TEST_CASE(distributed_in_all_ranks_lgr)
         // 64 new refined cells. 5x5x5 = 125 points (only 98 = 125 - 3x3x3 parent corners new points - new global ids).
         grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
         refinePatch_and_check(grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+
+        // Check global id is not duplicated for points for each LGR
+        // LGR1 dim 4x4x4 -> 5x5x5 = 125 points
+        std::vector<int> local_point_ids;
+        local_point_ids.reserve(125); // expected_point_ids in LGR1
+        for (const auto& element : elements(grid.levelGridView(1))) {
+            for (int corner = 0; corner < 8; ++corner)
+            {
+                const auto& point = element.subEntity<3>(corner);
+                local_point_ids.push_back(grid.currentData()[1]->globalIdSet().id(point));
+            }
+        }
+        auto [all_point_ids, displPoint ] = Opm::allGatherv(local_point_ids, grid.comm());
+        const std::set<int> all_point_ids_set(all_point_ids.begin(), all_point_ids.end());
+
+        /** [Bug] Uniqueness of point global ids cannot be checked in general since current code sets overlap layer size equal to 1,
+            which in particular means that cells that share corners or edges (and not faces) with interior cells are not considered/
+            seen by the process. Therefore, depending how the LGRs are distributed, there may be "multiple ids" for the same points.*/
+        // Difference with previous test case:
+        // Global cell ids of cells to be refined = {1,2,5,6,13,14,17,18}
+        // cell 1 = { interior in P0, overlap in P1, overlap in P2, does not exist in P3}
+        // cell 2 = { overlap in P0, does not exist in P1, interior in P2, overlap in P3}
+        // cell 5 = { interior in P0, overlap in P1, overlap in P2, does not exist in P3}
+        // cell 6 = { overlap in P0, does not exist in P1, interior in P2, does not exist in P3}
+        // cell 13 = { overlap in P0, interior in P1, does not exist in P2, overlap in P3}
+        // cell 14 = { does not exist in P0, overlap in P1, overlap in P2, interior in P3}
+        // cell 17 = { overlap in P0, interior in P1, overlap in P2, does not exist in P3}
+        // cell 18 = { does not exist in P0, overlap in P1, interior in P2, overlap in P3}
+        // Remark: the LGR is distributed in ALL processes BUT
+        // - P0 does NOT see cell 18, but sees all the others.
+        // - P1 does NOT see cells 2 and 6, but sees the rest of them.
+        // - P2 does NOT see cell 13, but sees all the others.
+        // - P3 does NOT see cell 1, 5 and 17, but sees all the others.
+        // More details:
+        // P0 creates +1 duplicated id (middle point edge)
+        // P1 creates +2 duplicated ids (middle point of an edge in cell 2, cell 6 respectively).
+        // P2 creates +1 duplicated id (middle point edge)
+        // P3 creates:
+        //  +5 duplicated ids on {I_FACE, false} cell 2 (seen in P3) [equivalent face: {I_FACE, true} of unseen-in-P3 cell 1]
+        //  +1 duplicated id on edge unseen-in-P3 cell 5
+        //  +5 duplicated ids on {J_FACE, true} cell 13 (seen in P3) [equivalent face: {J_FACE, false} of unseen-in-P3 cell 17]
+        //  +5 duplicated ids on {I_FACE, false} cell 18 (seen in P3) [equivalent face: {I_FACE, true} of unseen-in-P3 cell 17]
+        BOOST_CHECK( static_cast<int>(all_point_ids_set.size()) == 145); // Desired value: 125; 20 (=1+2+1+5+1+5+5) duplicated ids.
+
+        // Check global id is not duplicated for points
+        std::vector<int> localPointIds_vec;
+        localPointIds_vec.reserve(grid.currentData().back()->size(3));
+        for (const auto& point : vertices(grid.leafGridView())) {
+            // Notice that all partition type points are pushed back. Selecting only interior points does not bring us to the expected value.
+            localPointIds_vec.push_back(grid.currentData().back()->globalIdSet().id(point));
+        }
+        auto [allGlobalIds_points, displPointLeaf ] = Opm::allGatherv(localPointIds_vec, grid.comm());
+        const std::set<int> allGlobalIds_points_set(allGlobalIds_points.begin(), allGlobalIds_points.end());
+        // Total global ids in leaf grid view for points: 80 + (125 - 27) = 178 desired value; +20 duplicated ids.
+        BOOST_CHECK( allGlobalIds_points_set.size() == 198 );
     }
 }
 

--- a/tests/cpgrid/avoidNNCinLGRsCpGrid_test.cpp
+++ b/tests/cpgrid/avoidNNCinLGRsCpGrid_test.cpp
@@ -150,6 +150,18 @@ BOOST_AUTO_TEST_CASE(NNCAtSeveralLgrs)
     testCase(deckString, nnc,  cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec, true);
 }
 
+BOOST_AUTO_TEST_CASE(LgrWithNNC_and_lgrsWithoutNNC)
+{
+    Opm::NNC nnc;
+    nnc.addNNC(0, 2, 1.0); // connect cell 0 and cell 2 (both belong to LGR1). LGR2 does not have NNCs.
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {4,4,4}};
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0},{0,0,4}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{1,1,3}, {1,1,5}};
+    // LGR1 cell indices = {0,1,2}, LGR2 cell indices = {4}.
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2"};
+    testCase(deckString, nnc,  cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec, true);
+}
+
 BOOST_AUTO_TEST_CASE(NNCoutsideLgrs)
 {
     Opm::NNC nnc;


### PR DESCRIPTION
This PR introduces a structure to manage the point global IDs of all refined child cells per parent. This structure ensures the correct assignment of global point IDs in refined grids, gathering already-assigned IDs for interior cells and distributing them for overlap cells.

Current approach avoids duplicated point ids in the following setting:
Let's say a block of cells to be refined is distributed in P_{i_0}, ..., P_{i_n}, with n+1 < grid.comm().size().
If all cells to be refined are not "seen"(neither interior nor overlap) for every process P with P != P_{i_j}, j = 0, ..., n.

Points that may have multiple ids as shown and explained in OPM/opm-grid#806. 
Cells that only share corners (not faces) with interior cells of a process are not included in its overlap layer, therefore, some point may have multiple ids. 

Keeping this potential multiple point ids in mind, this PR allows distributing Local Grid Refinements (LGRs) across different processes, subject to first distribute level zero grid, and after that add the LGRs. To be able to run the simulation, some changes to respect this order must be done in opm-simulators.

Improvement/replacement for OPM/opm-grid#801

Not relevant for the Reference Manual