### PR TITLE
Remove symmetry assumption when searching parent face

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -128,6 +128,7 @@ if(Boost_VERSION_STRING VERSION_GREATER 1.53)
 	  tests/cpgrid/lgr_cartesian_idx_test.cpp
 	  tests/cpgrid/lookUpCellCentroid_cpgrid_test.cpp
 	  tests/cpgrid/lookupdataCpGrid_test.cpp
+      tests/cpgrid/replace_lgr1_corner_idx_by_lgr2_corner_idx_test.cpp
 	  tests/cpgrid/shifted_cart_test.cpp
 	  tests/test_graphofgrid.cpp
 	  tests/test_graphofgrid_parallel.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -128,7 +128,8 @@ if(Boost_VERSION_STRING VERSION_GREATER 1.53)
 	  tests/cpgrid/lgr_cartesian_idx_test.cpp
 	  tests/cpgrid/lookUpCellCentroid_cpgrid_test.cpp
 	  tests/cpgrid/lookupdataCpGrid_test.cpp
-      tests/cpgrid/replace_lgr1_corner_idx_by_lgr2_corner_idx_test.cpp
+    tests/cpgrid/replace_lgr1_corner_idx_by_lgr2_corner_idx_test.cpp
+		tests/cpgrid/replace_lgr1_face_idx_by_lgr2_face_idx_test.cpp
 	  tests/cpgrid/shifted_cart_test.cpp
 	  tests/test_graphofgrid.cpp
 	  tests/test_graphofgrid_parallel.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -128,8 +128,8 @@ if(Boost_VERSION_STRING VERSION_GREATER 1.53)
 	  tests/cpgrid/lgr_cartesian_idx_test.cpp
 	  tests/cpgrid/lookUpCellCentroid_cpgrid_test.cpp
 	  tests/cpgrid/lookupdataCpGrid_test.cpp
-    tests/cpgrid/replace_lgr1_corner_idx_by_lgr2_corner_idx_test.cpp
-		tests/cpgrid/replace_lgr1_face_idx_by_lgr2_face_idx_test.cpp
+	  tests/cpgrid/replace_lgr1_corner_idx_by_lgr2_corner_idx_test.cpp
+	  tests/cpgrid/replace_lgr1_face_idx_by_lgr2_face_idx_test.cpp
 	  tests/cpgrid/shifted_cart_test.cpp
 	  tests/test_graphofgrid.cpp
 	  tests/test_graphofgrid_parallel.cpp

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1029,6 +1029,7 @@ namespace Dune
         /// @param [in] elemLgr:          Cell index from starting grid, that has been refined into a single-cell-refinement.
         std::array<int,2> getParentFacesAssocWithNewRefinedCornLyingOnEdge(const std::array<int,3>& cells_per_dim, int cornerIdxInLgr, int elemLgr) const;
 
+    protected:
         /// @brief A refined corner appears in two single-cell-refinements. Given the corner index in the first single-cell-refinement, compute the
         ///         corner index in the neighboring single-cell-refinement.
         ///
@@ -1057,6 +1058,7 @@ namespace Dune
         int replaceLgr1FaceIdxByLgr2FaceIdx(const std::array<int,3>& cells_per_dim_lgr1, int faceIdxInLgr1,
                                             const std::shared_ptr<cpgrid::CpGridData>& elemLgr1_ptr,
                                             const std::array<int,3>& cells_per_dim_lgr2) const;
