### PR TITLE
On loadBalance(...) "addCornerCells" should be called "addEdgeCells"?

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -202,6 +202,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/grid/LookUpData.hh
   opm/grid/cpgrid/OrientedEntityTable.hpp
   opm/grid/cpgrid/ParentToChildrenCellGlobalIdHandle.hpp
+	opm/grid/cpgrid/ParentToChildCellToPointGlobalIdHandle.hpp
   opm/grid/cpgrid/PartitionIteratorRule.hpp
   opm/grid/cpgrid/PartitionTypeIndicator.hpp
   opm/grid/cpgrid/PersistentContainer.hpp

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -484,6 +484,8 @@ namespace Dune
 
         void populateCellIndexSetRefinedGrid(int level);
 
+        void populateCellIndexSetLeafGridView();
+
         /// --------------- Adaptivity (begin) ---------------
         /// @brief Mark entity for refinement (or coarsening).
         ///

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -468,11 +468,9 @@ namespace Dune
                                                  std::vector<int>& assignRefinedLevel,
                                                  std::vector<int>& lgr_with_at_least_one_active_cell);
 
-        void predictMinCellAndPointGlobalIdPerProcess(int& min_globalId_cell_in_proc,
-                                                      int& min_globalId_point_in_proc,
-                                                      const std::vector<int>& assignRefinedLevel,
-                                                      const std::vector<std::array<int,3>>& cells_per_dim_vec,
-                                                      const std::vector<int>& lgr_with_at_least_one_active_cell) const;
+        std::pair<int,int> predictMinCellAndPointGlobalIdPerProcess(const std::vector<int>& assignRefinedLevel,
+                                                                    const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                                                    const std::vector<int>& lgr_with_at_least_one_active_cell) const;
 
         void collectCellIdsAndCandidatePointIds( std::vector<std::vector<int>>& localToGlobal_cells_per_level,
                                                  std::vector<std::vector<int>>& localToGlobal_points_per_level,

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -415,28 +415,12 @@ namespace Dune
         template <int codim>
         cpgrid::Entity<codim> entity(const cpgrid::Entity<codim>& seed) const;
 
-        /// @brief Create a grid out of a coarse one and a refinement(LGR) of a selected block-shaped patch of cells from that coarse grid.
-        ///
-        /// Level0 refers to the coarse grid, assumed to be this-> data_[0]. Level1 refers to the LGR (stored in this->data_[1]).
-        /// LeafView (stored in this-> data_[2]) is built with the level0-entities which weren't involded in the
-        /// refinenment, together with the new born entities created in level1.
-        /// Old-corners and old-faces (from coarse grid) lying on the boundary of the patch, get replaced by new-born-equivalent corners
-        /// and new-born-faces.
-        ///
-        /// @param [in] cells_per_dim            Number of (refined) cells in each direction that each parent cell should be refined to.
-        /// @param [in] startIJK                 Cartesian triplet index where the patch starts.
-        /// @param [in] endIJK                   Cartesian triplet index where the patch ends.
-        ///                                      Last cell part of the lgr will be {endijk[0]-1, ... endIJK[2]-1}.
-        /// @param [in] lgr_name                 Name (std::string) for the lgr/level1
-        void addLgrUpdateLeafView(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK,
-                                  const std::array<int,3>& endIJK,  const std::string& lgr_name);
-
         /// @brief Create a grid out of a coarse one and (at most) 2 refinements(LGRs) of selected block-shaped disjoint patches
         ///        of cells from that coarse grid.
         ///
         /// Level0 refers to the coarse grid, assumed to be this-> data_[0]. Level1 and level2 refer to the LGRs (stored in this->data_[1]
         /// data_[2]). LeafView (stored in this-> data_[3]) is built with the level0-entities which weren't involded in the
-        /// refinenment, together with the new born entities created in level1 and level2. 
+        /// refinenment, together with the new born entities created in level1 and level2.
         /// Old-corners and old-faces (from coarse grid) lying on the boundary of the patches, get replaced by new-born-equivalent corners
         /// and new-born-faces.
         ///

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -460,6 +460,9 @@ namespace Dune
         //        from certain LGR
         Dune::cpgrid::Intersection getParentIntersectionFromLgrBoundaryFace(const Dune::cpgrid::Intersection& intersection) const;
 
+        // @brief Check if there non neighboring connections on blocks of cells selected for refinement.
+        bool nonNNCs( const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
+
 
         /// --------------- Adaptivity (begin) ---------------
         /// @brief Mark entity for refinement (or coarsening).

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -468,6 +468,12 @@ namespace Dune
                                                  std::vector<int>& assignRefinedLevel,
                                                  std::vector<int>& lgr_with_at_least_one_active_cell);
 
+        void predictMinCellAndPointGlobalIdPerProcess(int& min_globalId_cell_in_proc,
+                                                      int& min_globalId_point_in_proc,
+                                                      const std::vector<int>& assignRefinedLevel,
+                                                      const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                                      const std::vector<int>& lgr_with_at_least_one_active_cell) const;
+
 
         /// --------------- Adaptivity (begin) ---------------
         /// @brief Mark entity for refinement (or coarsening).

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -486,6 +486,8 @@ namespace Dune
 
         void populateCellIndexSetLeafGridView();
 
+        void populateLeafGlobalIdSet();
+
         /// --------------- Adaptivity (begin) ---------------
         /// @brief Mark entity for refinement (or coarsening).
         ///

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -463,6 +463,11 @@ namespace Dune
         // @brief Check if there non neighboring connections on blocks of cells selected for refinement.
         bool nonNNCs( const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
 
+        void markElemAssignLevelDetectActiveLgrs(const std::vector<std::array<int,3>>& startIJK_vec,
+                                                 const std::vector<std::array<int,3>>& endIJK_vec,
+                                                 std::vector<int>& assignRefinedLevel,
+                                                 std::vector<int>& lgr_with_at_least_one_active_cell);
+
 
         /// --------------- Adaptivity (begin) ---------------
         /// @brief Mark entity for refinement (or coarsening).

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -482,6 +482,7 @@ namespace Dune
                                   const std::vector<std::tuple<int,std::vector<int>>>& parent_to_children,
                                   const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
 
+        void populateCellIndexSetRefinedGrid(int level);
 
         /// --------------- Adaptivity (begin) ---------------
         /// @brief Mark entity for refinement (or coarsening).

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -474,6 +474,12 @@ namespace Dune
                                                       const std::vector<std::array<int,3>>& cells_per_dim_vec,
                                                       const std::vector<int>& lgr_with_at_least_one_active_cell) const;
 
+        void collectCellIdsAndCandidatePointIds( std::vector<std::vector<int>>& localToGlobal_cells_per_level,
+                                                 std::vector<std::vector<int>>& localToGlobal_points_per_level,
+                                                 int min_globalId_cell_in_proc,
+                                                 int min_globalId_point_in_proc,
+                                                 const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
+
 
         /// --------------- Adaptivity (begin) ---------------
         /// @brief Mark entity for refinement (or coarsening).

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1066,38 +1066,96 @@ namespace Dune
         /// @param [in] cells_per_dim:    Total children cells in each direction (x-,y-, and z-direction) of the single-cell-refinement.
         /// @param [in] faceIdxInLgr:     Face index in the single-cell-refinement.
         /// @param [in] elemLgr_ptr:      Pointer to the elemLgr single-cell-refinement grid.
-        /// @param [in] elemLgr:         Cell index from starting grid, that has been refined into a single-cell-refinement.
+        /// @param [in] elemLgr:          Cell index from starting grid, that has been refined into a single-cell-refinement.
         int getParentFaceWhereNewRefinedFaceLiesOn(const std::array<int,3>& cells_per_dim, int faceIdxInLgr,
                                                    const std::shared_ptr<cpgrid::CpGridData>& elemLgr_ptr,
                                                    int elemLgr)  const;
+        
         /// --------------- Auxiliary methods to support Adaptivity (end) ---------------
 
-              // @brief Check if there non neighboring connections on blocks of cells selected for refinement.
-        bool nonNNCs( const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
+        /// @brief Check if there are non neighboring connections on blocks of cells selected for refinement.
+        ///
+        /// @param [in] startIJK_vec    Vector of ijk values denoting the start of each block of cells selected for refinement.
+        /// @param [in] endIJK_vec      Vector of ijk values denoting the end of each block of cells selected for refinement.
+        ///
+        /// @return bool   True when all blocks of cells do not contain any NNCs (non-neighboring-connection).
+        ///                False when there is a block with at least one cell with a NNC.
+        bool nonNNCsSelectedCellsLGR( const std::vector<std::array<int,3>>& startIJK_vec,
+                                      const std::vector<std::array<int,3>>& endIJK_vec) const;
 
+        /// @brief Given blocks of cells selected for refinement, mark selected elements and assign them their corresponding
+        ///        (refined) level (grid).
+        ///        When level zero grid is distributed before refinement, detect which LGRs are active in each process.
+        ///
+        /// @param [in] startIJK_vec    Vector of ijk values denoting the start of each block of cells selected for refinement.
+        /// @param [in] endIJK_vec      Vector of ijk values denoting the end of each block of cells selected for refinement.
+        /// @param [out] assignRefinedLevel   Assign level for the refinement of each marked cell. Example: refined element from
+        ///                                   LGR1 have level 1, refined element rfom LGR2 have level 2, etc.
+        /// @param [out] lgr_with_at_least_one_active_cell Determine if an LGR is not empty in a given process, we set
+        ///                                                lgr_with_at_least_one_active_cell[in that level] to 1 if it contains
+        ///                                                at least one active cell, and to 0 otherwise.
         void markElemAssignLevelDetectActiveLgrs(const std::vector<std::array<int,3>>& startIJK_vec,
                                                  const std::vector<std::array<int,3>>& endIJK_vec,
                                                  std::vector<int>& assignRefinedLevel,
                                                  std::vector<int>& lgr_with_at_least_one_active_cell);
 
-        std::pair<int,int> predictMinCellAndPointGlobalIdPerProcess(const std::vector<int>& assignRefinedLevel,
-                                                                    const std::vector<std::array<int,3>>& cells_per_dim_vec,
-                                                                    const std::vector<int>& lgr_with_at_least_one_active_cell) const;
+        /// @brief Predict minimum cell and point global ids per process.
+        ///
+        /// Predict how many new cells/points (born in refined level grids) need new globalIds, so we can assign unique
+        /// new ids ( and anticipate the maximum). At this point, the grid is already refined according to the LGR specification.
+        ///
+        /// @param [in] assignRefinedLevel   Assign level for the refinement of each marked cell. Example: refined element from
+        ///                                  LGR1 have level 1, refined element rfom LGR2 have level 2, etc.
+        /// @param [in] cells_per_dim_vec    Total child cells in each direction (x-,y-, and z-direction) per block of cells.
+        /// @param [in] lgr_with_at_least_one_active_cell  Determine if an LGR is not empty in a given process:
+        ///                                                lgr_with_at_least_one_active_cell[level] = 1 if it contains
+        ///                                                at least one active cell in the current process, and 0 otherwise.
+        /// @param [out] min_globalId_cell_in_proc
+        /// @param [out] min_globalId_point_in_proc
+        void predictMinCellAndPointGlobalIdPerProcess(const std::vector<int>& assignRefinedLevel,
+                                                      const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                                      const std::vector<int>& lgr_with_at_least_one_active_cell,
+                                                      int& min_globalId_cell_in_proc,
+                                                      int& min_globalId_point_in_proc) const;
 
-        void collectCellIdsAndCandidatePointIds( std::vector<std::vector<int>>& localToGlobal_cells_per_level,
-                                                 std::vector<std::vector<int>>& localToGlobal_points_per_level,
-                                                 int min_globalId_cell_in_proc,
-                                                 int min_globalId_point_in_proc,
-                                                 const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
+        /// @brief Assign cell global ids of new born cell from refined level grids. Assign 'candidate' point global ids
+        ///        for points in refined level grids.
+        ///
+        /// @param [out] localToGlobal_cells_per_level    Relation local element.index() to assigned cell global id.
+        /// @param [out] localToGlobal_points_per_level   Relation local point.index() to assigned 'candidate' global id.
+        /// @param [in] min_globalId_cell_in_proc         Minimum cell global id per process.
+        /// @param [in] min_globalId_point_in_proc        Minimum point global id per process.
+        /// @param [in] cells_per_dim_vec                 Total child cells in each direction (x-,y-, and z-direction) per block of cells.
+        void assignCellIdsAndCandidatePointIds( std::vector<std::vector<int>>& localToGlobal_cells_per_level,
+                                                std::vector<std::vector<int>>& localToGlobal_points_per_level,
+                                                int min_globalId_cell_in_proc,
+                                                int min_globalId_point_in_proc,
+                                                const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
 
+        /// @brief Select and re-write point global ids.
+        ///
+        /// After assigning global IDs to points in refined-level grids, a single point may have
+        /// "multiple unique" global IDs, one in each process to which it belongs.
+        /// To reduce the unnucesary id assigments, since global IDs must be distinct across the global leaf view
+        /// and consistent across each refined-level grid, we will rewrite the entries in
+        /// localToGlobal_points_per_level. Using cell_to_point_ across all refined cells through
+        /// communication: gathering the 8 corner points of each interior cell and scattering the
+        /// 8 corner points of overlapping cells, for all child cells of a parent cell in level zero grid.
+        ///
+        /// @param [out] localToGlobal_points_per_level   Relation local point.index() to assigned 'candidate' global id.
+        /// @param [in] parent_to_children                The communication step is based on level zero grid, via the relation parent-children-cells.
+        /// @param [in] cells_per_dim_vec                 Total child cells in each direction (x-,y-, and z-direction) per block of cells.
         void selectWinnerPointIds(std::vector<std::vector<int>>&  localToGlobal_points_per_level,
                                   const std::vector<std::tuple<int,std::vector<int>>>& parent_to_children,
                                   const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
 
+        /// @brief For a grid whose level zero has been distributed and then locally refined, populate the cell_index_set_ of each refined level grid.
         void populateCellIndexSetRefinedGrid(int level);
 
+        /// @brief For a grid whose level zero has been distributed and then locally refined, populate the cell_index_set_ of the leaf grid view.
         void populateCellIndexSetLeafGridView();
 
+        /// @brief For a grid whose level zero has been distributed and then locally refined, populate the global_id_set_ of the leaf grid view.
         void populateLeafGlobalIdSet();
 
     public:

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -480,6 +480,10 @@ namespace Dune
                                                  int min_globalId_point_in_proc,
                                                  const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
 
+        void selectWinnerPointIds(std::vector<std::vector<int>>&  localToGlobal_points_per_level,
+                                  const std::vector<std::tuple<int,std::vector<int>>>& parent_to_children,
+                                  const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
+
 
         /// --------------- Adaptivity (begin) ---------------
         /// @brief Mark entity for refinement (or coarsening).

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -460,34 +460,6 @@ namespace Dune
         //        from certain LGR
         Dune::cpgrid::Intersection getParentIntersectionFromLgrBoundaryFace(const Dune::cpgrid::Intersection& intersection) const;
 
-        // @brief Check if there non neighboring connections on blocks of cells selected for refinement.
-        bool nonNNCs( const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
-
-        void markElemAssignLevelDetectActiveLgrs(const std::vector<std::array<int,3>>& startIJK_vec,
-                                                 const std::vector<std::array<int,3>>& endIJK_vec,
-                                                 std::vector<int>& assignRefinedLevel,
-                                                 std::vector<int>& lgr_with_at_least_one_active_cell);
-
-        std::pair<int,int> predictMinCellAndPointGlobalIdPerProcess(const std::vector<int>& assignRefinedLevel,
-                                                                    const std::vector<std::array<int,3>>& cells_per_dim_vec,
-                                                                    const std::vector<int>& lgr_with_at_least_one_active_cell) const;
-
-        void collectCellIdsAndCandidatePointIds( std::vector<std::vector<int>>& localToGlobal_cells_per_level,
-                                                 std::vector<std::vector<int>>& localToGlobal_points_per_level,
-                                                 int min_globalId_cell_in_proc,
-                                                 int min_globalId_point_in_proc,
-                                                 const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
-
-        void selectWinnerPointIds(std::vector<std::vector<int>>&  localToGlobal_points_per_level,
-                                  const std::vector<std::tuple<int,std::vector<int>>>& parent_to_children,
-                                  const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
-
-        void populateCellIndexSetRefinedGrid(int level);
-
-        void populateCellIndexSetLeafGridView();
-
-        void populateLeafGlobalIdSet();
-
         /// --------------- Adaptivity (begin) ---------------
         /// @brief Mark entity for refinement (or coarsening).
         ///
@@ -1099,6 +1071,34 @@ namespace Dune
                                                    const std::shared_ptr<cpgrid::CpGridData>& elemLgr_ptr,
                                                    int elemLgr)  const;
         /// --------------- Auxiliary methods to support Adaptivity (end) ---------------
+
+              // @brief Check if there non neighboring connections on blocks of cells selected for refinement.
+        bool nonNNCs( const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
+
+        void markElemAssignLevelDetectActiveLgrs(const std::vector<std::array<int,3>>& startIJK_vec,
+                                                 const std::vector<std::array<int,3>>& endIJK_vec,
+                                                 std::vector<int>& assignRefinedLevel,
+                                                 std::vector<int>& lgr_with_at_least_one_active_cell);
+
+        std::pair<int,int> predictMinCellAndPointGlobalIdPerProcess(const std::vector<int>& assignRefinedLevel,
+                                                                    const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                                                    const std::vector<int>& lgr_with_at_least_one_active_cell) const;
+
+        void collectCellIdsAndCandidatePointIds( std::vector<std::vector<int>>& localToGlobal_cells_per_level,
+                                                 std::vector<std::vector<int>>& localToGlobal_points_per_level,
+                                                 int min_globalId_cell_in_proc,
+                                                 int min_globalId_point_in_proc,
+                                                 const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
+
+        void selectWinnerPointIds(std::vector<std::vector<int>>&  localToGlobal_points_per_level,
+                                  const std::vector<std::tuple<int,std::vector<int>>>& parent_to_children,
+                                  const std::vector<std::array<int,3>>& cells_per_dim_vec) const;
+
+        void populateCellIndexSetRefinedGrid(int level);
+
+        void populateCellIndexSetLeafGridView();
+
+        void populateLeafGlobalIdSet();
 
     public:
 

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1266,6 +1266,84 @@ void CpGrid::markElemAssignLevelDetectActiveLgrs(const std::vector<std::array<in
     }
 }
 
+void CpGrid::predictMinCellAndPointGlobalIdPerProcess(int& min_globalId_cell_in_proc,
+                                                      int& min_globalId_point_in_proc,
+                                                      const std::vector<int>& assignRefinedLevel,
+                                                      const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                                      const std::vector<int>& lgr_with_at_least_one_active_cell) const
+{
+#if HAVE_MPI
+    // Maximum global id from level zero. (Then, new entities get global id values greater than max_globalId_levelZero).
+    // Recall that only cells and points are taken into account; faces are ignored (do not have any global id).
+    auto max_globalId_levelZero = comm().max(current_data_->front()->global_id_set_->getMaxGlobalId());
+
+    // Predict how many new cells/points (born in refined level grids) need new globalIds, so we can assign unique
+    // new ids ( and anticipate the maximum).
+    // At this point, neither cell_index_set_ nor partition_type_indicator_ are populated.
+    // Refined level grid cells:
+    //    1. Inherit their partition type from their parent cell (i.e., element.father().partitionType()).
+    //    2. Assign global ids only for interior cells.
+    //    3. Communicate the already assigned cell global ids from interior to overlap refined cells.
+    // Refined level grid points/vertices:
+    // There are 4 partition types: interior, border, front, overlap. This classification requires that both
+    // cell and face partition types are already defined, not available yet for refined level grids.
+    //    1. Assign for all partition type points a 'candidate of global id' (unique in each process).
+    //       Except the points that coincide with a point from level zero.
+    //    2. To make point ids globally unique, re-write the values for points that are corners of overlap
+    //       refined cells, via communication.
+    // Under the assumption of LGRs fully-interior, no communication is needed. In the general case, communication will be used
+    // to populate overlap cell/point global ids on the refined level grids.
+
+
+    // Predict how many new cell ids per process are needed.
+    std::vector<std::size_t> cell_ids_needed_by_proc(comm().size());
+    std::size_t local_cell_ids_needed = 0;
+    for ( const auto& element : elements( levelGridView(0), Dune::Partitions::interior) ) {
+        // Get old mark (from level zero). After calling adapt, all marks are set to zero.
+        bool hasBeenMarked = currentData().front()->getMark(element) == 1;
+        if ( hasBeenMarked ) {
+            const auto& level = assignRefinedLevel[element.index()];
+            // Shift level (to level -1) since cells_per_dim_vec stores number of subdivisions in each direction (xyz)
+            // per parent cell, per level, starting from level 1, ..., maxLevel.
+            local_cell_ids_needed += cells_per_dim_vec[level-1][0]*cells_per_dim_vec[level-1][1]*cells_per_dim_vec[level-1][2];
+        }
+    }
+    comm().allgather(&local_cell_ids_needed, 1, cell_ids_needed_by_proc.data());
+
+    // Overestimate ('predict') how many new point ids per process are needed.
+    // Assign for all partition type points a 'candidate of global id' (unique in each process).
+    std::vector<std::size_t> point_ids_needed_by_proc(comm().size());
+    std::size_t local_point_ids_needed = 0;
+    for (std::size_t level = 1; level < cells_per_dim_vec.size()+1; ++level){
+        if(lgr_with_at_least_one_active_cell[level-1]>0) {
+            // Amount of local_point_ids_needed might be overestimated.
+            for (const auto& point : vertices(levelGridView(level))){
+                // If point coincides with an existing corner from level zero, then it does not need a new global id.
+                if ( !(*current_data_)[level]->corner_history_.empty() ) {
+                    const auto& bornLevel_bornIdx =  (*current_data_)[level]->corner_history_[point.index()];
+                    if (bornLevel_bornIdx[0] == -1)  { // Corner is new-> it needs a new global id
+                        local_point_ids_needed += 1;
+                    }
+                }
+            }
+        }
+    }
+    comm().allgather(&local_point_ids_needed, 1, point_ids_needed_by_proc.data());
+
+    auto expected_max_globalId_cell = std::accumulate(cell_ids_needed_by_proc.begin(),
+                                                      cell_ids_needed_by_proc.end(),
+                                                      max_globalId_levelZero + 1);
+    min_globalId_cell_in_proc = std::accumulate(cell_ids_needed_by_proc.begin(),
+                                                cell_ids_needed_by_proc.begin()+comm().rank(),
+                                                max_globalId_levelZero + 1);
+    min_globalId_point_in_proc = std::accumulate(point_ids_needed_by_proc.begin(),
+                                                 point_ids_needed_by_proc.begin()+ comm().rank(),
+                                                 expected_max_globalId_cell);
+
+#endif
+}
+
+
 double CpGrid::cellCenterDepth(int cell_index) const
 {
     // Here cell center depth is computed as a raw average of cell corner depths.
@@ -2188,71 +2266,14 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
     // - Define ParallelIndex for overlap cells and their neighbors
     if(comm().size()>1) {
 #if HAVE_MPI
-        // Maximum global id from level zero. (Then, new entities get global id values greater than max_globalId_levelZero).
-        // Recall that only cells and points are taken into account; faces are ignored (do not have any global id).
-        auto max_globalId_levelZero = comm().max(current_data_->front()->global_id_set_->getMaxGlobalId());
-
-        // Predict how many new cells/points (born in refined level grids) need new globalIds, so we can assign unique
-        // new ids ( and anticipate the maximum).
-        // At this point, neither cell_index_set_ nor partition_type_indicator_ are populated.
-        // Refined level grid cells:
-        //    1. Inherit their partition type from their parent cell (i.e., element.father().partitionType()).
-        //    2. Assign global ids only for interior cells.
-        //    3. Communicate the already assigned cell global ids from interior to overlap refined cells.
-        // Refined level grid points/vertices:
-        // There are 4 partition types: interior, border, front, overlap. This classification requires that both
-        // cell and face partition types are already defined, not available yet for refined level grids.
-        //    1. Assign for all partition type points a 'candidate of global id' (unique in each process).
-        //       Except the points that coincide with a point from level zero.
-        //    2. To make point ids globally unique, re-write the values for points that are corners of overlap
-        //       refined cells, via communication.
-        // Under the assumption of LGRs fully-interior, no communication is needed. In the general case, communication will be used
-        // to populate overlap cell/point global ids on the refined level grids.
-
-        // Predict how many new cell ids per process are needed.
-        std::vector<std::size_t> cell_ids_needed_by_proc(comm().size());
-        std::size_t local_cell_ids_needed = 0;
-        for ( const auto& element : elements( levelGridView(0), Dune::Partitions::interior) ) {
-            // Get old mark (from level zero). After calling adapt, all marks are set to zero.
-            bool hasBeenMarked = currentData().front()->getMark(element) == 1;
-            if ( hasBeenMarked ) {
-                const auto& level = assignRefinedLevel[element.index()];
-                // Shift level (to level -1) since cells_per_dim_vec stores number of subdivisions in each direction (xyz)
-                // per parent cell, per level, starting from level 1, ..., maxLevel.
-                local_cell_ids_needed += cells_per_dim_vec[level-1][0]*cells_per_dim_vec[level-1][1]*cells_per_dim_vec[level-1][2];
-            }
-        }
-        comm().allgather(&local_cell_ids_needed, 1, cell_ids_needed_by_proc.data());
-
-        // Overestimate ('predict') how many new point ids per process are needed.
-        // Assign for all partition type points a 'candidate of global id' (unique in each process).
-        std::vector<std::size_t> point_ids_needed_by_proc(comm().size());
-        std::size_t local_point_ids_needed = 0;
-        for (std::size_t level = 1; level < cells_per_dim_vec.size()+1; ++level){
-            if(lgr_with_at_least_one_active_cell[level-1]>0) {
-                // Amount of local_point_ids_needed might be overestimated.
-                for (const auto& point : vertices(levelGridView(level))){
-                    // If point coincides with an existing corner from level zero, then it does not need a new global id.
-                    if ( !(*current_data_)[level]->corner_history_.empty() ) {
-                        const auto& bornLevel_bornIdx =  (*current_data_)[level]->corner_history_[point.index()];
-                        if (bornLevel_bornIdx[0] == -1)  { // Corner is new-> it needs a new global id
-                            local_point_ids_needed += 1;
-                        }
-                    }
-                }
-            }
-        }
-        comm().allgather(&local_point_ids_needed, 1, point_ids_needed_by_proc.data());
-
-        auto expected_max_globalId_cell = std::accumulate(cell_ids_needed_by_proc.begin(),
-                                                          cell_ids_needed_by_proc.end(),
-                                                          max_globalId_levelZero + 1);
-        auto min_globalId_cell_in_proc = std::accumulate(cell_ids_needed_by_proc.begin(),
-                                                         cell_ids_needed_by_proc.begin()+comm().rank(),
-                                                         max_globalId_levelZero + 1);
-        auto min_globalId_point_in_proc= std::accumulate(point_ids_needed_by_proc.begin(),
-                                                         point_ids_needed_by_proc.begin()+ comm().rank(),
-                                                         expected_max_globalId_cell);
+        // Prediction min cell and point global ids per process
+        int min_globalId_cell_in_proc = 0;
+        int min_globalId_point_in_proc = 0;
+        predictMinCellAndPointGlobalIdPerProcess(min_globalId_cell_in_proc,
+                                                 min_globalId_point_in_proc,
+                                                 assignRefinedLevel,
+                                                 cells_per_dim_vec,
+                                                 lgr_with_at_least_one_active_cell);
 
         // Only for level 1,2,.., maxLevel grids.
         // For each level, define the local-to-global maps for cells and points (for faces: empty).

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -2076,37 +2076,9 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
     //                                                              active/inactive cells, instead, relies on "ijk-computations".
     //                                                              TO DO: improve/remove.
     // To check "Compatibility of numbers of subdivisions of neighboring LGRs".
-    bool compatibleSubdivisionsHasFailed = false;
-    if (startIJK_vec.size() > 1) {
-        bool notAllowedYet = false;
-        for (std::size_t level = 0; level < startIJK_vec.size(); ++level) {
-            for (std::size_t otherLevel = level+1; otherLevel < startIJK_vec.size(); ++otherLevel) {
-                const auto& sharedFaceTag =
-                    current_view_data_->sharedFaceTag({startIJK_vec[level], startIJK_vec[otherLevel]}, {endIJK_vec[level],endIJK_vec[otherLevel]});
-                if(sharedFaceTag == -1){
-                    break; // Go to the next "other patch"
-                }
-                if (sharedFaceTag == 0 ) {
-                    notAllowedYet = notAllowedYet ||
-                        ((cells_per_dim_vec[level][1] != cells_per_dim_vec[otherLevel][1]) || (cells_per_dim_vec[level][2] != cells_per_dim_vec[otherLevel][2]));
-                }
-                if (sharedFaceTag == 1) {
-                    notAllowedYet = notAllowedYet ||
-                        ((cells_per_dim_vec[level][0] != cells_per_dim_vec[otherLevel][0]) || (cells_per_dim_vec[level][2] != cells_per_dim_vec[otherLevel][2]));
-                }
-                if (sharedFaceTag == 2) {
-                    notAllowedYet = notAllowedYet ||
-                        ((cells_per_dim_vec[level][0] != cells_per_dim_vec[otherLevel][0]) || (cells_per_dim_vec[level][1] != cells_per_dim_vec[otherLevel][1]));
-                }
-                if (notAllowedYet){
-                    compatibleSubdivisionsHasFailed = true;
-                    break;
-                }
-            } // end-otherLevel-for-loop
-        } // end-level-for-loop
-    }// end-if-patchesShareFace
-    compatibleSubdivisionsHasFailed = comm().max(compatibleSubdivisionsHasFailed);
-    if(compatibleSubdivisionsHasFailed) {
+    bool compatibleSubdivisions = current_view_data_->compatibleSubdivisions(cells_per_dim_vec, startIJK_vec, endIJK_vec);
+    compatibleSubdivisions= comm().max(compatibleSubdivisions);
+    if(!compatibleSubdivisions) {
         if (comm().rank()==0){
             OPM_THROW(std::logic_error, "Subdivisions of neighboring LGRs sharing at least one face do not coincide. Not suppported yet.");
         }

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1270,6 +1270,9 @@ std::pair<int,int> CpGrid::predictMinCellAndPointGlobalIdPerProcess([[maybe_unus
                                                                     [[maybe_unused]] const std::vector<std::array<int,3>>& cells_per_dim_vec,
                                                                     [[maybe_unused]] const std::vector<int>& lgr_with_at_least_one_active_cell) const
 {
+    int min_globalId_cell_in_proc = 0;
+    int min_globalId_point_in_proc = 0;
+
 #if HAVE_MPI
     // Maximum global id from level zero. (Then, new entities get global id values greater than max_globalId_levelZero).
     // Recall that only cells and points are taken into account; faces are ignored (do not have any global id).
@@ -1331,15 +1334,14 @@ std::pair<int,int> CpGrid::predictMinCellAndPointGlobalIdPerProcess([[maybe_unus
     auto expected_max_globalId_cell = std::accumulate(cell_ids_needed_by_proc.begin(),
                                                       cell_ids_needed_by_proc.end(),
                                                       max_globalId_levelZero + 1);
-    auto min_globalId_cell_in_proc = std::accumulate(cell_ids_needed_by_proc.begin(),
-                                                     cell_ids_needed_by_proc.begin()+comm().rank(),
-                                                     max_globalId_levelZero + 1);
-    auto min_globalId_point_in_proc = std::accumulate(point_ids_needed_by_proc.begin(),
-                                                      point_ids_needed_by_proc.begin()+ comm().rank(),
-                                                      expected_max_globalId_cell);
-
-    return std::make_pair<int,int>(std::move(min_globalId_cell_in_proc), std::move(min_globalId_point_in_proc));
+    min_globalId_cell_in_proc = std::accumulate(cell_ids_needed_by_proc.begin(),
+                                                cell_ids_needed_by_proc.begin()+comm().rank(),
+                                                max_globalId_levelZero + 1);
+    min_globalId_point_in_proc = std::accumulate(point_ids_needed_by_proc.begin(),
+                                                 point_ids_needed_by_proc.begin()+ comm().rank(),
+                                                 expected_max_globalId_cell);
 #endif
+    return std::make_pair<int,int>(std::move(min_globalId_cell_in_proc), std::move(min_globalId_point_in_proc));
 }
 
 void CpGrid::collectCellIdsAndCandidatePointIds( std::vector<std::vector<int>>& localToGlobal_cells_per_level,

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -2049,13 +2049,6 @@ void CpGrid::postAdapt()
     current_view_data_ -> postAdapt();
 }
 
-void CpGrid::addLgrUpdateLeafView(const std::array<int,3>& cells_per_dim, const std::array<int,3>& startIJK,
-                                  const std::array<int,3>& endIJK, const std::string& lgr_name)
-{
-    this -> addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
-}
-
-
 void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_per_dim_vec,
                                    const std::vector<std::array<int,3>>& startIJK_vec,
                                    const std::vector<std::array<int,3>>& endIJK_vec,

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1393,7 +1393,8 @@ void CpGrid::selectWinnerPointIds([[maybe_unused]] std::vector<std::vector<int>>
             }
         }
     }
-    ParentToChildCellToPointGlobalIdHandle parentToChildCellToPointGlobalId_handle(parent_to_children,
+    ParentToChildCellToPointGlobalIdHandle parentToChildCellToPointGlobalId_handle(comm(),
+                                                                                   parent_to_children,
                                                                                    level_cell_to_point,
                                                                                    level_winning_ranks,
                                                                                    localToGlobal_points_per_level);

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -2239,6 +2239,41 @@ void CpGridData::validStartEndIJKs(const std::vector<std::array<int,3>>& startIJ
     }
 }
 
+bool CpGridData::compatibleSubdivisions(const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                        const std::vector<std::array<int,3>>& startIJK_vec,
+                                        const std::vector<std::array<int,3>>& endIJK_vec) const
+{
+    bool compatibleSubdivisions = true;
+    if (startIJK_vec.size() > 1) {
+        bool notAllowedYet = false;
+        for (std::size_t level = 0; level < startIJK_vec.size(); ++level) {
+            for (std::size_t otherLevel = level+1; otherLevel < startIJK_vec.size(); ++otherLevel) {
+                const auto& sharedFaceTag = this-> sharedFaceTag({startIJK_vec[level], startIJK_vec[otherLevel]}, {endIJK_vec[level],endIJK_vec[otherLevel]});
+                if(sharedFaceTag == -1){
+                    break; // Go to the next "other patch"
+                }
+                if (sharedFaceTag == 0 ) {
+                    notAllowedYet = notAllowedYet ||
+                        ((cells_per_dim_vec[level][1] != cells_per_dim_vec[otherLevel][1]) || (cells_per_dim_vec[level][2] != cells_per_dim_vec[otherLevel][2]));
+                }
+                if (sharedFaceTag == 1) {
+                    notAllowedYet = notAllowedYet ||
+                        ((cells_per_dim_vec[level][0] != cells_per_dim_vec[otherLevel][0]) || (cells_per_dim_vec[level][2] != cells_per_dim_vec[otherLevel][2]));
+                }
+                if (sharedFaceTag == 2) {
+                    notAllowedYet = notAllowedYet ||
+                        ((cells_per_dim_vec[level][0] != cells_per_dim_vec[otherLevel][0]) || (cells_per_dim_vec[level][1] != cells_per_dim_vec[otherLevel][1]));
+                }
+                if (notAllowedYet){
+                    compatibleSubdivisions = false;
+                    break;
+                }
+            } // end-otherLevel-for-loop
+        } // end-level-for-loop
+    }// end-if-patchesShareFace
+    return compatibleSubdivisions;
+}
+
 Geometry<3,3> CpGridData::cellifyPatch(const std::array<int,3>& startIJK, const std::array<int,3>& endIJK,
                                        const std::vector<int>& patch_cells,
                                        DefaultGeometryPolicy& cellifiedPatch_geometry,

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -369,19 +369,6 @@ public:
     ///                                 Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
     void validStartEndIJKs(const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
 
-    /// @brief Check compatibility of number of subdivisions of neighboring LGRs.
-    ///
-    /// Check shared faces on boundaries of LGRs. Not optimal since the code below does not take into account
-    /// active/inactive cells, instead, relies on "ijk-computations".
-    ///
-    /// @param [in]  cells_per_dim_vec    Vector of expected subdivisions per cell, per direction, in each LGR.
-    /// @param [in]  startIJK_vec         Vector of Cartesian triplet indices where each patch starts.
-    /// @param [in]  endIJK_vec           Vector of Cartesian triplet indices where each patch ends.
-    ///                                   Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
-    bool compatibleSubdivisions(const std::vector<std::array<int,3>>& cells_per_dim_vec,
-                                const std::vector<std::array<int,3>>& startIJK_vec,
-                                const std::vector<std::array<int,3>>& endIJK_vec) const;
-
     /// @brief Check that every cell to be refined has cuboid shape.
     void checkCuboidShape(const std::vector<int>& cellIdx_vec) const;
 
@@ -425,6 +412,19 @@ public:
     void postAdapt();
 
 private:
+    /// @brief Check compatibility of number of subdivisions of neighboring LGRs.
+    ///
+    /// Check shared faces on boundaries of LGRs. Not optimal since the code below does not take into account
+    /// active/inactive cells, instead, relies on "ijk-computations".
+    ///
+    /// @param [in]  cells_per_dim_vec    Vector of expected subdivisions per cell, per direction, in each LGR.
+    /// @param [in]  startIJK_vec         Vector of Cartesian triplet indices where each patch starts.
+    /// @param [in]  endIJK_vec           Vector of Cartesian triplet indices where each patch ends.
+    ///                                   Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
+    bool compatibleSubdivisions(const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                const std::vector<std::array<int,3>>& startIJK_vec,
+                                const std::vector<std::array<int,3>>& endIJK_vec) const;
+
     std::array<Dune::FieldVector<double,3>,8> getReferenceRefinedCorners(int idx_in_parent_cell, const std::array<int,3>& cells_per_dim) const;
 
     /// @brief Compute amount of cells in each direction of a patch of cells. (Cartesian grid required).

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -364,10 +364,23 @@ public:
     /// @brief Check startIJK and endIJK of each patch of cells to be refined are valid, i.e.
     ///        startIJK and endIJK vectors have the same size and, startIJK < endIJK coordenate by coordenate.
     ///
-    /// @param [in]  startIJK_vec  Vector of Cartesian triplet indices where each patch starts.
-    /// @param [in]  endIJK_vec    Vector of Cartesian triplet indices where each patch ends.
-    ///                            Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
+    /// @param [in]  startIJK_vec       Vector of Cartesian triplet indices where each patch starts.
+    /// @param [in]  endIJK_vec         Vector of Cartesian triplet indices where each patch ends.
+    ///                                 Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
     void validStartEndIJKs(const std::vector<std::array<int,3>>& startIJK_vec, const std::vector<std::array<int,3>>& endIJK_vec) const;
+
+    /// @brief Check compatibility of number of subdivisions of neighboring LGRs.
+    ///
+    /// Check shared faces on boundaries of LGRs. Not optimal since the code below does not take into account
+    /// active/inactive cells, instead, relies on "ijk-computations".
+    ///
+    /// @param [in]  cells_per_dim_vec    Vector of expected subdivisions per cell, per direction, in each LGR.
+    /// @param [in]  startIJK_vec         Vector of Cartesian triplet indices where each patch starts.
+    /// @param [in]  endIJK_vec           Vector of Cartesian triplet indices where each patch ends.
+    ///                                   Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
+    bool compatibleSubdivisions(const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                const std::vector<std::array<int,3>>& startIJK_vec,
+                                const std::vector<std::array<int,3>>& endIJK_vec) const;
 
     /// @brief Check that every cell to be refined has cuboid shape.
     void checkCuboidShape(const std::vector<int>& cellIdx_vec) const;

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -421,6 +421,12 @@ private:
     /// @param [in]  startIJK_vec         Vector of Cartesian triplet indices where each patch starts.
     /// @param [in]  endIJK_vec           Vector of Cartesian triplet indices where each patch ends.
     ///                                   Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
+    /// @return bool True when all block of cells either do not share faces on their boundaries, or they may share faces with compatible
+    ///              subdivisions. Example: block1 and block2 share an I_FACE, then number of subdivisions NY NZ should coincide, i.e.
+    ///              if block1, block2 cells_per_dim values are {NX1, NY1, NZ1}, {NX2, NY2, NZ2}, respectively, then NY1 == NY2 and
+    ///              NZ1 == Nz2.
+    ///              False when at least two blocks share a face and their subdivions are not compatible. In the example above,
+    ///              if NY1 != NY2 or NZ1 != NZ2.
     bool compatibleSubdivisions(const std::vector<std::array<int,3>>& cells_per_dim_vec,
                                 const std::vector<std::array<int,3>>& startIJK_vec,
                                 const std::vector<std::array<int,3>>& endIJK_vec) const;

--- a/opm/grid/cpgrid/ParentToChildCellToPointGlobalIdHandle.hpp
+++ b/opm/grid/cpgrid/ParentToChildCellToPointGlobalIdHandle.hpp
@@ -76,20 +76,22 @@ struct ParentToChildCellToPointGlobalIdHandle {
     , level_point_global_ids_(level_point_global_ids)
     {}
 
-    // Not every cell has children. When they have children, the amount might vary.
     bool fixedSize(std::size_t, std::size_t)
     {
+        // Not every cell has children. When they have children, the amount might vary.
         return false;
     }
-    // Only communicate values attached to cells.
+
     bool contains(std::size_t, std::size_t codim)
     {
+        // Only communicate values attached to cells.
         return codim == 0;
     }
-    // Communicate variable size: 1 (rank) + (8* amount of child cells) from an interior parent cell from level zero grid.
+
     template <class T> // T = Entity<0>
     std::size_t size(const T& element)
     {
+        // Communicate variable size: 1 (rank) + (8* amount of child cells) from an interior parent cell from level zero grid.
         // Skip values that are not interior, or have no children (in that case, 'invalid' level = -1)
         const auto& [level, children] = parent_to_children_[element.index()];
         // [Bug in dune-common] VariableSizeCommunicator will deadlock if a process attempts to send a message of size zero.
@@ -117,7 +119,7 @@ struct ParentToChildCellToPointGlobalIdHandle {
         // Write the rank first, for example via the "corner 0" of cell_to_point_ of the first child:
         // First child: children[0]
         // First corner of first child:  level_cell_to_point_[ level -1 ][children[0]] [0]
-        buffer.write( comm_.rank() ); // winner rank level_winning_ranks_[level-1][ level_cell_to_point_[ level -1 ][children[0]] [0]
+        buffer.write( comm_.rank() );
         for (const auto& child : children)
             for (const auto& corner : level_cell_to_point_[level -1][child])
                 buffer.write(level_point_global_ids_[level-1][corner]);

--- a/opm/grid/cpgrid/ParentToChildCellToPointGlobalIdHandle.hpp
+++ b/opm/grid/cpgrid/ParentToChildCellToPointGlobalIdHandle.hpp
@@ -1,0 +1,172 @@
+//===========================================================================
+//
+// File: ParentToChildCellToPointGlobalIdHandle.hpp
+//
+// Created: November 19 2024
+//
+// Author(s): Antonella Ritorto <antonella.ritorto@opm-op.com>
+//            Markus Blatt      <markus.blatt@opm-op.com>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2024 Equinor ASA
+  This file is part of The Open Porous Media project  (OPM).
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_PARENTTOCHILDCELLTOPOINTGLOBALIDHANDLE_HEADER
+#define OPM_PARENTTOCHILDCELLTOPOINTGLOBALIDHANDLE_HEADER
+
+
+#include <opm/grid/cpgrid/Entity.hpp>
+
+#include <array>
+#include <tuple>
+#include <vector>
+
+
+namespace
+{
+#if HAVE_MPI
+
+/// \brief Handle for assignment of point global ids of refined cells.
+struct ParentToChildCellToPointGlobalIdHandle {
+    //   - The container used for gather and scatter contains "candidates" point global ids for interior elements of the refined level grids (LGRs).
+    //     Access is done with the local index of its parent cell index and its parent cell list of children.
+    //     level_point_global_ids[ level-1 ][ child_cell_local_index [ corner ] ] = "candidate" point global id,
+    //     when child_cell_local_index belongs to the children_local_index_list:
+    //     parent_to_children_[ element.index() ] =  parent_to_children_[ element.index() ] = { level, children_local_index_list }
+    //     and corner = 0, ...,7.
+    //     To decide which "candidate" point global id wins, we use the rank. The smallest ranks wins,
+    //     i.e., the other non-selected candidates get rewritten with the values from the smallest (winner) rank.
+    //   - In the scatter method, the "winner" rank and the 8 point global ids of each number of children) get rewritten.
+
+    using DataType = int;
+
+    /// \param parent_to_children      Map from parent index to all children, and the level they are stored.
+    ///                                parent_to_children_[ element.index() ] = { level, children_list local indices }
+    /// \param level_cell_to_point
+    /// \param level_point_global_ids  A container that for the elements of a level contains all candidate point global ids.
+    /// \param level_winning_ranks
+    /// \param level_point_global_ids
+    ParentToChildCellToPointGlobalIdHandle(const std::vector<std::tuple<int, std::vector<int>>>& parent_to_children,
+                                           const std::vector<std::vector<std::array<int,8>>>& level_cell_to_point,
+                                           std::vector<std::vector<DataType>>& level_winning_ranks,
+                                           std::vector<std::vector<DataType>>& level_point_global_ids)
+        : parent_to_children_(parent_to_children)
+        , level_cell_to_point_(level_cell_to_point)
+        , level_winning_ranks_(level_winning_ranks)
+        , level_point_global_ids_(level_point_global_ids)
+    {
+    }
+
+    // Not every cell has children. When they have children, the amount might vary.
+    bool fixedSize(std::size_t, std::size_t)
+    {
+        return false;
+    }
+    // Only communicate values attached to cells.
+    bool contains(std::size_t, std::size_t codim)
+    {
+        return codim == 0;
+    }
+    // Communicate variable size: 1 (rank) + (8* amount of child cells) from an interior parent cell from level zero grid.
+    template <class T> // T = Entity<0>
+    std::size_t size(const T& element)
+    {
+        // Skip values that are not interior, or have no children (in that case, 'invalid' level = -1)
+        const auto& [level, children] = parent_to_children_[element.index()];
+        // [Bug in dune-common] VariableSizeCommunicator will deadlock if a process attempts to send a message of size zero.
+        // This can happen if the size method returns zero for all entities that are shared with another process.
+        // Therefore, when skipping cells without children or for overlap cells, we set the size to 1.
+        if ( (element.partitionType() != Dune::InteriorEntity) || (level == -1))
+            return 1;
+        return 1 + ( 8*children.size()); // rank + 8 "winner" point global ids per child cell
+    }
+
+    // Gather global ids of child cells of a coarse interior parent cell
+    template <class B, class T> // T = Entity<0>
+    void gather(B& buffer, const T& element)
+    {
+        // Skip values that are not interior, or have no children (in that case, 'invalid level' = -1)
+        const auto& [level, children] = parent_to_children_[element.index()];
+        // [Bug in dune-common] VariableSizeCommunicator will deadlock if a process tries to send a message with size zero.
+        // To avoid this, for cells without children or for overlap cells, we set the size to 1 and write a single DataType
+        // value (e.g., '42').
+        if ( (element.partitionType() != Dune::InteriorEntity) || (level==-1)) {
+            buffer.write(42);
+            return;
+        }
+        // Store the children's corner global ids in the buffer when the element is interior and has children.
+        // Write the rank first, for example via the "corner 0" of cell_to_point_ of the first child:
+        // First child: children[0]
+        // First corner of first child:  level_cell_to_point_[ level -1 ][children[0]] [0]
+        buffer.write(level_winning_ranks_[level-1][ level_cell_to_point_[ level -1 ][children[0]] [0] ]); // winner rank
+        for (const auto& child : children)
+            for (const auto& corner : level_cell_to_point_[level -1][child])
+                buffer.write(level_point_global_ids_[level-1][corner]);
+    }
+
+    // Scatter global ids of child cells of a coarse overlap parent cell
+    template <class B, class T> // T = Entity<0>
+    void scatter(B& buffer, const T& element, std::size_t num_children) // check num_children
+    {
+        const auto& [level, children] = parent_to_children_[element.index()];
+        // Read all values to advance the pointer used by the buffer to the correct index.
+        // (Skip overlap-cells-without-children and interior-cells).
+        if ( ( (element.partitionType() == Dune::OverlapEntity) && (level==-1) ) || (element.partitionType() == Dune::InteriorEntity ) ) {
+            // Read all values to advance the pointer used by the buffer
+            // to the correct index
+            for (std::size_t child = 0; child < num_children;  ++child) { // this should be 1 + (8* total children)
+                DataType tmp;
+                buffer.read(tmp);
+            }
+        }
+        else { // Overlap cell with children.
+            // Read and store the values in the correct location directly.
+            // The order of the children is the same on each process.
+            assert(children.size()>0);
+            assert(level>0);
+            // Read and store the values in the correct location directly.
+            DataType tmp_rank;
+            buffer.read(tmp_rank);
+            for (const auto& child : children) {
+                for (const auto& corner : level_cell_to_point_[level -1][child]) {
+                    auto& min_rank = level_winning_ranks_[level-1][corner];
+                    // Rewrite the rank (smaller rank wins)
+                    if (tmp_rank < min_rank) {
+                        min_rank = tmp_rank;
+                        auto& target_entry = level_point_global_ids_[level-1][corner];
+                        buffer.read(target_entry);
+                    } else {
+                        DataType rubbish;
+                        buffer.read(rubbish);
+                    }
+                }
+            }
+        }
+    }
+
+private:
+    const std::vector<std::tuple<int, std::vector<int>>>& parent_to_children_;
+    const std::vector<std::vector<std::array<int,8>>>& level_cell_to_point_;
+    std::vector<std::vector<DataType>>& level_winning_ranks_;
+    std::vector<std::vector<DataType>>& level_point_global_ids_;
+};
+#endif // HAVE_MPI
+} // namespace
+#endif

--- a/tests/cpgrid/addLgrsOnDistributedGrid_test.cpp
+++ b/tests/cpgrid/addLgrsOnDistributedGrid_test.cpp
@@ -398,9 +398,12 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
     BOOST_CHECK( static_cast<int>(allGlobalIds_cells.size()) == global_cells_count);
     BOOST_CHECK( allGlobalIds_cells.size() == allGlobalIds_cells_set.size() );
 
-    /** [Bug] Uniqueness of point global ids cannot be checked in general since current code sets overlap layer size equal to 1,
+    /** Uniqueness of point global ids cannot be checked in general since current code sets overlap layer size equal to 1,
         which in particular means that cells that share corners or edges (and not faces) with interior cells are not considered/
-        seen by the process. Therefore, depending how the LGRs are distributed, there may be "multiple ids" for the same points.*/
+        seen by the process. Therefore, depending how the LGRs are distributed, there may be "multiple ids" for the same points.
+        To achieve unique point global ids, IN SOME CASES, we invoke loanBalance( parts, false, true) where parts determines
+        the rank of each cell, false represents ownerFisrt, true represents addCornerCells. The last defaulted argument is
+        overlapLayerSize = 1. */
 
     // Local/Global id sets for level grids (level 0, 1, ..., maxLevel). For level grids, local might differ from global id.
     for (int level = 0; level < coarse_grid.maxLevel() +1; ++level)
@@ -457,6 +460,7 @@ BOOST_AUTO_TEST_CASE(threeLgrs)
     const std::array<int, 3> grid_dim = {10,8,8};
     grid.createCartesian(grid_dim, cell_sizes);
 
+    // Fully interior LGRs
     std::vector<int> parts(640);
     for (int k = 0; k < 8; ++k) {
         for (int j = 0; j < 8; ++j) {
@@ -484,7 +488,8 @@ BOOST_AUTO_TEST_CASE(threeLgrs)
     }
     if(grid.comm().size()>1)
     {
-        grid.loadBalance(parts);
+        grid.loadBalance(parts); // ownerFirst = false, addCornerCells = false, overlapLayerSize = 1
+        // IT's not necessary to change the default values since the LGRs are fully interior.
 
         const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}, {4,4,4}};
         const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0}, {0,0,3}, {3,2,2}};
@@ -546,6 +551,7 @@ BOOST_AUTO_TEST_CASE(atLeastOneLgr_per_process_attempt)
                                                      {12,13,17,24,25,28,29,32,33},
                                                      {2,3,6,7,10,11,18,22,23},
                                                      {14,15,19,26,27,30,31,34,35} };
+    // Fully interior LGRs
     for (int rank = 0; rank < 4; ++rank) {
         for (const auto& elemIdx : cells_per_rank[rank]) {
             parts[elemIdx] = rank;
@@ -553,7 +559,8 @@ BOOST_AUTO_TEST_CASE(atLeastOneLgr_per_process_attempt)
     }
     if(grid.comm().size()>1)
     {
-        grid.loadBalance(parts);
+        grid.loadBalance(parts); // ownerFirst = false, addCornerCells = false, overlapLayerSize =1
+        // IT's not necessary to change the default values since the LGRs are fully interior.
 
         const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}, {4,4,4}, {2,2,2}};
         const std::vector<std::array<int,3>> startIJK_vec = {{0,1,0}, {0,0,2}, {3,2,0}, {3,0,2}};
@@ -572,7 +579,7 @@ BOOST_AUTO_TEST_CASE(atLeastOneLgr_per_process_attempt)
         // Total global ids in leaf grid view for cells: 36-(6 marked cells) + 16 + 27 + 64 + 16 = 153
         // Total global ids in leaf grid view for points: 80 + 33 + 56 + 117 + 33 = 319
         refinePatch_and_check(grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
-        
+
         // Check global id is not duplicated for points for each LGR
         // LGR1 dim 2x4x2 -> 3x5x3 = 45 points
         // LGR2 dim 3x3x3 -> 4x4x4 = 64 points
@@ -608,7 +615,8 @@ BOOST_AUTO_TEST_CASE(atLeastOneLgr_per_process_attempt)
     }
 }
 
-BOOST_AUTO_TEST_CASE(throw_not_fully_interior_lgr)
+
+BOOST_AUTO_TEST_CASE(not_fully_interior_lgr)
 {
     // Create a grid
     Dune::CpGrid grid;
@@ -621,6 +629,7 @@ BOOST_AUTO_TEST_CASE(throw_not_fully_interior_lgr)
                                                      {12,13,17,24,25,28,29,32,33},
                                                      {2,3,6,7,10,11,18,22,23},
                                                      {14,15,19,26,27,30,31,34,35} };
+    // NOT fully interior LGRs
     for (int rank = 0; rank < 4; ++rank) {
         for (const auto& elemIdx : cells_per_rank[rank]) {
             parts[elemIdx] = rank;
@@ -628,7 +637,8 @@ BOOST_AUTO_TEST_CASE(throw_not_fully_interior_lgr)
     }
     if(grid.comm().size()>1)
     {
-        grid.loadBalance(parts);
+        grid.loadBalance(parts, false, true); // ownerFirst = false, addCornerCells = true, overlapLayerSize = 1
+        // We set addCornersCells to achieve unique global ids for points belonging to refined level grids.
 
         const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {3,3,3}, {4,4,4}, {2,2,2}};
         const std::vector<std::array<int,3>> startIJK_vec = {{0,1,0}, {0,0,2}, {3,1,0}, {3,0,2}};
@@ -685,6 +695,7 @@ BOOST_AUTO_TEST_CASE(globalRefine2)
     const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
     const std::array<int, 3> grid_dim = {4,3,3};
     grid.createCartesian(grid_dim, cell_sizes);
+
     // Distribute the grid
     if(grid.comm().size()>1)
     {
@@ -714,7 +725,8 @@ BOOST_AUTO_TEST_CASE(distributed_lgr)
     }
     if(grid.comm().size()>1)
     {
-        grid.loadBalance(parts);
+        grid.loadBalance(parts, false, true); // ownerFirst = false, addCornerCells = true, overlapLayerSize = 1
+        // We set addCornersCells to achieve unique global ids for points belonging to refined level grids.
 
         const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}};
         const std::vector<std::array<int,3>> startIJK_vec = {{1,0,0}};
@@ -739,29 +751,7 @@ BOOST_AUTO_TEST_CASE(distributed_lgr)
         }
         auto [all_point_ids, displPoint ] = Opm::allGatherv(local_point_ids, grid.comm());
         const std::set<int> all_point_ids_set(all_point_ids.begin(), all_point_ids.end());
-        // Coarse cells 1 in rank 0 and 2 in rank 2 share an I_FACE where (LGR1_dim[1]+1)*(LGR1_dim[2]+ 1),
-        // here (2 +1)*(2 +1) = 9 points lying on, 4 of them being the 4 corners of the coarse I_FACE shared
-        // by cell 1 and cell 2. Leaving us with 9 - 4 = 5 potential duplicated ids.
-        //
-        // Global cell ids of cells to be refined = {1, 2}
-        // cell 1 = { interior in P0, overlap in P1, overlap in P2, does not exist in P3}
-        // cell 2 = { overlap in P0, does not exist in P1, interior in P2, overlap in P3}
-        // Remark: the LGR is distributed in only two of the four processes, P0 and P2.
-        // - P0 sees the entire LGR.
-        // - P1 does NOT see cell 2, but sees cell 1
-        // - P2 does NOT see the LGR at all.
-        // - P3 does NOT see cell 1, but sees cell 2
-        // P3 creates:
-        //  +5 duplicated ids on {I_FACE, false} cell 2 (seen in P3) [equivalent face: {I_FACE, true} of unseen-in-P3 cell 1]
-        // That means that the "unfortunate" expected point ids count is 45 (desired value) + 5 (duplicated laying on
-        // shared I_FACE) = 50.
-        BOOST_CHECK( static_cast<int>(all_point_ids_set.size()) == 50);
-        
-        /** Current approach avoids duplicated point ids when
-         // 1. the LGR is distributed in P_{i_0}, ..., P_{i_n}, with n+1 < grid.comm().size(),
-         // AND
-         // 2. there is no coarse cell seen by a process P with P != P_{i_j}, j = 0, ..., n.
-         // Otherwise, there will be points with multiple ids.*/ 
+        BOOST_CHECK( static_cast<int>(all_point_ids_set.size()) == 45); // LGR1 dim 4x2x2 -> 5x3x3 = 45 points
 
         // Check global id is not duplicated for points
         std::vector<int> localPointIds_vec;
@@ -772,8 +762,8 @@ BOOST_AUTO_TEST_CASE(distributed_lgr)
         }
         auto [allGlobalIds_points, displPointLeaf ] = Opm::allGatherv(localPointIds_vec, grid.comm());
         const std::set<int> allGlobalIds_points_set(allGlobalIds_points.begin(), allGlobalIds_points.end());
-        // Total global ids in leaf grid view for points: 80 + (45 - 12) + 5 (undesired duplicated ids on shared I_FACE) = 118
-        BOOST_CHECK( allGlobalIds_points_set.size() == 118 );
+        // Total global ids in leaf grid view for points: 80 + (45 - 12) = 113
+        BOOST_CHECK( allGlobalIds_points_set.size() == 113 );
     }
 }
 
@@ -797,7 +787,8 @@ BOOST_AUTO_TEST_CASE(distributed_lgr_II)
     }
     if(grid.comm().size()>1)
     {
-        grid.loadBalance(parts);
+        grid.loadBalance(parts, false, true); // ownerFirst = false, addCornerCells = true, overlapLayerSize = 1
+        // We set addCornersCells to achieve unique global ids for points belonging to refined level grids.
 
         const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}};
         const std::vector<std::array<int,3>> startIJK_vec = {{0,2,0}};
@@ -818,16 +809,6 @@ BOOST_AUTO_TEST_CASE(distributed_lgr_II)
         auto [all_point_ids, displPoint ] = Opm::allGatherv(local_point_ids, grid.comm());
         const std::set<int> all_point_ids_set(all_point_ids.begin(), all_point_ids.end());
         BOOST_CHECK( static_cast<int>(all_point_ids_set.size()) == 63);
-        // Difference with previous test case:
-        // Global cell ids of cells to be refined = {8, 9, 10}
-        // cell 8 = { interior in P0, does not exist in P1, does not exist in P2, does not exist in P3}
-        // cell 9 = { interior in P0, does not exist in P1, overlap in P2, does not exist in P3}
-        // cell 10 = { overlap in P0, does not exist in P1, interior in P2, does not exist in P3}
-        // Remark: the LGR is distributed only in 2 processes which are the only two processes seeing these cells.
-        // - P0 sees the entire LGR.
-        // - P1 does NOT see the LGR at all.
-        // - P2 does NOT see cell 8, but NO OTHER process sees cell 8 since it's fully inteior of P0.
-        // - P3 does NOT see the LGR at all.
 
         // Check global id is not duplicated for points
         std::vector<int> localPointIds_vec;
@@ -862,7 +843,10 @@ BOOST_AUTO_TEST_CASE(distributed_in_all_ranks_lgr)
     }
     if(grid.comm().size()>1)
     {
-        grid.loadBalance(parts);
+        grid.loadBalance(parts, false, true); // ownerFirst = false, addCornerCells = true, overlapLayerSize = 1
+        // We set addCornersCells to achieve unique global ids for points belonging to refined level grids.
+        /** This is not enough to get unique point ids. */
+
         const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}};
         const std::vector<std::array<int,3>> startIJK_vec = {{1,0,0}};
         const std::vector<std::array<int,3>> endIJK_vec = {{3,2,2}};
@@ -881,6 +865,7 @@ BOOST_AUTO_TEST_CASE(distributed_in_all_ranks_lgr)
         // LGR1 dim 4x4x4 -> 5x5x5 = 125 points
         std::vector<int> local_point_ids;
         local_point_ids.reserve(125); // expected_point_ids in LGR1
+
         for (const auto& element : elements(grid.levelGridView(1))) {
             for (int corner = 0; corner < 8; ++corner)
             {
@@ -891,34 +876,13 @@ BOOST_AUTO_TEST_CASE(distributed_in_all_ranks_lgr)
         auto [all_point_ids, displPoint ] = Opm::allGatherv(local_point_ids, grid.comm());
         const std::set<int> all_point_ids_set(all_point_ids.begin(), all_point_ids.end());
 
-        /** [Bug] Uniqueness of point global ids cannot be checked in general since current code sets overlap layer size equal to 1,
-            which in particular means that cells that share corners or edges (and not faces) with interior cells are not considered/
-            seen by the process. Therefore, depending how the LGRs are distributed, there may be "multiple ids" for the same points.*/
-        // Difference with preveious test case:
-        // Global cell ids of cells to be refined = {1,2,5,6,13,14,17,18}
-        // cell 1 = { interior in P0, overlap in P1, overlap in P2, does not exist in P3}
-        // cell 2 = { overlap in P0, does not exist in P1, interior in P2, overlap in P3}
-        // cell 5 = { interior in P0, overlap in P1, overlap in P2, does not exist in P3}
-        // cell 6 = { overlap in P0, does not exist in P1, interior in P2, does not exist in P3}
-        // cell 13 = { overlap in P0, interior in P1, does not exist in P2, overlap in P3}
-        // cell 14 = { does not exist in P0, overlap in P1, overlap in P2, interior in P3}
-        // cell 17 = { overlap in P0, interior in P1, overlap in P2, does not exist in P3}
-        // cell 18 = { does not exist in P0, overlap in P1, interior in P2, overlap in P3}
         // Remark: the LGR is distributed in ALL processes BUT
-        // - P0 does NOT see cell 18, but sees all the others.
-        // - P1 does NOT see cells 2 and 6, but sees the rest of them.
-        // - P2 does NOT see cell 13, but sees all the others.
-        // - P3 does NOT see cell 1, 5 and 17, but sees all the others.
-        // More details:
-        // P0 creates +1 duplicated id (middle point edge)
-        // P1 creates +2 duplicated ids (middle point of an edge in cell 2, cell 6 respectively).
-        // P2 creates +1 duplicated id (middle point edge)
-        // P3 creates:
-        //  +5 duplicated ids on {I_FACE, false} cell 2 (seen in P3) [equivalent face: {I_FACE, true} of unseen-in-P3 cell 1]
-        //  +1 duplicated id on edge unseen-in-P3 cell 5
-        //  +5 duplicated ids on {J_FACE, true} cell 13 (seen in P3) [equivalent face: {J_FACE, false} of unseen-in-P3 cell 17]
-        //  +5 duplicated ids on {I_FACE, false} cell 18 (seen in P3) [equivalent face: {I_FACE, true} of unseen-in-P3 cell 17]
-        BOOST_CHECK( static_cast<int>(all_point_ids_set.size()) == 145); // Desired value: 125; 20 (=1+2+1+5+1+5+5) duplicated ids.
+        // - P0, P1, P2 see the entire LGR (due to the argument addCornerCells = true).
+        // However, P3 does NOT see cell 5, but sees all the other parent cells {1,2,6,13,14,17,18},
+        // In P3, {1,6,11,17,21} are (overlap) added corner cells, and {2,3,7,13, 18,22,,25,29,33} are overlap
+        // cells coming from overlapLayerSize = 1.
+        // P3 creates +7 duplicated ids on the unseen-in-P3 cell 5
+        BOOST_CHECK( static_cast<int>(all_point_ids_set.size()) == (125 + 7) ); // expected +  7 "multi-ids"
 
         // Check global id is not duplicated for points
         std::vector<int> localPointIds_vec;
@@ -929,10 +893,83 @@ BOOST_AUTO_TEST_CASE(distributed_in_all_ranks_lgr)
         }
         auto [allGlobalIds_points, displPointLeaf ] = Opm::allGatherv(localPointIds_vec, grid.comm());
         const std::set<int> allGlobalIds_points_set(allGlobalIds_points.begin(), allGlobalIds_points.end());
-        // Total global ids in leaf grid view for points: 80 + (125 - 27) = 178 desired value; +20 duplicated ids.
-        BOOST_CHECK( allGlobalIds_points_set.size() == 198 );
+        // Total global ids in leaf grid view for points: 80 + (125 - 27) = 178
+        BOOST_CHECK( allGlobalIds_points_set.size() == (178 + 7) ); //  expected +  7 "multi-ids"
     }
 }
+
+BOOST_AUTO_TEST_CASE(distributed_in_all_ranks_lgr_II)
+{
+    // Create a grid
+    Dune::CpGrid grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    grid.createCartesian(grid_dim, cell_sizes);
+    std::vector<int> parts(36);
+    std::vector<std::vector<int>> cells_per_rank = { {0,1,4,5,8,9,16,20,21},
+                                                     {12,13,17,24,25,28,29,32,33},
+                                                     {2,3,6,7,10,11,18,22,23},
+                                                     {14,15,19,26,27,30,31,34,35} };
+    for (int rank = 0; rank < 4; ++rank) {
+        for (const auto& elemIdx : cells_per_rank[rank]) {
+            parts[elemIdx] = rank;
+        }
+    }
+    if(grid.comm().size()>1)
+    {
+        grid.loadBalance(parts, false, true); // ownerFirst = false, addCornerCells = true, overlapLayerSize = 1
+        // We set addCornersCells to achieve unique global ids for points belonging to refined level grids.
+        /** This is not enough to get unique point ids. */
+
+        const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}};
+        const std::vector<std::array<int,3>> startIJK_vec = {{1,0,1}};
+        const std::vector<std::array<int,3>> endIJK_vec = {{3,2,3}};
+        const std::vector<std::string> lgr_name_vec = {"LGR1"};
+        // LGR1 element indices = {13,14,17,18,25,26,29,30} where
+        // 13,17,25,29 in rank 1,
+        // 18 in rank 2,
+        // 14,26,30 in rank 3.
+        // Block of cells to refine dim 2x2x2. LGR1 dim 4x4x4.
+        // 64 new refined cells. 5x5x5 = 125 points (only 98 = 125 - 3x3x3 parent corners new points - new global ids).
+        grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+        refinePatch_and_check(grid, cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
+
+        // Check global id is not duplicated for points for each LGR
+        // LGR1 dim 4x4x4 -> 5x5x5 = 125 points
+        std::vector<int> local_point_ids;
+        local_point_ids.reserve(125); // expected_point_ids in LGR1
+
+        for (const auto& element : elements(grid.levelGridView(1))) {
+            for (int corner = 0; corner < 8; ++corner)
+            {
+                const auto& point = element.subEntity<3>(corner);
+                local_point_ids.push_back(grid.currentData()[1]->globalIdSet().id(point));
+            }
+        }
+        auto [all_point_ids, displPoint ] = Opm::allGatherv(local_point_ids, grid.comm());
+        const std::set<int> all_point_ids_set(all_point_ids.begin(), all_point_ids.end());
+
+        // Remark: the LGR is distributed in P1-P3 processes BUT
+        // - P0 does NOT see cells 25,26,30 R (even though the argument addCornerCells = true has been used).
+        // - P2 does NOT see cell 25.
+        // - P1 and P3 sees the entire LGR (due to the argument addCornerCells = true).
+        // 4 extra unnecessary point ids are created.
+        BOOST_CHECK( static_cast<int>(all_point_ids_set.size()) == (125 + 4) ); // expected +  4 "multi-ids"
+
+        // Check global id is not duplicated for points
+        std::vector<int> localPointIds_vec;
+        localPointIds_vec.reserve(grid.currentData().back()->size(3));
+        for (const auto& point : vertices(grid.leafGridView())) {
+            // Notice that all partition type points are pushed back. Selecting only interior points does not bring us to the expected value.
+            localPointIds_vec.push_back(grid.currentData().back()->globalIdSet().id(point));
+        }
+        auto [allGlobalIds_points, displPointLeaf ] = Opm::allGatherv(localPointIds_vec, grid.comm());
+        const std::set<int> allGlobalIds_points_set(allGlobalIds_points.begin(), allGlobalIds_points.end());
+        // Total global ids in leaf grid view for points: 80 + (125 - 27) = 178
+        BOOST_CHECK( allGlobalIds_points_set.size() == (178 + 4) ); //  expected +  4 "multi-ids"
+    }
+}
+
 
 
 BOOST_AUTO_TEST_CASE(call_adapt_on_distributed_grid)
@@ -957,7 +994,9 @@ BOOST_AUTO_TEST_CASE(call_adapt_on_distributed_grid)
     }
     if(grid.comm().size()>1)
     {
-        grid.loadBalance(parts);
+        grid.loadBalance(parts, false, true); // ownerFirst = false, addCornerCells = true, overlapLayerSize = 1
+        // We set addCornersCells to achieve unique global ids for points belonging to refined level grids.
+
         // grid.adapt(); It does not throw an exeption. Note: adapt() implements global refinement.
         //
         // The following test fails. TODO: Move the assignment of global IDs for refined level grids and the leaf grid view

--- a/tests/cpgrid/avoidNNCinLGRsCpGrid_test.cpp
+++ b/tests/cpgrid/avoidNNCinLGRsCpGrid_test.cpp
@@ -150,6 +150,18 @@ BOOST_AUTO_TEST_CASE(NNCAtSeveralLgrs)
     testCase(deckString, nnc,  cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec, true);
 }
 
+BOOST_AUTO_TEST_CASE(LgrWithNNC_and_lgrsWithoutNNC)
+{
+    Opm::NNC nnc;
+    nnc.addNNC(0, 2, 1.0); // connect cell 0 and cell 2 (both belong to LGR1). LGR2 does not have NNCs.
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{2,2,2}, {4,4,4}};
+    const std::vector<std::array<int,3>> startIJK_vec = {{0,0,0},{0,0,4}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{1,1,3}, {1,1,5}};
+    // LGR1 cell indices = {0,1,2}, LGR2 cell indices = {4}.
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2"};
+    testCase(deckString, nnc,  cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec, true);
+}
+
 BOOST_AUTO_TEST_CASE(NNCoutsideLgrs)
 {
     Opm::NNC nnc;


### PR DESCRIPTION
In an attempt to assign unique point ids on a distributed grid with LGRs, I invoked loadBalance, enabling the inclusion of cells that share corners with interior cells on each process by setting addCornerCells = true (one of the function arguments in loadBalance). However, instead of adding corner-sharing cells, this configuration primarily adds cells that share edges, in addition to the overlap layer of size 1. As a result, cells that share only a corner are not included, which can impact the uniqueness of point ids in certain cases.

In the test addLgrsOnDistributedGrid_test.cpp, both escenarios are included:
- cases where setting addCornerCells=true fix the issue of unique point ids 
- cases where setting addCornerCells=true is not enough to achieve unique point ids (cells that share only corners - and not edges - are not included)

Based on OPM/opm-grid#802. 

Not relevant for the Reference Manual. 