### PR TITLE
Global refinement partially supported on distributed CpGrid

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -202,6 +202,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/grid/LookUpData.hh
   opm/grid/cpgrid/OrientedEntityTable.hpp
   opm/grid/cpgrid/ParentToChildrenCellGlobalIdHandle.hpp
+	opm/grid/cpgrid/ParentToChildCellToPointGlobalIdHandle.hpp
   opm/grid/cpgrid/PartitionIteratorRule.hpp
   opm/grid/cpgrid/PartitionTypeIndicator.hpp
   opm/grid/cpgrid/PersistentContainer.hpp

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -484,6 +484,8 @@ namespace Dune
 
         void populateCellIndexSetRefinedGrid(int level);
 
+        void populateCellIndexSetLeafGridView();
+
         /// --------------- Adaptivity (begin) ---------------
         /// @brief Mark entity for refinement (or coarsening).
         ///

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -468,11 +468,9 @@ namespace Dune
                                                  std::vector<int>& assignRefinedLevel,
                                                  std::vector<int>& lgr_with_at_least_one_active_cell);
 
-        void predictMinCellAndPointGlobalIdPerProcess(int& min_globalId_cell_in_proc,
-                                                      int& min_globalId_point_in_proc,
-                                                      const std::vector<int>& assignRefinedLevel,
-                                                      const std::vector<std::array<int,3>>& cells_per_dim_vec,
-                                                      const std::vector<int>& lgr_with_at_least_one_active_cell) const;
+        std::pair<int,int> predictMinCellAndPointGlobalIdPerProcess(const std::vector<int>& assignRefinedLevel,
+                                                                    const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                                                    const std::vector<int>& lgr_with_at_least_one_active_cell) const;
 
         void collectCellIdsAndCandidatePointIds( std::vector<std::vector<int>>& localToGlobal_cells_per_level,
                                                  std::vector<std::vector<int>>& localToGlobal_points_per_level,

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -415,28 +415,12 @@ namespace Dune
         template <int codim>
         cpgrid::Entity<codim> entity(const cpgrid::Entity<codim>& seed) const;
 
-        /// @brief Create a grid out of a coarse one and a refinement(LGR) of a selected block-shaped patch of cells from that coarse grid.
-        ///
-        /// Level0 refers to the coarse grid, assumed to be this-> data_[0]. Level1 refers to the LGR (stored in this->data_[1]).
-        /// LeafView (stored in this-> data_[2]) is built with the level0-entities which weren't involded in the
-        /// refinenment, together with the new born entities created in level1.
-        /// Old-corners and old-faces (from coarse grid) lying on the boundary of the patch, get replaced by new-born-equivalent corners
-        /// and new-born-faces.
-        ///
-        /// @param [in] cells_per_dim            Number of (refined) cells in each direction that each parent cell should be refined to.
-        /// @param [in] startIJK                 Cartesian triplet index where the patch starts.
-        /// @param [in] endIJK                   Cartesian triplet index where the patch ends.
-        ///                                      Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
-        /// @param [in] lgr_name                 Name (std::string) for the lgr/level1
-        void addLgrUpdateLeafView(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK,
-                                  const std::array<int,3>& endIJK,  const std::string& lgr_name);
-
         /// @brief Create a grid out of a coarse one and (at most) 2 refinements(LGRs) of selected block-shaped disjoint patches
         ///        of cells from that coarse grid.
         ///
         /// Level0 refers to the coarse grid, assumed to be this-> data_[0]. Level1 and level2 refer to the LGRs (stored in this->data_[1]
         /// data_[2]). LeafView (stored in this-> data_[3]) is built with the level0-entities which weren't involded in the
-        /// refinenment, together with the new born entities created in level1 and level2. 
+        /// refinenment, together with the new born entities created in level1 and level2.
         /// Old-corners and old-faces (from coarse grid) lying on the boundary of the patches, get replaced by new-born-equivalent corners
         /// and new-born-faces.
         ///

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -460,6 +460,9 @@ namespace Dune
         //        from certain LGR
         Dune::cpgrid::Intersection getParentIntersectionFromLgrBoundaryFace(const Dune::cpgrid::Intersection& intersection) const;
 
+        // @brief Check if there non neighboring connections on blocks of cells selected for refinement.
+        bool nonNNCs( const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
+
 
         /// --------------- Adaptivity (begin) ---------------
         /// @brief Mark entity for refinement (or coarsening).

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -468,6 +468,12 @@ namespace Dune
                                                  std::vector<int>& assignRefinedLevel,
                                                  std::vector<int>& lgr_with_at_least_one_active_cell);
 
+        void predictMinCellAndPointGlobalIdPerProcess(int& min_globalId_cell_in_proc,
+                                                      int& min_globalId_point_in_proc,
+                                                      const std::vector<int>& assignRefinedLevel,
+                                                      const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                                      const std::vector<int>& lgr_with_at_least_one_active_cell) const;
+
 
         /// --------------- Adaptivity (begin) ---------------
         /// @brief Mark entity for refinement (or coarsening).

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -486,6 +486,8 @@ namespace Dune
 
         void populateCellIndexSetLeafGridView();
 
+        void populateLeafGlobalIdSet();
+
         /// --------------- Adaptivity (begin) ---------------
         /// @brief Mark entity for refinement (or coarsening).
         ///

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -463,6 +463,11 @@ namespace Dune
         // @brief Check if there non neighboring connections on blocks of cells selected for refinement.
         bool nonNNCs( const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
 
+        void markElemAssignLevelDetectActiveLgrs(const std::vector<std::array<int,3>>& startIJK_vec,
+                                                 const std::vector<std::array<int,3>>& endIJK_vec,
+                                                 std::vector<int>& assignRefinedLevel,
+                                                 std::vector<int>& lgr_with_at_least_one_active_cell);
+
 
         /// --------------- Adaptivity (begin) ---------------
         /// @brief Mark entity for refinement (or coarsening).

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -482,6 +482,7 @@ namespace Dune
                                   const std::vector<std::tuple<int,std::vector<int>>>& parent_to_children,
                                   const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
 
+        void populateCellIndexSetRefinedGrid(int level);
 
         /// --------------- Adaptivity (begin) ---------------
         /// @brief Mark entity for refinement (or coarsening).

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -474,6 +474,12 @@ namespace Dune
                                                       const std::vector<std::array<int,3>>& cells_per_dim_vec,
                                                       const std::vector<int>& lgr_with_at_least_one_active_cell) const;
 
+        void collectCellIdsAndCandidatePointIds( std::vector<std::vector<int>>& localToGlobal_cells_per_level,
+                                                 std::vector<std::vector<int>>& localToGlobal_points_per_level,
+                                                 int min_globalId_cell_in_proc,
+                                                 int min_globalId_point_in_proc,
+                                                 const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
+
 
         /// --------------- Adaptivity (begin) ---------------
         /// @brief Mark entity for refinement (or coarsening).

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1072,13 +1072,16 @@ namespace Dune
                                                    int elemLgr)  const;
         /// --------------- Auxiliary methods to support Adaptivity (end) ---------------
 
-              // @brief Check if there non neighboring connections on blocks of cells selected for refinement.
+        // @brief Check if there non neighboring connections on blocks of cells selected for refinement.
         bool nonNNCs( const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
 
-        void markElemAssignLevelDetectActiveLgrs(const std::vector<std::array<int,3>>& startIJK_vec,
-                                                 const std::vector<std::array<int,3>>& endIJK_vec,
-                                                 std::vector<int>& assignRefinedLevel,
-                                                 std::vector<int>& lgr_with_at_least_one_active_cell);
+        void markElemAssignLevel(const std::vector<std::array<int,3>>& startIJK_vec,
+                                 const std::vector<std::array<int,3>>& endIJK_vec,
+                                 std::vector<int>& assignRefinedLevel);
+
+        void detectActiveLgrs(const std::vector<std::array<int,3>>& startIJK_vec,
+                              const std::vector<std::array<int,3>>& endIJK_vec,
+                              std::vector<int>& lgr_with_at_least_one_active_cell);
 
         std::pair<int,int> predictMinCellAndPointGlobalIdPerProcess(const std::vector<int>& assignRefinedLevel,
                                                                     const std::vector<std::array<int,3>>& cells_per_dim_vec,

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -480,6 +480,10 @@ namespace Dune
                                                  int min_globalId_point_in_proc,
                                                  const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
 
+        void selectWinnerPointIds(std::vector<std::vector<int>>&  localToGlobal_points_per_level,
+                                  const std::vector<std::tuple<int,std::vector<int>>>& parent_to_children,
+                                  const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
+
 
         /// --------------- Adaptivity (begin) ---------------
         /// @brief Mark entity for refinement (or coarsening).

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -460,34 +460,6 @@ namespace Dune
         //        from certain LGR
         Dune::cpgrid::Intersection getParentIntersectionFromLgrBoundaryFace(const Dune::cpgrid::Intersection& intersection) const;
 
-        // @brief Check if there non neighboring connections on blocks of cells selected for refinement.
-        bool nonNNCs( const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
-
-        void markElemAssignLevelDetectActiveLgrs(const std::vector<std::array<int,3>>& startIJK_vec,
-                                                 const std::vector<std::array<int,3>>& endIJK_vec,
-                                                 std::vector<int>& assignRefinedLevel,
-                                                 std::vector<int>& lgr_with_at_least_one_active_cell);
-
-        std::pair<int,int> predictMinCellAndPointGlobalIdPerProcess(const std::vector<int>& assignRefinedLevel,
-                                                                    const std::vector<std::array<int,3>>& cells_per_dim_vec,
-                                                                    const std::vector<int>& lgr_with_at_least_one_active_cell) const;
-
-        void collectCellIdsAndCandidatePointIds( std::vector<std::vector<int>>& localToGlobal_cells_per_level,
-                                                 std::vector<std::vector<int>>& localToGlobal_points_per_level,
-                                                 int min_globalId_cell_in_proc,
-                                                 int min_globalId_point_in_proc,
-                                                 const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
-
-        void selectWinnerPointIds(std::vector<std::vector<int>>&  localToGlobal_points_per_level,
-                                  const std::vector<std::tuple<int,std::vector<int>>>& parent_to_children,
-                                  const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
-
-        void populateCellIndexSetRefinedGrid(int level);
-
-        void populateCellIndexSetLeafGridView();
-
-        void populateLeafGlobalIdSet();
-
         /// --------------- Adaptivity (begin) ---------------
         /// @brief Mark entity for refinement (or coarsening).
         ///
@@ -1099,6 +1071,34 @@ namespace Dune
                                                    const std::shared_ptr<cpgrid::CpGridData>& elemLgr_ptr,
                                                    int elemLgr)  const;
         /// --------------- Auxiliary methods to support Adaptivity (end) ---------------
+
+              // @brief Check if there non neighboring connections on blocks of cells selected for refinement.
+        bool nonNNCs( const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
+
+        void markElemAssignLevelDetectActiveLgrs(const std::vector<std::array<int,3>>& startIJK_vec,
+                                                 const std::vector<std::array<int,3>>& endIJK_vec,
+                                                 std::vector<int>& assignRefinedLevel,
+                                                 std::vector<int>& lgr_with_at_least_one_active_cell);
+
+        std::pair<int,int> predictMinCellAndPointGlobalIdPerProcess(const std::vector<int>& assignRefinedLevel,
+                                                                    const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                                                    const std::vector<int>& lgr_with_at_least_one_active_cell) const;
+
+        void collectCellIdsAndCandidatePointIds( std::vector<std::vector<int>>& localToGlobal_cells_per_level,
+                                                 std::vector<std::vector<int>>& localToGlobal_points_per_level,
+                                                 int min_globalId_cell_in_proc,
+                                                 int min_globalId_point_in_proc,
+                                                 const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
+
+        void selectWinnerPointIds(std::vector<std::vector<int>>&  localToGlobal_points_per_level,
+                                  const std::vector<std::tuple<int,std::vector<int>>>& parent_to_children,
+                                  const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
+
+        void populateCellIndexSetRefinedGrid(int level);
+
+        void populateCellIndexSetLeafGridView();
+
+        void populateLeafGlobalIdSet();
 
     public:
 

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1266,6 +1266,84 @@ void CpGrid::markElemAssignLevelDetectActiveLgrs(const std::vector<std::array<in
     }
 }
 
+void CpGrid::predictMinCellAndPointGlobalIdPerProcess(int& min_globalId_cell_in_proc,
+                                                      int& min_globalId_point_in_proc,
+                                                      const std::vector<int>& assignRefinedLevel,
+                                                      const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                                      const std::vector<int>& lgr_with_at_least_one_active_cell) const
+{
+#if HAVE_MPI
+    // Maximum global id from level zero. (Then, new entities get global id values greater than max_globalId_levelZero).
+    // Recall that only cells and points are taken into account; faces are ignored (do not have any global id).
+    auto max_globalId_levelZero = comm().max(current_data_->front()->global_id_set_->getMaxGlobalId());
+
+    // Predict how many new cells/points (born in refined level grids) need new globalIds, so we can assign unique
+    // new ids ( and anticipate the maximum).
+    // At this point, neither cell_index_set_ nor partition_type_indicator_ are populated.
+    // Refined level grid cells:
+    //    1. Inherit their partition type from their parent cell (i.e., element.father().partitionType()).
+    //    2. Assign global ids only for interior cells.
+    //    3. Communicate the already assigned cell global ids from interior to overlap refined cells.
+    // Refined level grid points/vertices:
+    // There are 4 partition types: interior, border, front, overlap. This classification requires that both
+    // cell and face partition types are already defined, not available yet for refined level grids.
+    //    1. Assign for all partition type points a 'candidate of global id' (unique in each process).
+    //       Except the points that coincide with a point from level zero.
+    //    2. To make point ids globally unique, re-write the values for points that are corners of overlap
+    //       refined cells, via communication.
+    // Under the assumption of LGRs fully-interior, no communication is needed. In the general case, communication will be used
+    // to populate overlap cell/point global ids on the refined level grids.
+
+
+    // Predict how many new cell ids per process are needed.
+    std::vector<std::size_t> cell_ids_needed_by_proc(comm().size());
+    std::size_t local_cell_ids_needed = 0;
+    for ( const auto& element : elements( levelGridView(0), Dune::Partitions::interior) ) {
+        // Get old mark (from level zero). After calling adapt, all marks are set to zero.
+        bool hasBeenMarked = currentData().front()->getMark(element) == 1;
+        if ( hasBeenMarked ) {
+            const auto& level = assignRefinedLevel[element.index()];
+            // Shift level (to level -1) since cells_per_dim_vec stores number of subdivisions in each direction (xyz)
+            // per parent cell, per level, starting from level 1, ..., maxLevel.
+            local_cell_ids_needed += cells_per_dim_vec[level-1][0]*cells_per_dim_vec[level-1][1]*cells_per_dim_vec[level-1][2];
+        }
+    }
+    comm().allgather(&local_cell_ids_needed, 1, cell_ids_needed_by_proc.data());
+
+    // Overestimate ('predict') how many new point ids per process are needed.
+    // Assign for all partition type points a 'candidate of global id' (unique in each process).
+    std::vector<std::size_t> point_ids_needed_by_proc(comm().size());
+    std::size_t local_point_ids_needed = 0;
+    for (std::size_t level = 1; level < cells_per_dim_vec.size()+1; ++level){
+        if(lgr_with_at_least_one_active_cell[level-1]>0) {
+            // Amount of local_point_ids_needed might be overestimated.
+            for (const auto& point : vertices(levelGridView(level))){
+                // If point coincides with an existing corner from level zero, then it does not need a new global id.
+                if ( !(*current_data_)[level]->corner_history_.empty() ) {
+                    const auto& bornLevel_bornIdx =  (*current_data_)[level]->corner_history_[point.index()];
+                    if (bornLevel_bornIdx[0] == -1)  { // Corner is new-> it needs a new global id
+                        local_point_ids_needed += 1;
+                    }
+                }
+            }
+        }
+    }
+    comm().allgather(&local_point_ids_needed, 1, point_ids_needed_by_proc.data());
+
+    auto expected_max_globalId_cell = std::accumulate(cell_ids_needed_by_proc.begin(),
+                                                      cell_ids_needed_by_proc.end(),
+                                                      max_globalId_levelZero + 1);
+    min_globalId_cell_in_proc = std::accumulate(cell_ids_needed_by_proc.begin(),
+                                                cell_ids_needed_by_proc.begin()+comm().rank(),
+                                                max_globalId_levelZero + 1);
+    min_globalId_point_in_proc = std::accumulate(point_ids_needed_by_proc.begin(),
+                                                 point_ids_needed_by_proc.begin()+ comm().rank(),
+                                                 expected_max_globalId_cell);
+
+#endif
+}
+
+
 double CpGrid::cellCenterDepth(int cell_index) const
 {
     // Here cell center depth is computed as a raw average of cell corner depths.
@@ -2188,71 +2266,14 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
     // - Define ParallelIndex for overlap cells and their neighbors
     if(comm().size()>1) {
 #if HAVE_MPI
-        // Maximum global id from level zero. (Then, new entities get global id values greater than max_globalId_levelZero).
-        // Recall that only cells and points are taken into account; faces are ignored (do not have any global id).
-        auto max_globalId_levelZero = comm().max(current_data_->front()->global_id_set_->getMaxGlobalId());
-
-        // Predict how many new cells/points (born in refined level grids) need new globalIds, so we can assign unique
-        // new ids ( and anticipate the maximum).
-        // At this point, neither cell_index_set_ nor partition_type_indicator_ are populated.
-        // Refined level grid cells:
-        //    1. Inherit their partition type from their parent cell (i.e., element.father().partitionType()).
-        //    2. Assign global ids only for interior cells.
-        //    3. Communicate the already assigned cell global ids from interior to overlap refined cells.
-        // Refined level grid points/vertices:
-        // There are 4 partition types: interior, border, front, overlap. This classification requires that both
-        // cell and face partition types are already defined, not available yet for refined level grids.
-        //    1. Assign for all partition type points a 'candidate of global id' (unique in each process).
-        //       Except the points that coincide with a point from level zero.
-        //    2. To make point ids globally unique, re-write the values for points that are corners of overlap
-        //       refined cells, via communication.
-        // Under the assumption of LGRs fully-interior, no communication is needed. In the general case, communication will be used
-        // to populate overlap cell/point global ids on the refined level grids.
-
-        // Predict how many new cell ids per process are needed.
-        std::vector<std::size_t> cell_ids_needed_by_proc(comm().size());
-        std::size_t local_cell_ids_needed = 0;
-        for ( const auto& element : elements( levelGridView(0), Dune::Partitions::interior) ) {
-            // Get old mark (from level zero). After calling adapt, all marks are set to zero.
-            bool hasBeenMarked = currentData().front()->getMark(element) == 1;
-            if ( hasBeenMarked ) {
-                const auto& level = assignRefinedLevel[element.index()];
-                // Shift level (to level -1) since cells_per_dim_vec stores number of subdivisions in each direction (xyz)
-                // per parent cell, per level, starting from level 1, ..., maxLevel.
-                local_cell_ids_needed += cells_per_dim_vec[level-1][0]*cells_per_dim_vec[level-1][1]*cells_per_dim_vec[level-1][2];
-            }
-        }
-        comm().allgather(&local_cell_ids_needed, 1, cell_ids_needed_by_proc.data());
-
-        // Overestimate ('predict') how many new point ids per process are needed.
-        // Assign for all partition type points a 'candidate of global id' (unique in each process).
-        std::vector<std::size_t> point_ids_needed_by_proc(comm().size());
-        std::size_t local_point_ids_needed = 0;
-        for (std::size_t level = 1; level < cells_per_dim_vec.size()+1; ++level){
-            if(lgr_with_at_least_one_active_cell[level-1]>0) {
-                // Amount of local_point_ids_needed might be overestimated.
-                for (const auto& point : vertices(levelGridView(level))){
-                    // If point coincides with an existing corner from level zero, then it does not need a new global id.
-                    if ( !(*current_data_)[level]->corner_history_.empty() ) {
-                        const auto& bornLevel_bornIdx =  (*current_data_)[level]->corner_history_[point.index()];
-                        if (bornLevel_bornIdx[0] == -1)  { // Corner is new-> it needs a new global id
-                            local_point_ids_needed += 1;
-                        }
-                    }
-                }
-            }
-        }
-        comm().allgather(&local_point_ids_needed, 1, point_ids_needed_by_proc.data());
-
-        auto expected_max_globalId_cell = std::accumulate(cell_ids_needed_by_proc.begin(),
-                                                          cell_ids_needed_by_proc.end(),
-                                                          max_globalId_levelZero + 1);
-        auto min_globalId_cell_in_proc = std::accumulate(cell_ids_needed_by_proc.begin(),
-                                                         cell_ids_needed_by_proc.begin()+comm().rank(),
-                                                         max_globalId_levelZero + 1);
-        auto min_globalId_point_in_proc= std::accumulate(point_ids_needed_by_proc.begin(),
-                                                         point_ids_needed_by_proc.begin()+ comm().rank(),
-                                                         expected_max_globalId_cell);
+        // Prediction min cell and point global ids per process
+        int min_globalId_cell_in_proc = 0;
+        int min_globalId_point_in_proc = 0;
+        predictMinCellAndPointGlobalIdPerProcess(min_globalId_cell_in_proc,
+                                                 min_globalId_point_in_proc,
+                                                 assignRefinedLevel,
+                                                 cells_per_dim_vec,
+                                                 lgr_with_at_least_one_active_cell);
 
         // Only for level 1,2,.., maxLevel grids.
         // For each level, define the local-to-global maps for cells and points (for faces: empty).

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -2076,37 +2076,9 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
     //                                                              active/inactive cells, instead, relies on "ijk-computations".
     //                                                              TO DO: improve/remove.
     // To check "Compatibility of numbers of subdivisions of neighboring LGRs".
-    bool compatibleSubdivisionsHasFailed = false;
-    if (startIJK_vec.size() > 1) {
-        bool notAllowedYet = false;
-        for (std::size_t level = 0; level < startIJK_vec.size(); ++level) {
-            for (std::size_t otherLevel = level+1; otherLevel < startIJK_vec.size(); ++otherLevel) {
-                const auto& sharedFaceTag =
-                    current_view_data_->sharedFaceTag({startIJK_vec[level], startIJK_vec[otherLevel]}, {endIJK_vec[level],endIJK_vec[otherLevel]});
-                if(sharedFaceTag == -1){
-                    break; // Go to the next "other patch"
-                }
-                if (sharedFaceTag == 0 ) {
-                    notAllowedYet = notAllowedYet ||
-                        ((cells_per_dim_vec[level][1] != cells_per_dim_vec[otherLevel][1]) || (cells_per_dim_vec[level][2] != cells_per_dim_vec[otherLevel][2]));
-                }
-                if (sharedFaceTag == 1) {
-                    notAllowedYet = notAllowedYet ||
-                        ((cells_per_dim_vec[level][0] != cells_per_dim_vec[otherLevel][0]) || (cells_per_dim_vec[level][2] != cells_per_dim_vec[otherLevel][2]));
-                }
-                if (sharedFaceTag == 2) {
-                    notAllowedYet = notAllowedYet ||
-                        ((cells_per_dim_vec[level][0] != cells_per_dim_vec[otherLevel][0]) || (cells_per_dim_vec[level][1] != cells_per_dim_vec[otherLevel][1]));
-                }
-                if (notAllowedYet){
-                    compatibleSubdivisionsHasFailed = true;
-                    break;
-                }
-            } // end-otherLevel-for-loop
-        } // end-level-for-loop
-    }// end-if-patchesShareFace
-    compatibleSubdivisionsHasFailed = comm().max(compatibleSubdivisionsHasFailed);
-    if(compatibleSubdivisionsHasFailed) {
+    bool compatibleSubdivisions = current_view_data_->compatibleSubdivisions(cells_per_dim_vec, startIJK_vec, endIJK_vec);
+    compatibleSubdivisions= comm().max(compatibleSubdivisions);
+    if(!compatibleSubdivisions) {
         if (comm().rank()==0){
             OPM_THROW(std::logic_error, "Subdivisions of neighboring LGRs sharing at least one face do not coincide. Not suppported yet.");
         }

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1270,6 +1270,9 @@ std::pair<int,int> CpGrid::predictMinCellAndPointGlobalIdPerProcess([[maybe_unus
                                                                     [[maybe_unused]] const std::vector<std::array<int,3>>& cells_per_dim_vec,
                                                                     [[maybe_unused]] const std::vector<int>& lgr_with_at_least_one_active_cell) const
 {
+    int min_globalId_cell_in_proc = 0;
+    int min_globalId_point_in_proc = 0;
+
 #if HAVE_MPI
     // Maximum global id from level zero. (Then, new entities get global id values greater than max_globalId_levelZero).
     // Recall that only cells and points are taken into account; faces are ignored (do not have any global id).
@@ -1331,15 +1334,14 @@ std::pair<int,int> CpGrid::predictMinCellAndPointGlobalIdPerProcess([[maybe_unus
     auto expected_max_globalId_cell = std::accumulate(cell_ids_needed_by_proc.begin(),
                                                       cell_ids_needed_by_proc.end(),
                                                       max_globalId_levelZero + 1);
-    auto min_globalId_cell_in_proc = std::accumulate(cell_ids_needed_by_proc.begin(),
-                                                     cell_ids_needed_by_proc.begin()+comm().rank(),
-                                                     max_globalId_levelZero + 1);
-    auto min_globalId_point_in_proc = std::accumulate(point_ids_needed_by_proc.begin(),
-                                                      point_ids_needed_by_proc.begin()+ comm().rank(),
-                                                      expected_max_globalId_cell);
-
-    return std::make_pair<int,int>(std::move(min_globalId_cell_in_proc), std::move(min_globalId_point_in_proc));
+    min_globalId_cell_in_proc = std::accumulate(cell_ids_needed_by_proc.begin(),
+                                                cell_ids_needed_by_proc.begin()+comm().rank(),
+                                                max_globalId_levelZero + 1);
+    min_globalId_point_in_proc = std::accumulate(point_ids_needed_by_proc.begin(),
+                                                 point_ids_needed_by_proc.begin()+ comm().rank(),
+                                                 expected_max_globalId_cell);
 #endif
+    return std::make_pair<int,int>(std::move(min_globalId_cell_in_proc), std::move(min_globalId_point_in_proc));
 }
 
 void CpGrid::collectCellIdsAndCandidatePointIds( std::vector<std::vector<int>>& localToGlobal_cells_per_level,

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -2049,13 +2049,6 @@ void CpGrid::postAdapt()
     current_view_data_ -> postAdapt();
 }
 
-void CpGrid::addLgrUpdateLeafView(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK,
-                                  const std::array<int,3>& endIJK, const std::string& lgr_name)
-{
-    this -> addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
-}
-
-
 void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_per_dim_vec,
                                    const std::vector<std::array<int,3>>& startIJK_vec,
                                    const std::vector<std::array<int,3>>& endIJK_vec,

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1241,10 +1241,9 @@ bool CpGrid::nonNNCs( const std::vector<std::array<int,3>>& startIJK_vec, const 
     return nonNNCs;
 }
 
-void CpGrid::markElemAssignLevelDetectActiveLgrs(const std::vector<std::array<int,3>>& startIJK_vec,
-                                                 const std::vector<std::array<int,3>>& endIJK_vec,
-                                                 std::vector<int>& assignRefinedLevel,
-                                                 std::vector<int>& lgr_with_at_least_one_active_cell)
+void CpGrid::markElemAssignLevel(const std::vector<std::array<int,3>>& startIJK_vec,
+                                 const std::vector<std::array<int,3>>& endIJK_vec,
+                                 std::vector<int>& assignRefinedLevel)
 {
     // Find out which (ACTIVE) elements belong to the block cells defined by startIJK and endIJK values.
     for(const auto& element: elements(this->leafGridView())) {
@@ -1260,6 +1259,28 @@ void CpGrid::markElemAssignLevelDetectActiveLgrs(const std::vector<std::array<in
             if(belongsToLevel) {
                 this-> mark(1, element);
                 assignRefinedLevel[element.index()] = level+1; // shifted since starting grid is level 0, and refined grids levels are >= 1.
+            }
+        }
+    }
+}
+
+void CpGrid::detectActiveLgrs(const std::vector<std::array<int,3>>& startIJK_vec,
+                              const std::vector<std::array<int,3>>& endIJK_vec,
+                              std::vector<int>& lgr_with_at_least_one_active_cell)
+{
+    // Find out which (ACTIVE) elements belong to the block cells defined by startIJK and endIJK values.
+    for(const auto& element: elements(this->leafGridView())) {
+        std::array<int,3> ijk;
+        getIJK(element.index(), ijk);
+        for (std::size_t level = 0; level < startIJK_vec.size(); ++level) {
+            bool belongsToLevel = true;
+            for (int c = 0; c < 3; ++c) {
+                belongsToLevel = belongsToLevel && ( (ijk[c] >= startIJK_vec[level][c]) && (ijk[c] < endIJK_vec[level][c]) );
+                if (!belongsToLevel)
+                    break;
+            }
+            if(belongsToLevel) {
+                // shifted since starting grid is level 0, and refined grids levels are >= 1.
                 lgr_with_at_least_one_active_cell[level] = 1;
             }
         }
@@ -1947,7 +1968,13 @@ bool CpGrid::adapt(const std::vector<std::array<int,3>>& cells_per_dim_vec,
     const auto& preAdaptGrid_corner_history = (preAdaptMaxLevel>0) ? current_view_data_->corner_history_ : std::vector<std::array<int,2>>();
 
     auto& data = currentData(); // data pointed by current_view_data_ (data_ or distributed_data_[if loadBalance() has been invoked before adapt()]).
-      
+
+    // To determine if an LGR is not empty in a given process, we set
+    // lgr_with_at_least_one_active_cell[in that level] to 1 if it contains
+    // at least one active cell, and to 0 otherwise.
+    std::vector<int> lgr_with_at_least_one_active_cell(levels);
+    detectActiveLgrs(startIJK_vec, endIJK_vec, lgr_with_at_least_one_active_cell);
+
     // To store/build refined level grids.
     std::vector<std::vector<std::shared_ptr<Dune::cpgrid::CpGridData>>> refined_data_vec(levels, data);
     std::vector<std::shared_ptr<Dune::cpgrid::CpGridData>> refined_grid_ptr_vec(levels);
@@ -2372,103 +2399,7 @@ bool CpGrid::adapt(const std::vector<std::array<int,3>>& cells_per_dim_vec,
         this->global_id_set_ptr_->insertIdSet(*data[refinedLevelGridIdx]);
     }
 
-    // Print total amount of cells on the adapted grid
-    Opm::OpmLog::info(std::to_string(markedElem_count) + " elements have been marked (in " + std::to_string(comm().rank()) + " rank).\n");
-    Opm::OpmLog::info(std::to_string(levels)  + " (new) refined level grid(s) (in " + std::to_string(comm().rank()) + " rank).\n");
-    Opm::OpmLog::info(std::to_string(cell_count)  + " total cells on the leaf grid view (in " + std::to_string(comm().rank()) + " rank).\n");
-
-    return preAdapt();
-}
-
-void CpGrid::postAdapt()
-{
-    // - Resize with the new amount of cells on the leaf grid view
-    // - Set marks equal to zero (representing 'doing nothing')
-    current_view_data_ -> postAdapt();
-}
-
-void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_per_dim_vec,
-                                   const std::vector<std::array<int,3>>& startIJK_vec,
-                                   const std::vector<std::array<int,3>>& endIJK_vec,
-                                   const std::vector<std::string>& lgr_name_vec)
-{
-    // For parallel run, level zero grid is stored in distributed_data_[0]. If CpGrid::scatterGrid has been invoked,
-    // then current_view_data_ == distributed_data_[0].
-    // For serial run, level zero grid is stored in data_[0]. In this case, current_view_data_ == data_[0].
-    // Note: currentData() returns data_ (if grid is not distributed) or distributed_data_ otherwise.
-
-    // Check startIJK_vec and endIJK_vec have same size, and "startIJK[patch][coordinate] < endIJK[patch][coordinate]"
-    current_view_data_->validStartEndIJKs(startIJK_vec, endIJK_vec);
-
-    // Sizes of provided vectors (number of subivisions per cells and lgrs name) should coincide.
-    bool matchingSizeHasFailed = false;
-    if ( (cells_per_dim_vec.size() != startIJK_vec.size())  || (lgr_name_vec.size() != startIJK_vec.size())) {
-        matchingSizeHasFailed = true;
-    }
-    matchingSizeHasFailed = comm().max(matchingSizeHasFailed);
-    if (matchingSizeHasFailed) {
-        OPM_THROW(std::invalid_argument, "Sizes of provided vectors with subdivisions per cell and LGR names need to match.");
-    }
-
-    // Compatibility of number of subdivisions of neighboring LGRs: Check shared faces on boundaries of LGRs.
-    //                                                              Not optimal since the code below does not take into account
-    //                                                              active/inactive cells, instead, relies on "ijk-computations".
-    //                                                              TO DO: improve/remove.
-    // To check "Compatibility of numbers of subdivisions of neighboring LGRs".
-    bool compatibleSubdivisions = current_view_data_->compatibleSubdivisions(cells_per_dim_vec, startIJK_vec, endIJK_vec);
-    compatibleSubdivisions= comm().max(compatibleSubdivisions);
-    if(!compatibleSubdivisions) {
-        if (comm().rank()==0){
-            OPM_THROW(std::logic_error, "Subdivisions of neighboring LGRs sharing at least one face do not coincide. Not suppported yet.");
-        }
-        else{
-            OPM_THROW_NOLOG(std::logic_error, "Subdivisions of neighboring LGRs sharing at least one face do not coincide. Not suppported yet.");
-        }
-    }
-    
-    // Non neighboring connections: Currently, adding LGRs whose cells have NNCs is not supported yet.
-    bool nonNNCs = this->nonNNCs(startIJK_vec, endIJK_vec);
-    // To check "Non-NNCs (non non neighboring connections)" for all processes.
-    nonNNCs = comm().max(nonNNCs);
-    if(!nonNNCs) {
-        OPM_THROW(std::logic_error, "NNC face on a cell containing LGR is not supported yet.");
-    }
-    
-    // To determine if an LGR is not empty in a given process, we set
-    // lgr_with_at_least_one_active_cell[in that level] to 1 if it contains
-    // at least one active cell, and to 0 otherwise.
-    std::vector<int> lgr_with_at_least_one_active_cell(startIJK_vec.size());
-    // Determine the assigned level for the refinement of each marked cell
-    std::vector<int> assignRefinedLevel(current_view_data_->size(0));
-
-    markElemAssignLevelDetectActiveLgrs(startIJK_vec,
-                                        endIJK_vec,
-                                        assignRefinedLevel,
-                                        lgr_with_at_least_one_active_cell);
-
-    int non_empty_lgrs = 0;
-    for (std::size_t level = 0; level < startIJK_vec.size(); ++level) {
-        // Do not throw if all cells of an LGR are inactive in a parallel run (The process might not 'see' those cells.)
-        if (lgr_with_at_least_one_active_cell[level] == 0) {
-            Opm::OpmLog::warning("LGR" + std::to_string(level+1) + " contains only inactive cells (in " + std::to_string(comm().rank()) + " rank).\n");
-        }
-        else {
-            ++non_empty_lgrs;
-        }
-    }
-
-    // Notice that in a parallel run, non_empty_lgrs represents the local active lgrs, i.e. the lgrs containing active cells which also belong
-    // to the current process.
-    auto globalActiveLgrs = comm().sum(non_empty_lgrs);
-    if(globalActiveLgrs == 0) {
-        Opm::OpmLog::warning("All the LGRs contain only inactive cells.\n");
-    }
-
-    preAdapt();
-    adapt(cells_per_dim_vec, assignRefinedLevel, lgr_name_vec, true, startIJK_vec, endIJK_vec);
-    postAdapt();
-
-    // Only for parallel runs
+     // Only for parallel runs
     // - Define global ids for refined level grids (level 1, 2, ..., maxLevel)
     // - Define GlobalIdMapping (cellMapping, faceMapping, pointMapping required per level)
     // - Define ParallelIndex for overlap cells and their neighbors
@@ -2570,6 +2501,105 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
         assert(static_cast<std::size_t>(current_data_->back()->cellIndexSet().size()) == static_cast<std::size_t>(current_data_->back()->size(0)) );
 #endif
     } // end-if-comm().size()>1
+
+
+    // Print total amount of cells on the adapted grid
+    Opm::OpmLog::info(std::to_string(markedElem_count) + " elements have been marked (in " + std::to_string(comm().rank()) + " rank).\n");
+    Opm::OpmLog::info(std::to_string(levels)  + " (new) refined level grid(s) (in " + std::to_string(comm().rank()) + " rank).\n");
+    Opm::OpmLog::info(std::to_string(cell_count)  + " total cells on the leaf grid view (in " + std::to_string(comm().rank()) + " rank).\n");
+
+    return preAdapt();
+}
+
+void CpGrid::postAdapt()
+{
+    // - Resize with the new amount of cells on the leaf grid view
+    // - Set marks equal to zero (representing 'doing nothing')
+    current_view_data_ -> postAdapt();
+}
+
+void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                   const std::vector<std::array<int,3>>& startIJK_vec,
+                                   const std::vector<std::array<int,3>>& endIJK_vec,
+                                   const std::vector<std::string>& lgr_name_vec)
+{
+    // For parallel run, level zero grid is stored in distributed_data_[0]. If CpGrid::scatterGrid has been invoked,
+    // then current_view_data_ == distributed_data_[0].
+    // For serial run, level zero grid is stored in data_[0]. In this case, current_view_data_ == data_[0].
+    // Note: currentData() returns data_ (if grid is not distributed) or distributed_data_ otherwise.
+
+    // Check startIJK_vec and endIJK_vec have same size, and "startIJK[patch][coordinate] < endIJK[patch][coordinate]"
+    current_view_data_->validStartEndIJKs(startIJK_vec, endIJK_vec);
+
+    // Sizes of provided vectors (number of subivisions per cells and lgrs name) should coincide.
+    bool matchingSizeHasFailed = false;
+    if ( (cells_per_dim_vec.size() != startIJK_vec.size())  || (lgr_name_vec.size() != startIJK_vec.size())) {
+        matchingSizeHasFailed = true;
+    }
+    matchingSizeHasFailed = comm().max(matchingSizeHasFailed);
+    if (matchingSizeHasFailed) {
+        OPM_THROW(std::invalid_argument, "Sizes of provided vectors with subdivisions per cell and LGR names need to match.");
+    }
+
+    // Compatibility of number of subdivisions of neighboring LGRs: Check shared faces on boundaries of LGRs.
+    //                                                              Not optimal since the code below does not take into account
+    //                                                              active/inactive cells, instead, relies on "ijk-computations".
+    //                                                              TO DO: improve/remove.
+    // To check "Compatibility of numbers of subdivisions of neighboring LGRs".
+    bool compatibleSubdivisions = current_view_data_->compatibleSubdivisions(cells_per_dim_vec, startIJK_vec, endIJK_vec);
+    compatibleSubdivisions= comm().max(compatibleSubdivisions);
+    if(!compatibleSubdivisions) {
+        if (comm().rank()==0){
+            OPM_THROW(std::logic_error, "Subdivisions of neighboring LGRs sharing at least one face do not coincide. Not suppported yet.");
+        }
+        else{
+            OPM_THROW_NOLOG(std::logic_error, "Subdivisions of neighboring LGRs sharing at least one face do not coincide. Not suppported yet.");
+        }
+    }
+
+    // Non neighboring connections: Currently, adding LGRs whose cells have NNCs is not supported yet.
+    bool nonNNCs = this->nonNNCs(startIJK_vec, endIJK_vec);
+    // To check "Non-NNCs (non non neighboring connections)" for all processes.
+    nonNNCs = comm().max(nonNNCs);
+    if(!nonNNCs) {
+        OPM_THROW(std::logic_error, "NNC face on a cell containing LGR is not supported yet.");
+    }
+
+    // Determine the assigned level for the refinement of each marked cell
+    std::vector<int> assignRefinedLevel(current_view_data_->size(0));
+    markElemAssignLevel(startIJK_vec,
+                        endIJK_vec,
+                        assignRefinedLevel);
+
+    // To determine if an LGR is not empty in a given process, we set
+    // lgr_with_at_least_one_active_cell[in that level] to 1 if it contains
+    // at least one active cell, and to 0 otherwise.
+    std::vector<int> lgr_with_at_least_one_active_cell(startIJK_vec.size());
+    detectActiveLgrs(startIJK_vec,
+                     endIJK_vec,
+                     lgr_with_at_least_one_active_cell);
+
+    int non_empty_lgrs = 0;
+    for (std::size_t level = 0; level < startIJK_vec.size(); ++level) {
+        // Do not throw if all cells of an LGR are inactive in a parallel run (The process might not 'see' those cells.)
+        if (lgr_with_at_least_one_active_cell[level] == 0) {
+            Opm::OpmLog::warning("LGR" + std::to_string(level+1) + " contains only inactive cells (in " + std::to_string(comm().rank()) + " rank).\n");
+        }
+        else {
+            ++non_empty_lgrs;
+        }
+    }
+
+    // Notice that in a parallel run, non_empty_lgrs represents the local active lgrs, i.e. the lgrs containing active cells which also belong
+    // to the current process.
+    auto globalActiveLgrs = comm().sum(non_empty_lgrs);
+    if(globalActiveLgrs == 0) {
+        Opm::OpmLog::warning("All the LGRs contain only inactive cells.\n");
+    }
+
+    preAdapt();
+    adapt(cells_per_dim_vec, assignRefinedLevel, lgr_name_vec, true, startIJK_vec, endIJK_vec);
+    postAdapt();
 
     // Print total refined level grids and total cells on the leaf grid view
     Opm::OpmLog::info(std::to_string(non_empty_lgrs) + " (new) refined level grid(s) (in " + std::to_string(comm().rank()) + " rank).\n");

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -2239,6 +2239,41 @@ void CpGridData::validStartEndIJKs(const std::vector<std::array<int,3>>& startIJ
     }
 }
 
+bool CpGridData::compatibleSubdivisions(const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                        const std::vector<std::array<int,3>>& startIJK_vec,
+                                        const std::vector<std::array<int,3>>& endIJK_vec) const
+{
+    bool compatibleSubdivisions = true;
+    if (startIJK_vec.size() > 1) {
+        bool notAllowedYet = false;
+        for (std::size_t level = 0; level < startIJK_vec.size(); ++level) {
+            for (std::size_t otherLevel = level+1; otherLevel < startIJK_vec.size(); ++otherLevel) {
+                const auto& sharedFaceTag = this-> sharedFaceTag({startIJK_vec[level], startIJK_vec[otherLevel]}, {endIJK_vec[level],endIJK_vec[otherLevel]});
+                if(sharedFaceTag == -1){
+                    break; // Go to the next "other patch"
+                }
+                if (sharedFaceTag == 0 ) {
+                    notAllowedYet = notAllowedYet ||
+                        ((cells_per_dim_vec[level][1] != cells_per_dim_vec[otherLevel][1]) || (cells_per_dim_vec[level][2] != cells_per_dim_vec[otherLevel][2]));
+                }
+                if (sharedFaceTag == 1) {
+                    notAllowedYet = notAllowedYet ||
+                        ((cells_per_dim_vec[level][0] != cells_per_dim_vec[otherLevel][0]) || (cells_per_dim_vec[level][2] != cells_per_dim_vec[otherLevel][2]));
+                }
+                if (sharedFaceTag == 2) {
+                    notAllowedYet = notAllowedYet ||
+                        ((cells_per_dim_vec[level][0] != cells_per_dim_vec[otherLevel][0]) || (cells_per_dim_vec[level][1] != cells_per_dim_vec[otherLevel][1]));
+                }
+                if (notAllowedYet){
+                    compatibleSubdivisions = false;
+                    break;
+                }
+            } // end-otherLevel-for-loop
+        } // end-level-for-loop
+    }// end-if-patchesShareFace
+    return compatibleSubdivisions;
+}
+
 Geometry<3,3> CpGridData::cellifyPatch(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK,
                                        const std::vector<int>& patch_cells,
                                        DefaultGeometryPolicy& cellifiedPatch_geometry,

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -369,19 +369,6 @@ public:
     ///                                 Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
     void validStartEndIJKs(const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
 
-    /// @brief Check compatibility of number of subdivisions of neighboring LGRs.
-    ///
-    /// Check shared faces on boundaries of LGRs. Not optimal since the code below does not take into account
-    /// active/inactive cells, instead, relies on "ijk-computations".
-    ///
-    /// @param [in]  cells_per_dim_vec    Vector of expected subdivisions per cell, per direction, in each LGR.
-    /// @param [in]  startIJK_vec         Vector of Cartesian triplet indices where each patch starts.
-    /// @param [in]  endIJK_vec           Vector of Cartesian triplet indices where each patch ends.
-    ///                                   Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
-    bool compatibleSubdivisions(const std::vector<std::array<int,3>>& cells_per_dim_vec,
-                                const std::vector<std::array<int,3>>& startIJK_vec,
-                                const std::vector<std::array<int,3>>& endIJK_vec) const;
-
     /// @brief Check that every cell to be refined has cuboid shape.
     void checkCuboidShape(const std::vector<int>& cellIdx_vec) const;
 
@@ -425,6 +412,19 @@ public:
     void postAdapt();
 
 private:
+    /// @brief Check compatibility of number of subdivisions of neighboring LGRs.
+    ///
+    /// Check shared faces on boundaries of LGRs. Not optimal since the code below does not take into account
+    /// active/inactive cells, instead, relies on "ijk-computations".
+    ///
+    /// @param [in]  cells_per_dim_vec    Vector of expected subdivisions per cell, per direction, in each LGR.
+    /// @param [in]  startIJK_vec         Vector of Cartesian triplet indices where each patch starts.
+    /// @param [in]  endIJK_vec           Vector of Cartesian triplet indices where each patch ends.
+    ///                                   Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
+    bool compatibleSubdivisions(const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                const std::vector<std::array<int,3>>& startIJK_vec,
+                                const std::vector<std::array<int,3>>& endIJK_vec) const;
+
     std::array<Dune::FieldVector<double,3>,8> getReferenceRefinedCorners(int idx_in_parent_cell, const std::array<int,3>& cells_per_dim) const;
 
     /// @brief Compute amount of cells in each direction of a patch of cells. (Cartesian grid required).

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -364,10 +364,23 @@ public:
     /// @brief Check startIJK and endIJK of each patch of cells to be refined are valid, i.e.
     ///        startIJK and endIJK vectors have the same size and, startIJK < endIJK coordenate by coordenate.
     ///
-    /// @param [in]  startIJK_vec  Vector of Cartesian triplet indices where each patch starts.
-    /// @param [in]  endIJK_vec    Vector of Cartesian triplet indices where each patch ends.
-    ///                            Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
+    /// @param [in]  startIJK_vec       Vector of Cartesian triplet indices where each patch starts.
+    /// @param [in]  endIJK_vec         Vector of Cartesian triplet indices where each patch ends.
+    ///                                 Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
     void validStartEndIJKs(const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
+
+    /// @brief Check compatibility of number of subdivisions of neighboring LGRs.
+    ///
+    /// Check shared faces on boundaries of LGRs. Not optimal since the code below does not take into account
+    /// active/inactive cells, instead, relies on "ijk-computations".
+    ///
+    /// @param [in]  cells_per_dim_vec    Vector of expected subdivisions per cell, per direction, in each LGR.
+    /// @param [in]  startIJK_vec         Vector of Cartesian triplet indices where each patch starts.
+    /// @param [in]  endIJK_vec           Vector of Cartesian triplet indices where each patch ends.
+    ///                                   Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
+    bool compatibleSubdivisions(const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                const std::vector<std::array<int,3>>& startIJK_vec,
+                                const std::vector<std::array<int,3>>& endIJK_vec) const;
 
     /// @brief Check that every cell to be refined has cuboid shape.
     void checkCuboidShape(const std::vector<int>& cellIdx_vec) const;

--- a/opm/grid/cpgrid/ParentToChildCellToPointGlobalIdHandle.hpp
+++ b/opm/grid/cpgrid/ParentToChildCellToPointGlobalIdHandle.hpp
@@ -1,0 +1,172 @@
+//===========================================================================
+//
+// File: ParentToChildCellToPointGlobalIdHandle.hpp
+//
+// Created: November 19 2024
+//
+// Author(s): Antonella Ritorto <antonella.ritorto@opm-op.com>
+//            Markus Blatt      <markus.blatt@opm-op.com>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2024 Equinor ASA
+  This file is part of The Open Porous Media project  (OPM).
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_PARENTTOCHILDCELLTOPOINTGLOBALIDHANDLE_HEADER
+#define OPM_PARENTTOCHILDCELLTOPOINTGLOBALIDHANDLE_HEADER
+
+
+#include <opm/grid/cpgrid/Entity.hpp>
+
+#include <array>
+#include <tuple>
+#include <vector>
+
+
+namespace
+{
+#if HAVE_MPI
+
+/// \brief Handle for assignment of point global ids of refined cells.
+struct ParentToChildCellToPointGlobalIdHandle {
+    //   - The container used for gather and scatter contains "candidates" point global ids for interior elements of the refined level grids (LGRs).
+    //     Access is done with the local index of its parent cell index and its parent cell list of children.
+    //     level_point_global_ids[ level-1 ][ child_cell_local_index [ corner ] ] = "candidate" point global id,
+    //     when child_cell_local_index belongs to the children_local_index_list:
+    //     parent_to_children_[ element.index() ] =  parent_to_children_[ element.index() ] = { level, children_local_index_list }
+    //     and corner = 0, ...,7.
+    //     To decide which "candidate" point global id wins, we use the rank. The smallest ranks wins,
+    //     i.e., the other non-selected candidates get rewritten with the values from the smallest (winner) rank.
+    //   - In the scatter method, the "winner" rank and the 8 point global ids of each number of children) get rewritten.
+
+    using DataType = int;
+
+    /// \param parent_to_children      Map from parent index to all children, and the level they are stored.
+    ///                                parent_to_children_[ element.index() ] = { level, children_list local indices }
+    /// \param level_cell_to_point
+    /// \param level_point_global_ids  A container that for the elements of a level contains all candidate point global ids.
+    /// \param level_winning_ranks
+    /// \param level_point_global_ids
+    ParentToChildCellToPointGlobalIdHandle(const std::vector<std::tuple<int, std::vector<int>>>& parent_to_children,
+                                           const std::vector<std::vector<std::array<int,8>>>& level_cell_to_point,
+                                           std::vector<std::vector<DataType>>& level_winning_ranks,
+                                           std::vector<std::vector<DataType>>& level_point_global_ids)
+        : parent_to_children_(parent_to_children)
+        , level_cell_to_point_(level_cell_to_point)
+        , level_winning_ranks_(level_winning_ranks)
+        , level_point_global_ids_(level_point_global_ids)
+    {
+    }
+
+    // Not every cell has children. When they have children, the amount might vary.
+    bool fixedSize(std::size_t, std::size_t)
+    {
+        return false;
+    }
+    // Only communicate values attached to cells.
+    bool contains(std::size_t, std::size_t codim)
+    {
+        return codim == 0;
+    }
+    // Communicate variable size: 1 (rank) + (8* amount of child cells) from an interior parent cell from level zero grid.
+    template <class T> // T = Entity<0>
+    std::size_t size(const T& element)
+    {
+        // Skip values that are not interior, or have no children (in that case, 'invalid' level = -1)
+        const auto& [level, children] = parent_to_children_[element.index()];
+        // [Bug in dune-common] VariableSizeCommunicator will deadlock if a process attempts to send a message of size zero.
+        // This can happen if the size method returns zero for all entities that are shared with another process.
+        // Therefore, when skipping cells without children or for overlap cells, we set the size to 1.
+        if ( (element.partitionType() != Dune::InteriorEntity) || (level == -1))
+            return 1;
+        return 1 + ( 8*children.size()); // rank + 8 "winner" point global ids per child cell
+    }
+
+    // Gather global ids of child cells of a coarse interior parent cell
+    template <class B, class T> // T = Entity<0>
+    void gather(B& buffer, const T& element)
+    {
+        // Skip values that are not interior, or have no children (in that case, 'invalid level' = -1)
+        const auto& [level, children] = parent_to_children_[element.index()];
+        // [Bug in dune-common] VariableSizeCommunicator will deadlock if a process tries to send a message with size zero.
+        // To avoid this, for cells without children or for overlap cells, we set the size to 1 and write a single DataType
+        // value (e.g., '42').
+        if ( (element.partitionType() != Dune::InteriorEntity) || (level==-1)) {
+            buffer.write(42);
+            return;
+        }
+        // Store the children's corner global ids in the buffer when the element is interior and has children.
+        // Write the rank first, for example via the "corner 0" of cell_to_point_ of the first child:
+        // First child: children[0]
+        // First corner of first child:  level_cell_to_point_[ level -1 ][children[0]] [0]
+        buffer.write(level_winning_ranks_[level-1][ level_cell_to_point_[ level -1 ][children[0]] [0] ]); // winner rank
+        for (const auto& child : children)
+            for (const auto& corner : level_cell_to_point_[level -1][child])
+                buffer.write(level_point_global_ids_[level-1][corner]);
+    }
+
+    // Scatter global ids of child cells of a coarse overlap parent cell
+    template <class B, class T> // T = Entity<0>
+    void scatter(B& buffer, const T& element, std::size_t num_children) // check num_children
+    {
+        const auto& [level, children] = parent_to_children_[element.index()];
+        // Read all values to advance the pointer used by the buffer to the correct index.
+        // (Skip overlap-cells-without-children and interior-cells).
+        if ( ( (element.partitionType() == Dune::OverlapEntity) && (level==-1) ) || (element.partitionType() == Dune::InteriorEntity ) ) {
+            // Read all values to advance the pointer used by the buffer
+            // to the correct index
+            for (std::size_t child = 0; child < num_children;  ++child) { // this should be 1 + (8* total children)
+                DataType tmp;
+                buffer.read(tmp);
+            }
+        }
+        else { // Overlap cell with children.
+            // Read and store the values in the correct location directly.
+            // The order of the children is the same on each process.
+            assert(children.size()>0);
+            assert(level>0);
+            // Read and store the values in the correct location directly.
+            DataType tmp_rank;
+            buffer.read(tmp_rank);
+            for (const auto& child : children) {
+                for (const auto& corner : level_cell_to_point_[level -1][child]) {
+                    auto& min_rank = level_winning_ranks_[level-1][corner];
+                    // Rewrite the rank (smaller rank wins)
+                    if (tmp_rank < min_rank) {
+                        min_rank = tmp_rank;
+                        auto& target_entry = level_point_global_ids_[level-1][corner];
+                        buffer.read(target_entry);
+                    } else {
+                        DataType rubbish;
+                        buffer.read(rubbish);
+                    }
+                }
+            }
+        }
+    }
+
+private:
+    const std::vector<std::tuple<int, std::vector<int>>>& parent_to_children_;
+    const std::vector<std::vector<std::array<int,8>>>& level_cell_to_point_;
+    std::vector<std::vector<DataType>>& level_winning_ranks_;
+    std::vector<std::vector<DataType>>& level_point_global_ids_;
+};
+#endif // HAVE_MPI
+} // namespace
+#endif

--- a/tests/cpgrid/addLgrsOnDistributedGrid_test.cpp
+++ b/tests/cpgrid/addLgrsOnDistributedGrid_test.cpp
@@ -104,8 +104,8 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
         {
             Dune::cpgrid::Entity<0> entity = Dune::cpgrid::Entity<0>(*data[0], cell, true);
             BOOST_CHECK( entity.hasFather() == false);
-            // BOOST_CHECK_THROW(entity.father(), std::logic_error);
-            // BOOST_CHECK_THROW(entity.geometryInFather(), std::logic_error);
+            BOOST_CHECK_THROW(entity.father(), std::logic_error);
+            BOOST_CHECK_THROW(entity.geometryInFather(), std::logic_error);
             BOOST_CHECK( entity.getOrigin() ==  entity);
             BOOST_CHECK( entity.getOrigin().level() == 0);
             auto it = entity.hbegin(coarse_grid.maxLevel());
@@ -181,7 +181,6 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
             const auto& maxCartesianIdxLevel = data[level]->logical_cartesian_size_[0]*data[level]->logical_cartesian_size_[1]* data[level]->logical_cartesian_size_[2];
             BOOST_CHECK( *itMax < maxCartesianIdxLevel);
         }
-
 
         // LGRs
         for (int cell = 0; cell <  data[level]-> size(0); ++cell)
@@ -276,8 +275,8 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
                 BOOST_CHECK( level_cellIdx[0] == entity.level());
             }
             else{
-                // BOOST_CHECK_THROW(entity.father(), std::logic_error);
-                // BOOST_CHECK_THROW(entity.geometryInFather(), std::logic_error);
+                BOOST_CHECK_THROW(entity.father(), std::logic_error);
+                BOOST_CHECK_THROW(entity.geometryInFather(), std::logic_error);
                 BOOST_CHECK_EQUAL(child_to_parent[0], -1);
                 BOOST_CHECK_EQUAL(child_to_parent[1], -1);
                 BOOST_CHECK( level_cellIdx[0] == 0);
@@ -568,7 +567,7 @@ BOOST_AUTO_TEST_CASE(atLeastOneLgr_per_process_attempt)
         // Total global ids in leaf grid view for cells: 36-(6 marked cells) + 16 + 27 + 64 + 16 = 153
         // Total global ids in leaf grid view for points: 80 + 33 + 56 + 117 + 33 = 319
         refinePatch_and_check(grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
-        
+
         // Check global id is not duplicated for points for each LGR
         // LGR1 dim 2x4x2 -> 3x5x3 = 45 points
         // LGR2 dim 3x3x3 -> 4x4x4 = 64 points
@@ -673,7 +672,37 @@ BOOST_AUTO_TEST_CASE(throw_not_fully_interior_lgr)
     }
 }
 
-//Calling globalRefine on a distributed grid is not supported yet.
+//Calling globalRefine on a distributed grid is supported now.
+BOOST_AUTO_TEST_CASE(globalRefine1)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,2,1};
+    grid.createCartesian(grid_dim, cell_sizes);
+
+    std::vector<int> parts(8);
+    std::vector<std::vector<int>> cells_per_rank = {{0,4},{1,5},{2,6}, {3,7}};
+    for (int rank = 0; rank < 4; ++rank) {
+        for (const auto& elemIdx : cells_per_rank[rank]) {
+            parts[elemIdx] = rank;
+        }
+    }
+    // Distribute the grid
+    if(grid.comm().size()>1)
+    {
+        grid.loadBalance();
+
+        grid.globalRefine(1);
+        const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}};
+        const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}};
+        const std::vector<std::array<int,3>> endIJK_vec = {{4,2,1}};
+        const std::vector<std::string> lgr_name_vec = {"GR1"}; // GR stands for GLOBAL REFINEMENT
+
+        refinePatch_and_check(grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(globalRefine2)
 {
     // Create a grid
@@ -681,12 +710,28 @@ BOOST_AUTO_TEST_CASE(globalRefine2)
     const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
     const std::array<int, 3> grid_dim = {4,3,3};
     grid.createCartesian(grid_dim, cell_sizes);
+
+     std::vector<int> parts(36);
+    std::vector<std::vector<int>> cells_per_rank = { {0,1,4,5,8,9,16,20,21},
+                                                     {12,13,17,24,25,28,29,32,33},
+                                                     {2,3,6,7,10,11,18,22,23},
+                                                     {14,15,19,26,27,30,31,34,35} };
+    for (int rank = 0; rank < 4; ++rank) {
+        for (const auto& elemIdx : cells_per_rank[rank]) {
+            parts[elemIdx] = rank;
+        }
+    }
     // Distribute the grid
     if(grid.comm().size()>1)
     {
         grid.loadBalance();
 
-        BOOST_CHECK_THROW(grid.globalRefine(1), std::logic_error);
+        grid.globalRefine(1);
+        const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}};
+        const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}};
+        const std::vector<std::array<int,3>> endIJK_vec = {{4,3,3}};
+        const std::vector<std::string> lgr_name_vec = {"GR1"}; // GR stands for GLOBAL REFINEMENT
+        refinePatch_and_check(grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
     }
 }
 
@@ -752,12 +797,12 @@ BOOST_AUTO_TEST_CASE(distributed_lgr)
         // That means that the "unfortunate" expected point ids count is 45 (desired value) + 5 (duplicated laying on
         // shared I_FACE) = 50.
         BOOST_CHECK( static_cast<int>(all_point_ids_set.size()) == 50);
-        
-        /** Current approach avoids duplicated point ids when
+
+         // Current approach avoids duplicated point ids when
          // 1. the LGR is distributed in P_{i_0}, ..., P_{i_n}, with n+1 < grid.comm().size(),
          // AND
          // 2. there is no coarse cell seen by a process P with P != P_{i_j}, j = 0, ..., n.
-         // Otherwise, there will be duplicated point ids.*/ 
+         // Otherwise, there will be duplicated point ids.
 
         // Check global id is not duplicated for points
         std::vector<int> localPointIds_vec;
@@ -930,6 +975,56 @@ BOOST_AUTO_TEST_CASE(distributed_in_all_ranks_lgr)
     }
 }
 
+BOOST_AUTO_TEST_CASE(call_adapt_with_args_on_distributed_grid)
+{
+    // Only for testing assignment of new global ids for refined entities (cells and point belonging to
+    // refined level grids).
+
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    grid.createCartesian(grid_dim, cell_sizes);
+    std::vector<int> parts(36);
+    std::vector<std::vector<int>> cells_per_rank = { {0,1,4,5,8,9,16,20,21},
+                                                     {12,13,17,24,25,28,29,32,33},
+                                                     {2,3,6,7,10,11,18,22,23},
+                                                     {14,15,19,26,27,30,31,34,35} };
+    for (int rank = 0; rank < 4; ++rank) {
+        for (const auto& elemIdx : cells_per_rank[rank]) {
+            parts[elemIdx] = rank;
+        }
+    }
+    if(grid.comm().size()>1)
+    {
+        grid.loadBalance(parts);
+
+        const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}};
+        const std::vector<std::array<int,3>> startIJK_vec = {{1,0,0}};
+        const std::vector<std::array<int,3>> endIJK_vec = {{3,2,2}};
+        const std::vector<std::string> lgr_name_vec = {"LGR1"};
+        // LGR1 element indices = {1,2,5,6,13,14,17,18} where
+        // 1,5 in rank 0,
+        // 13,17 in rank 1,
+        // 2,6,18 in rank 2,
+        // 14 in rank 3.
+        // Block of cells to refine dim 2x2x2. LGR1 dim 4x4x4.
+        // 64 new refined cells. 5x5x5 = 125 points (only 98 = 125 - 3x3x3 parent corners new points - new global ids).
+        const std::vector<int>& marked_elemIdx = {1,2,5,6,13,14,17,18};
+        std::vector<int> assignRefinedLevel(grid.currentData().front()->size(0));
+        for (const auto& idx : marked_elemIdx)
+            assignRefinedLevel[idx] = 1;
+
+        grid.adapt(cells_per_dim_vec,
+                   assignRefinedLevel,
+                   lgr_name_vec,
+                   true,
+                   startIJK_vec,
+                   endIJK_vec);
+
+        refinePatch_and_check(grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+    }
+}
 
 BOOST_AUTO_TEST_CASE(call_adapt_on_distributed_grid)
 {
@@ -954,37 +1049,20 @@ BOOST_AUTO_TEST_CASE(call_adapt_on_distributed_grid)
     if(grid.comm().size()>1)
     {
         grid.loadBalance(parts);
-        // grid.adapt(); It does not throw an exeption. Note: adapt() implements global refinement.
-        //
-        // The following test fails. TODO: Move the assignment of global IDs for refined level grids and the leaf grid view
-        // into the adapt(...) function, as it is invoked within 'addLgrsUpdateLeafGridView', not the other way around.
-        // refinePatch_and_check(grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+        // Mark all elements -> indirect global refinement
+        for (const auto& element : elements(grid.leafGridView())){
+            grid.mark(1, element);
+        }
+        grid.preAdapt();
+        grid.adapt();
+        grid.postAdapt();
 
         const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}};
         const std::vector<std::array<int,3>> startIJK_vec = {{1,0,0}};
-        const std::vector<std::array<int,3>> endIJK_vec = {{3,2,2}};
-        const std::vector<std::string> lgr_name_vec = {"LGR1"};
-        // LGR1 element indices = {1,2,5,6,13,14,17,18} where
-        // 1,5 in rank 0,
-        // 13,17 in rank 1,
-        // 2,6,18 in rank 2,
-        // 14 in rank 3.
-        // Block of cells to refine dim 2x2x2. LGR1 dim 4x4x4.
-        // 64 new refined cells. 5x5x5 = 125 points (only 98 = 125 - 3x3x3 parent corners new points - new global ids).
-        const std::vector<int>& marked_elemIdx = {1,2,5,6,13,14,17,18};
-        std::vector<int> assignRefinedLevel(grid.currentData().front()->size(0));
-        for (const auto& idx : marked_elemIdx)
-            assignRefinedLevel[idx] = 1;
+        const std::vector<std::array<int,3>> endIJK_vec = {{4,3,3}};
+        const std::vector<std::string> lgr_name_vec = {"GR1"};
 
-        grid.adapt(cells_per_dim_vec,
-                   assignRefinedLevel,
-                   lgr_name_vec,
-                   true,
-                   startIJK_vec,
-                   endIJK_vec);
-        // The following test fails. TODO: Move the assignment of global IDs for refined level grids and the leaf grid view
-        // into the adapt(...) function, as it is invoked within 'addLgrsUpdateLeafGridView', not the other way around.
-        // refinePatch_and_check(grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+        refinePatch_and_check(grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
     }
 }
 


### PR DESCRIPTION
Based on OPM/opm-grid#802.

This PR moves the definition of global ids from addLgrsUpdateLeafView(...) to adapt(...), allowing refinement in a more general setting. For example, global refinement (currently, only possible to invoke once with argument equal to 1), or refinement of elements not necessary forming a block of cells.

Not relevant for the Reference Manual.