+    private:
 
         /// @brief Get the parent face index where the new refined face lays on.
         ///

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -4317,7 +4317,7 @@ int CpGrid::replaceLgr1CornerIdxByLgr2CornerIdx(const std::array<int,3>& cells_p
         return  (ijkLgr1[1]*(cells_per_dim_lgr2[0]+1)*(cells_per_dim_lgr2[2]+1)) + (ijkLgr1[0]*(cells_per_dim_lgr2[2]+1));
     }
     if (ijkLgr1[0] == 0) { // same j,k, but i = cells_per_dim[0]
-        return   (ijkLgr1[1]*(cells_per_dim_lgr2[0]+1)*(cells_per_dim_lgr2[2]+1)) + (cells_per_dim_lgr1[0]*(cells_per_dim_lgr2[2]+1))+ ijkLgr1[2];
+        return   (ijkLgr1[1]*(cells_per_dim_lgr2[0]+1)*(cells_per_dim_lgr2[2]+1)) + (cells_per_dim_lgr2[0]*(cells_per_dim_lgr2[2]+1))+ ijkLgr1[2];
     }
     if (ijkLgr1[1] == 0) { // same i,k, but j = cells_per_Dim[1]
         return  (cells_per_dim_lgr2[1]*(cells_per_dim_lgr2[0]+1)*(cells_per_dim_lgr2[2]+1)) + (ijkLgr1[0]*(cells_per_dim_lgr2[2]+1)) + ijkLgr1[2];

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -3979,8 +3979,9 @@ std::array<int,3>  CpGrid::getRefinedCornerIJK(const std::array<int,3>& cells_pe
     return ijk;
 }
 
-std::array<int,3>  CpGrid::getRefinedFaceIJK(const std::array<int,3>& cells_per_dim, int faceIdxInLgr,
-                                             const std::shared_ptr<cpgrid::CpGridData>& elemLgr_ptr) const
+std::array<int,3> CpGrid::getRefinedFaceIJK(const std::array<int,3>& cells_per_dim,
+                                            int faceIdxInLgr,
+                                            const std::shared_ptr<cpgrid::CpGridData>& elemLgr_ptr) const
 {
     // Order defined in Geometry::refine
     // K_FACES  (k*cells_per_dim[0]*cells_per_dim[1]) + (j*cells_per_dim[0]) + i
@@ -3989,6 +3990,14 @@ std::array<int,3>  CpGrid::getRefinedFaceIJK(const std::array<int,3>& cells_per_
     // J_FACES  (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2] +1))
     //                    + ((cells_per_dim[0]+1)*cells_per_dim[1]*cells_per_dim[2])
     //                    + (j*cells_per_dim[0]*cells_per_dim[2]) + (i*cells_per_dim[2]) + k
+    const auto& i_faces =  (cells_per_dim[0] +1)*cells_per_dim[1]*cells_per_dim[2];
+    const auto& j_faces =  cells_per_dim[0]*(cells_per_dim[1]+1)*cells_per_dim[2];
+    const auto& k_faces =  cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1);
+
+    if (faceIdxInLgr >= i_faces + j_faces + k_faces) {
+        OPM_THROW(std::logic_error, "Invalid face index from single-cell-refinement.\n");
+    }
+
     const auto& faceEntity =  Dune::cpgrid::EntityRep<1>(faceIdxInLgr, true);
     const auto& faceTag = elemLgr_ptr ->face_tag_[faceEntity];
     std::array<int,3> ijk;
@@ -4444,7 +4453,7 @@ int CpGrid::replaceLgr1FaceIdxByLgr2FaceIdx(const std::array<int,3>& cells_per_d
             return kFacesLgr2 + iFacesLgr2 + (ijkLgr1[0]*cells_per_dim_lgr2[2]) + ijkLgr1[2];
         }
         else { // same i,k, but j = cells_per_dim[1]
-            return kFacesLgr2 + iFacesLgr2 + (cells_per_dim_lgr1[1]*cells_per_dim_lgr2[0]*cells_per_dim_lgr2[2])
+            return kFacesLgr2 + iFacesLgr2 + (cells_per_dim_lgr2[1]*cells_per_dim_lgr2[0]*cells_per_dim_lgr2[2])
                 + (ijkLgr1[0]*cells_per_dim_lgr2[2]) + ijkLgr1[2];
         }
     }

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -3963,6 +3963,10 @@ void CpGrid::updateCornerHistoryLevels(const std::vector<std::vector<std::array<
 
 std::array<int,3>  CpGrid::getRefinedCornerIJK(const std::array<int,3>& cells_per_dim, int cornerIdxInLgr) const
 {
+    const auto& total_corners = (cells_per_dim[0] +1)*(cells_per_dim[1]+1)*(cells_per_dim[2]+1);
+    if (cornerIdxInLgr >= total_corners) {
+        OPM_THROW(std::logic_error, "Invalid corner index from single-cell-refinement.\n");
+    }
     // Order defined in Geometry::refine
     //  (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) + k
     std::array<int,3> ijk;

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -2456,7 +2456,7 @@ bool CpGrid::adapt(const std::vector<std::array<int,3>>& cells_per_dim_vec,
         // Under the assumption of LGRs fully-interior, no communication is needed. In the general case, communication will be used
         // to populate overlap cell/point global ids on the refined level grids.
         /** Warning: due to the overlap layer size (equal to 1) cells that share corners or edges (not faces) with interior cells
-            are not included/seen by the process. This, in some cases, ends up in multiple ids for a same point. */
+            are not included/seen by the process. This, in some cases, ends up in multiple ids for the same point. */
 
         int min_globalId_cell_in_proc = 0;
         int min_globalId_point_in_proc = 0;
@@ -4234,7 +4234,7 @@ int CpGrid::getParentFaceWhereNewRefinedFaceLiesOn(const std::array<int,3>& cell
     // cell_to_face_ [ element ] = { I false, I true, J false, J true, K false, K true } if current_view_data_ is level zero
 
     if(parentCell_to_face.size()>6){
-        const auto& message = "The associted parent cell has more than six faces. Refinment/Adaptivity not supported yet.";
+        const auto& message = "The associated parent cell has more than six faces. Refinement/Adaptivity not supported yet.";
         if (comm().rank() == 0){
             OPM_THROW(std::logic_error, message);
         }
@@ -4285,7 +4285,7 @@ int CpGrid::getParentFaceWhereNewRefinedFaceLiesOn(const std::array<int,3>& cell
             }
         }
     }
-    const auto& message = "Cannot find parent face index where the new refined face lays on.";
+    const auto& message = "Cannot find index of parent face where the new refined face lies on.";
     if (comm().rank() == 0){
         OPM_THROW(std::logic_error, message);
     }
@@ -4305,7 +4305,7 @@ int CpGrid::replaceLgr1CornerIdxByLgr2CornerIdx(const std::array<int,3>& cells_p
     // On a parallel run, no symmetry between neighboring elements should be assumed. Therefore, all the six cases
     // (i = 0, cells_per_dim[0], j = 0, cells_per_dim[1], and k = 0, cells_per_dim[2]) have to be taken into account.
     // On a serial run, it would be enough to consider i = cells_per_dim[0], j = cells_per_dim[1], and k = cells_per_dim[2].
-    // To cover all possible escenarios, serial and parallel, we consider the six cases.
+    // To cover all possible scenarios, serial and parallel, we consider the six cases.
 
     if (ijkLgr1[0] == cells_per_dim_lgr1[0]) { // same j, k, but i = 0
         return   (ijkLgr1[1]*(cells_per_dim_lgr2[0]+1)*(cells_per_dim_lgr2[2]+1)) + ijkLgr1[2];
@@ -4350,7 +4350,7 @@ int CpGrid::replaceLgr1CornerIdxByLgr2CornerIdx(const std::array<int,3>& cells_p
     const auto& parentCell_to_face = current_view_data_->cell_to_face_[cpgrid::EntityRep<0>(elemLgr1, true)];
 
     if(parentCell_to_face.size()>6){
-        const auto& message = "The associted parent cell has more than six faces. Refinment/Adaptivity not supported yet.";
+        const auto& message = "The associated parent cell has more than six faces. Refinement/Adaptivity not supported yet.";
         if (comm().rank() == 0){
             OPM_THROW(std::logic_error, message);
         }

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -313,11 +313,6 @@ public:
         return cell_to_face_[cpgrid::EntityRep<0>(cell, true)][local_index].index();
     }
 
-    enum face_tag faceTag(const  Dune::cpgrid::EntityRep<1>& face) const
-    {
-        return face_tag_[face];
-    }
-    
     /// Return global_cell_ of any level grid, or the leaf grid view (in presence of refinement).
     /// global_cell_ has size number of cells present on a process and maps to the underlying Cartesian Grid.
     ///

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -308,6 +308,16 @@ public:
         ijk = getIJK(global_cell_[c], logical_cartesian_size_);
     }
 
+    int cellFace(int cell, int local_index) const
+    {
+        return cell_to_face_[cpgrid::EntityRep<0>(cell, true)][local_index].index();
+    }
+
+    enum face_tag faceTag(const  Dune::cpgrid::EntityRep<1>& face) const
+    {
+        return face_tag_[face];
+    }
+    
     /// Return global_cell_ of any level grid, or the leaf grid view (in presence of refinement).
     /// global_cell_ has size number of cells present on a process and maps to the underlying Cartesian Grid.
     ///

--- a/tests/cpgrid/addLgrsOnDistributedGrid_test.cpp
+++ b/tests/cpgrid/addLgrsOnDistributedGrid_test.cpp
@@ -133,6 +133,7 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
                     BOOST_CHECK(childElem.hasFather() == true);
                     BOOST_CHECK(childElem.level() == lgr);
                     referenceElemOneParent_volume += childElem.geometryInFather().volume();
+                    BOOST_CHECK( childElem.geometryInFather().volume() > 0 );
                     for (int c = 0; c < 3; ++c)  {
                         referenceElem_entity_center[c] += (childElem.geometryInFather().center())[c];
                     }

--- a/tests/cpgrid/replace_lgr1_corner_idx_by_lgr2_corner_idx_test.cpp
+++ b/tests/cpgrid/replace_lgr1_corner_idx_by_lgr2_corner_idx_test.cpp
@@ -80,6 +80,11 @@ BOOST_GLOBAL_FIXTURE(Fixture);
 
 std::array<int,3> getRefinedCornerIJK(const std::array<int,3>& cells_per_dim, int cornerIdxInLgr)
 {
+    const auto& total_corners = (cells_per_dim[0] +1)*(cells_per_dim[1]+1)*(cells_per_dim[2]+1);
+    if (cornerIdxInLgr >= total_corners) {
+        OPM_THROW(std::logic_error, "Invalid corner index from single-cell-refinement.\n");
+    }
+
     // Order defined in Geometry::refine
     //  (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) + k
     std::array<int,3> ijk;
@@ -225,6 +230,12 @@ BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_x)
                                                                  lgrLeft_to_lgrRight,
                                                                  lgr2_dim,
                                                                  lgr1_dim);
+
+    // lgr1 has (3+1)x(3+1)x(3+1) = 64 corners (with indices 0, ..., 63).
+    // lgr2 has (4+1)x(3+1)x(3+1) = 80 corners (with indices 0, ..., 79).
+    const auto& non_existing_corner = 80; // non exisitng corner index for both lgrs.
+    BOOST_CHECK_THROW( replaceLgr1CornerIdxByLgr2CornerIdx(lgr1_dim, non_existing_corner, lgr2_dim), std::logic_error);
+    BOOST_CHECK_THROW( replaceLgr1CornerIdxByLgr2CornerIdx(lgr2_dim, non_existing_corner, lgr1_dim), std::logic_error);
 }
 
 BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_y)

--- a/tests/cpgrid/replace_lgr1_corner_idx_by_lgr2_corner_idx_test.cpp
+++ b/tests/cpgrid/replace_lgr1_corner_idx_by_lgr2_corner_idx_test.cpp
@@ -156,11 +156,11 @@ const std::shared_ptr<Dune::cpgrid::CpGridData> createSingleCellGridAndRefine(co
     return lgr_ptr;
 }
 
-void check4CornersOfSharedRefinedFaceBetweenSingleCellRefinements(const Dune::cpgrid::Entity<0>& elemLgrA,
-                                                                  const Dune::cpgrid::Entity<0>& elemLgrB,
-                                                                  const std::unordered_map<int, int>& lgrA_to_lgrB,
-                                                                  const std::array<int,3>& lgrA_dim,
-                                                                  const std::array<int,3>& lgrB_dim)
+void checkOrderDoesNotMatterWhenReplaceCornerIdxOfSharedRefinedFaceBetweenSingleCellRefinements(const Dune::cpgrid::Entity<0>& elemLgrA,
+                                                                                                const Dune::cpgrid::Entity<0>& elemLgrB,
+                                                                                                const std::unordered_map<int, int>& lgrA_to_lgrB,
+                                                                                                const std::array<int,3>& lgrA_dim,
+                                                                                                const std::array<int,3>& lgrB_dim)
 {
     for (const auto& [idx_in_cell_lgrA, idx_in_cell_lgrB] : lgrA_to_lgrB)
     {
@@ -208,11 +208,11 @@ BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_x)
     const auto& elem14_lgr1 =  Dune::cpgrid::Entity<0>(*(lgr1_ptr), 14, true);
     const auto& elem16_lgr2 =  Dune::cpgrid::Entity<0>(*(lgr2_ptr), 16, true);
 
-    check4CornersOfSharedRefinedFaceBetweenSingleCellRefinements(elem14_lgr1,
-                                                                 elem16_lgr2,
-                                                                 lgrLeft_to_lgrRight,
-                                                                 lgr1_dim,
-                                                                 lgr2_dim);
+    checkOrderDoesNotMatterWhenReplaceCornerIdxOfSharedRefinedFaceBetweenSingleCellRefinements(elem14_lgr1,
+                                                                                               elem16_lgr2,
+                                                                                               lgrLeft_to_lgrRight,
+                                                                                               lgr1_dim,
+                                                                                               lgr2_dim);
 
     // Illustration of cells on the boundary between LGR1 and LGR2, for k=1,
     // if LGR2 refines cell 0 and LGR1 refines cell 1.
@@ -227,11 +227,11 @@ BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_x)
     const auto& elem19_lgr2 =  Dune::cpgrid::Entity<0>(*(lgr2_ptr), 19, true);
     const auto& elem12_lgr1 =  Dune::cpgrid::Entity<0>(*(lgr1_ptr), 12, true);
 
-    check4CornersOfSharedRefinedFaceBetweenSingleCellRefinements(elem19_lgr2,
-                                                                 elem12_lgr1,
-                                                                 lgrLeft_to_lgrRight,
-                                                                 lgr2_dim,
-                                                                 lgr1_dim);
+    checkOrderDoesNotMatterWhenReplaceCornerIdxOfSharedRefinedFaceBetweenSingleCellRefinements(elem19_lgr2,
+                                                                                               elem12_lgr1,
+                                                                                               lgrLeft_to_lgrRight,
+                                                                                               lgr2_dim,
+                                                                                               lgr1_dim);
 
     // lgr1 has (3+1)x(3+1)x(3+1) = 64 corners (with indices 0, ..., 63).
     // lgr2 has (4+1)x(3+1)x(3+1) = 80 corners (with indices 0, ..., 79).
@@ -283,11 +283,11 @@ BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_y)
     const auto& elem16_lgr1 =  Dune::cpgrid::Entity<0>(*(lgr1_ptr), 16, true);
     const auto& elem13_lgr2 =  Dune::cpgrid::Entity<0>(*(lgr2_ptr), 13, true);
 
-    check4CornersOfSharedRefinedFaceBetweenSingleCellRefinements(elem16_lgr1,
-                                                                 elem13_lgr2,
-                                                                 lgrBack_to_lgrFront,
-                                                                 lgr1_dim,
-                                                                 lgr2_dim);
+    checkOrderDoesNotMatterWhenReplaceCornerIdxOfSharedRefinedFaceBetweenSingleCellRefinements(elem16_lgr1,
+                                                                                               elem13_lgr2,
+                                                                                               lgrBack_to_lgrFront,
+                                                                                               lgr1_dim,
+                                                                                               lgr2_dim);
 
     // Illustration of cells on the boundary between LGR1 and LGR2, for k=1,
     // if LGR1 refines cell 1 and LGR2 refined cell 0.
@@ -306,11 +306,11 @@ BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_y)
     const auto& elem22_lgr2 =  Dune::cpgrid::Entity<0>(*(lgr2_ptr), 22, true);
     const auto& elem10_lgr1 =  Dune::cpgrid::Entity<0>(*(lgr1_ptr), 10, true);
 
-    check4CornersOfSharedRefinedFaceBetweenSingleCellRefinements(elem22_lgr2,
-                                                                 elem10_lgr1,
-                                                                 lgrBack_to_lgrFront,
-                                                                 lgr2_dim,
-                                                                 lgr1_dim);
+    checkOrderDoesNotMatterWhenReplaceCornerIdxOfSharedRefinedFaceBetweenSingleCellRefinements(elem22_lgr2,
+                                                                                               elem10_lgr1,
+                                                                                               lgrBack_to_lgrFront,
+                                                                                               lgr2_dim,
+                                                                                               lgr1_dim);
 }
 
 BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_z)
