### PR TITLE
Add Support for Edge Conformal Corner-Point Grid Processing

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -58,6 +58,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/grid/cornerpoint_grid.c
   opm/grid/cpgpreprocess/facetopology.c
   opm/grid/cpgpreprocess/geometry.c
+  opm/grid/cpgpreprocess/make_edge_conformal.cpp
   opm/grid/cpgpreprocess/preprocess.c
   opm/grid/cpgpreprocess/uniquepoints.c
   opm/grid/UnstructuredGrid.c
@@ -257,6 +258,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/grid/cornerpoint_grid.h
   opm/grid/cpgpreprocess/facetopology.h
   opm/grid/cpgpreprocess/geometry.h
+  opm/grid/cpgpreprocess/make_edge_conformal.hpp
   opm/grid/cpgpreprocess/preprocess.h
   opm/grid/cpgpreprocess/uniquepoints.h
   opm/grid/transmissibility/trans_tpfa.h

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -40,15 +40,20 @@
 #define OPM_CPGRID_HEADER
 
 // Warning suppression for Dune includes.
-#include <opm/grid/utility/platform_dependent/disable_warnings.h>  // Not really needed it seems, but alas.
+#include <opm/grid/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/grid/common/grid.hh>
+
+#include <opm/grid/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/grid/common/GridEnums.hpp>
+
 #include <opm/grid/cpgrid/CpGridDataTraits.hpp>
 #include <opm/grid/cpgrid/DefaultGeometryPolicy.hpp>
 #include <opm/grid/cpgrid/OrientedEntityTable.hpp>
+
 #include <opm/grid/cpgpreprocess/preprocess.h>
-#include <opm/grid/utility/platform_dependent/reenable_warnings.h> //  Not really needed it seems, but alas.
-#include "common/GridEnums.hpp"
+
 #include <opm/grid/utility/OpmWellType.hpp>
 
 #include <set>
@@ -224,58 +229,113 @@ namespace Dune
 #if HAVE_ECL_INPUT
         /// Read the Eclipse grid format ('grdecl').
         ///
-        /// \return Vector of global indices to the cells which have
-        ///         been removed in the grid processing due to small pore volume. Function only returns
-        ///         indices on rank 0, the vector is empty of other ranks.
-        /// \param ecl_grid the high-level object from opm-parser which represents the simulation's grid
-        ///        In a parallel run this may be a nullptr on all ranks but rank zero.
-        /// \param ecl_state the object from opm-parser provide information regarding to pore volume, NNC,
-        ///        aquifer information when ecl_state is available. NNC and aquifer connection
-        ///        information will also be updated during the function call when available and necessary.
-        /// \param periodic_extension if true, the grid will be (possibly) refined, so that
-        ///        intersections/faces along i and j boundaries will match those on the other
-        ///        side. That is, i- faces will match i+ faces etc.
-        /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
-        /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
-        /// \param pinchActive Force specific pinch behaviour. If true a face will connect two vertical cells, that are
-        ///           topological connected, even if there are cells with zero volume between them. If false these
-        ///           cells will not be connected despite their faces coinciding.
+        /// \return Vector of global indices to the cells which have been
+        /// removed in the grid processing due to small pore volume.
+        /// Function only returns indices on rank 0, the vector is empty on
+        /// other ranks.
+        ///
+        /// \param[in] ecl_grid the high-level object from opm-common which
+        /// represents the simulation's grid.  In a parallel run this may be
+        /// a nullptr on all ranks but rank zero.
+        ///
+        /// \param[in,out] ecl_state Object from opm-common that provides
+        /// information regarding to pore volume, NNC, aquifer information.
+        /// NNC and aquifer connection information will also be updated
+        /// during the function call when available and necessary.
+        ///
+        /// \param[in] periodic_extension Whether or not to process the
+        /// resulting grid in order to have intersections/faces along i and
+        /// j boundaries match those on the other side. That is, i- faces
+        /// will match i+ faces etc.
+        ///
+        /// \param[in] turn_normals Whether or not to turn all normals.
+        /// This is intended for handling inputs with wrong orientations.
+        ///
+        /// \param[in] clip_z Whether or not to clip the result grid in
+        /// order to have planar top and bottom surfaces.
+        ///
+        /// \param[in] pinchActive Whether or not to force specific pinch
+        /// behaviour.  If set, a face will connect two vertical cells, that
+        /// are topological connected, even if there are cells with zero
+        /// volume between them. If false these cells will not be connected
+        /// despite their faces coinciding.
+        ///
+        /// \param[in] edge_conformal Whether or not to construct an
+        /// edge-conformal grid.  Typically useful in geo-mechanical
+        /// applications.
         std::vector<std::size_t>
         processEclipseFormat(const Opm::EclipseGrid* ecl_grid,
                              Opm::EclipseState* ecl_state,
-                             bool periodic_extension, bool turn_normals, bool clip_z,
-                             bool pinchActive);
+                             bool periodic_extension,
+                             bool turn_normals,
+                             bool clip_z,
+                             bool pinchActive,
+                             bool edge_conformal);
 
         /// Read the Eclipse grid format ('grdecl').
         ///
-        /// Pinch behaviour is determind from the parameter ecl_grid. If ecl_grid is a nullptr or PINCH was specified for
-        /// the grid, then a face will connect two vertical cells, that are topological connected, even if there are
-        /// cells with zero volume between them, Otherwise these cells will not be connected despite their faces coinciding.
+        /// Pinch behaviour is determind from the parameter ecl_grid. If
+        /// ecl_grid is a nullptr or PINCH was specified for the grid, then
+        /// a face will connect two vertical cells, that are topological
+        /// connected, even if there are cells with zero volume between
+        /// them, Otherwise these cells will not be connected despite their
+        /// faces coinciding.
         ///
