### PR TITLE
Do not throw in getLevelElem() and remove getEquivLevelElem()

### DIFF
--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -285,11 +285,8 @@ public:
     ///                    its "origin".
     Entity<0> getOrigin() const;
 
-    /// \brief To be invoked only for leaf-grid-view entities. Get equivalent element on the level grid the leaf-entity was born.
-    Entity<0> getLevelElem() const;
-
     /// \brief Get equivalent element on the level grid where the entity was born, if grid = leaf-grid-view. Otherwise, return itself.
-    Entity<0> getEquivLevelElem() const;
+    Entity<0> getLevelElem() const;
 
     /// \brief Get Cartesian Index in the level grid view where the Entity was born.
     int getLevelCartesianIdx() const;
@@ -575,22 +572,6 @@ template<int codim>
 Dune::cpgrid::Entity<0> Dune::cpgrid::Entity<codim>::getLevelElem() const
 {
     // Check that the element belongs to the leaf grid view
-    // This is needed to get the index of the element in the level it was born.
-    // leaf_to_level_cells_ [leaf idx] = {level where the entity was born, equivalent cell idx in that level}
-    if (!(pgrid_ -> leaf_to_level_cells_.empty())) // entity on the LeafGridView
-    {
-        const int& entityLevelIdx = pgrid_->leaf_to_level_cells_[this->index()][1];
-        return Dune::cpgrid::Entity<0>( *((*(pgrid_ -> level_data_ptr_))[this->level()].get()), entityLevelIdx, true);
-    }
-    else {
-        throw std::invalid_argument("The entity provided does not belong to the leaf grid view. ");
-    }
-}
-
-template<int codim>
-Dune::cpgrid::Entity<0> Dune::cpgrid::Entity<codim>::getEquivLevelElem() const
-{
-    // Check if the element belongs to the leaf grid view
     // This is needed to get the index of the element in the level it was born.
     // leaf_to_level_cells_ [leaf idx] = {level where the entity was born, equivalent cell idx in that level}
     if (!(pgrid_ -> leaf_to_level_cells_.empty())) // entity on the LeafGridView

--- a/opm/grid/cpgrid/Indexsets.hpp
+++ b/opm/grid/cpgrid/Indexsets.hpp
@@ -263,7 +263,7 @@ namespace Dune
                     // Level 1, 2, ...., maxLevel refined grids
                     if ( (gridIdx>0) && (gridIdx < static_cast<int>(grid_.levelData().size() -1)) ) {
                         if ((e.level() != gridIdx)) { // cells equiv to pre-existing cells
-                            return  grid_.levelData()[e.level()]->localIdSet().id(e.getEquivLevelElem());
+                            return  grid_.levelData()[e.level()]->localIdSet().id(e.getLevelElem());
                         }
                         else {
                             // Count (and add to myId) all the entities of all the codimensions (for CpGrid, only 0 and 3)

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -393,7 +393,7 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
             allIds_set.insert(localId);
             allIds_vec.push_back(localId);
             // Check that the global_id_set_ptr_ has the correct id (id from the level where the entity was born).
-            BOOST_CHECK_EQUAL( coarse_grid.globalIdSet().id(element), data[element.level()]->localIdSet().id(element.getEquivLevelElem()));
+            BOOST_CHECK_EQUAL( coarse_grid.globalIdSet().id(element), data[element.level()]->localIdSet().id(element.getLevelElem()));
         }
         // Check injectivity of the map local_id_set_ (and, indirectly, global_id_set_) after adding cell ids.
         BOOST_CHECK( allIds_set.size() == allIds_vec.size());
@@ -434,7 +434,7 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
                   [localId, data](const Dune::cpgrid::Entity<0>& leafElem)
                   { return (localId == data.back()->localIdSet().id(leafElem)); });
                   itIsLeaf != elements(coarse_grid.leafGridView()).end()) {
-                  BOOST_CHECK( itIsLeaf->getEquivLevelElem() == element);
+                  BOOST_CHECK( itIsLeaf->getLevelElem() == element);
                   }*/
                 if (element.isLeaf()) { // Check that the id of a cell not involved in any further refinement appears on the IdSet of the leaf grid view.
                     BOOST_CHECK( std::find(allIds_set.begin(), allIds_set.end(), localId) != allIds_set.end());

--- a/tests/cpgrid/addLgrsOnDistributedGrid_test.cpp
+++ b/tests/cpgrid/addLgrsOnDistributedGrid_test.cpp
@@ -342,7 +342,7 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
         allIds_set.insert(localId);
         allIds_vec.push_back(localId);
         // Check that the global_id_set_ptr_ has the correct id (id from the level where the entity was born).
-        BOOST_CHECK_EQUAL( coarse_grid.globalIdSet().id(element), data[element.level()]->globalIdSet().id(element.getEquivLevelElem()));
+        BOOST_CHECK_EQUAL( coarse_grid.globalIdSet().id(element), data[element.level()]->globalIdSet().id(element.getLevelElem()));
     }
     // Check injectivity of the map local_id_set_ (and, indirectly, global_id_set_) after adding cell ids.
     BOOST_CHECK( allIds_set.size() == allIds_vec.size());