@@ -354,11 +354,11 @@ BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_z)
     const auto& elem22_lgr1 =  Dune::cpgrid::Entity<0>(*(lgr1_ptr), 22, true);
     const auto& elem4_lgr2 =  Dune::cpgrid::Entity<0>(*(lgr2_ptr), 4, true);
 
-    check4CornersOfSharedRefinedFaceBetweenSingleCellRefinements(elem22_lgr1,
-                                                                 elem4_lgr2,
-                                                                 lgrTop_to_lgrBottom,
-                                                                 lgr1_dim,
-                                                                 lgr2_dim);
+    checkOrderDoesNotMatterWhenReplaceCornerIdxOfSharedRefinedFaceBetweenSingleCellRefinements(elem22_lgr1,
+                                                                                               elem4_lgr2,
+                                                                                               lgrTop_to_lgrBottom,
+                                                                                               lgr1_dim,
+                                                                                               lgr2_dim);
 
     // Illustration of cells on the boundary between LGR1 and LGR2,
     // if LGR1 refines cell 1 and LGR2 refined cell 0.
@@ -377,9 +377,9 @@ BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_z)
     const auto& elem31_lgr2 =  Dune::cpgrid::Entity<0>(*(lgr2_ptr), 31, true);
     const auto& elem4_lgr1 =  Dune::cpgrid::Entity<0>(*(lgr1_ptr), 4, true);
 
-    check4CornersOfSharedRefinedFaceBetweenSingleCellRefinements(elem31_lgr2,
-                                                                 elem4_lgr1,
-                                                                 lgrTop_to_lgrBottom,
-                                                                 lgr2_dim,
-                                                                 lgr1_dim);
+    checkOrderDoesNotMatterWhenReplaceCornerIdxOfSharedRefinedFaceBetweenSingleCellRefinements(elem31_lgr2,
+                                                                                               elem4_lgr1,
+                                                                                               lgrTop_to_lgrBottom,
+                                                                                               lgr2_dim,
+                                                                                               lgr1_dim);
 }

--- a/tests/cpgrid/replace_lgr1_corner_idx_by_lgr2_corner_idx_test.cpp
+++ b/tests/cpgrid/replace_lgr1_corner_idx_by_lgr2_corner_idx_test.cpp
@@ -1,6 +1,6 @@
 //===========================================================================
 //
-// File: replace_corner_idx_neigh_cells_test.cpp
+// File: replace_lgr1_corner_idx_by_lgr2_corner_idx_test.cpp
 //
 // Created: Friday 24.01.2025 11:55:00
 //

--- a/tests/cpgrid/replace_lgr1_corner_idx_by_lgr2_corner_idx_test.cpp
+++ b/tests/cpgrid/replace_lgr1_corner_idx_by_lgr2_corner_idx_test.cpp
@@ -42,9 +42,11 @@
 
 
 #include <opm/grid/CpGrid.hpp>
-#include <opm/grid/cpgrid/CpGridData.hpp>
 
 #include <array>
+#include <memory>
+#include <stdexcept>
+#include <unordered_map>
 
 
 struct Fixture
@@ -139,8 +141,8 @@ const std::shared_ptr<Dune::cpgrid::CpGridData> createSingleCellGridAndRefine(co
 {
     // Create two grids, one single cell in each grid.
     Dune::CpGrid lgr;
-    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int,3> coarse_grid_dim = {1,1,1};
+    const std::array<double,3>& cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int,3>& coarse_grid_dim = {1,1,1};
     lgr.createCartesian(coarse_grid_dim, cell_sizes);
 
     // Single-cell-refinement for the only cell contained in lgr grid.
@@ -176,8 +178,8 @@ BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_x)
     // lgr1 and lgr2 grids mimick single-cell-refinements sharing I_FACE: | 0 | 1 |
 
     // Refine grids lgr1 and lgr2.
-    const std::array<int, 3> lgr1_dim = {3,3,3};
-    const std::array<int, 3> lgr2_dim = {4,3,3};
+    const std::array<int, 3>& lgr1_dim = {3,3,3};
+    const std::array<int, 3>& lgr2_dim = {4,3,3};
     // Number of subbivisions in y- and z- direction must coincide, when cells
     // from different LGRs share I_FACEs. In x-direction, they can differ.
 
@@ -191,7 +193,7 @@ BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_x)
     //     2 -- 3    BOTTOM FACE
     //    /    /
     //   0 -- 1
-    std::unordered_map<int, int> lgrLeft_to_lgrRight = {{1,0}, {3,2}, {5,4}, {7,6}};
+    const std::unordered_map<int, int>& lgrLeft_to_lgrRight = {{1,0}, {3,2}, {5,4}, {7,6}};
 
     // Illustration of cells on the boundary between LGR1 and LGR2, for k=1,
     // if LGR1 refines cell 0 and LGR2 refined cell 1.
@@ -247,8 +249,8 @@ BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_y)
     //  ---
 
     // Refine grids lgr1 and lgr2.
-    const std::array<int, 3> lgr1_dim = {3,3,3};
-    const std::array<int, 3> lgr2_dim = {3,4,3};
+    const std::array<int, 3>& lgr1_dim = {3,3,3};
+    const std::array<int, 3>& lgr2_dim = {3,4,3};
     // Number of subbivisions in x- and z- direction must coincide, when cells
     // from different LGRs share J_FACEs. In y-direction, they can differ.
     const auto& lgr1_ptr = createSingleCellGridAndRefine(lgr1_dim);