-        /// \return Vector of global indices to the cells which have
-        ///         been removed in the grid processing due to small pore volume. Function only returns
-        ///         indices on rank 0, the vector is empty of other ranks.
-        /// \param ecl_grid the high-level object from opm-parser which represents the simulation's grid
-        ///        In a parallel run this may be a nullptr on all ranks but rank zero.
-        /// \param ecl_state the object from opm-parser provide information regarding to pore volume, NNC,
-        ///        aquifer information when ecl_state is available. NNC and aquifer connection
-        ///        information will also be updated during the function call when available and necessary.
-        /// \param periodic_extension if true, the grid will be (possibly) refined, so that
-        ///        intersections/faces along i and j boundaries will match those on the other
-        ///        side. That is, i- faces will match i+ faces etc.
-        /// \param turn_normals if true, all normals will be turned. This is intended for handling inputs with wrong orientations.
-        /// \param clip_z if true, the grid will be clipped so that the top and bottom will be planar.
+        /// \return Vector of global indices to the cells which have been
+        /// removed in the grid processing due to small pore volume.
+        /// Function only returns indices on rank 0, the vector is empty on
+        /// other ranks.
+        ///
+        /// \param[in] ecl_grid Object from opm-common which represents the
+        /// simulation's grid.  In a parallel run this may be a nullptr on
+        /// all ranks other than rank zero.
+        ///
+        /// \param[in,out] ecl_state Object from opm-common which provides
+        /// information regarding to pore volume, NNC, and aquifers.  NNC
+        /// and aquifer connection information will be updated during the
+        /// function call when necessary provided \p ecl_state is available.
+        ///
+        /// \param[in] periodic_extension Whether or not to process the
+        /// resulting grid in order to have intersections/faces along i and
+        /// j boundaries match those on the other side. That is, i- faces
+        /// will match i+ faces etc.
+        ///
+        /// \param[in] turn_normals Whether or not to turn all normals.
+        /// This is intended for handling inputs with wrong orientations.
+        ///
+        /// \param[in] clip_z Whether or not to clip the result grid in
+        /// order to have planar top and bottom surfaces.
+        ///
+        /// \param[in] edge_conformal Whether or not to construct an
+        /// edge-conformal grid.  Typically useful in geo-mechanical
+        /// applications.
         std::vector<std::size_t>
         processEclipseFormat(const Opm::EclipseGrid* ecl_grid,
                              Opm::EclipseState* ecl_state,
-                             bool periodic_extension, bool turn_normals = false, bool clip_z = false);
-
-#endif
+                             bool periodic_extension,
+                             bool turn_normals = false,
+                             bool clip_z = false,
+                             bool edge_conformal = false);
+#endif // HAVE_ECL_INPUT
 
         /// Read the Eclipse grid format ('grdecl').
-        /// \param input_data the data in grdecl format, declared in preprocess.h.
-        /// \param remove_ij_boundary if true, will remove (i, j) boundaries. Used internally.
-        void processEclipseFormat(const grdecl& input_data, bool remove_ij_boundary, bool turn_normals = false);
+        ///
+        /// \param[in] input_data the data in grdecl format, declared in
+        /// preprocess.h.
+        ///
+        /// \param[in] remove_ij_boundary if true, will remove (i, j)
+        /// boundaries. Used internally.
+        ///
+        /// \param[in] turn_normals if true, all normals will be turned. This is
+        /// intended for handling inputs with wrong orientations.
+        ///
+        /// \param[in] edge_conformal Whether or not to construct an
+        /// edge-conformal grid.  Typically useful in geo-mechanical
+        /// applications.
+        void processEclipseFormat(const grdecl& input_data,
+                                  bool remove_ij_boundary,
+                                  bool turn_normals = false,
+                                  bool edge_conformal = false);
 
         //@}
 

--- a/opm/grid/GridManager.cpp
+++ b/opm/grid/GridManager.cpp
@@ -40,18 +40,20 @@ namespace Opm
 
 #if HAVE_ECL_INPUT
     /// Construct a 3d corner-point grid from a deck.
-    GridManager::GridManager(const Opm::EclipseGrid& inputGrid)
+    GridManager::GridManager(const Opm::EclipseGrid& inputGrid,
+                             const bool edge_conformal)
         : ug_(0)
     {
-        initFromEclipseGrid(inputGrid, std::vector<double>());
+        initFromEclipseGrid(inputGrid, std::vector<double>(), edge_conformal);
     }
 
 
     GridManager::GridManager(const Opm::EclipseGrid& inputGrid,
-                             const std::vector<double>& poreVolumes)
+                             const std::vector<double>& poreVolumes,
+                             const bool edge_conformal)
         : ug_(0)
     {
-        initFromEclipseGrid(inputGrid, poreVolumes);
+        initFromEclipseGrid(inputGrid, poreVolumes, edge_conformal);
     }
 #endif
 
@@ -133,9 +135,10 @@ namespace Opm
 #if HAVE_ECL_INPUT
     // Construct corner-point grid from EclipseGrid.
     void GridManager::initFromEclipseGrid(const Opm::EclipseGrid& inputGrid,
-                                          const std::vector<double>& poreVolumes)
+                                          const std::vector<double>& poreVolumes,
+                                          const bool edge_conformal)
     {
-        struct grdecl g;
+        grdecl g{};
 
         g.dims[0] = inputGrid.getNX();
         g.dims[1] = inputGrid.getNY();
@@ -166,7 +169,7 @@ namespace Opm
                        actnum, opmfil, zcorn.data());
         }
 
-        ug_ = create_grid_cornerpoint(&g, z_tolerance);
+        ug_ = create_grid_cornerpoint(&g, z_tolerance, edge_conformal);
         if (!ug_) {
             OPM_THROW(std::runtime_error, "Failed to construct grid.");
         }

