### PR TITLE
Changing IdType to int64_t

### DIFF
--- a/opm/grid/LookUpData.hh
+++ b/opm/grid/LookUpData.hh
@@ -330,7 +330,6 @@ std::vector<IntType> Opm::LookUpData<Grid,GridView>::assignFieldPropsIntOnLeaf(c
                                                                                const bool& needsTranslation,
                                                                                std::function<void(IntType, int)> valueCheck) const
 {
-    using IndexType = typename Dune::MultipleCodimMultipleGeomTypeMapper<GridView>::Index;
     std::vector<IntType> fieldPropOnLeaf;
     unsigned int numElements = gridView_.size(0);
     fieldPropOnLeaf.resize(numElements);
@@ -376,8 +375,8 @@ auto Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const IndexType& elementOrI
 {
     constexpr static bool isIntegral = std::is_integral_v<IndexType>;
     if constexpr (std::is_same_v<GridType, Dune::CpGrid>) {
+        static_assert(std::is_same_v<Grid,GridType>);
         if constexpr (isIntegral) {
-            static_assert(std::is_same_v<Grid,GridType>);
             const auto& elem = Dune::cpgrid::Entity<0>(*(gridView_.grid().currentData().back()), elementOrIndex, true);
             if (isFieldPropInLgr_ && elem.level()) { // level > 0 == true ; level == 0 == false
                 // In case some LGRs do not have refined field properties, the next line need to be modified.
@@ -387,7 +386,6 @@ auto Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const IndexType& elementOrI
                 return elem.getOrigin().index();
             }
         } else {
-            static_assert(std::is_same_v<Grid,GridType>);
             static_assert(std::is_same_v<IndexType, Dune::cpgrid::Entity<0>>);
             if (isFieldPropInLgr_ && elementOrIndex.level()) { // level > 0 == true ; level == 0 == false
                 // In case some LGRs do not have refined field properties, the next line need to be modified.
@@ -398,13 +396,12 @@ auto Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const IndexType& elementOrI
             }
         }
     } else {
+        static_assert(std::is_same_v<Grid,GridType>);
         if constexpr (isIntegral) {
-            static_assert(std::is_same_v<Grid,GridType>);
             // Check there are no LGRs. LGRs (level>0) only supported for CpGrid.
             assert(gridView_.grid().maxLevel() == 0);
             return elementOrIndex;
         } else {
-            static_assert(std::is_same_v<Grid,GridType>);
             assert(elementOrIndex.level() == 0); // LGRs (level>0) only supported for CpGrid.
             return this-> elemMapper_.index(elementOrIndex);
         }
@@ -491,12 +488,11 @@ auto Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const Ele
 {
     constexpr static bool isIntegral = std::is_integral_v<ElementType>;
     if constexpr (std::is_same_v<GridType, Dune::CpGrid>) {
+        static_assert(std::is_same_v<Grid,GridType>);
         if constexpr (isIntegral) {
-            static_assert(std::is_same_v<Grid,GridType>);
             const auto& elem = Dune::cpgrid::Entity<0>(*(gridView_.grid().currentData().back()), elementOrIndex, true);
             return this -> getFieldPropCartesianIdx<Dune::CpGrid>(elem);
         } else {
-            static_assert(std::is_same_v<Grid,GridType>);
             if (isFieldPropInLgr_ && elementOrIndex.level()) { // level == 0 false; level > 0 true
                 return elementOrIndex.getLevelCartesianIdx();
             }

--- a/opm/grid/LookUpData.hh
+++ b/opm/grid/LookUpData.hh
@@ -419,18 +419,10 @@ template<typename IndexType, typename FieldPropType>
 auto Opm::LookUpCartesianData<Grid,GridView>::operator()(const IndexType& elementOrIndex,
                                                          const FieldPropType& fieldProp) const
 {
-    constexpr static bool isIntegral = std::is_integral_v<IndexType>;
-    if constexpr (isIntegral) {
-        assert(cartMapper_);
-        const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<Grid>(elementOrIndex);
-        assert(0 <=  fieldPropCartIdx && (static_cast<int>(fieldProp.size()) > fieldPropCartIdx));
-        return fieldProp[fieldPropCartIdx];
-    } else {
-        assert(cartMapper_);
-        const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<Grid>(elementOrIndex);
-        assert( (0 <= fieldPropCartIdx) && (static_cast<int>(fieldProp.size()) > fieldPropCartIdx) );
-        return fieldProp[fieldPropCartIdx];
-    }    
+    assert(cartMapper_);
+    const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<Grid>(elementOrIndex);
+    assert(0 <=  fieldPropCartIdx && (static_cast<int>(fieldProp.size()) > fieldPropCartIdx));
+    return fieldProp[fieldPropCartIdx];
 }
 
 template<typename Grid, typename GridView>

--- a/opm/grid/LookUpData.hh
+++ b/opm/grid/LookUpData.hh
@@ -37,7 +37,9 @@
 #include <dune/grid/common/mcmgmapper.hh>
 
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+#include <opm/grid/common/CartesianIndexMapper.hpp>
 #include <opm/grid/cpgrid/Entity.hpp>
+
 
 #include <functional>
 #include <string>
@@ -80,8 +82,9 @@ public:
     ///         For general grids, the field property vector is assumed to be given for the gridView_.
     ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
     ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
-    template<typename FieldPropType>
-    FieldPropType operator()(const int& elemIdx, const std::vector<FieldPropType>& fieldProp) const;
+    template<typename IdType, typename FieldPropType>
+    typename std::enable_if_t<std::is_integral_v<IdType>, FieldPropType>
+    operator()(const IdType& elemIdx, const std::vector<FieldPropType>& fieldProp) const;
 
     /// \brief: Get field propertry for an element in the leaf grid view, from a vector.
     ///
@@ -89,7 +92,7 @@ public:
     ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
     ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
     template<typename EntityType, typename FieldPropType>
-    typename std::enable_if_t<!std::is_same_v<EntityType, unsigned int>, FieldPropType>
+    typename std::enable_if_t<!std::is_integral_v<EntityType>, FieldPropType>
     operator()(const EntityType& elem, const std::vector<FieldPropType>& fieldProp) const;
 
     /// \brief: Get field property of type double from field properties manager by name.
@@ -120,7 +123,7 @@ public:
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
     template<typename EntityType, typename GridType = Grid>
-    typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid> && !std::is_same_v<EntityType, unsigned int>,int>
+    typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid> && !std::is_integral_v<EntityType>,int>
     getFieldPropIdx(const EntityType& elem) const;
 
     /// \brief: Return index to search for the field propertries, for CpGrids.
@@ -132,16 +135,16 @@ public:
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
     template<typename EntityType, typename GridType = Grid>
-    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid> && !std::is_same_v<EntityType, unsigned int>,int>
+    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid> && !std::is_integral_v<EntityType>,int>
     getFieldPropIdx(const EntityType& elem) const;
 
     /// \brief: Return the same element index for all grids different from CpGrid.
     ///
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
-    template<typename GridType>
-    typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
-    getFieldPropIdx(const int& elemIdx) const;
+    template<typename IdType, typename GridType>
+    typename std::enable_if_t<std::is_integral_v<IdType> && !std::is_same_v<GridType,Dune::CpGrid>,int>
+    getFieldPropIdx(const IdType& elemIdx) const;
 
     /// \brief: Return the index to search for the field properties, for CpGrids.
     ///
@@ -151,9 +154,9 @@ public:
     ///
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
-    template<typename GridType = Grid>
-    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
-    getFieldPropIdx(const int& elemIdx) const;
+    template<typename IdType, typename GridType = Grid>
+    typename std::enable_if_t<std::is_integral_v<IdType> && std::is_same_v<GridType,Dune::CpGrid>,int>
+    getFieldPropIdx(const IdType& elemIdx) const;
 
 
 protected:
@@ -195,8 +198,9 @@ public:
     ///         For general grids, the field property vector is assumed to be given for the gridView_.
     ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
     ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
-    template<typename FieldPropType>
-    FieldPropType operator()(const int& elemIdx, const std::vector<FieldPropType>& fieldProp) const;
+    template<typename IdType, typename FieldPropType>
+    std::enable_if_t<std::is_integral_v<IdType>, FieldPropType> operator()(const IdType& elemIdx,
+                                                                           const std::vector<FieldPropType>& fieldProp) const;
 
     /// \brief: Get field property for an element in the leaf grid view, from a vector, via Cartesian Index.
     ///
@@ -204,7 +208,7 @@ public:
     ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
     ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
     template<typename EntityType, typename FieldPropType>
-    typename std::enable_if_t<!std::is_same_v<EntityType, unsigned int>, FieldPropType>
+    typename std::enable_if_t<!std::is_integral_v<EntityType>, FieldPropType>
     operator()(const EntityType& elem,const std::vector<FieldPropType>& fieldProp) const;
 
     /// \brief: Get field property of type double from field properties manager by name.
@@ -235,7 +239,7 @@ public:
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
     template<typename EntityType, typename GridType = Grid>
-    typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>  && !std::is_same_v<EntityType, unsigned int>,int>
+    typename std::enable_if_t<(!std::is_same_v<GridType,Dune::CpGrid>)  && !std::is_integral_v<EntityType>,int>
     getFieldPropCartesianIdx(const EntityType& elem) const;
 
     /// \brief: Return index to search for the field propertries, for CpGrids.
@@ -246,16 +250,16 @@ public:
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
     template<typename EntityType, typename GridType = Grid>
-    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid> && !std::is_same_v<EntityType, unsigned int>,int>
+    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid> && !std::is_integral_v<EntityType>,int>
     getFieldPropCartesianIdx(const EntityType& elem) const;
 
     /// \brief: Return the same element index for all grids different from CpGrid.
     ///
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
-    template<typename GridType = Grid>
-    typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
-    getFieldPropCartesianIdx(const int& elemIdx) const;
+    template< typename IdType, typename GridType>
+    typename std::enable_if_t<std::is_integral_v<IdType> && !std::is_same_v<GridType,Dune::CpGrid>,int>
+    getFieldPropCartesianIdx(const IdType& elemIdx) const;
 
     /// \brief: Return index to search for the field propertries, for CpGrids.
     ///
@@ -264,9 +268,9 @@ public:
     ///         When isFieldPropInLgr_ == true  : fieldPropIdx == Index of the equivalent cell in the LGR (level>0).
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
-    template<typename GridType = Grid>
-    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
-    getFieldPropCartesianIdx(const int& elemIdx) const;
+    template< typename IdType, typename GridType = Grid>
+    typename std::enable_if_t<std::is_integral_v<IdType> && std::is_same_v<GridType,Dune::CpGrid>,int>
+    getFieldPropCartesianIdx(const IdType& elemIdx) const;
 
 protected:
     const GridView& gridView_;
@@ -282,18 +286,18 @@ protected:
 /// LookUpData
 
 template<typename Grid, typename GridView>
-template<typename FieldPropType>
-FieldPropType Opm::LookUpData<Grid,GridView>::operator()(const int& elemIdx,
+template<typename IdType, typename FieldPropType>
+std::enable_if_t<std::is_integral_v<IdType>, FieldPropType> Opm::LookUpData<Grid,GridView>::operator()(const IdType& elemIdx,
                                                          const std::vector<FieldPropType>& fieldProp) const
 {
-    const auto& fieldPropIdx = this->getFieldPropIdx<Grid>(elemIdx);
+    const auto& fieldPropIdx = this->getFieldPropIdx<IdType, Grid>(elemIdx);
     assert(0 <= fieldPropIdx && static_cast<int>(fieldProp.size()) > fieldPropIdx);
     return fieldProp[fieldPropIdx];
 }
 
 template<typename Grid, typename GridView>
 template<typename EntityType, typename FieldPropType>
-typename std::enable_if_t<!std::is_same_v<EntityType, unsigned int>,FieldPropType>
+typename std::enable_if_t<!std::is_integral_v<EntityType>,FieldPropType>
 Opm::LookUpData<Grid,GridView>::operator()(const EntityType& elem,
                                            const std::vector<FieldPropType>& fieldProp) const
 {
@@ -306,6 +310,8 @@ template<typename Grid, typename GridView>
 std::vector<double> Opm::LookUpData<Grid,GridView>::assignFieldPropsDoubleOnLeaf(const FieldPropsManager& fieldPropsManager,
                                                                                  const std::string& propString) const
 {
+    using IndexType = typename Dune::MultipleCodimMultipleGeomTypeMapper<GridView>::Index;
+
     std::vector<double> fieldPropOnLeaf;
     unsigned int numElements = gridView_.size(0);
     fieldPropOnLeaf.resize(numElements);
@@ -317,7 +323,7 @@ std::vector<double> Opm::LookUpData<Grid,GridView>::assignFieldPropsDoubleOnLeaf
         // volume of a parent cell coincides with the sum of the pore volume of its children.
         for (const auto& element : elements(gridView_)) {
             const auto& elemIdx = this-> elemMapper_.index(element);
-            const auto& fieldPropIdx = this->getFieldPropIdx<Grid>(elemIdx); // gets parentIdx (or (lgr)levelIdx) for CpGrid with LGRs
+            const auto& fieldPropIdx = this->getFieldPropIdx<IndexType, Grid>(elemIdx); // gets parentIdx (or (lgr)levelIdx) for CpGrid with LGRs
             if (element.hasFather()) {
                 const auto fatherVolume = element.father().geometry().volume();
                 const auto& elemVolume = element.geometry().volume();
@@ -331,7 +337,7 @@ std::vector<double> Opm::LookUpData<Grid,GridView>::assignFieldPropsDoubleOnLeaf
     else {
         for (const auto& element : elements(gridView_)) {
             const auto& elemIdx = this-> elemMapper_.index(element);
-            const auto& fieldPropIdx = this->getFieldPropIdx<Grid>(elemIdx); // gets parentIdx (or (lgr)levelIdx) for CpGrid with LGRs
+            const auto& fieldPropIdx = this->getFieldPropIdx<IndexType, Grid>(elemIdx); // gets parentIdx (or (lgr)levelIdx) for CpGrid with LGRs
             fieldPropOnLeaf[elemIdx] = fieldProp[fieldPropIdx];
         }
     }
@@ -345,13 +351,14 @@ std::vector<IntType> Opm::LookUpData<Grid,GridView>::assignFieldPropsIntOnLeaf(c
                                                                                const bool& needsTranslation,
                                                                                std::function<void(IntType, int)> valueCheck) const
 {
+    using IndexType = typename Dune::MultipleCodimMultipleGeomTypeMapper<GridView>::Index;
     std::vector<IntType> fieldPropOnLeaf;
     unsigned int numElements = gridView_.size(0);
     fieldPropOnLeaf.resize(numElements);
     const auto& fieldProp = fieldPropsManager.get_int(propString);
     for (const auto& element : elements(gridView_)) {
         const auto& elemIdx = this-> elemMapper_.index(element);
-        const auto& fieldPropIdx = this->getFieldPropIdx<Grid>(elemIdx); // gets parentIdx (or (lgr)levelIdx) for CpGrid with LGRs
+        const auto& fieldPropIdx = this->getFieldPropIdx<IndexType, Grid>(elemIdx); // gets parentIdx (or (lgr)levelIdx) for CpGrid with LGRs
         fieldPropOnLeaf[elemIdx] = fieldProp[fieldPropIdx] - needsTranslation;
         valueCheck(fieldProp[fieldPropIdx], fieldPropIdx);
     }
@@ -380,7 +387,7 @@ int Opm::LookUpData<Grid,GridView>::fieldPropInt(const FieldPropsManager& fieldP
 
 template<typename Grid, typename GridView>
 template<typename EntityType, typename GridType>
-typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid> && !std::is_same_v<EntityType, unsigned int>,int>
+typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid> && !std::is_integral_v<EntityType>,int>
 Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const EntityType& elem) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
@@ -390,7 +397,7 @@ Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const EntityType& elem) const
 
 template<typename Grid, typename GridView>
 template<typename EntityType,typename GridType>
-typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid> && !std::is_same_v<EntityType, unsigned int>,int>
+typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid> && !std::is_integral_v<EntityType>,int>
 Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const EntityType& elem) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
@@ -405,9 +412,9 @@ Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const EntityType& elem) const
 }
 
 template<typename Grid, typename GridView>
-template<typename GridType>
-typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const int& elemIdx) const
+template< typename IdType, typename GridType>
+typename std::enable_if_t<std::is_integral_v<IdType> && !std::is_same_v<GridType,Dune::CpGrid>,int>
+Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const IdType& elemIdx) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
     // Check there are no LGRs. LGRs (level>0) only supported for CpGrid.
@@ -416,9 +423,9 @@ Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const int& elemIdx) const
 }
 
 template<typename Grid, typename GridView>
-template<typename GridType>
-typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const int& elemIdx) const
+template< typename IdType, typename GridType>
+typename std::enable_if_t<std::is_integral_v<IdType> && std::is_same_v<GridType,Dune::CpGrid>,int>
+Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const IdType& elemIdx) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
     const auto& elem = Dune::cpgrid::Entity<0>(*(gridView_.grid().currentData().back()), elemIdx, true);
@@ -436,19 +443,19 @@ Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const int& elemIdx) const
 /// LookUpCartesianData
 
 template<typename Grid, typename GridView>
-template<typename FieldPropType>
-FieldPropType Opm::LookUpCartesianData<Grid,GridView>::operator()(const int& elemIdx,
+template<typename IdType, typename FieldPropType>
+std::enable_if_t<std::is_integral_v<IdType>, FieldPropType> Opm::LookUpCartesianData<Grid,GridView>::operator()(const IdType& elemIdx,
                                                                   const std::vector<FieldPropType>& fieldProp) const
 {
     assert(cartMapper_);
-    const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<Grid>(elemIdx);
+    const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<IdType, Grid>(elemIdx);
     assert(0 <=  fieldPropCartIdx && (static_cast<int>(fieldProp.size()) > fieldPropCartIdx));
     return fieldProp[fieldPropCartIdx];
 }
 
 template<typename Grid, typename GridView>
 template<typename EntityType, typename FieldPropType>
-typename std::enable_if_t<!std::is_same_v<EntityType, unsigned int>,FieldPropType>
+typename std::enable_if_t<!std::is_integral_v<EntityType>,FieldPropType>
 Opm::LookUpCartesianData<Grid,GridView>::operator()(const EntityType& elem,
                                                     const std::vector<FieldPropType>& fieldProp) const
 {
@@ -467,7 +474,7 @@ std::vector<double> Opm::LookUpCartesianData<Grid,GridView>::assignFieldPropsDou
     fieldPropOnLeaf.resize(numElements);
     const auto& fieldProp = fieldPropsManager.get_double(propString);
     for (unsigned int elemIdx = 0; elemIdx < numElements; ++elemIdx) {
-        const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<Grid>(elemIdx);
+        const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<decltype(elemIdx), Grid>(elemIdx);
         fieldPropOnLeaf[elemIdx] = fieldProp[fieldPropCartIdx];
     }
     return fieldPropOnLeaf;
@@ -485,7 +492,7 @@ std::vector<IntType> Opm::LookUpCartesianData<Grid,GridView>::assignFieldPropsIn
     fieldPropOnLeaf.resize(numElements);
     const auto& fieldProp = fieldPropsManager.get_int(propString);
     for (unsigned elemIdx = 0; elemIdx < numElements; ++elemIdx) {
-        const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<Grid>(elemIdx);
+        const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<decltype(elemIdx), Grid>(elemIdx);
         fieldPropOnLeaf[elemIdx] = fieldProp[fieldPropCartIdx] - needsTranslation;
         valueCheck(fieldProp[fieldPropCartIdx], fieldPropCartIdx);
     }
@@ -514,7 +521,7 @@ int Opm::LookUpCartesianData<Grid,GridView>::fieldPropInt(const FieldPropsManage
 
 template<typename Grid, typename GridView>
 template<typename EntityType, typename GridType>
-typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid> && !std::is_same_v<EntityType, unsigned int>,int>
+typename std::enable_if_t<(!std::is_same_v<GridType,Dune::CpGrid>) && !std::is_integral_v<EntityType>,int>
 Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const EntityType& elem) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
@@ -525,7 +532,7 @@ Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const EntityTy
 
 template<typename Grid, typename GridView>
 template<typename EntityType, typename GridType>
-typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid> && !std::is_same_v<EntityType, unsigned int>,int>
+typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid> && !std::is_integral_v<EntityType>,int>
 Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const EntityType& elem) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
@@ -538,18 +545,18 @@ Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const EntityTy
 }
 
 template<typename Grid, typename GridView>
-template<typename GridType>
-typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const int& elemIdx) const
+template< typename IdType, typename GridType>
+typename std::enable_if_t<std::is_integral_v<IdType> && !std::is_same_v<GridType,Dune::CpGrid>,int>
+Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const IdType& elemIdx) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
     return  cartMapper_-> cartesianIndex(elemIdx);
 }
 
 template<typename Grid, typename GridView>