@@ -261,7 +263,7 @@ BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_y)
     //     2 -- 3    BOTTOM FACE
     //    /    /
     //   0 -- 1
-    std::unordered_map<int, int> lgrBack_to_lgrFront = {{2,0}, {3,1}, {6,4}, {7,5}};
+    const std::unordered_map<int, int>& lgrBack_to_lgrFront = {{2,0}, {3,1}, {6,4}, {7,5}};
 
     // Illustration of cells on the boundary between LGR1 and LGR2, for k=1,
     // if LGR1 refines cell 0 and LGR2 refined cell 1.
@@ -320,8 +322,8 @@ BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_z)
     //  ---
 
     // Refine grids lgr1 and lgr2.
-    const std::array<int, 3> lgr1_dim = {3,3,3};
-    const std::array<int, 3> lgr2_dim = {3,3,4};
+    const std::array<int, 3>& lgr1_dim = {3,3,3};
+    const std::array<int, 3>& lgr2_dim = {3,3,4};
     // Number of subbivisions in x- and y- direction must coincide, when cells
     // from different LGRs share K_FACEs. In z-direction, they can differ.
     const auto& lgr1_ptr = createSingleCellGridAndRefine(lgr1_dim);
@@ -334,7 +336,7 @@ BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_z)
     //     2 -- 3    BOTTOM FACE
     //    /    /
     //   0 -- 1
-    std::unordered_map<int, int> lgrTop_to_lgrBottom = {{4,0}, {5,1}, {6,2}, {7,3}};
+    const std::unordered_map<int, int>& lgrTop_to_lgrBottom = {{4,0}, {5,1}, {6,2}, {7,3}};
 
     // Illustration of cells on the boundary between LGR1 and LGR2,
     // if LGR1 refines cell 1 and LGR2 refined cell 0.

