### PR TITLE
AllowDistributedWells with (default) partitioning method 3

### DIFF
--- a/opm/grid/GraphOfGridWrappers.hpp
+++ b/opm/grid/GraphOfGridWrappers.hpp
@@ -267,6 +267,7 @@ zoltanPartitioningWithGraphOfGrid(const Dune::CpGrid& grid,
                                   Dune::EdgeWeightMethod edgeWeightMethod,
                                   int root,
                                   const double zoltanImbalanceTol,
+                                  bool allowDistributedWells,
                                   const std::map<std::string,std::string>& params);
 
 /// \brief Make complete export lists from a vector holding destination rank for each global ID
@@ -295,6 +296,7 @@ zoltanSerialPartitioningWithGraphOfGrid(const Dune::CpGrid& grid,
                                         Dune::EdgeWeightMethod edgeWeightMethod,
                                         int root,
                                         const double zoltanImbalanceTol,
+                                        bool allowDistributedWells,
                                         const std::map<std::string,std::string>& params);
 #endif // HAVE_MPI
 

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -172,7 +172,6 @@ CpGrid::CpGrid()
     current_view_data_ = data_[0].get();
     current_data_ = &data_;
     global_id_set_ptr_ = std::make_shared<cpgrid::GlobalIdSet>(*current_view_data_);
-    
 }
 
 CpGrid::CpGrid(MPIHelper::MPICommunicator comm)
@@ -186,7 +185,6 @@ CpGrid::CpGrid(MPIHelper::MPICommunicator comm)
     current_view_data_ = data_[0].get();
     current_data_ = &data_;
     global_id_set_ptr_ = std::make_shared<cpgrid::GlobalIdSet>(*current_view_data_);
-    
 }
 
 std::vector<int>
@@ -359,8 +357,8 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
 #ifdef HAVE_ZOLTAN
                 std::tie(computedCellPart, wells_on_proc, exportList, importList, wellConnections)
                     = serialPartitioning
-                    ? Opm::zoltanSerialPartitioningWithGraphOfGrid(*this, wells, possibleFutureConnections, transmissibilities, cc, method, 0, imbalanceTol, partitioningParams)
-                    : Opm::zoltanPartitioningWithGraphOfGrid(*this, wells, possibleFutureConnections, transmissibilities, cc, method, 0, imbalanceTol, partitioningParams);
+                    ? Opm::zoltanSerialPartitioningWithGraphOfGrid(*this, wells, possibleFutureConnections, transmissibilities, cc, method, 0, imbalanceTol, allowDistributedWells, partitioningParams)
+                    : Opm::zoltanPartitioningWithGraphOfGrid(*this, wells, possibleFutureConnections, transmissibilities, cc, method, 0, imbalanceTol, allowDistributedWells, partitioningParams);
 #else
                 OPM_THROW(std::runtime_error, "Parallel runs depend on ZOLTAN if useZoltan is true. Please install!");
 #endif // HAVE_ZOLTAN


### PR DESCRIPTION
Switch off the merging of the well cells when `--allowDistributedWells==true`.

This goes against the nature of the partitioner that was designed to allow cell merging. However, with this flag set to true the partitioning results are still different<sup>1</sup> to `partitioning-method=1` (normal Zoltan). For this reason I think it is better to switch off the main feature of this partitioner instead of delegating the work to the partitioning method 1 when the `--allowDistributedWells==true`.

<sup>1</sup> From my limited experimenting, the partitioning of method 3 has fewer overlap cells than method 1. It is also slower on a small grid but gets faster on a big grid (limited testing! one grid with >1.5 million cells) and needs a negligible amount of extra memory (less than 1% extra, and there are procedures before and after partitioning that demand more memory - it is far from peak requirements).