--- a/opm/grid/GridManager.hpp
+++ b/opm/grid/GridManager.hpp
@@ -47,7 +47,8 @@ class EclipseGrid;
 
 #if HAVE_ECL_INPUT
         /// Construct a grid from an EclipseState::EclipseGrid instance.
-        explicit GridManager(const EclipseGrid& inputGrid);
+        explicit GridManager(const EclipseGrid& inputGrid,
+                             bool edge_conformal = false);
 
         /// Construct a grid from an EclipseState::EclipseGrid instance,
         /// giving an explicit set of pore volumes to be used for MINPV
@@ -55,7 +56,8 @@ class EclipseGrid;
         /// \input[in] eclipseGrid    encapsulates a corner-point grid given from a deck
         /// \input[in] poreVolumes    one element per logical cartesian grid element
         GridManager(const EclipseGrid& inputGrid,
-                    const std::vector<double>& poreVolumes);
+                    const std::vector<double>& poreVolumes,
+                    bool edge_conformal);
 #endif
 
         /// Construct a 2d cartesian grid with cells of unit size.
@@ -92,7 +94,8 @@ class EclipseGrid;
 #if HAVE_ECL_INPUT
         // Construct corner-point grid from EclipseGrid.
         void initFromEclipseGrid(const EclipseGrid& inputGrid,
-                                 const std::vector<double>& poreVolumes);
+                                 const std::vector<double>& poreVolumes,
+                                 bool edge_conformal);
 #endif
 
         // The managed UnstructuredGrid.

--- a/opm/grid/cornerpoint_grid.h
+++ b/opm/grid/cornerpoint_grid.h
@@ -41,6 +41,7 @@
  */
 
 #include <opm/grid/UnstructuredGrid.h>
+
 #include <opm/grid/cpgpreprocess/preprocess.h>
 
 #ifdef __cplusplus