--- a/tests/cpgrid/replace_lgr1_corner_idx_by_lgr2_corner_idx_test.cpp
+++ b/tests/cpgrid/replace_lgr1_corner_idx_by_lgr2_corner_idx_test.cpp
@@ -1,0 +1,372 @@
+//===========================================================================
+//
+// File: replace_corner_idx_neigh_cells_test.cpp
+//
+// Created: Friday 24.01.2025 11:55:00
+//
+// Author(s): Antonella Ritorto   <antonella.ritorto@opm-op.com>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+/*
+  Copyright 2025 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#define BOOST_TEST_MODULE ReplaceCornerIdxNeighCellsTests
+#include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
+
+
+#include <opm/grid/CpGrid.hpp>
+#include <opm/grid/cpgrid/CpGridData.hpp>
+
+#include <array>
+
+
+struct Fixture
+{
+    Fixture()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        Dune::MPIHelper::instance(m_argc, m_argv);
+        Opm::OpmLog::setupSimpleDefaultLogging();
+    }
+};
+
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+/* To add LGRs in a CpGrid, each marked element for refinement gets refined into a
+   single-cell-refinement. To store new born refined entities [points or faces]
+   only once, we detect equivalent entities via their indices in each single-cell-refinement.
+
+   To test replaceLgr1CornerIdxByLgr2CornerIdx(...), we create two grids, each of them
+   containing only one cell. Add different LGRs in each grid, in different cases to
+   create all possible escenarios (the two coarse cells sharing I_FACE, J_FACE or K_FACE).
+
+   To avoid friend declarations, we 'copy' here replaceLgr1CornerIdxByLgr2CornerIdx
+   (and getRefinedCornerIJK).
+
+   Why single-cell-refinements instead of adding LGRs in one grid?:
+   replaceLgr1CornerIdxByLgr2CornerIdx is a private method in CpGrid, meant to be
+   used between independent/un-related single-cell-refinements (stored in CpGridData objects).
+   Therefore, creating a grid, adding LGRs to it, and checking corner indices afterwards in
+   refined cells on bouandary of the LGRs is not the escenario where this method should be tested.
+*/
+
+std::array<int,3> getRefinedCornerIJK(const std::array<int,3>& cells_per_dim, int cornerIdxInLgr)
+{
+    // Order defined in Geometry::refine
+    //  (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) + k
+    std::array<int,3> ijk;
+    ijk[2] = cornerIdxInLgr % (cells_per_dim[2] +1);
+    cornerIdxInLgr -= ijk[2];
+    cornerIdxInLgr /= (cells_per_dim[2] +1);
+    ijk[0] = cornerIdxInLgr % (cells_per_dim[0]+1);
+    cornerIdxInLgr -=ijk[0];
+    ijk[1] = cornerIdxInLgr / (cells_per_dim[0]+1);
+    return ijk;
+}
+
+// Mimic CpGrid::replaceLgr1CornerIdxByLgr2CornerIdx
+int replaceLgr1CornerIdxByLgr2CornerIdx(const std::array<int,3>& cells_per_dim_lgr1,
+                                        int cornerIdxLgr1,
+                                        const std::array<int,3>& cells_per_dim_lgr2)
+{
+    const auto& ijkLgr1 = getRefinedCornerIJK(cells_per_dim_lgr1, cornerIdxLgr1);
+    // Order defined in Geometry::refine
+    // (j*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (i*(cells_per_dim[2]+1)) + k
+
+    // On a parallel run, no symmetry between neighboring elements should be assumed. Therefore, all the six cases
+    // (i = 0, cells_per_dim[0], j = 0, cells_per_dim[1], and k = 0, cells_per_dim[2]) have to be taken into account.
+    // On a serial run, it would be enough to consider i = cells_per_dim[0], j = cells_per_dim[1], and k = cells_per_dim[2].
+    // To cover all possible scenarios, serial and parallel, we consider the six cases.
+
+    if (ijkLgr1[0] == cells_per_dim_lgr1[0]) { // same j, k, but i = 0
+        return   (ijkLgr1[1]*(cells_per_dim_lgr2[0]+1)*(cells_per_dim_lgr2[2]+1)) + ijkLgr1[2];
+    }
+    if (ijkLgr1[1] == cells_per_dim_lgr1[1]) { // same i,k, but j = 0
+        return  (ijkLgr1[0]*(cells_per_dim_lgr2[2]+1)) + ijkLgr1[2];
+    }
+    if (ijkLgr1[2] == cells_per_dim_lgr1[2]) { // same i,j, but k = 0
+        return  (ijkLgr1[1]*(cells_per_dim_lgr2[0]+1)*(cells_per_dim_lgr2[2]+1)) + (ijkLgr1[0]*(cells_per_dim_lgr2[2]+1));
+    }
+    if (ijkLgr1[0] == 0) { // same j,k, but i = cells_per_dim[0]
+        return   (ijkLgr1[1]*(cells_per_dim_lgr2[0]+1)*(cells_per_dim_lgr2[2]+1)) + (cells_per_dim_lgr2[0]*(cells_per_dim_lgr2[2]+1))+ ijkLgr1[2];
+    }
+    if (ijkLgr1[1] == 0) { // same i,k, but j = cells_per_dim[1]
+        return  (cells_per_dim_lgr2[1]*(cells_per_dim_lgr2[0]+1)*(cells_per_dim_lgr2[2]+1)) + (ijkLgr1[0]*(cells_per_dim_lgr2[2]+1)) + ijkLgr1[2];
+    }
+    if (ijkLgr1[2] == 0) { // same i,j, but k = cells_per_dim[2]
+        return  (ijkLgr1[1]*(cells_per_dim_lgr2[0]+1)*(cells_per_dim_lgr2[2]+1)) + (ijkLgr1[0]*(cells_per_dim_lgr2[2]+1)) + cells_per_dim_lgr2[2];
+    }
+    else {
+        const auto& message = "Cannot convert corner index from one LGR to its neighboring LGR.";
+        OPM_THROW(std::logic_error, message);
+    }
+}
+
+const std::shared_ptr<Dune::cpgrid::CpGridData> createSingleCellGridAndRefine(const std::array<int,3>& lgr_dim)
+{
+    // Create two grids, one single cell in each grid.
+    Dune::CpGrid lgr;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int,3> coarse_grid_dim = {1,1,1};
+    lgr.createCartesian(coarse_grid_dim, cell_sizes);
+
+    // Single-cell-refinement for the only cell contained in lgr grid.
+    const auto& [lgr_ptr,
+                 lgr_parentCorners_to_equivalentRefinedCorners,
+                 lgr_parentFace_to_itsRefinedFaces,
+                 lgr_parentCell_to_itsRefinedCells,
+                 lgr_refinedFace_to_itsParentFace,
+                 lgr_refinedCell_to_itsParentCell]
+        = lgr.currentData().back()->refineSingleCell(lgr_dim, 0);
+    return lgr_ptr;
+}
+
+void check4CornersOfSharedRefinedFaceBetweenSingleCellRefinements(const Dune::cpgrid::Entity<0>& elemLgrA,
+                                                                  const Dune::cpgrid::Entity<0>& elemLgrB,
+                                                                  const std::unordered_map<int, int>& lgrA_to_lgrB,
+                                                                  const std::array<int,3>& lgrA_dim,
+                                                                  const std::array<int,3>& lgrB_dim)
+{
+    for (const auto& [idx_in_cell_lgrA, idx_in_cell_lgrB] : lgrA_to_lgrB)
+    {
+        const auto& corn_lgrA = elemLgrA.subEntity<3>( idx_in_cell_lgrA ).index();
+        const auto& corn_lgrB = elemLgrB.subEntity<3>( idx_in_cell_lgrB ).index();
+
+        BOOST_CHECK_EQUAL( replaceLgr1CornerIdxByLgr2CornerIdx(lgrA_dim, corn_lgrA, lgrB_dim), corn_lgrB);
+        BOOST_CHECK_EQUAL( replaceLgr1CornerIdxByLgr2CornerIdx(lgrB_dim, corn_lgrB, lgrA_dim), corn_lgrA);
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_x)
+{
+    // lgr1 and lgr2 grids mimick single-cell-refinements sharing I_FACE: | 0 | 1 |
+
+    // Refine grids lgr1 and lgr2.
+    const std::array<int, 3> lgr1_dim = {3,3,3};
+    const std::array<int, 3> lgr2_dim = {4,3,3};
+    // Number of subbivisions in y- and z- direction must coincide, when cells
+    // from different LGRs share I_FACEs. In x-direction, they can differ.
+
+    const auto& lgr1_ptr = createSingleCellGridAndRefine(lgr1_dim);
+    const auto& lgr2_ptr = createSingleCellGridAndRefine(lgr2_dim);
+
+    // Recall how the 8 corners of a cell are stored in cell_to_point_
+    //     6 -- 7    TOP FACE
+    //    /    /
+    //   4 -- 5
+    //     2 -- 3    BOTTOM FACE
+    //    /    /
+    //   0 -- 1
+    std::unordered_map<int, int> lgrLeft_to_lgrRight = {{1,0}, {3,2}, {5,4}, {7,6}};
+
+    // Illustration of cells on the boundary between LGR1 and LGR2, for k=1,
+    // if LGR1 refines cell 0 and LGR2 refined cell 1.
+    //      LGR1   LGR2
+    //  15 16 17 | 20 21 22 23
+    //  12 13 14 | 16 17 18 19
+    //   9 10 11 | 12 13 14 15
+
+    // elem 14 from lgr1 corners 1,2,5,7
+    // should coincide with
+    // elem 16 from lgr2 corners 0,3,4,6 respectively.
+    const auto& elem14_lgr1 =  Dune::cpgrid::Entity<0>(*(lgr1_ptr), 14, true);
+    const auto& elem16_lgr2 =  Dune::cpgrid::Entity<0>(*(lgr2_ptr), 16, true);
+
+    check4CornersOfSharedRefinedFaceBetweenSingleCellRefinements(elem14_lgr1,
+                                                                 elem16_lgr2,
+                                                                 lgrLeft_to_lgrRight,
+                                                                 lgr1_dim,
+                                                                 lgr2_dim);
+
+    // Illustration of cells on the boundary between LGR1 and LGR2, for k=1,
+    // if LGR2 refines cell 0 and LGR1 refines cell 1.
+    //         LGR2   LGR1
+    //  20 21 22 23 | 15 16 17
+    //  16 17 18 19 | 12 13 14
+    //  12 13 14 15 |  9 10 11
+
+    // elem 12 from lgr1 corners 1,2,5,7
+    // should coincide with
+    // elem 19 from lgr2 corners 0,3,4,6 respectively.
+    const auto& elem19_lgr2 =  Dune::cpgrid::Entity<0>(*(lgr2_ptr), 19, true);
+    const auto& elem12_lgr1 =  Dune::cpgrid::Entity<0>(*(lgr1_ptr), 12, true);
+
+    check4CornersOfSharedRefinedFaceBetweenSingleCellRefinements(elem19_lgr2,
+                                                                 elem12_lgr1,
+                                                                 lgrLeft_to_lgrRight,
+                                                                 lgr2_dim,
+                                                                 lgr1_dim);
+}
+
+BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_y)
+{
+    // lgr1 and lgr2 mimick a coarse grid having 2 cells sharing J_FACE:
+    //   / 1 /
+    //   ---   shared J_FACE
+    //  / 0 /
+    //  ---
+
+    // Refine grids lgr1 and lgr2.
+    const std::array<int, 3> lgr1_dim = {3,3,3};
+    const std::array<int, 3> lgr2_dim = {3,4,3};
+    // Number of subbivisions in x- and z- direction must coincide, when cells
+    // from different LGRs share J_FACEs. In y-direction, they can differ.
+    const auto& lgr1_ptr = createSingleCellGridAndRefine(lgr1_dim);
+    const auto& lgr2_ptr = createSingleCellGridAndRefine(lgr2_dim);
+
+    // Recall how the 8 corners of a cell are stored in cell_to_point_
+    //     6 -- 7    TOP FACE
+    //    /    /
+    //   4 -- 5
+    //     2 -- 3    BOTTOM FACE
+    //    /    /
+    //   0 -- 1
+    std::unordered_map<int, int> lgrBack_to_lgrFront = {{2,0}, {3,1}, {6,4}, {7,5}};
+
+    // Illustration of cells on the boundary between LGR1 and LGR2, for k=1,
+    // if LGR1 refines cell 0 and LGR2 refined cell 1.
+    //        21 22 23  LGR2
+    //       18 19 20
+    //      15 16 17
+    //     12 13 14
+    //    ---------
+    //    15 16 17      LGR1
+    //   12 13 14
+    //  9 10 11
+
+
+    // elem 16 from lgr1 corners 0,1,4,5
+    // should coincide with
+    // elem 13 from lgr2 corners 2,3,6,7 respectively.
+    const auto& elem16_lgr1 =  Dune::cpgrid::Entity<0>(*(lgr1_ptr), 16, true);
+    const auto& elem13_lgr2 =  Dune::cpgrid::Entity<0>(*(lgr2_ptr), 13, true);
+
+    check4CornersOfSharedRefinedFaceBetweenSingleCellRefinements(elem16_lgr1,
+                                                                 elem13_lgr2,
+                                                                 lgrBack_to_lgrFront,
+                                                                 lgr1_dim,
+                                                                 lgr2_dim);
+
+    // Illustration of cells on the boundary between LGR1 and LGR2, for k=1,
+    // if LGR1 refines cell 1 and LGR2 refined cell 0.
+    //        15 16 17  LGR1
+    //       12 13 14
+    //      9 10 11
+    //     -------
+    //    21 22 23      LGR2
+    //   18 19 20
+    //  15 16 17
+    // 12 13 14
+
+    // elem 10 from lgr1 corners 0,1,4,5
+    // should coincide with
+    // elem 22 from lgr2 corners 2,3,6,7 respectively.
+    const auto& elem22_lgr2 =  Dune::cpgrid::Entity<0>(*(lgr2_ptr), 22, true);
+    const auto& elem10_lgr1 =  Dune::cpgrid::Entity<0>(*(lgr1_ptr), 10, true);
+
+    check4CornersOfSharedRefinedFaceBetweenSingleCellRefinements(elem22_lgr2,
+                                                                 elem10_lgr1,
+                                                                 lgrBack_to_lgrFront,
+                                                                 lgr2_dim,
+                                                                 lgr1_dim);
+}
+
+BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_z)
+{
+    // lgr1 and lgr2  mimick a coarse grid has 2 cells sharing K_FACE:
+    //   / 1 /
+    //   ---   shared K_FACE
+    //  / 0 /
+    //  ---
+
+    // Refine grids lgr1 and lgr2.
+    const std::array<int, 3> lgr1_dim = {3,3,3};
+    const std::array<int, 3> lgr2_dim = {3,3,4};
+    // Number of subbivisions in x- and y- direction must coincide, when cells
+    // from different LGRs share K_FACEs. In z-direction, they can differ.
+    const auto& lgr1_ptr = createSingleCellGridAndRefine(lgr1_dim);
+    const auto& lgr2_ptr = createSingleCellGridAndRefine(lgr2_dim);
+
+    // Recall how the 8 corners of a cell are stored in cell_to_point_
+    //     6 -- 7    TOP FACE
+    //    /    /
+    //   4 -- 5
+    //     2 -- 3    BOTTOM FACE
+    //    /    /
+    //   0 -- 1
+    std::unordered_map<int, int> lgrTop_to_lgrBottom = {{4,0}, {5,1}, {6,2}, {7,3}};
+
+    // Illustration of cells on the boundary between LGR1 and LGR2,
+    // if LGR1 refines cell 1 and LGR2 refined cell 0.
+    //         6  7  8  LGR2 BOTTOM
+    //        3  4  5
+    //       0  1  2
+    //      ------
+    //     24 25 26  LGR1 TOP
+    //    21 22 23
+    //   18 19 20
+
+    // elem 22 from lgr1 corners 4,5,6,7
+    // should coincide with
+    // elem 4 from lgr2 corners 0,1,2,3 respectively.
+    const auto& elem22_lgr1 =  Dune::cpgrid::Entity<0>(*(lgr1_ptr), 22, true);
+    const auto& elem4_lgr2 =  Dune::cpgrid::Entity<0>(*(lgr2_ptr), 4, true);
+
+    check4CornersOfSharedRefinedFaceBetweenSingleCellRefinements(elem22_lgr1,
+                                                                 elem4_lgr2,
+                                                                 lgrTop_to_lgrBottom,
+                                                                 lgr1_dim,
+                                                                 lgr2_dim);
+
+    // Illustration of cells on the boundary between LGR1 and LGR2,
+    // if LGR1 refines cell 1 and LGR2 refined cell 0.
+    //         6  7  8  LGR1 BOTTOM
+    //        3  4  5
+    //       0  1  2
+    //     -------
+    //    33 34 35      LGR2 TOP
+    //   30 31 32
+    //  27 28 29
+
+
+    // elem 4 from lgr1 corners 4,5,6,7
+    // should coincide with
+    // elem 31 from lgr2 corners 0,1,2,3 respectively.
+    const auto& elem31_lgr2 =  Dune::cpgrid::Entity<0>(*(lgr2_ptr), 31, true);
+    const auto& elem4_lgr1 =  Dune::cpgrid::Entity<0>(*(lgr1_ptr), 4, true);
+
+    check4CornersOfSharedRefinedFaceBetweenSingleCellRefinements(elem31_lgr2,
+                                                                 elem4_lgr1,
+                                                                 lgrTop_to_lgrBottom,
+                                                                 lgr2_dim,
+                                                                 lgr1_dim);
+}

