### PR TITLE
Bugfix: case with no wells

### DIFF
--- a/opm/grid/GraphOfGrid.cpp
+++ b/opm/grid/GraphOfGrid.cpp
@@ -39,7 +39,7 @@ void GraphOfGrid<Grid>::createGraph (const double* transmissibilities,
     WeightType logMinTransm = std::numeric_limits<WeightType>::max();
     if (transmissibilities && edgeWeightMethod==Dune::EdgeWeightMethod::logTransEdgeWgt)
     {
-        for (int face = 0; face < getGrid().numFaces(); ++face)
+        for (int face = 0; face < grid.numFaces(); ++face)
         {
             WeightType transm = transmissibilities[face];
             if (transm > 0 && transm < logMinTransm)

--- a/opm/grid/GraphOfGridWrappers.cpp
+++ b/opm/grid/GraphOfGridWrappers.cpp
@@ -475,6 +475,11 @@ makeImportAndExportLists(const GraphOfGrid<Dune::CpGrid>& gog,
         auto wellRanks = getWellRanks(gIDtoRank, wellConnections);
         parallel_wells = wellsOnThisRank(*wells, wellRanks, cc, root);
     }
+    else
+    {
+        std::sort(myExportList.begin(), myExportList.end());
+        std::sort(myImportList.begin(), myImportList.end());
+    }
     return std::make_tuple( std::move(gIDtoRank),
                             std::move(parallel_wells),
                             std::move(myExportList),
@@ -550,8 +555,8 @@ zoltanPartitioningWithGraphOfGrid(const Dune::CpGrid& grid,
     // non-root processes have empty grid and no wells
     GraphOfGrid gog(grid, transmissibilities, edgeWeightMethod);
     assert(gog.size()==0 || !partitionIsEmpty);
-    auto wellConnections=partitionIsEmpty ? Dune::cpgrid::WellConnections()
-                                          : Dune::cpgrid::WellConnections(*wells, possibleFutureConnections, grid);
+    auto wellConnections = partitionIsEmpty || !wells ? Dune::cpgrid::WellConnections()
+                                                      : Dune::cpgrid::WellConnections(*wells, possibleFutureConnections, grid);
     addWellConnections(gog, wellConnections);
     gog.addNeighboringCellsToWells(layers);
 
@@ -723,7 +728,7 @@ zoltanSerialPartitioningWithGraphOfGrid(const Dune::CpGrid& grid,
     std::vector<std::tuple<int, int, char, int>> myImportList;
     std::vector<std::vector<int>> exportedCells;
     auto wellConnections = partitionIsEmpty || !wells ? Dune::cpgrid::WellConnections()
-                                            : Dune::cpgrid::WellConnections(*wells, possibleFutureConnections, grid);
+                                                      : Dune::cpgrid::WellConnections(*wells, possibleFutureConnections, grid);
 
     if (cc.rank() == root) {
         std::tie(rc, gIDtoRank) = applySerialZoltan(grid,


### PR DESCRIPTION
Fix the partitioning for the case without any wells. The problem was dereferencing of the null pointer in the call of the constructor of WellConnections. Moreover, the sorting of the lists was skipped.

I noticed this bug while working on the small PR #840 but a partial fix already appeared in the PR #837.

The PR #840 made the `zoltanGoG` default partitioner of the `CpGrid` for the cases when wells are used, following the changes in opm-simulators. The `CpGrid`'s `loadBalance` method without wells keep `zoltan` as the default partitioner. (There is no need to construct the graph representation of the grid to give the partitioner the same information. There is one small difference, namely that `zoltanGoG` stores global IDs in an unordered map so the partitioning tool loads them in a different order. That often leads to a different partitioning of the same quality.)