@@ -63,13 +64,21 @@ extern "C" {
      *
      * @param[in] tol Absolute tolerance of node-coincidence.
      *
+     * @param[in] edge_conformal Whether or not to create an edge-conformal
+     *                grid structure.  This is an experimental feature,
+     *                aimed at supporting geo-mechanical workflows, that
+     *                should typically not be used in production runs of
+     *                traditional reservoir simulations.  Non-zero to enable
+     *                edge-conformal processing, zero to disable this mode.
+     *
      * @return Fully formed grid data structure that manages the grid defined by
      * the input corner-point specification. Must be destroyed using function
      * destroy_grid().
      */
     struct UnstructuredGrid *
-    create_grid_cornerpoint(const struct grdecl *in, double tol);
-
+    create_grid_cornerpoint(const struct grdecl *in,
+                            double tol,
+                            int edge_conformal);
 
     /**
      * Compute derived geometric primitives in a grid.

--- a/opm/grid/cpgpreprocess/facetopology.h
+++ b/opm/grid/cpgpreprocess/facetopology.h
@@ -35,8 +35,13 @@
 #ifndef OPM_FACETOPOLOGY_HEADER
 #define OPM_FACETOPOLOGY_HEADER
 
+#include <stdbool.h>
 
-void findconnections(int n, int *pts[4],
+struct processed_grid;
+
+void findconnections(bool edge_conformal,
+                     int n,
+                     int *pts[4],
                      int *intersectionlist,
                      int *work,
                      struct processed_grid *out);

--- a/opm/grid/cpgpreprocess/make_edge_conformal.cpp
+++ b/opm/grid/cpgpreprocess/make_edge_conformal.cpp
@@ -1,0 +1,381 @@
+/*
+  Copyright 2025 Equinor AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#include <opm/grid/cpgpreprocess/make_edge_conformal.hpp>
+
+#include <opm/grid/cpgpreprocess/preprocess.h>
+
+#include <algorithm>
+#include <array>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+void my_assert(const bool fine, std::string_view message = "")
+{
+    if (! fine) {
+        throw std::runtime_error { message.data() };
+    }
+}
+
+struct less_than_key {
+    inline bool operator()(const std::array<int,2>& edge1,
+                           const std::array<int,2>& edge2) const
+    {
+        std::array<int,2> sedge1 = edge1;
+        std::array<int,2> sedge2 = edge2;
+        std::sort(sedge1.begin(), sedge1.end());
+        std::sort(sedge2.begin(), sedge2.end());
+
+        if (sedge1[0] < sedge2[0]) {
+            return true;
+        }
+        else if (sedge1[0] == sedge2[0]) {
+            return sedge1[1] < sedge2[1];
+        }
+        else {
+            return false;
+        }
+
+        my_assert(false, "compare");
+    }
+};
+
+struct opposite {
+    inline bool operator()(const std::array<int,2>& edge1,
+                           const std::array<int,2>& edge2) const
+    {
+        return (edge1[0] == edge2[1])
+            && (edge1[1] == edge2[0]);
+    }
+};
+
+std::vector<int>
+sorted_outer_boundary(const processed_grid&   grid,
+                      const std::vector<int>& dir_faces,
+                      const std::vector<int>& dir_hfaces,
+                      const int               cell)
+{
+    std::vector<std::array<int,2>> edges{};
+
+    for (auto locind = 0*dir_faces.size();
+         locind < dir_faces.size(); ++locind)
+    {
+        const int hface = dir_hfaces[locind];
+        const int face = grid.cell_faces[hface];
+
+        std::vector<std::array<int,2>> face_edges{};
+
+        // Add edges
+        for (auto fnodePos = grid.face_node_ptr[face + 0];
+             fnodePos < grid.face_node_ptr[face + 1] - 1;
+             ++fnodePos)
+        {
+            face_edges.emplace_back() = std::array {
+                grid.face_nodes[fnodePos + 0],
+                grid.face_nodes[fnodePos + 1],
+            };
+        }
+
+        face_edges.emplace_back() = std::array {
+            grid.face_nodes[grid.face_node_ptr[face + 1] - 1],
+            grid.face_nodes[grid.face_node_ptr[face + 0] + 0],
+        };
+
+        if (cell == grid.face_neighbors[2*face + 1]) {
+            // Reverse edges
+            for (auto& edge : face_edges) {
+                std::swap(edge[0], edge[1]);
+            }
+        }
+
+        edges.insert(edges.end(), face_edges.begin(), face_edges.end());
+    }
+
+    // Sort internal edges into contiguous order.
+    std::sort(edges.begin(), edges.end(), less_than_key{});
+
+    std::vector<std::array<int,2>> new_edges;
+
+    // Remove internal edges.
+    auto iter = edges.begin();
+    auto iternext = iter;
+    ++iternext;
+
+    const opposite is_opposite{};
+    for (; iternext != edges.end();) {
+        if (is_opposite(*iter, *iternext)) {
+            iter = iternext;
+            ++iter;
+            if (iter != edges.end()) {
+                iternext = iter;
+                ++iternext;
+            }
+            else {
+                iternext = iter;
+            }
+        }
+        else {
+            new_edges.push_back(*iter);
+            ++iter;
+            ++iternext;
+        }
+    }
+
+    if (iter != edges.end()) {
+        new_edges.push_back(*iter);
+    }
+
+    edges = new_edges;
+
+    // At this point, edges should only contain oriented outer edges.  Put
+    // them after each other.
+    std::vector<std::array<int,2>> sedges{};
+
+    sedges.push_back(edges.front());
+    edges.erase(edges.begin());
+    while (!edges.empty()) {
+        auto cedges = sedges.back();
+        auto nextelem = std::find_if(edges.begin(), edges.end(),
+                                     [cedges](std::array<int,2> &s)
+                                     { return s[0] == cedges[1]; });
+
+        sedges.push_back(*nextelem);
+        edges.erase(nextelem);
+    }
+
+    std::vector<int> sedge;
+    for (const auto& edge: sedges) {
+        sedge.push_back(edge[0]);
+    }
+
+    return sedge;
+}
+
+std::vector<int>
+new_tb(const std::vector<int>&  bfnodes_in,
+       const std::vector<int>&  sedge,
+       const std::array<int,2>& bedge,
+       const int                fsigntb)
+{
+    std::vector<int> newedge{};
+    std::vector<int> bfnodes = bfnodes_in;
+
+    const auto ind2 = find_if(sedge.begin(), sedge.end(), [&bedge](const int s) { return s == bedge[1]; });
+    const auto ind1 = find_if(sedge.begin(), sedge.end(), [&bedge](const int s) { return s == bedge[0]; });
+
+    my_assert(ind1 != sedge.end(), "ind1 not found");
+    my_assert(ind2 != sedge.end(), "ind2 not found");
+
+    int addnode = 0;
+    if ((ind1 == std::prev(sedge.end())) && (ind2 == sedge.begin())) {
+        addnode = 0;
+    }
+    else if (ind2 - ind1 < 0) {
+        newedge.insert(newedge.end(), ind1, sedge.end());
+        newedge.insert(newedge.end(), sedge.begin(), std::next(ind2));
+        addnode = newedge.size() -2;
+    }
+    else if (ind2 - ind1 > 0) {
+        newedge.insert(newedge.end(), ind1, std::next(ind2));
+        addnode = newedge.size() -2;
+    }
+    else {
+        my_assert(false,"Do not exist");
+    }
+
+    if (fsigntb == 1) {
+        std::reverse(newedge.begin(), newedge.end());
+    }
+
+    // add possibly modified nodes
+    if (addnode > 0) {
+        auto iterstart = newedge.begin();
+        ++iterstart;
+
+        auto iterend = newedge.end();
+        --iterend;
+
+        auto node2 = std::find_if(bfnodes.begin(), bfnodes.end(),
+                                  [vert = newedge.back()](const int s)
+                                  { return vert == s; });
+
+        auto node1 = std::find_if(bfnodes.begin(), bfnodes.end(),
+                                  [vert = newedge.front()](const int s)
+                                  { return vert == s; });
+
+        if ((node1 == std::prev(bfnodes.end())) &&
+            (node2 == bfnodes.begin())) {
+            bfnodes.insert(bfnodes.end(), iterstart, iterend);
+        }
+        else if (node2 - node1 == 1) {
+            bfnodes.insert(std::next(node1), iterstart, iterend);
+        }
+        else {
+            // nodes should already be added
+            auto node_end = node2;
+            auto it1 = node1;
+            auto it2 = newedge.begin();
+            while ((it1 != node_end) && (it1 != bfnodes.end())) {
+                my_assert(*it1 == *it2, "Existing face wrong");
+                ++it1;
+                ++it2;
+            }
+
+            if ((it1 == bfnodes.end()) && (node2 != std::prev(bfnodes.end()))) {
+                it1 = bfnodes.begin();
+                while ((it1 != node_end) && (it1 != bfnodes.end())) {
+                    my_assert(*it1 == *it2, "Existing face wrong cyclic case");
+                    ++it1;
+                    ++it2;
+                }
+            }
+        }
+    }
+
+    return bfnodes;
+}
+
+void fix_edges_at_top(const struct processed_grid& grid,
+                      std::vector<int>& nodes,
+                      std::vector<int>& nodePos)
+{
+    // are going to be the new face nodes
+    std::vector<std::vector<int>> face_nodes{};
+    face_nodes.reserve(grid.number_of_faces);
+    for (auto i = 0*grid.number_of_faces; i < grid.number_of_faces; ++i) {
+        face_nodes.emplace_back(grid.face_nodes + grid.face_node_ptr[i + 0],
+                                grid.face_nodes + grid.face_node_ptr[i + 1]);
+    }
+
+    const auto nhf = grid.cell_face_ptr[grid.number_of_cells];
+
+    for (auto cell = 0*grid.number_of_cells; cell < grid.number_of_cells; ++cell) {
+        // Process top and bottom faces of each cell.
+        std::array<std::vector<int>, 6> dir_faces{};
+        std::array<std::vector<int>, 6> dir_hfaces{};
+
+        for (auto hface = grid.cell_face_ptr[cell + 0];
+             hface < grid.cell_face_ptr[cell + 1]; ++hface)
+        {
+            const auto hface_tag = grid.cell_faces[1*nhf + hface];
+
+            dir_faces [hface_tag].push_back(grid.cell_faces[0*nhf + hface]);
+            dir_hfaces[hface_tag].push_back(hface);
+        }
+
+        my_assert(dir_faces[4].size() == 1, "face size wrong top");
+        my_assert(dir_faces[5].size() == 1, "face size wrong bottom");
+
+        for (int dir = 0; dir < 4; ++dir) {
+            if (dir_faces[dir].size() <= 1) {
+                // There are no additional intersections that could possibly
+                // affect the top surface's vertices when there is at most
+                // one face in this direction.
+                continue;
+            }
+
+            // Find all oriented edges in this direction.
+            //
+            // 'Sedge' holds an oriented list of edges (vertex pairs),
+            // ordered cyclically around the face, in such a way that
+            // equivalent edges appear next to each other.
+            const auto sedge = sorted_outer_boundary
+                (grid, dir_faces[dir], dir_hfaces[dir], cell);
+
+            std::array<int,2> bedge{};
+
+            // Find top/bottom edge to be considered.
+            for (int tb = 4; tb < 6; ++tb) {
+                my_assert(dir_faces[tb].size() == 1, "face size wrong tb/bottom");
+
+                const int bface = dir_faces[tb][0];
+                const auto org_bfnodes = std::vector<int> {
+                    grid.face_nodes + grid.face_node_ptr[bface + 0],
+                    grid.face_nodes + grid.face_node_ptr[bface + 1]
+                };
+
+                const auto bfnodes = face_nodes[bface]; //bd
+
+                {
+                    const std::array<int,4> odir {0, 2, 1, 3};
+                    if (odir[dir] == 0) {
+                        bedge[0] = org_bfnodes[3];
+                        bedge[1] = org_bfnodes[0];
+                    }
+                    else {
+                        bedge[0] = org_bfnodes[odir[dir] - 1];
+                        bedge[1] = org_bfnodes[odir[dir] + 0];
+                    }
+                }
+
+                const int fsigntb = (grid.face_neighbors[2*bface + 1] == cell)
+                    ? -1 : 1;
+
+                if (fsigntb == 1) {
+                    std::reverse(bedge.begin(), bedge.end());
+                }
+
+                face_nodes[bface] = new_tb(bfnodes, sedge, bedge, fsigntb);
+            } // end tb
+        } // end dir
+    } // end cell
+
+    nodePos.resize(face_nodes.size() + 1);
+    nodePos[0] = 0;
+    int count = 0;
+    for (const auto& face : face_nodes) {
+        nodes.insert(nodes.end(), face.begin(), face.end());
+        nodePos[count + 1] = nodePos[count] + face.size();
+        ++count;
+    }
+}
+
+} // Anonymous namespace
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+int make_edge_conformal(struct processed_grid* grid)
+{
+    try {
+        std::vector<int> faceNodes{};
+        std::vector<int> nodePos{};
+
+        fix_edges_at_top(*grid, faceNodes, nodePos);
+
+        std::copy_n(nodePos.begin(), grid->number_of_faces + 1, grid->face_node_ptr);
+        std::copy_n(faceNodes.begin(), grid->face_node_ptr[grid->number_of_faces], grid->face_nodes);
+    }
+    catch (const std::exception& e) {
+        return 0;
+    }
+
+    return 1;
+}
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus

--- a/opm/grid/cpgpreprocess/make_edge_conformal.hpp
+++ b/opm/grid/cpgpreprocess/make_edge_conformal.hpp
@@ -1,0 +1,16 @@
+#ifndef OPM_MAKE_EDGE_CONFORMAL_HEADER
+#define OPM_MAKE_EDGE_CONFORMAL_HEADER
+
+#include <opm/grid/cpgpreprocess/preprocess.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+int make_edge_conformal(struct processed_grid* grid);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#endif // OPM_MAKE_EDGE_CONFORMAL_HEADER

--- a/tests/test_column_extract.cpp
+++ b/tests/test_column_extract.cpp
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(DisjointColumn)
     for (size_t i = 1; i <= (3 * 3 * 3); i++)
         actnum.push_back(i != 14); // ACTNUM 13*1 0 13* 1
     ep.resetACTNUM(actnum);
-    Opm::GridManager manager(ep);
+    Opm::GridManager manager(ep, /* edge_conformal = */ false);
 
     VVI columns;
     Opm::extractColumn(*manager.c_grid(), columns);