--- a/tests/cpgrid/replace_lgr1_face_idx_by_lgr2_face_idx_test.cpp
+++ b/tests/cpgrid/replace_lgr1_face_idx_by_lgr2_face_idx_test.cpp
@@ -1,0 +1,402 @@
+//===========================================================================
+//
+// File: replace_lgr1_face_idx_by_lgr2_face_idx_test.cpp
+//
+// Created: Monday 27.01.2025 10:32:00
+//
+// Author(s): Antonella Ritorto   <antonella.ritorto@opm-op.com>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+/*
+  Copyright 2025 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#define BOOST_TEST_MODULE ReplaceLgr1FaceIdxByLgr2FaceIdxTests
+#include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
+
+
+#include <opm/grid/CpGrid.hpp>
+
+#include <array>
+#include <memory>
+#include <stdexcept>
+
+
+struct Fixture
+{
+    Fixture()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        Dune::MPIHelper::instance(m_argc, m_argv);
+        Opm::OpmLog::setupSimpleDefaultLogging();
+    }
+};
+
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+/* To add LGRs in a CpGrid, each marked element for refinement gets refined into a
+   single-cell-refinement. To store new born refined entities [points or faces]
+   only once, we detect equivalent entities via their indices in each single-cell-refinement.
+
+   To test replaceLgr1FaceIdxByLgr2FaceIdx(...), we create two grids, each of them
+   containing only one cell. Add different LGRs in each grid, in different cases to
+   create all possible escenarios (the two coarse cells sharing I_FACE, J_FACE or K_FACE).
+
+   To avoid friend declarations, we 'copy' here replaceLgr1FaceIdxByLgr2FaceIdx
+   (and getRefinedFaceIJK).
+
+   Why single-cell-refinements instead of adding LGRs in one grid?:
+   replaceLgr1FaceIdxByLgr2FaceIdx is a private method in CpGrid, meant to be
+   used between independent/un-related single-cell-refinements (stored in CpGridData objects).
+   Therefore, creating a grid, adding LGRs to it, and checking face indices afterwards in
+   refined cells on bouandary of the LGRs is not the escenario where this method should be tested.
+*/
+
+
+std::array<int,3> getRefinedFaceIJK(const std::array<int,3>& cells_per_dim,
+                                    int faceIdxInLgr,
+                                    const std::shared_ptr<Dune::cpgrid::CpGridData>& elemLgr_ptr)
+{
+    // Order defined in Geometry::refine
+    // K_FACES  (k*cells_per_dim[0]*cells_per_dim[1]) + (j*cells_per_dim[0]) + i
+    // I_FACES  (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1))
+    //           + (i*cells_per_dim[1]*cells_per_dim[2]) + (k*cells_per_dim[1]) + j
+    // J_FACES  (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2] +1))
+    //                    + ((cells_per_dim[0]+1)*cells_per_dim[1]*cells_per_dim[2])
+    //                    + (j*cells_per_dim[0]*cells_per_dim[2]) + (i*cells_per_dim[2]) + k
+    const auto& i_faces =  (cells_per_dim[0] +1)*cells_per_dim[1]*cells_per_dim[2];
+    const auto& j_faces =  cells_per_dim[0]*(cells_per_dim[1]+1)*cells_per_dim[2];
+    const auto& k_faces =  cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1);
+
+    if (faceIdxInLgr >= i_faces + j_faces + k_faces) {
+        OPM_THROW(std::logic_error, "Invalid face index from single-cell-refinement.\n");
+    }
+
+    const auto& faceEntity =  Dune::cpgrid::EntityRep<1>(faceIdxInLgr, true);
+    const auto& faceTag = elemLgr_ptr ->faceTag(faceEntity);
+    std::array<int,3> ijk;
+    switch (faceTag) {
+    case I_FACE:
+        faceIdxInLgr -= (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1));
+        // faceIdxInLgr =  (i*cells_per_dim[1]*cells_per_dim[2]) + (k*cells_per_dim[1]) + j
+        ijk[1] = faceIdxInLgr % cells_per_dim[1];
+        faceIdxInLgr -= ijk[1]; // (i*cells_per_dim[1]*cells_per_dim[2]) + (k*cells_per_dim[1])
+        faceIdxInLgr /= cells_per_dim[1]; // (i*cells_per_dim[2]) + k
+        ijk[2] = faceIdxInLgr % cells_per_dim[2];
+        faceIdxInLgr -=ijk[2]; // i*cells_per_dim[2]
+        ijk[0] = faceIdxInLgr / cells_per_dim[2];
+        break;
+    case J_FACE:
+        faceIdxInLgr -=  (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2] +1))
+            + ((cells_per_dim[0]+1)*cells_per_dim[1]*cells_per_dim[2]);
+        // faceIdxInLgr =  (j*cells_per_dim[0]*cells_per_dim[2]) + (i*cells_per_dim[2]) + k
+        ijk[2] = faceIdxInLgr % cells_per_dim[2];
+        faceIdxInLgr -= ijk[2]; // (j*cells_per_dim[0]*cells_per_dim[2]) + (i*cells_per_dim[2])
+        faceIdxInLgr /= cells_per_dim[2]; // (j*cells_per_dim[0]) + i
+        ijk[0] = faceIdxInLgr % cells_per_dim[0];
+        faceIdxInLgr -=ijk[0]; // j*cells_per_dim[0]
+        ijk[1] = faceIdxInLgr / cells_per_dim[0];
+        break;
+    case K_FACE:
+        //  (k*cells_per_dim[0]*cells_per_dim[1]) + (j*cells_per_dim[0]) + i
+        ijk[0] = faceIdxInLgr % cells_per_dim[0];
+        faceIdxInLgr -= ijk[0]; // (k*cells_per_dim[0]*cells_per_dim[1]) + (j*cells_per_dim[0])
+        faceIdxInLgr /= cells_per_dim[0]; // (k*cells_per_dim[1]) + j
+        ijk[1] = faceIdxInLgr % cells_per_dim[1];
+        faceIdxInLgr -=ijk[1]; // k*cells_per_dim[1]
+        ijk[2] = faceIdxInLgr / cells_per_dim[1];
+        break;
+    default:
+        OPM_THROW(std::logic_error, "FaceTag is not I, J, or K!");
+    }
+    return ijk;
+}
+
+
+int replaceLgr1FaceIdxByLgr2FaceIdx(const std::array<int,3>& cells_per_dim_lgr1,
+                                    int faceIdxInLgr1,
+                                    const std::shared_ptr<Dune::cpgrid::CpGridData>& elemLgr1_ptr,
+                                    const std::array<int,3>& cells_per_dim_lgr2)
+{
+    const auto& ijkLgr1 = getRefinedFaceIJK(cells_per_dim_lgr1, faceIdxInLgr1, elemLgr1_ptr);
+    // lgr1 represents an element index < lgr2 (neighboring cells sharing a face with lgr1-element)
+    // Order defined in Geometry::refine
+    // K_FACES (k*cells_per_dim[0]*cells_per_dim[1]) + (j*cells_per_dim[0]) + i
+    // I_FACES  (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1))
+    //           + (i*cells_per_dim[1]*cells_per_dim[2]) + (k*cells_per_dim[1]) + j
+    // J_FACES  (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2] +1))
+    //                    + ((cells_per_dim[0]+1)*cells_per_dim[1]*cells_per_dim[2])
+    //                    + (j*cells_per_dim[0]*cells_per_dim[2]) + (i*cells_per_dim[2]) + k
+    const int& kFacesLgr2 = cells_per_dim_lgr2[0]*cells_per_dim_lgr2[1]*(cells_per_dim_lgr2[2]+1);
+    const int& iFacesLgr2 = ((cells_per_dim_lgr2[0]+1)*cells_per_dim_lgr2[1]*cells_per_dim_lgr2[2]);
+
+    const auto& face_lgr1 =  Dune::cpgrid::EntityRep<1>(faceIdxInLgr1, true);
+    const auto& face_tag = elemLgr1_ptr-> faceTag(face_lgr1);
+
+    if (face_tag == I_FACE) {
+        assert( cells_per_dim_lgr1[1] == cells_per_dim_lgr2[1]);
+        assert( cells_per_dim_lgr1[2] == cells_per_dim_lgr2[2]);
+        if (ijkLgr1[0] == cells_per_dim_lgr1[0]) { // same j,k, but i = 0
+            return  kFacesLgr2 + (ijkLgr1[2]*cells_per_dim_lgr2[1]) + ijkLgr1[1];
+        }
+        else { // same j,k, but i = cells_per_dim[0]
+            return  kFacesLgr2 + (cells_per_dim_lgr2[0]*cells_per_dim_lgr2[1]*cells_per_dim_lgr2[2])
+                + (ijkLgr1[2]*cells_per_dim_lgr2[1]) + ijkLgr1[1];
+        }
+    }
+    if (face_tag == J_FACE) {
+        assert( cells_per_dim_lgr1[0] == cells_per_dim_lgr2[0]);
+        assert( cells_per_dim_lgr1[2] == cells_per_dim_lgr2[2]);
+        if (ijkLgr1[1] == cells_per_dim_lgr1[1]) { // same i,k, but j = 0
+            return kFacesLgr2 + iFacesLgr2 + (ijkLgr1[0]*cells_per_dim_lgr2[2]) + ijkLgr1[2];
+        }
+        else { // same i,k, but j = cells_per_dim[1]
+            return kFacesLgr2 + iFacesLgr2 + (cells_per_dim_lgr2[1]*cells_per_dim_lgr2[0]*cells_per_dim_lgr2[2])
+                + (ijkLgr1[0]*cells_per_dim_lgr2[2]) + ijkLgr1[2];
+        }
+    }
+    if (face_tag == K_FACE) {
+        assert( cells_per_dim_lgr1[0] == cells_per_dim_lgr2[0]);
+        assert( cells_per_dim_lgr1[1] == cells_per_dim_lgr2[1]);
+        if (ijkLgr1[2] == cells_per_dim_lgr1[2]) { // same i,j, but k = 0
+            return  (ijkLgr1[1]*cells_per_dim_lgr2[0]) + ijkLgr1[0];
+        }
+        else{ // same i, j, but k = cells_per_dim[2]
+            return  (cells_per_dim_lgr2[2]*cells_per_dim_lgr2[0]*cells_per_dim_lgr2[1])
+                + (ijkLgr1[1]*cells_per_dim_lgr2[0]) + ijkLgr1[0];
+        }
+    }
+    OPM_THROW(std::logic_error,  "Cannot convert face index from one LGR to its neighboring LGR.");
+}
+
+
+const std::shared_ptr<Dune::cpgrid::CpGridData> createSingleCellGridAndRefine(const std::array<int,3>& lgr_dim)
+{
+    Dune::CpGrid lgr;
+    // Create a single-cell-grid
+    const std::array<double,3>& cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int,3>& coarse_grid_dim = {1,1,1};
+    lgr.createCartesian(coarse_grid_dim, cell_sizes);
+
+    // Single-cell-refinement for the only cell contained in lgr grid.
+    const auto& [lgr_ptr,
+                 lgr_parentCorners_to_equivalentRefinedCorners,
+                 lgr_parentFace_to_itsRefinedFaces,
+                 lgr_parentCell_to_itsRefinedCells,
+                 lgr_refinedFace_to_itsParentFace,
+                 lgr_refinedCell_to_itsParentCell]
+        = lgr.currentData().back()->refineSingleCell(lgr_dim, 0);
+    return lgr_ptr;
+}
+
+
+BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_x)
+{
+    // lgr1 and lgr2 grids mimick single-cell-refinements sharing I_FACE: | 0 | 1 |
+
+    // Refine grids lgr1 and lgr2.
+    const std::array<int, 3>& lgr1_dim = {3,3,3};
+    const std::array<int, 3>& lgr2_dim = {4,3,3};
+    // Number of subbivisions in y- and z- direction must coincide, when cells
+    // from different LGRs share I_FACEs. In x-direction, they can differ.
+
+    const auto& lgr1_ptr = createSingleCellGridAndRefine(lgr1_dim);
+    const auto& lgr2_ptr = createSingleCellGridAndRefine(lgr2_dim);
+
+    // Illustration of cells on the boundary between LGR1 and LGR2, for k=1,
+    // if LGR1 refines cell 0 and LGR2 refined cell 1.
+    //      LGR1   LGR2
+    //  15 16 17 | 20 21 22 23
+    //  12 13 14 | 16 17 18 19
+    //   9 10 11 | 12 13 14 15
+
+    // elem 14 from lgr1 face {I true}
+    // should coincide with
+    // elem 16 from lgr2 face {I false}
+
+    // Recall how the 6 faces of a cell are stored in cell_to_face_
+    // in Geometry::refine
+    // cell_to_face_ [ element ] = {{K false}, {J false}, {I false}, {I true}, {J true}, {K true}}.
+    const auto& faceTrue_lgr1 = lgr1_ptr-> cellFace( /*elemIdx*/ 14, /*local face index*/ 3); // I true for elem14_lgr1
+    const auto& faceFalse_lgr2 = lgr2_ptr -> cellFace( /*elemIdx*/ 16, /*local face index*/ 2); // I false for elem16_lgr2
+
+    BOOST_CHECK_EQUAL( replaceLgr1FaceIdxByLgr2FaceIdx(lgr1_dim, faceTrue_lgr1, lgr1_ptr, lgr2_dim), faceFalse_lgr2);
+    BOOST_CHECK_EQUAL( replaceLgr1FaceIdxByLgr2FaceIdx(lgr2_dim, faceFalse_lgr2, lgr2_ptr, lgr1_dim), faceTrue_lgr1);
+
+    // Illustration of cells on the boundary between LGR1 and LGR2, for k=1,
+    // if LGR2 refines cell 0 and LGR1 refines cell 1.
+    //         LGR2   LGR1
+    //  20 21 22 23 | 15 16 17
+    //  16 17 18 19 | 12 13 14
+    //  12 13 14 15 |  9 10 11
+
+    // elem 12 from lgr1 face {I true}
+    // should coincide with
+    // elem 19 from lgr2 face {I false}
+
+    const auto& faceTrue_lgr2 = lgr2_ptr-> cellFace( /*elemIdx*/ 19, /*local face index*/ 3);; // I true for elem19_lgr2
+    const auto& faceFalse_lgr1 = lgr1_ptr -> cellFace( /*elemIdx*/ 12, /*local face index*/ 2); // I false for elem12_lgr1
+
+    BOOST_CHECK_EQUAL( replaceLgr1FaceIdxByLgr2FaceIdx(lgr2_dim, faceTrue_lgr2, lgr2_ptr, lgr1_dim), faceFalse_lgr1);
+    BOOST_CHECK_EQUAL( replaceLgr1FaceIdxByLgr2FaceIdx(lgr1_dim, faceFalse_lgr1, lgr1_ptr, lgr2_dim), faceTrue_lgr2);
+
+    // lgr1 has 108 faces (with indices 0, ..., 107).
+    // lgr2 has 141 faces (with indices 0, ..., 140).
+    const auto& non_existing_face = 141; // non exisitng face index for both lgrs.
+    BOOST_CHECK_THROW( replaceLgr1FaceIdxByLgr2FaceIdx(lgr1_dim, non_existing_face, lgr1_ptr, lgr2_dim), std::logic_error);
+    BOOST_CHECK_THROW( replaceLgr1FaceIdxByLgr2FaceIdx(lgr2_dim, non_existing_face, lgr2_ptr, lgr1_dim), std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_y)
+{
+    // lgr1 and lgr2 mimick a coarse grid having 2 cells sharing J_FACE:
+    //   / 1 /
+    //   ---   shared J_FACE
+    //  / 0 /
+    //  ---
+
+    // Refine grids lgr1 and lgr2.
+    const std::array<int, 3>& lgr1_dim = {3,3,3};
+    const std::array<int, 3>& lgr2_dim = {3,4,3};
+    // Number of subbivisions in x- and z- direction must coincide, when cells
+    // from different LGRs share J_FACEs. In y-direction, they can differ.
+    const auto& lgr1_ptr = createSingleCellGridAndRefine(lgr1_dim);
+    const auto& lgr2_ptr = createSingleCellGridAndRefine(lgr2_dim);
+
+    // Illustration of cells on the boundary between LGR1 and LGR2, for k=1,
+    // if LGR1 refines cell 0 and LGR2 refined cell 1.
+    //        21 22 23  LGR2
+    //       18 19 20
+    //      15 16 17
+    //     12 13 14
+    //    ---------
+    //    15 16 17      LGR1
+    //   12 13 14
+    //  9 10 11
+
+    // elem 16 from lgr1 face {J true}
+    // should coincide with
+    // elem 13 from lgr2 face {J false}
+
+    // Recall how the 6 faces of a cell are stored in cell_to_face_
+    // in Geometry::refine
+    // cell_to_face_ [ element ] = {{K false}, {J false}, {I false}, {I true}, {J true}, {K true}}.
+    const auto& faceTrue_lgr1 = lgr1_ptr-> cellFace( /*elemIdx*/ 16, /*local face index*/ 4); // J true for elem16_lgr1
+    const auto& faceFalse_lgr2 = lgr2_ptr -> cellFace( /*elemIdx*/ 13, /*local face index*/ 1); // J false for elem13_lgr2
+
+    BOOST_CHECK_EQUAL( replaceLgr1FaceIdxByLgr2FaceIdx(lgr1_dim, faceTrue_lgr1, lgr1_ptr, lgr2_dim), faceFalse_lgr2);
+    BOOST_CHECK_EQUAL( replaceLgr1FaceIdxByLgr2FaceIdx(lgr2_dim, faceFalse_lgr2, lgr2_ptr, lgr1_dim), faceTrue_lgr1);
+
+
+    // Illustration of cells on the boundary between LGR1 and LGR2, for k=1,
+    // if LGR1 refines cell 1 and LGR2 refined cell 0.
+    //        15 16 17  LGR1
+    //       12 13 14
+    //      9 10 11
+    //     -------
+    //    21 22 23      LGR2
+    //   18 19 20
+    //  15 16 17
+    // 12 13 14
+
+    // elem 10 from lgr1 face {J false}
+    // should coincide with
+    // elem 22 from lgr2 face {J true}
+
+    const auto& faceTrue_lgr2 = lgr2_ptr-> cellFace( /*elemIdx*/ 22, /*local face index*/ 4); // J true for elem22_lgr2
+    const auto& faceFalse_lgr1 = lgr1_ptr -> cellFace( /*elemIdx*/ 10, /*local face index*/ 1); // J false for elem10_lgr1
+
+    BOOST_CHECK_EQUAL( replaceLgr1FaceIdxByLgr2FaceIdx(lgr2_dim, faceTrue_lgr2, lgr2_ptr, lgr1_dim), faceFalse_lgr1);
+    BOOST_CHECK_EQUAL( replaceLgr1FaceIdxByLgr2FaceIdx(lgr1_dim, faceFalse_lgr1, lgr1_ptr, lgr2_dim), faceTrue_lgr2);
+
+}
+
+BOOST_AUTO_TEST_CASE(neighboring_singleCellRefinements_z)
+{
+    // lgr1 and lgr2  mimick a coarse grid has 2 cells sharing K_FACE:
+    //   / 1 /
+    //   ---   shared K_FACE
+    //  / 0 /
+    //  ---
+
+    // Refine grids lgr1 and lgr2.
+    const std::array<int, 3>& lgr1_dim = {3,3,3};
+    const std::array<int, 3>& lgr2_dim = {3,3,4};
+    // Number of subbivisions in x- and y- direction must coincide, when cells
+    // from different LGRs share K_FACEs. In z-direction, they can differ.
+    const auto& lgr1_ptr = createSingleCellGridAndRefine(lgr1_dim);
+    const auto& lgr2_ptr = createSingleCellGridAndRefine(lgr2_dim);
+
+    // Illustration of cells on the boundary between LGR1 and LGR2,
+    // if LGR1 refines cell 1 and LGR2 refined cell 0.
+    //         6  7  8  LGR2 BOTTOM
+    //        3  4  5
+    //       0  1  2
+    //      ------
+    //     24 25 26  LGR1 TOP
+    //    21 22 23
+    //   18 19 20
+
+    // elem 22 from lgr1 {K true}
+    // should coincide with
+    // elem 4 from lgr2 {K false}
+
+    // Recall how the 6 faces of a cell are stored in cell_to_face_
+    // in Geometry::refine
+    // cell_to_face_ [ element ] = {{K false}, {J false}, {I false}, {I true}, {J true}, {K true}}.
+    const auto& faceTrue_lgr1 = lgr1_ptr-> cellFace( /*elemIdx*/ 22, /*local face index*/ 5); // J true for elem22_lgr1
+    const auto& faceFalse_lgr2 = lgr2_ptr -> cellFace( /*elemIdx*/ 4, /*local face index*/ 0); // K false for elem4_lgr2
+
+    BOOST_CHECK_EQUAL( replaceLgr1FaceIdxByLgr2FaceIdx(lgr1_dim, faceTrue_lgr1, lgr1_ptr, lgr2_dim), faceFalse_lgr2);
+    BOOST_CHECK_EQUAL( replaceLgr1FaceIdxByLgr2FaceIdx(lgr2_dim, faceFalse_lgr2, lgr2_ptr, lgr1_dim), faceTrue_lgr1);
+
+
+    // Illustration of cells on the boundary between LGR1 and LGR2,
+    // if LGR1 refines cell 1 and LGR2 refined cell 0.
+    //         6  7  8  LGR1 BOTTOM
+    //        3  4  5
+    //       0  1  2
+    //     -------
+    //    33 34 35      LGR2 TOP
+    //   30 31 32
+    //  27 28 29
+
+
+    // elem 4 from lgr1 face {K false}
+    // should coincide with
+    // elem 31 from lgr2 {K true}
+
+    const auto& faceTrue_lgr2 = lgr2_ptr-> cellFace( /*elemIdx*/ 31, /*local face index*/ 5);; // K true for elem31_lgr2
+    const auto& faceFalse_lgr1 = lgr1_ptr -> cellFace( /*elemIdx*/ 4, /*local face index*/ 0); // K false for elem4_lgr1
+
+    BOOST_CHECK_EQUAL( replaceLgr1FaceIdxByLgr2FaceIdx(lgr2_dim, faceTrue_lgr2, lgr2_ptr, lgr1_dim), faceFalse_lgr1);
+    BOOST_CHECK_EQUAL( replaceLgr1FaceIdxByLgr2FaceIdx(lgr1_dim, faceFalse_lgr1, lgr1_ptr, lgr2_dim), faceTrue_lgr2);
+}
+


### PR DESCRIPTION
Toward supporting adding LGRs after distributing level zero grid, this PR removes the symmetry assumption when searching parent face of refined faces.

Symmetry assumption: 
To add LGRs on the grid, we loop on the elements. If an element got marked for refinement, we do a single-cell-refinement. To create the refined level grids and the leaf grid view, we analyze different cases when two neighboring cells got refined, and discard repetition of refined faces and corners. With this in mind, the methods replaceLgr1CornerIdxByLgr2CornerIdx and replaceLgr1FaceIdxByLgr2FaceIdx help us to translate the index of a new refined corner or face from one single-cell-refinement to its neighboring single-cell-refinement. 

Two neighboring coarse elements with indices '1' and '2' get refined into single-cell-refinements denoted by elemLgr1 and elemLgr1 and elemLgr2. 
Old code assumed elemLgr1 < elemLgr2 implies that the shared face is one of {I_FACE true}, {J_FACE, true}, {K_FACE true}, which is true sometimes, for example in a serial run with all active cells. 
This PR removes that assumption, adding the other cases (false oriented faces).

Not relevant for the Reference Manual. 