### PR TITLE
Serial Zoltan with graph representing a well a by single vertex

### DIFF
--- a/opm/grid/GraphOfGridWrappers.cpp
+++ b/opm/grid/GraphOfGridWrappers.cpp
@@ -652,7 +652,7 @@ zoltanSerialPartitioningWithGraphOfGrid(const Dune::CpGrid& grid,
         rc = Zoltan_Initialize(argc, argv, &ver);
 
         zz = Zoltan_Create(MPI_COMM_SELF);
-        if (rc == ZOLTAN_OK){
+        if (rc == ZOLTAN_OK) {
             setDefaultZoltanParameters(zz);
             Zoltan_Set_Param(zz, "IMBALANCE_TOL", std::to_string(zoltanImbalanceTol).c_str());
             Zoltan_Set_Param(zz, "NUM_GLOBAL_PARTS", std::to_string(cc.size()).c_str());
@@ -727,22 +727,21 @@ zoltanSerialPartitioningWithGraphOfGrid(const Dune::CpGrid& grid,
             myImportList.emplace_back(cell, root, static_cast<char>(AttributeSet::owner), -1);
         }
     }
-    std::sort(myExportList.begin(),myExportList.end());
-    std::sort(myImportList.begin(),myImportList.end());
+    std::sort(myExportList.begin(), myExportList.end());
+    std::sort(myImportList.begin(), myImportList.end());
 
     // get the distribution of wells
     std::vector<std::pair<std::string, bool>> parallel_wells;
-    if( wells )
-    {
+    if (wells) {
         auto wellRanks = getWellRanks(gIDtoRank, wellConnections);
         parallel_wells = wellsOnThisRank(*wells, wellRanks, cc, root);
     }
 
-    return std::make_tuple( std::move(gIDtoRank),
-                            std::move(parallel_wells),
-                            std::move(myExportList),
-                            std::move(myImportList),
-                            std::move(wellConnections));
+    return std::make_tuple(std::move(gIDtoRank),
+                           std::move(parallel_wells),
+                           std::move(myExportList),
+                           std::move(myImportList),
+                           std::move(wellConnections));
 }
 #endif // HAVE_MPI
 

--- a/opm/grid/GraphOfGridWrappers.hpp
+++ b/opm/grid/GraphOfGridWrappers.hpp
@@ -255,7 +255,6 @@ makeImportAndExportLists(const GraphOfGrid<Dune::CpGrid>& gog,
 ///
 /// GraphOfGrid represents a well by one vertex, so wells can not be
 /// spread over several processes.
-/// transmissiblities are currently not supported, but are queued
 std::tuple<std::vector<int>, std::vector<std::pair<std::string, bool>>,
            std::vector<std::tuple<int,int,char> >,
            std::vector<std::tuple<int,int,char,int> >,
@@ -269,6 +268,34 @@ zoltanPartitioningWithGraphOfGrid(const Dune::CpGrid& grid,
                                   int root,
                                   const double zoltanImbalanceTol,
                                   const std::map<std::string,std::string>& params);
+
+/// \brief Make complete export lists from a vector holding destination rank for each global ID
+///
+/// Intended to use on the root, as other ranks can not construct gIDtoRank.
+/// Export lists include root's cells that stay on root.
+/// \param gIDtoRank a vector indexed by global ID holding rank to which it is exported
+/// \param ccsize the number of ranks, cc.size()
+/// \return vector of vectors, vector[i] holds a vector of global IDs exported to rank i
+std::vector<std::vector<int> >
+makeExportListsFromGIDtoRank(const std::vector<int>& gIDtoRank, int ccsize);
+
+/// \brief Call serial Zoltan partitioner on GraphOfGrid
+///
+/// GraphOfGrid represents a well by one vertex, so wells can not be
+/// spread over several processes.
+std::tuple<std::vector<int>, std::vector<std::pair<std::string, bool>>,
+           std::vector<std::tuple<int,int,char> >,
+           std::vector<std::tuple<int,int,char,int> >,
+           Dune::cpgrid::WellConnections>
+zoltanSerialPartitioningWithGraphOfGrid(const Dune::CpGrid& grid,
+                                        const std::vector<Dune::cpgrid::OpmWellType> * wells,
+                                        const std::unordered_map<std::string, std::set<int>>& possibleFutureConnections,
+                                        const double* transmissibilities,
+                                        const Dune::cpgrid::CpGridDataTraits::Communication& cc,
+                                        Dune::EdgeWeightMethod edgeWeightMethod,
+                                        int root,
+                                        const double zoltanImbalanceTol,
+                                        const std::map<std::string,std::string>& params);
 #endif // HAVE_MPI
 
 } // end namespace Opm

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -357,10 +357,10 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
             else if (partitionMethod == Dune::PartitionMethod::zoltanGoG)
             {
 #ifdef HAVE_ZOLTAN
-                if (serialPartitioning)
-                    OPM_MESSAGE("Warning: Serial partitioning is set to true and Zoltan with GraphOfGrid was selected to partition the grid, but only parallel case is implemented. Continuing with prallel partitioning...");
                 std::tie(computedCellPart, wells_on_proc, exportList, importList, wellConnections)
-                    = Opm::zoltanPartitioningWithGraphOfGrid(*this, wells, possibleFutureConnections, transmissibilities, cc, method, 0, imbalanceTol, partitioningParams);
+                    = serialPartitioning
+                    ? Opm::zoltanSerialPartitioningWithGraphOfGrid(*this, wells, possibleFutureConnections, transmissibilities, cc, method, 0, imbalanceTol, partitioningParams)
+                    : Opm::zoltanPartitioningWithGraphOfGrid(*this, wells, possibleFutureConnections, transmissibilities, cc, method, 0, imbalanceTol, partitioningParams);
 #else
                 OPM_THROW(std::runtime_error, "Parallel runs depend on ZOLTAN if useZoltan is true. Please install!");
 #endif // HAVE_ZOLTAN


### PR DESCRIPTION
Add an option to do serial partitioning with Zoltan using the graph representation of grid that contract all cells of a well into one graph vertex - via class `GraphOfGrid`. The parallel partitioning with `GraphOfGrid` is already available and is currently the default partitioner.