--- a/tests/test_process_grdecl.cpp
+++ b/tests/test_process_grdecl.cpp
@@ -4,10 +4,13 @@
 
 #define BOOST_TEST_MODULE Process_Grdecl
 #include <boost/test/unit_test.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include <opm/grid/cpgpreprocess/preprocess.h>
+#include <opm/grid/cpgpreprocess/make_edge_conformal.hpp>
 
 #include <array>
+#include <cstddef>
 #include <initializer_list>
 #include <optional>
 #include <vector>
@@ -57,6 +60,12 @@ namespace {
             return *this;
         }
 
+        TestGrid& edgeConformal(const bool conformal)
+        {
+            this->edge_conformal_ = static_cast<int>(conformal);
+            return *this;
+        }
+
         TestGrid& process()
         {
             auto input = grdecl{};
@@ -70,11 +79,17 @@ namespace {
             this->g_.emplace(processed_grid{});
 
             this->status_ =
-                process_grdecl(&input,
+                process_grdecl(this->pinch_active_,
+                               this->edge_conformal_,
                                this->ztol_,
-                               nullptr,
-                               &*this->g_,
-                               this->pinch_active_);
+                               &input,
+                               /* is_aquifer_cell = */ nullptr,
+                               &*this->g_);
+
+            if ((this->status_ != 0) && (this->edge_conformal_ != 0)) {
+                add_cell_face_mapping(&*this->g_);
+                this->status_ = make_edge_conformal(&*this->g_);
+            }
 
             return *this;
         }
@@ -91,6 +106,7 @@ namespace {
 
         double ztol_{0.0};
         int pinch_active_{0};
+        int edge_conformal_{0};
         int status_{};
 
         std::optional<processed_grid> g_{};
@@ -161,7 +177,52 @@ namespace {
 
             .actnum({ 1, 0, 1, });
     }
+
+    TestGrid singleFaultConnection()
+    {
+        return TestGrid {{ 2, 1, 1 }}
+            .coord({
+                    0.0, 0.0, 0.0,   0.0, 0.0, 2.0,
+                    1.0, 0.0, 0.0,   1.0, 0.0, 2.0,
+                    2.0, 0.0, 0.0,   2.0, 0.0, 2.0,
+                    0.0, 1.0, 0.0,   0.0, 1.0, 2.0,
+                    1.0, 1.0, 0.0,   1.0, 1.0, 2.0,
+                    2.0, 1.0, 0.0,   2.0, 1.0, 2.0,
+                })
+
+            .zcorn({
+                    // Left cell, back row, top surface
+                    1.0, 1.0,
+
+                    // Right cell, back row, top surface
+                    1.5, 1.5,
+
+                    // Left cell, front row, top surface
+                    1.0, 1.0,
+
+                    // Right cell, front row, top surface
+                    0.5, 1.0,
+
+                    // ----------------------------------
+
+                    // Left cell, back row, bottom surface
+                    2.0, 2.0,
+
+                    // Right cell, back row, bottom surface
+                    2.0, 2.0,
+
+                    // Left cell, front row, bottom surface
+                    2.0, 2.0,
+
+                    // Right cell, front row, bottom surface
+                    2.0, 2.0,
+                })
+
+            .actnum({ 1, 1, });
+    }
 } // Anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(Regular_Processing)
 
 BOOST_AUTO_TEST_CASE(Zero_Thickness_Middle_No_Pinch)
 {
@@ -437,3 +498,346 @@ BOOST_AUTO_TEST_CASE(Unit_Thickness_Middle_With_Pinch)
                                       expect.begin(), expect.end());
     }
 }
