### PR TITLE
Add and require partition support to ElementChunks.

### DIFF
--- a/examples/griditer.cpp
+++ b/examples/griditer.cpp
@@ -88,7 +88,7 @@ int main(int argc, char** argv)
         omp_set_num_threads(num_threads);
         Opm::time::StopWatch clock;
         clock.start();
-        Opm::ElementChunks chunks(gv, num_threads);
+        Opm::ElementChunks chunks(gv, Dune::Partitions::all, num_threads);
 #pragma omp parallel for
         for (const auto& chunk : chunks) {
             for (const auto& elem : chunk) {

--- a/opm/grid/utility/ElementChunks.hpp
+++ b/opm/grid/utility/ElementChunks.hpp
@@ -22,6 +22,7 @@
 #include <opm/grid/utility/createThreadIterators.hpp>
 
 #include <cstddef>
+#include <iterator>
 #include <utility>
 #include <vector>
 
@@ -71,18 +72,21 @@ namespace Opm
 ///         // Do something else with elem
 ///     }
 /// }
-template <class GridView>
+template <class GridView, class PartitionSet>
 class ElementChunks
 {
 private:
-    using Iter = typename GridView::template Codim<0>::Iterator;
+    using Iter = decltype(std::begin(elements(std::declval<const GridView&>(), PartitionSet())));
     using Storage = std::vector<Iter>;
     using StorageIter = decltype(Storage().cbegin());
 
 public:
-    ElementChunks(const GridView& gv, const std::size_t num_chunks)
+    ElementChunks(const GridView& gv,
+                  const PartitionSet included_partition,
+                  const std::size_t num_chunks)
     {
-        grid_chunk_iterators_ = Opm::createChunkIterators(elements(gv), gv.size(0), num_chunks);
+        grid_chunk_iterators_
+            = Opm::createChunkIterators(elements(gv, included_partition), gv.size(0), num_chunks);
     }
 
     struct Chunk


### PR DESCRIPTION
Existing code would always include all cells, i.e. Dune::Partitions::all, the new code enables you to only do Dune::Partitions::interior for example. It also requires this argument (no default) to force the user to think through what is the correct partition to iterate over.

Draft PR for now, as it will require downstream changes.