-template<typename GridType>
-typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const int& elemIdx) const
+template< typename IdType, typename GridType>
+typename std::enable_if_t<std::is_integral_v<IdType> && std::is_same_v<GridType,Dune::CpGrid>,int>
+Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const IdType& elemIdx) const
 {
     static_assert(std::is_same_v<Grid,GridType>);
     const auto& elem = Dune::cpgrid::Entity<0>(*(gridView_.grid().currentData().back()), elemIdx, true);

--- a/opm/grid/LookUpData.hh
+++ b/opm/grid/LookUpData.hh
@@ -37,9 +37,7 @@
 #include <dune/grid/common/mcmgmapper.hh>
 
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
-#include <opm/grid/common/CartesianIndexMapper.hpp>
 #include <opm/grid/cpgrid/Entity.hpp>
-
 
 #include <functional>
 #include <string>
@@ -77,23 +75,15 @@ public:
     {
     }
 
-    /// \brief: Get field propertry for an element in the leaf grid view, from a vector and element index.
+    /// \brief: Get field propertry for an element or index in the leaf grid view, from a vector and element index.
     ///
     ///         For general grids, the field property vector is assumed to be given for the gridView_.
     ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
     ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
-    template<typename IdType, typename FieldPropType>
-    typename std::enable_if_t<std::is_integral_v<IdType>, FieldPropType>
-    operator()(const IdType& elemIdx, const std::vector<FieldPropType>& fieldProp) const;
-
-    /// \brief: Get field propertry for an element in the leaf grid view, from a vector.
     ///
-    ///         For general grids, the field property vector is assumed to be given for the gridView_.
-    ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
-    ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
-    template<typename EntityType, typename FieldPropType>
-    typename std::enable_if_t<!std::is_integral_v<EntityType>, FieldPropType>
-    operator()(const EntityType& elem, const std::vector<FieldPropType>& fieldProp) const;
+    /// \param [in] elementOrIdx  Element or index of the element in the leaf grid view.
+    /// \param [in] fieldProp     Vector (indexable collection) of field properties.
+    auto operator()(const auto& elementOrIdx, const auto& fieldProp) const;
 
     /// \brief: Get field property of type double from field properties manager by name.
     std::vector<double> assignFieldPropsDoubleOnLeaf(const FieldPropsManager& fieldPropsManager,
@@ -122,42 +112,8 @@ public:
     ///
     /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
     ///                         Default: GridType = Grid.
-    template<typename EntityType, typename GridType = Grid>
-    typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid> && !std::is_integral_v<EntityType>,int>
-    getFieldPropIdx(const EntityType& elem) const;
-
-    /// \brief: Return index to search for the field propertries, for CpGrids.
-    ///
-    ///         When isFieldPropInLgr_ == false : fieldPropIdx == Index of the origin cell (parent/equivalent cell when element
-    ///                                           has nofather) in level 0.
-    ///         When isFieldPropInLgr_ == true  : fieldPropIdx == Index of the equivalent cell in the LGR (level>0).
-    ///
-    /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
-    ///                         Default: GridType = Grid.
-    template<typename EntityType, typename GridType = Grid>
-    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid> && !std::is_integral_v<EntityType>,int>
-    getFieldPropIdx(const EntityType& elem) const;
-
-    /// \brief: Return the same element index for all grids different from CpGrid.
-    ///
-    /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
-    ///                         Default: GridType = Grid.
-    template<typename IdType, typename GridType>
-    typename std::enable_if_t<std::is_integral_v<IdType> && !std::is_same_v<GridType,Dune::CpGrid>,int>
-    getFieldPropIdx(const IdType& elemIdx) const;
-
-    /// \brief: Return the index to search for the field properties, for CpGrids.
-    ///
-    ///         When isFieldPropInLgr_ == false : fieldPropIdx == Index of the origin cell (parent/equivalent cell when element
-    ///                                           has nofather) in level 0.
-    ///         When isFieldPropInLgr_ == true  : fieldPropIdx == Index of the equivalent cell in the LGR (level>0).
-    ///
-    /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
-    ///                         Default: GridType = Grid.
-    template<typename IdType, typename GridType = Grid>
-    typename std::enable_if_t<std::is_integral_v<IdType> && std::is_same_v<GridType,Dune::CpGrid>,int>
-    getFieldPropIdx(const IdType& elemIdx) const;
-
+    template<typename GridType = Grid>
+    auto getFieldPropIdx(const auto& elem) const;
 
 protected:
     const GridView& gridView_;
@@ -198,18 +154,8 @@ public:
     ///         For general grids, the field property vector is assumed to be given for the gridView_.
     ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
     ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
-    template<typename IdType, typename FieldPropType>
-    std::enable_if_t<std::is_integral_v<IdType>, FieldPropType> operator()(const IdType& elemIdx,
-                                                                           const std::vector<FieldPropType>& fieldProp) const;
+    auto operator()(const auto& elemIdx, const auto& fieldProp) const;
 
-    /// \brief: Get field property for an element in the leaf grid view, from a vector, via Cartesian Index.
-    ///
-    ///         For general grids, the field property vector is assumed to be given for the gridView_.
-    ///         For CpGrid, the field property vector is assumed to be given for level 0 when isFieldPropLgr_ == false,
-    ///         and for certain LGR/level > 0 when isFieldPropLgr_ == true.
-    template<typename EntityType, typename FieldPropType>
-    typename std::enable_if_t<!std::is_integral_v<EntityType>, FieldPropType>
-    operator()(const EntityType& elem,const std::vector<FieldPropType>& fieldProp) const;
 
     /// \brief: Get field property of type double from field properties manager by name.
     std::vector<double> assignFieldPropsDoubleOnLeaf(const FieldPropsManager& fieldPropsManager,
@@ -234,43 +180,8 @@ public:
                      const std::string& propString,
                      const ElemOrIndex& elemOrIndex) const;
 
-    /// \brief: Return the same element index for all grids different from CpGrid.
-    ///
-    /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
-    ///                         Default: GridType = Grid.
-    template<typename EntityType, typename GridType = Grid>
-    typename std::enable_if_t<(!std::is_same_v<GridType,Dune::CpGrid>)  && !std::is_integral_v<EntityType>,int>
-    getFieldPropCartesianIdx(const EntityType& elem) const;
-
-    /// \brief: Return index to search for the field propertries, for CpGrids.
-    ///
-    ///         When isFieldPropInLgr_ == false : fieldPropIdx == Index of the origin cell (parent/equivalent cell when element
-    ///                                           has nofather) in level 0.
-    ///         When isFieldPropInLgr_ == true  : fieldPropIdx == Index of the equivalent cell in the LGR (level>0).
-    /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
-    ///                         Default: GridType = Grid.
-    template<typename EntityType, typename GridType = Grid>
-    typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid> && !std::is_integral_v<EntityType>,int>
-    getFieldPropCartesianIdx(const EntityType& elem) const;
-
-    /// \brief: Return the same element index for all grids different from CpGrid.
-    ///
-    /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
-    ///                         Default: GridType = Grid.
-    template< typename IdType, typename GridType>
-    typename std::enable_if_t<std::is_integral_v<IdType> && !std::is_same_v<GridType,Dune::CpGrid>,int>
-    getFieldPropCartesianIdx(const IdType& elemIdx) const;
-
-    /// \brief: Return index to search for the field propertries, for CpGrids.
-    ///
-    ///         When isFieldPropInLgr_ == false : fieldPropIdx == Index of the origin cell (parent/equivalent cell when element
-    ///                                           has nofather) in level 0.
-    ///         When isFieldPropInLgr_ == true  : fieldPropIdx == Index of the equivalent cell in the LGR (level>0).
-    /// \tparam     GridType    Auxiliary type to overload the method, distinguishing general grids from CpGrid, with std::enable_if.
-    ///                         Default: GridType = Grid.
-    template< typename IdType, typename GridType = Grid>
-    typename std::enable_if_t<std::is_integral_v<IdType> && std::is_same_v<GridType,Dune::CpGrid>,int>
-    getFieldPropCartesianIdx(const IdType& elemIdx) const;
+    template<typename GridType = Grid>
+    auto getFieldPropCartesianIdx(const auto& elemIdx) const;
 
 protected:
     const GridView& gridView_;
@@ -286,23 +197,11 @@ protected:
 /// LookUpData
 
 template<typename Grid, typename GridView>
-template<typename IdType, typename FieldPropType>
-std::enable_if_t<std::is_integral_v<IdType>, FieldPropType> Opm::LookUpData<Grid,GridView>::operator()(const IdType& elemIdx,
-                                                         const std::vector<FieldPropType>& fieldProp) const
+auto Opm::LookUpData<Grid,GridView>::operator()(const auto& elemIdx,
+                                                const auto& fieldProp) const
 {
-    const auto& fieldPropIdx = this->getFieldPropIdx<IdType, Grid>(elemIdx);
+    const auto& fieldPropIdx = this->getFieldPropIdx<Grid>(elemIdx);
     assert(0 <= fieldPropIdx && static_cast<int>(fieldProp.size()) > fieldPropIdx);
-    return fieldProp[fieldPropIdx];
-}
-
-template<typename Grid, typename GridView>
-template<typename EntityType, typename FieldPropType>
-typename std::enable_if_t<!std::is_integral_v<EntityType>,FieldPropType>
-Opm::LookUpData<Grid,GridView>::operator()(const EntityType& elem,
-                                           const std::vector<FieldPropType>& fieldProp) const
-{
-    const auto& fieldPropIdx = this->getFieldPropIdx<EntityType,Grid>(elem);
-    assert( (0 <= fieldPropIdx) && (static_cast<int>(fieldProp.size()) > fieldPropIdx));
     return fieldProp[fieldPropIdx];
 }
 
@@ -323,7 +222,7 @@ std::vector<double> Opm::LookUpData<Grid,GridView>::assignFieldPropsDoubleOnLeaf
         // volume of a parent cell coincides with the sum of the pore volume of its children.
         for (const auto& element : elements(gridView_)) {
             const auto& elemIdx = this-> elemMapper_.index(element);
-            const auto& fieldPropIdx = this->getFieldPropIdx<IndexType, Grid>(elemIdx); // gets parentIdx (or (lgr)levelIdx) for CpGrid with LGRs
+            const auto& fieldPropIdx = this->getFieldPropIdx<Grid>(elemIdx); // gets parentIdx (or (lgr)levelIdx) for CpGrid with LGRs
             if (element.hasFather()) {
                 const auto fatherVolume = element.father().geometry().volume();
                 const auto& elemVolume = element.geometry().volume();
@@ -337,7 +236,7 @@ std::vector<double> Opm::LookUpData<Grid,GridView>::assignFieldPropsDoubleOnLeaf
     else {
         for (const auto& element : elements(gridView_)) {
             const auto& elemIdx = this-> elemMapper_.index(element);
-            const auto& fieldPropIdx = this->getFieldPropIdx<IndexType, Grid>(elemIdx); // gets parentIdx (or (lgr)levelIdx) for CpGrid with LGRs
+            const auto& fieldPropIdx = this->getFieldPropIdx<Grid>(elemIdx); // gets parentIdx (or (lgr)levelIdx) for CpGrid with LGRs
             fieldPropOnLeaf[elemIdx] = fieldProp[fieldPropIdx];
         }
     }
@@ -358,7 +257,7 @@ std::vector<IntType> Opm::LookUpData<Grid,GridView>::assignFieldPropsIntOnLeaf(c
     const auto& fieldProp = fieldPropsManager.get_int(propString);
     for (const auto& element : elements(gridView_)) {
         const auto& elemIdx = this-> elemMapper_.index(element);
-        const auto& fieldPropIdx = this->getFieldPropIdx<IndexType, Grid>(elemIdx); // gets parentIdx (or (lgr)levelIdx) for CpGrid with LGRs
+        const auto& fieldPropIdx = this->getFieldPropIdx<Grid>(elemIdx); // gets parentIdx (or (lgr)levelIdx) for CpGrid with LGRs
         fieldPropOnLeaf[elemIdx] = fieldProp[fieldPropIdx] - needsTranslation;
         valueCheck(fieldProp[fieldPropIdx], fieldPropIdx);
     }
@@ -386,83 +285,69 @@ int Opm::LookUpData<Grid,GridView>::fieldPropInt(const FieldPropsManager& fieldP
 }
 
 template<typename Grid, typename GridView>
-template<typename EntityType, typename GridType>
-typename std::enable_if_t<!std::is_same_v<GridType,Dune::CpGrid> && !std::is_integral_v<EntityType>,int>
-Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const EntityType& elem) const
+template<typename GridType>
+auto Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const auto& elementOrIndex) const
 {
-    static_assert(std::is_same_v<Grid,GridType>);
-    assert(elem.level() == 0); // LGRs (level>0) only supported for CpGrid.
-    return this-> elemMapper_.index(elem);
-}
-
-template<typename Grid, typename GridView>
-template<typename EntityType,typename GridType>
-typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid> && !std::is_integral_v<EntityType>,int>
-Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const EntityType& elem) const
-{
-    static_assert(std::is_same_v<Grid,GridType>);
-    static_assert(std::is_same_v<EntityType,Dune::cpgrid::Entity<0>>);
-    if (isFieldPropInLgr_ && elem.level()) { // level > 0 == true ; level == 0 == false
-        // In case some LGRs do not have refined field properties, the next line need to be modified.
-        return elem.getLevelElem().index();
+    using IndexType = std::remove_const_t<std::remove_reference_t<decltype(elementOrIndex)>>;
+    constexpr static bool isIntegral = std::is_integral_v<IndexType>;
+    if constexpr (std::is_same_v<GridType, Dune::CpGrid>) {
+        if constexpr (isIntegral) {
+            static_assert(std::is_same_v<Grid,GridType>);
+            const auto& elem = Dune::cpgrid::Entity<0>(*(gridView_.grid().currentData().back()), elementOrIndex, true);
+            if (isFieldPropInLgr_ && elem.level()) { // level > 0 == true ; level == 0 == false
+                // In case some LGRs do not have refined field properties, the next line need to be modified.
+                return elem.getLevelElem().index();
+            }
+            else {
+                return elem.getOrigin().index();
+            }
+        } else {
+            static_assert(std::is_same_v<Grid,GridType>);
+            static_assert(std::is_same_v<IndexType, Dune::cpgrid::Entity<0>>);
+            if (isFieldPropInLgr_ && elementOrIndex.level()) { // level > 0 == true ; level == 0 == false
+                // In case some LGRs do not have refined field properties, the next line need to be modified.
+                return elementOrIndex.getLevelElem().index();
+            }
+            else {
+                return elementOrIndex.getOrigin().index();
+            }
+        }
+    } else {
+        if constexpr (isIntegral) {
+            static_assert(std::is_same_v<Grid,GridType>);
+            // Check there are no LGRs. LGRs (level>0) only supported for CpGrid.
+            assert(gridView_.grid().maxLevel() == 0);
+            return elementOrIndex;
+        } else {
+            static_assert(std::is_same_v<Grid,GridType>);
+            assert(elementOrIndex.level() == 0); // LGRs (level>0) only supported for CpGrid.
+            return this-> elemMapper_.index(elementOrIndex);
+        }
     }
-    else {
-        return elem.getOrigin().index();
-    }
+    
 }
-
-template<typename Grid, typename GridView>
-template< typename IdType, typename GridType>
-typename std::enable_if_t<std::is_integral_v<IdType> && !std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const IdType& elemIdx) const
-{
-    static_assert(std::is_same_v<Grid,GridType>);
-    // Check there are no LGRs. LGRs (level>0) only supported for CpGrid.
-    assert(gridView_.grid().maxLevel() == 0);
-    return elemIdx;
-}
-
-template<typename Grid, typename GridView>
-template< typename IdType, typename GridType>
-typename std::enable_if_t<std::is_integral_v<IdType> && std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpData<Grid,GridView>::getFieldPropIdx(const IdType& elemIdx) const
-{
-    static_assert(std::is_same_v<Grid,GridType>);
-    const auto& elem = Dune::cpgrid::Entity<0>(*(gridView_.grid().currentData().back()), elemIdx, true);
-    if (isFieldPropInLgr_ && elem.level()) { // level > 0 == true ; level == 0 == false
-        // In case some LGRs do not have refined field properties, the next line need to be modified.
-        return elem.getLevelElem().index();
-    }
-    else {
-        return elem.getOrigin().index();
-    }
-}
-
-
 
 /// LookUpCartesianData
 
 template<typename Grid, typename GridView>
-template<typename IdType, typename FieldPropType>
-std::enable_if_t<std::is_integral_v<IdType>, FieldPropType> Opm::LookUpCartesianData<Grid,GridView>::operator()(const IdType& elemIdx,
-                                                                  const std::vector<FieldPropType>& fieldProp) const
+//template<typename IdType, typename FieldPropType>
+//std::enable_if_t<std::is_integral_v<IdType>, FieldPropType>
+auto Opm::LookUpCartesianData<Grid,GridView>::operator()(const auto& elementOrIndex,
+                                                         const auto& fieldProp) const
 {
-    assert(cartMapper_);
-    const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<IdType, Grid>(elemIdx);
-    assert(0 <=  fieldPropCartIdx && (static_cast<int>(fieldProp.size()) > fieldPropCartIdx));
-    return fieldProp[fieldPropCartIdx];
-}
-
-template<typename Grid, typename GridView>
-template<typename EntityType, typename FieldPropType>
-typename std::enable_if_t<!std::is_integral_v<EntityType>,FieldPropType>
-Opm::LookUpCartesianData<Grid,GridView>::operator()(const EntityType& elem,
-                                                    const std::vector<FieldPropType>& fieldProp) const
-{
-    assert(cartMapper_);
-    const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<EntityType,Grid>(elem);
-    assert( (0 <= fieldPropCartIdx) && (static_cast<int>(fieldProp.size()) > fieldPropCartIdx) );
-    return fieldProp[fieldPropCartIdx];
+    using IndexType = std::remove_const_t<std::remove_reference_t<decltype(elementOrIndex)>>;
+    constexpr static bool isIntegral = std::is_integral_v<IndexType>;
+    if constexpr (isIntegral) {
+        assert(cartMapper_);
+        const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<Grid>(elementOrIndex);
+        assert(0 <=  fieldPropCartIdx && (static_cast<int>(fieldProp.size()) > fieldPropCartIdx));
+        return fieldProp[fieldPropCartIdx];
+    } else {
+        assert(cartMapper_);
+        const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<Grid>(elementOrIndex);
+        assert( (0 <= fieldPropCartIdx) && (static_cast<int>(fieldProp.size()) > fieldPropCartIdx) );
+        return fieldProp[fieldPropCartIdx];
+    }    
 }
 
 template<typename Grid, typename GridView>
@@ -474,7 +359,7 @@ std::vector<double> Opm::LookUpCartesianData<Grid,GridView>::assignFieldPropsDou
     fieldPropOnLeaf.resize(numElements);
     const auto& fieldProp = fieldPropsManager.get_double(propString);
     for (unsigned int elemIdx = 0; elemIdx < numElements; ++elemIdx) {
-        const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<decltype(elemIdx), Grid>(elemIdx);
+        const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<Grid>(elemIdx);
         fieldPropOnLeaf[elemIdx] = fieldProp[fieldPropCartIdx];
     }
     return fieldPropOnLeaf;
@@ -492,7 +377,7 @@ std::vector<IntType> Opm::LookUpCartesianData<Grid,GridView>::assignFieldPropsIn
     fieldPropOnLeaf.resize(numElements);
     const auto& fieldProp = fieldPropsManager.get_int(propString);
     for (unsigned elemIdx = 0; elemIdx < numElements; ++elemIdx) {
-        const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<decltype(elemIdx), Grid>(elemIdx);
+        const auto fieldPropCartIdx = this->getFieldPropCartesianIdx<Grid>(elemIdx);
         fieldPropOnLeaf[elemIdx] = fieldProp[fieldPropCartIdx] - needsTranslation;
         valueCheck(fieldProp[fieldPropCartIdx], fieldPropCartIdx);
     }
@@ -520,47 +405,36 @@ int Opm::LookUpCartesianData<Grid,GridView>::fieldPropInt(const FieldPropsManage
 }
 
 template<typename Grid, typename GridView>
-template<typename EntityType, typename GridType>
-typename std::enable_if_t<(!std::is_same_v<GridType,Dune::CpGrid>) && !std::is_integral_v<EntityType>,int>
-Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const EntityType& elem) const
+template<typename GridType>
+auto Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const auto& elementOrIndex) const
 {
-    static_assert(std::is_same_v<Grid,GridType>);
-    // Check there are no LGRs. LGRs (level>0) only supported for CpGrid.
-    assert(gridView_.grid().maxLevel() == 0);
-    return cartMapper_-> cartesianIndex(this->elemMapper_.index(elem));
-}
-
-template<typename Grid, typename GridView>
-template<typename EntityType, typename GridType>
-typename std::enable_if_t<std::is_same_v<GridType,Dune::CpGrid> && !std::is_integral_v<EntityType>,int>
-Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const EntityType& elem) const
-{
-    static_assert(std::is_same_v<Grid,GridType>);
-    if (isFieldPropInLgr_ && elem.level()) { // level == 0 false; level > 0 true
-        return elem.getLevelCartesianIdx();
+    using IndexType = std::remove_const_t<std::remove_reference_t<decltype(elementOrIndex)>>;
+    constexpr static bool isIntegral = std::is_integral_v<IndexType>;
+    if constexpr (std::is_same_v<GridType, Dune::CpGrid>) {
+        if constexpr (isIntegral) {
+            static_assert(std::is_same_v<Grid,GridType>);
+            const auto& elem = Dune::cpgrid::Entity<0>(*(gridView_.grid().currentData().back()), elementOrIndex, true);
+            return this -> getFieldPropCartesianIdx<Dune::CpGrid>(elem);
+        } else {
+            static_assert(std::is_same_v<Grid,GridType>);
+            if (isFieldPropInLgr_ && elementOrIndex.level()) { // level == 0 false; level > 0 true
+                return elementOrIndex.getLevelCartesianIdx();
+            }
+            else {
+                return cartMapper_-> cartesianIndex(this->elemMapper_.index(elementOrIndex));
+            }
+        }
+    } else {
+        if constexpr (isIntegral) {
+            static_assert(std::is_same_v<Grid,GridType>);
+            return  cartMapper_-> cartesianIndex(elementOrIndex);
+        } else {
+            static_assert(std::is_same_v<Grid,GridType>);
+            // Check there are no LGRs. LGRs (level>0) only supported for CpGrid.
+            assert(gridView_.grid().maxLevel() == 0);
+            return cartMapper_-> cartesianIndex(this->elemMapper_.index(elementOrIndex));            
+        }
     }
-    else {
-        return cartMapper_-> cartesianIndex(this->elemMapper_.index(elem));
-    }
+    
 }
-
-template<typename Grid, typename GridView>
-template< typename IdType, typename GridType>
-typename std::enable_if_t<std::is_integral_v<IdType> && !std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const IdType& elemIdx) const
-{
-    static_assert(std::is_same_v<Grid,GridType>);
-    return  cartMapper_-> cartesianIndex(elemIdx);
-}
-
-template<typename Grid, typename GridView>
-template< typename IdType, typename GridType>
-typename std::enable_if_t<std::is_integral_v<IdType> && std::is_same_v<GridType,Dune::CpGrid>,int>
-Opm::LookUpCartesianData<Grid,GridView>::getFieldPropCartesianIdx(const IdType& elemIdx) const
-{
-    static_assert(std::is_same_v<Grid,GridType>);
-    const auto& elem = Dune::cpgrid::Entity<0>(*(gridView_.grid().currentData().back()), elemIdx, true);
-    return this -> getFieldPropCartesianIdx<Dune::cpgrid::Entity<0>,Dune::CpGrid>(elem);
-}
-
 #endif