@@ -385,7 +385,7 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
     localInteriorCellIds_vec.reserve(data.back()->size(0)); // more than actually needed since only care about interior cells
     int local_interior_cells_count = 0;
     for (const auto& element: elements(coarse_grid.leafGridView())) {
-        const auto& elemPartitionType = element.getEquivLevelElem().partitionType();
+        const auto& elemPartitionType = element.getLevelElem().partitionType();
         if ( elemPartitionType == Dune::InteriorEntity) {
             localInteriorCellIds_vec.push_back(data.back()->globalIdSet().id(element));
             ++local_interior_cells_count;
@@ -423,7 +423,7 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
                                               [localId, data](const Dune::cpgrid::Entity<0>& leafElem)
                                               { return (localId == data.back()->localIdSet().id(leafElem)); });
                 itIsLeaf != elements(coarse_grid.leafGridView()).end()) {
-                BOOST_CHECK( itIsLeaf->getEquivLevelElem() == element);
+                BOOST_CHECK( itIsLeaf->getLevelElem() == element);
             }
             if (element.isLeaf()) { // Check that the id of a cell not involved in any further refinement appears on the IdSet of the leaf grid view.
                 BOOST_CHECK( std::find(allIds_set.begin(), allIds_set.end(), localId) != allIds_set.end());

--- a/tests/cpgrid/grid_lgr_test.cpp
+++ b/tests/cpgrid/grid_lgr_test.cpp
@@ -502,7 +502,7 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
             allIds_set.insert(localId);
             allIds_vec.push_back(localId);
             // Check that the global_id_set_ptr_ has the correct id (id from the level where the entity was born).
-            BOOST_CHECK_EQUAL( coarse_grid.globalIdSet().id(element), data[element.level()]->localIdSet().id(element.getEquivLevelElem()));
+            BOOST_CHECK_EQUAL( coarse_grid.globalIdSet().id(element), data[element.level()]->localIdSet().id(element.getLevelElem()));
         }
         // Check injectivity of the map local_id_set_ (and, indirectly, global_id_set_) after adding cell ids.
         BOOST_CHECK( allIds_set.size() == allIds_vec.size());
