### PR TITLE
Changes for more resonable partitioning:

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -725,7 +725,8 @@ namespace Dune
         bool loadBalance(int overlapLayers=1,
                          int partitionMethod = Dune::PartitionMethod::zoltan,
                          double imbalanceTol = 1.1,
-                         int level =-1)
+                         int level =-1,
+                         bool addCornerCells = true)
         {
             using std::get;
             return get<0>(scatterGrid(/* edgeWeightMethod = */ defaultTransEdgeWgt,
@@ -734,7 +735,7 @@ namespace Dune
                                       /* possibleFutureConnections = */ {},
                                       /* serialPartitioning = */ false,
                                       /* transmissibilities = */ nullptr,
-                                      /* addCornerCells = */ true,
+                                      addCornerCells,
                                       overlapLayers,
                                       partitionMethod,
                                       imbalanceTol,

--- a/opm/grid/common/GridPartitioning.cpp
+++ b/opm/grid/common/GridPartitioning.cpp
@@ -508,7 +508,8 @@ void addOverlapLayerNoZeroTrans(const CpGrid& grid,
                 {
                     // Note: multiple adds for same process are possible
                     exportList.emplace_back(nb_index, owner, AttributeSet::copy);
-                    exportList.emplace_back(index, cell_part[nb_index],  AttributeSet::copy);
+                    // not need or check if
+                    //exportList.emplace_back(index, cell_part[nb_index],  AttributeSet::copy);
                     if ( recursion_deps>0 )
                     {
                         // Add another layer

--- a/opm/grid/common/ZoltanPartition.cpp
+++ b/opm/grid/common/ZoltanPartition.cpp
@@ -288,7 +288,7 @@ void setDefaultZoltanParameters(Zoltan_Struct* zz) {
     Zoltan_Set_Param(zz, "CHECK_GRAPH", "2");
     Zoltan_Set_Param(zz,"EDGE_WEIGHT_DIM","0");
     Zoltan_Set_Param(zz, "OBJ_WEIGHT_DIM", "0");
-    Zoltan_Set_Param(zz, "PHG_EDGE_SIZE_THRESHOLD", ".35");  /* 0-remove all, 1-remove none */
+    Zoltan_Set_Param(zz, "PHG_EDGE_SIZE_THRESHOLD", "1");  /* 0-remove all, 1-remove none */
 }
 
 

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -222,7 +222,6 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
     // Silence any unused argument warnings that could occur with various configurations.
     static_cast<void>(wells);
     static_cast<void>(transmissibilities);
-    static_cast<void>(overlapLayers);
     static_cast<void>(method);
     static_cast<void>(imbalanceTol);
     static_cast<void>(level);
@@ -397,7 +396,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
                                                cc,
                                                addCornerCells,
                                                transmissibilities,
-                                               1 /*layers*/,
+                                               overlapLayers,
                                                level);
         // importList contains all the indices that will be here.
         auto compareImport = [](const std::tuple<int,int,char,int>& t1,

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -223,7 +223,6 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
     // Silence any unused argument warnings that could occur with various configurations.
     static_cast<void>(wells);
     static_cast<void>(transmissibilities);
-    static_cast<void>(overlapLayers);
     static_cast<void>(method);
     static_cast<void>(imbalanceTol);
     static_cast<void>(level);
@@ -399,7 +398,7 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
                                                addCornerCells,
                                                transmissibilities,
                                                useTransToFilterOverlap,
-                                               1 /*layers*/,
+                                               overlapLayers,
                                                level);
         // importList contains all the indices that will be here.
         auto compareImport = [](const std::tuple<int,int,char,int>& t1,


### PR DESCRIPTION
- option to not remove anything from partitioning graph
- added possibility for setting overlap
- changed export list: need testing in particular in parallel (if it is intended to work there)