--- a/opm/grid/cpgrid/Indexsets.hpp
+++ b/opm/grid/cpgrid/Indexsets.hpp
@@ -42,7 +42,9 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 #include "Intersection.hpp"
 
 #include <unordered_map>
+#include <cstdint>
 #include <utility>
+#include <cstdint>
 
 namespace Dune
 {
@@ -56,7 +58,7 @@ namespace Dune
         public:
             /// @brief
             /// @todo Doc me!
-            typedef int IndexType;
+            typedef std::int64_t IndexType;
 
             /** \brief Export the type of the entity used as parameter in the index(...) method */
             template <int cc>
@@ -200,7 +202,7 @@ namespace Dune
             friend class Dune::cpgrid::CpGridData;
             //friend class Dune::cpgrid::LevelGlobalIdSet; Not needed due to repeated code in LevelGlobalIdSet (computeId_cell and computeId_point)
         public:
-            typedef int IdType;
+            typedef std::int64_t IdType;
 
             explicit IdSet(const CpGridData& grid)
                 : grid_(grid)
@@ -352,7 +354,7 @@ namespace Dune
             friend class CpGridData;
             friend class ReversePointGlobalIdSet;
         public:
-            typedef int IdType;
+            typedef std::int64_t IdType;
 
             void swap(std::vector<int>& cellMapping,
                       std::vector<int>& faceMapping,

--- a/opm/grid/cpgrid/Indexsets.hpp
+++ b/opm/grid/cpgrid/Indexsets.hpp
@@ -41,10 +41,9 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 #include "GlobalIdMapping.hpp"
 #include "Intersection.hpp"
 
+#include <cstdint>
 #include <unordered_map>
-#include <cstdint>
 #include <utility>
-#include <cstdint>
 
 namespace Dune
 {

--- a/tests/test_lookupdata_polyhedral.cpp
+++ b/tests/test_lookupdata_polyhedral.cpp
@@ -30,6 +30,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "config.h"
+#include <type_traits>
 
 #define BOOST_TEST_MODULE LookUpDataPolyhedralGridTest
 #include <boost/test/unit_test.hpp>
@@ -115,23 +116,25 @@ void lookup_check(const Dune::PolyhedralGrid<3,3>& grid)
         BOOST_CHECK(featureInElemDoubleCartesian == lookUpData.getFieldPropIdx(elem) +.5);
         // Search via INDEX
         const auto idx = mapper.index(elem);
+        using IndexType = decltype(idx);
+        using ElementType = std::remove_reference_t<decltype(elem)>;
         const auto featureInElemIDX = lookUpData(idx, fake_feature);
         const auto featureInElemDoubleIDX = lookUpData(idx, fake_feature_double);
         const auto featureInElemCartesianIDX = lookUpCartesianData(idx, fake_feature);
         const auto featureInElemDoubleCartesianIDX = lookUpCartesianData(idx, fake_feature_double);
-        BOOST_CHECK(featureInElemIDX == (lookUpData.getFieldPropIdx<Dune::PolyhedralGrid<3,3>>(idx))+3);
-        BOOST_CHECK(featureInElemDoubleIDX == (lookUpData.getFieldPropIdx<Dune::PolyhedralGrid<3,3>>(idx)) +.5);
-        BOOST_CHECK(featureInElemCartesianIDX == (lookUpData.getFieldPropIdx<Dune::PolyhedralGrid<3,3>>(idx)) +3);
-        BOOST_CHECK(featureInElemDoubleCartesianIDX == (lookUpData.getFieldPropIdx<Dune::PolyhedralGrid<3,3>>(idx)) +.5);
-        BOOST_CHECK(idx == (lookUpData.getFieldPropIdx<Dune::PolyhedralGrid<3,3>>(idx)));
+        BOOST_CHECK(featureInElemIDX == (lookUpData.getFieldPropIdx<IndexType, Dune::PolyhedralGrid<3,3>>(idx))+3);
+        BOOST_CHECK(featureInElemDoubleIDX == (lookUpData.getFieldPropIdx<IndexType, Dune::PolyhedralGrid<3,3>>(idx)) +.5);
+        BOOST_CHECK(featureInElemCartesianIDX == (lookUpData.getFieldPropIdx<IndexType, Dune::PolyhedralGrid<3,3>>(idx)) +3);
+        BOOST_CHECK(featureInElemDoubleCartesianIDX == (lookUpData.getFieldPropIdx<IndexType, Dune::PolyhedralGrid<3,3>>(idx)) +.5);
+        BOOST_CHECK(idx == (lookUpData.getFieldPropIdx<IndexType, Dune::PolyhedralGrid<3,3>>(idx)));
         BOOST_CHECK(featureInElemIDX == featureInElem);
         BOOST_CHECK(featureInElemDoubleIDX == featureInElemDouble);
         BOOST_CHECK(featureInElemCartesianIDX == featureInElemCartesian);
         BOOST_CHECK(featureInElemDoubleCartesianIDX == featureInElemDoubleCartesian);
         // Extra checks related to Cartesian Index
         const auto cartIdx = cartMapper.cartesianIndex(idx);
-        BOOST_CHECK(cartIdx == lookUpCartesianData.getFieldPropCartesianIdx(elem));
-        BOOST_CHECK(cartIdx == lookUpCartesianData.getFieldPropCartesianIdx(idx));
+        BOOST_CHECK(cartIdx == (lookUpCartesianData.getFieldPropCartesianIdx<ElementType, Dune::PolyhedralGrid<3,3>>(elem)));
+        BOOST_CHECK(cartIdx == (lookUpCartesianData.getFieldPropCartesianIdx<IndexType, Dune::PolyhedralGrid<3,3>>(idx)));
         // Extra checks related to Cartesian Coordinate
         std::array<int,3> ijk;
         cartMapper.cartesianCoordinate(idx, ijk);

--- a/tests/test_lookupdata_polyhedral.cpp
+++ b/tests/test_lookupdata_polyhedral.cpp
@@ -30,7 +30,6 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "config.h"
-#include <type_traits>
 
 #define BOOST_TEST_MODULE LookUpDataPolyhedralGridTest
 #include <boost/test/unit_test.hpp>
@@ -116,25 +115,23 @@ void lookup_check(const Dune::PolyhedralGrid<3,3>& grid)
         BOOST_CHECK(featureInElemDoubleCartesian == lookUpData.getFieldPropIdx(elem) +.5);
         // Search via INDEX
         const auto idx = mapper.index(elem);
-        using IndexType = decltype(idx);
-        using ElementType = std::remove_reference_t<decltype(elem)>;
         const auto featureInElemIDX = lookUpData(idx, fake_feature);
         const auto featureInElemDoubleIDX = lookUpData(idx, fake_feature_double);
         const auto featureInElemCartesianIDX = lookUpCartesianData(idx, fake_feature);
         const auto featureInElemDoubleCartesianIDX = lookUpCartesianData(idx, fake_feature_double);
-        BOOST_CHECK(featureInElemIDX == (lookUpData.getFieldPropIdx<IndexType, Dune::PolyhedralGrid<3,3>>(idx))+3);
-        BOOST_CHECK(featureInElemDoubleIDX == (lookUpData.getFieldPropIdx<IndexType, Dune::PolyhedralGrid<3,3>>(idx)) +.5);
-        BOOST_CHECK(featureInElemCartesianIDX == (lookUpData.getFieldPropIdx<IndexType, Dune::PolyhedralGrid<3,3>>(idx)) +3);
-        BOOST_CHECK(featureInElemDoubleCartesianIDX == (lookUpData.getFieldPropIdx<IndexType, Dune::PolyhedralGrid<3,3>>(idx)) +.5);
-        BOOST_CHECK(idx == (lookUpData.getFieldPropIdx<IndexType, Dune::PolyhedralGrid<3,3>>(idx)));
+        BOOST_CHECK(featureInElemIDX == (lookUpData.getFieldPropIdx<Dune::PolyhedralGrid<3,3>>(idx))+3);
+        BOOST_CHECK(featureInElemDoubleIDX == (lookUpData.getFieldPropIdx<Dune::PolyhedralGrid<3,3>>(idx)) +.5);
+        BOOST_CHECK(featureInElemCartesianIDX == (lookUpData.getFieldPropIdx<Dune::PolyhedralGrid<3,3>>(idx)) +3);
+        BOOST_CHECK(featureInElemDoubleCartesianIDX == (lookUpData.getFieldPropIdx<Dune::PolyhedralGrid<3,3>>(idx)) +.5);
+        BOOST_CHECK(idx == (lookUpData.getFieldPropIdx<Dune::PolyhedralGrid<3,3>>(idx)));
         BOOST_CHECK(featureInElemIDX == featureInElem);
         BOOST_CHECK(featureInElemDoubleIDX == featureInElemDouble);
         BOOST_CHECK(featureInElemCartesianIDX == featureInElemCartesian);
         BOOST_CHECK(featureInElemDoubleCartesianIDX == featureInElemDoubleCartesian);
         // Extra checks related to Cartesian Index
         const auto cartIdx = cartMapper.cartesianIndex(idx);
-        BOOST_CHECK(cartIdx == (lookUpCartesianData.getFieldPropCartesianIdx<ElementType, Dune::PolyhedralGrid<3,3>>(elem)));
-        BOOST_CHECK(cartIdx == (lookUpCartesianData.getFieldPropCartesianIdx<IndexType, Dune::PolyhedralGrid<3,3>>(idx)));
+        BOOST_CHECK(cartIdx == lookUpCartesianData.getFieldPropCartesianIdx(elem));
+        BOOST_CHECK(cartIdx == lookUpCartesianData.getFieldPropCartesianIdx(idx));
         // Extra checks related to Cartesian Coordinate
         std::array<int,3> ijk;
         cartMapper.cartesianCoordinate(idx, ijk);


### PR DESCRIPTION
This pull request changes the `IdType` to `int64_t` to avoid some overflow errors seen previously.

No change in opm-simulators is needed.