+
+BOOST_AUTO_TEST_CASE(Single_Fault_Connection)
+{
+    auto testCase = singleFaultConnection()
+        .pinchActive(true)
+        .ztol(0.0);
+
+    testCase.process();
+    BOOST_REQUIRE_EQUAL(testCase.status(), 1);
+
+    const auto& out = testCase.grid();
+
+    BOOST_CHECK_EQUAL(out.dimensions[0], 2);
+    BOOST_CHECK_EQUAL(out.dimensions[1], 1);
+    BOOST_CHECK_EQUAL(out.dimensions[2], 1);
+
+    BOOST_CHECK_EQUAL(out.number_of_nodes, 15);
+    BOOST_CHECK_EQUAL(out.number_of_faces, 13);
+    BOOST_CHECK_EQUAL(out.number_of_cells,  2);
+
+    // Face-to-cell mapping
+    {
+        const auto expect = std::vector {
+            -1, 0,              // 0, I-min (left)
+            -1, 1,              // 1, I-min (right)
+            0, -1,              // 2, I-max (1, left)
+            0,  1,              // 3, I-max (2, left)
+            1, -1,              // 4, I-max (right)
+
+            // -------------------------------
+
+            -1, 0,              // 5, J-min (left)
+            -1, 1,              // 6, J-min (right)
+            0, -1,              // 7, J-max (left)
+            1, -1,              // 8, J-max (right)
+
+            // -------------------------------
+
+            -1, 0,              //  9, K-min (left)
+            0, -1,              // 10, K-max (left)
+            -1, 1,              // 11, K-min (right)
+            1, -1,              // 12, K-max (right)
+        };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(out.face_neighbors,
+                                      out.face_neighbors + 2*out.number_of_faces,
+                                      expect.begin(), expect.end());
+    }
+
+    // Face taxonomy
+    {
+        const auto expect = std::vector {
+            face_tag::I_FACE, face_tag::I_FACE, face_tag::I_FACE, face_tag::I_FACE, face_tag::I_FACE,
+            face_tag::J_FACE, face_tag::J_FACE, face_tag::J_FACE, face_tag::J_FACE,
+            face_tag::K_FACE, face_tag::K_FACE, face_tag::K_FACE, face_tag::K_FACE,
+        };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(out.face_tag,
+                                      out.face_tag + out.number_of_faces,
+                                      expect.begin(), expect.end());
+    }
+
+    // Vertex coordinates
+    {
+        const auto expect = std::array {
+            // Back left pillar
+            std::array { 0.0, 0.0, 1.0 }, // 0
+            std::array { 0.0, 0.0, 2.0 }, // 1
+
+            // Back centre pillar
+            std::array { 1.0, 0.0, 1.0 }, // 2
+            std::array { 1.0, 0.0, 1.5 }, // 3
+            std::array { 1.0, 0.0, 2.0 }, // 4
+
+            // Back right pillar
+            std::array { 2.0, 0.0, 1.5 }, // 5
+            std::array { 2.0, 0.0, 2.0 }, // 6
+
+            // -------------------------------
+
+            // Front left pillar
+            std::array { 0.0, 1.0, 1.0 }, // 7
+            std::array { 0.0, 1.0, 2.0 }, // 8
+
+            // Front centre pillar
+            std::array { 1.0, 1.0, 0.5 }, //  9
+            std::array { 1.0, 1.0, 1.0 }, // 10
+            std::array { 1.0, 1.0, 2.0 }, // 11
+
+            // Front right pillar
+            std::array { 2.0, 1.0, 1.0 }, // 12
+            std::array { 2.0, 1.0, 2.0 }, // 13
+
+            // --------------------------------
+
+            // Fault node
+            std::array { 1.0, 0.5, 1.0 }, // 14
+        };
+
+        BOOST_REQUIRE_EQUAL(expect.size(), static_cast<std::size_t>(out.number_of_nodes));
+
+        auto vertexId = 0*expect.size();
+        const auto* coord = out.node_coordinates;
+        for (const auto& vertex : expect) {
+            auto coordCompId = 0*vertex.size();
+            for (const auto& component : vertex) {
+                BOOST_TEST_MESSAGE("Vertex " << vertexId <<
+                                   ", component " << coordCompId);
+                BOOST_CHECK_CLOSE(*coord++, component, 1.0e-8);
+
+                ++coordCompId;
+            }
+
+            ++vertexId;
+        }
+    }
+
+    // Face vertices (offsets)
+    {
+        const auto expect = std::array {
+            // I faces (0..4)
+            0, 4, 7, 10, 15,
+
+            // J faces (5..9)
+            19, 23, 27, 31,
+
+            // K faces (10..13)
+            35, 39, 43, 47,
+
+            // End
+            51,
+        };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(out.face_node_ptr, out.face_node_ptr + out.number_of_faces + 1,
+                                      expect.begin(), expect.end());
+    }
+
+    // Face vertices (vertex IDs)
+    {
+        const auto expect = std::array {
+            0, 7, 8, 1,         // 0, I-min (left)
+            14, 9, 10,          // 1, I-min (right)
+            2, 14, 3,           // 2, I-max (1, left)
+            3, 14, 10, 11, 4,   // 3, I-max (2, left)
+            5, 12, 13, 6,       // 4, I-max (right)
+
+            // --------------------------------------
+
+            2, 0, 1, 4,         // 5, J-min (left)
+            5, 3, 4, 6,         // 6, J-max (left)
+            10, 7, 8, 11,       // 7, J-min (right)
+            12, 9, 11, 13,      // 8, J-max (right)
+
+            // --------------------------------------
+
+            0, 2, 10, 7,        //  9, K-min (left)
+            1, 4, 11, 8,        // 10, K-max (left)
+            3, 5, 12, 9,        // 11, K-min (right)
+            4, 6, 13, 11,       // 12, K-max (right)
+        };
+
+        BOOST_REQUIRE_EQUAL(expect.size(), static_cast<std::size_t>(out.face_node_ptr[out.number_of_faces]));
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(out.face_nodes, out.face_nodes + out.face_node_ptr[out.number_of_faces],
+                                      expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Regular_Processing
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Edge_Conformal_Processing)
+
+BOOST_AUTO_TEST_CASE(Single_Fault_Connection)
+{
+    auto testCase = singleFaultConnection()
+        .edgeConformal(true)
+        .pinchActive(true)
+        .ztol(0.0);
+
+    testCase.process();
+    BOOST_REQUIRE_EQUAL(testCase.status(), 1);
+
+    const auto& out = testCase.grid();
+
+    BOOST_CHECK_EQUAL(out.dimensions[0], 2);
+    BOOST_CHECK_EQUAL(out.dimensions[1], 1);
+    BOOST_CHECK_EQUAL(out.dimensions[2], 1);
+
+    BOOST_CHECK_EQUAL(out.number_of_nodes, 15);
+    BOOST_CHECK_EQUAL(out.number_of_faces, 13);
+    BOOST_CHECK_EQUAL(out.number_of_cells,  2);
+
+    // Face-to-cell mapping
+    {
+        const auto expect = std::vector {
+            -1, 0,              // 0, I-min (left)
+            -1, 1,              // 1, I-min (right)
+            0, -1,              // 2, I-max (1, left)
+            0,  1,              // 3, I-max (2, left)
+            1, -1,              // 4, I-max (right)
+
+            // -------------------------------
+
+            -1, 0,              // 5, J-min (left)
+            -1, 1,              // 6, J-min (right)
+            0, -1,              // 7, J-max (left)
+            1, -1,              // 8, J-max (right)
+
+            // -------------------------------
+
+            -1, 0,              //  9, K-min (left)
+            0, -1,              // 10, K-max (left)
+            -1, 1,              // 11, K-min (right)
+            1, -1,              // 12, K-max (right)
+        };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(out.face_neighbors,
+                                      out.face_neighbors + 2*out.number_of_faces,
+                                      expect.begin(), expect.end());
+    }
+
+    // Face taxonomy
+    {
+        const auto expect = std::vector {
+            face_tag::I_FACE, face_tag::I_FACE, face_tag::I_FACE, face_tag::I_FACE, face_tag::I_FACE,
+            face_tag::J_FACE, face_tag::J_FACE, face_tag::J_FACE, face_tag::J_FACE,
+            face_tag::K_FACE, face_tag::K_FACE, face_tag::K_FACE, face_tag::K_FACE,
+        };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(out.face_tag,
+                                      out.face_tag + out.number_of_faces,
+                                      expect.begin(), expect.end());
+    }
+
+    // Vertex coordinates
+    {
+        const auto expect = std::array {
+            // Back left pillar
+            std::array { 0.0, 0.0, 1.0 }, // 0
+            std::array { 0.0, 0.0, 2.0 }, // 1
+
+            // Back centre pillar
+            std::array { 1.0, 0.0, 1.0 }, // 2
+            std::array { 1.0, 0.0, 1.5 }, // 3
+            std::array { 1.0, 0.0, 2.0 }, // 4
+
+            // Back right pillar
+            std::array { 2.0, 0.0, 1.5 }, // 5
+            std::array { 2.0, 0.0, 2.0 }, // 6
+
+            // -------------------------------
+
+            // Front left pillar
+            std::array { 0.0, 1.0, 1.0 }, // 7
+            std::array { 0.0, 1.0, 2.0 }, // 8
+
+            // Front centre pillar
+            std::array { 1.0, 1.0, 0.5 }, //  9
+            std::array { 1.0, 1.0, 1.0 }, // 10
+            std::array { 1.0, 1.0, 2.0 }, // 11
+
+            // Front right pillar
+            std::array { 2.0, 1.0, 1.0 }, // 12
+            std::array { 2.0, 1.0, 2.0 }, // 13
+
+            // --------------------------------
+
+            // Fault node
+            std::array { 1.0, 0.5, 1.0 }, // 14
+        };
+
+        BOOST_REQUIRE_EQUAL(expect.size(), static_cast<std::size_t>(out.number_of_nodes));
+
+        auto vertexId = 0*expect.size();
+        const auto* coord = out.node_coordinates;
+        for (const auto& vertex : expect) {
+            auto coordCompId = 0*vertex.size();
+            for (const auto& component : vertex) {
+                BOOST_TEST_MESSAGE("Vertex " << vertexId <<
+                                   ", component " << coordCompId);
+                BOOST_CHECK_CLOSE(*coord++, component, 1.0e-8);
+
+                ++coordCompId;
+            }
+
+            ++vertexId;
+        }
+    }
+
+    // Face vertices (offsets)
+    {
+        const auto expect = std::array {
+            // I faces (0..4)
+            0, 4, 7, 10, 15,
+
+            // J faces (5..9)
+            19, 23, 27, 31,
+
+            // K faces (10..13)
+            35, 40, 44, 49,
+
+            // End
+            53,
+        };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(out.face_node_ptr, out.face_node_ptr + out.number_of_faces + 1,
+                                      expect.begin(), expect.end());
+    }
+
+    // Face vertices (vertex IDs)
+    {
+        const auto expect = std::array {
+            0, 7, 8, 1,         // 0, I-min (left)
+            14, 9, 10,          // 1, I-min (right)
+            2, 14, 3,           // 2, I-max (1, left)
+            3, 14, 10, 11, 4,   // 3, I-max (2, left)
+            5, 12, 13, 6,       // 4, I-max (right)
+
+            // --------------------------------------
+
+            2, 0, 1, 4,         // 5, J-min (left)
+            5, 3, 4, 6,         // 6, J-max (left)
+            10, 7, 8, 11,       // 7, J-min (right)
+            12, 9, 11, 13,      // 8, J-max (right)
+
+            // --------------------------------------
+
+            0, 2, 14, 10, 7,    //  9, K-min (left)
+            1, 4, 11, 8,        // 10, K-max (left)
+            3, 5, 12, 9, 14,    // 11, K-min (right)
+            4, 6, 13, 11,       // 12, K-max (right)
+        };
+
+        BOOST_REQUIRE_EQUAL(expect.size(), static_cast<std::size_t>(out.face_node_ptr[out.number_of_faces]));
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(out.face_nodes, out.face_nodes + out.face_node_ptr[out.number_of_faces],
+                                      expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Edge_Conformal_Processing

--- a/tests/test_ug.cpp
+++ b/tests/test_ug.cpp
@@ -79,8 +79,9 @@ BOOST_AUTO_TEST_CASE(Equal) {
     BOOST_CHECK( deck1.hasKeyword("ZCORN") );
     BOOST_CHECK( deck1.hasKeyword("COORD") );
 
-    Opm::GridManager grid1(es1.getInputGrid());
-    Opm::GridManager grid2(es2.getInputGrid());
+    const bool edge_conformal = false;
+    Opm::GridManager grid1(es1.getInputGrid(), edge_conformal);
+    Opm::GridManager grid2(es2.getInputGrid(), edge_conformal);
 
     const UnstructuredGrid* cgrid1 = grid1.c_grid();
     const UnstructuredGrid* cgrid2 = grid2.c_grid();
@@ -120,7 +121,7 @@ BOOST_AUTO_TEST_CASE(EqualEclipseGrid) {
         g.actnum = actnum.getIntData().data();
 
 
-        cgrid2 = create_grid_cornerpoint(&g , 0.0);
+        cgrid2 = create_grid_cornerpoint(&g, 0.0, /* edge_conformal = */ false);
         if (!cgrid2)
             throw std::runtime_error("Failed to construct grid.");
     }


### PR DESCRIPTION
Initially supported fully only for the `UnstructuredGrid` (`create_grid_cornerpoint()` constructor, `PolyhedralGrid` wrapper), this PR introduces amended logic that aims to create edge conformal cell complexes.  Specifically, the faces of the `processed_grid` structure from `process_grdecl()` contains **all** vertices along the pillars, not just the top and bottom vertices of the traditional corner-point description.  Moreover, the `create_grid_cornerpoint()` function will insert additional vertices in the top and bottom **faces** when the edge conformal mode is activated.  This aspect is not yet available in the `CpGrid` implementation, though the vertices along the pillars will be included in that case too.

Client code may activate this mode by setting the `edge_conformal` flag to `true`.  The flag is a `bool` (i.e., `_Bool`) in both the C and the C++ code, but transmitted as an `int` across the language boundary.

At this time, the mode is intended to support geo-mechanical workflows and should typically not be enabled in production runs of regular reservoir simulations.  Furthermore, this is not tested or supported in parallel runs.

While here, split some long lines and mark objects `const` where possible.

---

Work by @hnil.