### PR TITLE
anonymize unused parameters

### DIFF
--- a/examples/finitevolume/transportproblem2.hh
+++ b/examples/finitevolume/transportproblem2.hh
@@ -22,7 +22,7 @@ double c0 (const Dune::FieldVector<ct,dimworld>& x)
 
 // the boundary condition b on inflow boundary
 template<int dimworld, class ct>
-double b (const Dune::FieldVector<ct,dimworld>& x, double t)
+double b (const Dune::FieldVector<ct,dimworld>& /*x*/, double /*t*/)
 {
   return 0.0;
   // if (x.two_norm()<t+0.125)


### PR DESCRIPTION
That was stupid. Quell sca issue just to introduce compiler warnings was not the intention.