@@ -537,7 +537,7 @@ void refinePatch_and_check(Dune::CpGrid& coarse_grid,
                                                   [localId, data](const Dune::cpgrid::Entity<0>& leafElem)
                                                   { return (localId == data.back()->localIdSet().id(leafElem)); });
                     itIsLeaf != elements(coarse_grid.leafGridView()).end()) {
-                    BOOST_CHECK( itIsLeaf->getEquivLevelElem() == element);
+                    BOOST_CHECK( itIsLeaf->getLevelElem() == element);
                 }
                 if (element.isLeaf()) { // Check that the id of a cell not involved in any further refinement appears on the IdSet of the leaf grid view.
                     BOOST_CHECK( std::find(allIds_set.begin(), allIds_set.end(), localId) != allIds_set.end());

--- a/tests/cpgrid/inactiveCell_lgr_test.cpp
+++ b/tests/cpgrid/inactiveCell_lgr_test.cpp
@@ -318,7 +318,7 @@ void testInactiveCellsLgrs(const std::string& deckString,
             allIds_set.insert(localId);
             allIds_vec.push_back(localId);
             // Check that the global_id_set_ptr_ has the correct id (id from the level where the entity was born).
-            BOOST_CHECK_EQUAL( grid.globalIdSet().id(element), (*data[element.level()]).globalIdSet().id(element.getEquivLevelElem()));
+            BOOST_CHECK_EQUAL( grid.globalIdSet().id(element), (*data[element.level()]).globalIdSet().id(element.getLevelElem()));
         }
         // Check injectivity of the map local_id_set_ (and, indirectly, global_id_set_) after adding cell ids.
         BOOST_CHECK( allIds_set.size() == allIds_vec.size());
@@ -355,7 +355,7 @@ void testInactiveCellsLgrs(const std::string& deckString,
                                                   [localId, data](const Dune::cpgrid::Entity<0>& leafElem)
                                                   { return (localId == data.back()->localIdSet().id(leafElem)); });
                     itIsLeaf != elements(grid.leafGridView()).end()) {
-                    BOOST_CHECK( itIsLeaf->getEquivLevelElem() == element);
+                    BOOST_CHECK( itIsLeaf->getLevelElem() == element);
                 }
                 if (element.isLeaf()) { // Check that the id of a cell not involved in any further refinement appears on the IdSet of the leaf grid view.
                     BOOST_CHECK( std::find(allIds_set.begin(), allIds_set.end(), localId) != allIds_set.end());

--- a/tests/cpgrid/lgr_cartesian_idx_test.cpp
+++ b/tests/cpgrid/lgr_cartesian_idx_test.cpp
@@ -106,12 +106,12 @@ void checkGlobalCellLgr(Dune::CpGrid& grid)
         // How to get the Level Cartesian Index of a cell on the leaf grid view.
         // Each LGR can be seen as a Cartesian Grid itself, with its own (local) logical_cartesian_size and its own (local) Cartesian indices.
         // Given a leaf cell, via the CartesianIndexMapper and its method cartesianIndexLevel(...), we get the local-Cartesian-index.
-        const auto& cartesian_idx_from_level_elem =  levelCartMapp.cartesianIndex( element.getEquivLevelElem().index(), element.level() );
-        const auto& global_cell_idx_level = grid.currentData()[element.level()]->globalCell()[element.getEquivLevelElem().index()];
+        const auto& cartesian_idx_from_level_elem =  levelCartMapp.cartesianIndex( element.getLevelElem().index(), element.level() );
+        const auto& global_cell_idx_level = grid.currentData()[element.level()]->globalCell()[element.getLevelElem().index()];
         BOOST_CHECK_EQUAL(cartesian_idx_from_level_elem, global_cell_idx_level);
         // local_ijk represents the ijk values of the equivalent cell on the level its was born.
         std::array<int,3> local_ijk = {0,0,0};
-        levelCartMapp.cartesianCoordinate( element.getEquivLevelElem().index(), local_ijk, element.level() );
+        levelCartMapp.cartesianCoordinate( element.getLevelElem().index(), local_ijk, element.level() );
 
         // For leaf cells that were not involved in any refinement, global_ijk and local_ijk must coincide.
         if(element.level()==0)


### PR DESCRIPTION
getLevelElem() throws an exception if the grid view is not a leaf, whereas getEquivLevelElem() always returns an entity regardless of the grid view state.

This PR merges both methods into a single one that no longer throws an exception.

Not relevant for the reference manual.