### PR TITLE
[Bugfix] work around buggy cpgrid copy

### DIFF
--- a/opm/grid/common/GridPartitioning.cpp
+++ b/opm/grid/common/GridPartitioning.cpp
@@ -551,15 +551,15 @@ void addOverlapLayerNoZeroTrans(const CpGrid& grid,
     }
 }
 
-int addOverlapLayer(const CpGrid& grid,
-                    const std::vector<int>& cell_part,
-                    std::vector<std::tuple<int,int,char>>& exportList,
-                    std::vector<std::tuple<int,int,char,int>>& importList,
-                    const Communication<Dune::MPIHelper::MPICommunicator>& cc,
+int addOverlapLayer([[maybe_unused]] const CpGrid& grid,
+                    [[maybe_unused]] const std::vector<int>& cell_part,
+                    [[maybe_unused]] std::vector<std::tuple<int,int,char>>& exportList,
+                    [[maybe_unused]] std::vector<std::tuple<int,int,char,int>>& importList,
+                    [[maybe_unused]] const Communication<Dune::MPIHelper::MPICommunicator>& cc,
                     [[maybe_unused]] bool addCornerCells,
                     [[maybe_unused]] const double* trans,
-                    int layers,
-                    int level)
+                    [[maybe_unused]] int layers,
+                    [[maybe_unused]] int level)
 {
 #ifdef HAVE_MPI
     using AttributeSet = Dune::cpgrid::CpGridData::AttributeSet;
@@ -663,13 +663,6 @@ int addOverlapLayer(const CpGrid& grid,
               { return std::get<0>(t1) < std::get<0>(t2);});
     return importOwnerSize;
 #else
-    static_cast<void> grid;
-    static_cast<void> cell_part;
-    static_cast<void> exportList;
-    static_cast<void> importList;
-    static_cast<void> cc;
-    static_cast<void> layers;
-    static_cast<void> level;
     DUNE_THROW(InvalidStateException, "MPI is missing from the system");
 
     return 0;

--- a/tests/cpgrid/addLgrsOnDistributedGrid_test.cpp
+++ b/tests/cpgrid/addLgrsOnDistributedGrid_test.cpp
@@ -88,9 +88,8 @@ void check(const Dune::CpGrid& grid,
     */
 }
 
-std::pair<Dune::CpGrid, std::vector<int>> createTestCartesianGridAndParts()
+std::vector<int> createTestCartesianGridAndParts(Dune::CpGrid& grid)
 {
-    Dune::CpGrid grid;
     grid.createCartesian({4,3,3} /*grid_dim*/, {1.0, 1.0, 1.0} /*cell_sizes*/);
 
     std::vector<int> parts(36);
@@ -103,12 +102,13 @@ std::pair<Dune::CpGrid, std::vector<int>> createTestCartesianGridAndParts()
             parts[elemIdx] = rank;
         }
     }
-    return std::make_pair(grid, parts);
+    return parts;
 }
 
 BOOST_AUTO_TEST_CASE(fullyInteriorLgrsHaveUniqueVertexGlobalIds)
 {
-    auto [grid, parts]  = createTestCartesianGridAndParts();
+    Dune::CpGrid grid;
+    auto parts  = createTestCartesianGridAndParts(grid);
 
     if(grid.comm().size()>1)
     {
@@ -136,7 +136,8 @@ BOOST_AUTO_TEST_CASE(fullyInteriorLgrsHaveUniqueVertexGlobalIds)
 
 BOOST_AUTO_TEST_CASE(interiorLgrWithOverlapNeighborHasUniqueVertexGlobalIdsIfAddCornerCellsIsTrue)
 {
-    auto [grid, parts]  = createTestCartesianGridAndParts();
+    Dune::CpGrid grid;
+    auto parts  = createTestCartesianGridAndParts(grid);
 
     if(grid.comm().size()>1)
     {
@@ -165,7 +166,8 @@ BOOST_AUTO_TEST_CASE(interiorLgrWithOverlapNeighborHasUniqueVertexGlobalIdsIfAdd
 
 BOOST_AUTO_TEST_CASE(distributedLgrHasUniqueVertexGlobalIdsIfAddCornerCellsTrue)
 {
-    auto [grid, parts]  = createTestCartesianGridAndParts();
+    Dune::CpGrid grid;
+    auto parts  = createTestCartesianGridAndParts(grid);
 
     if(grid.comm().size()>1)
     {
@@ -190,7 +192,8 @@ BOOST_AUTO_TEST_CASE(distributedLgrHasUniqueVertexGlobalIdsIfAddCornerCellsTrue)
 
 BOOST_AUTO_TEST_CASE(distributedLgrFailsVertexGlobalIdsUniquenessWithAddCornerCellsTrue)
 {
-    auto [grid, parts]  = createTestCartesianGridAndParts();
+    Dune::CpGrid grid;
+    auto parts   = createTestCartesianGridAndParts(grid);
 
     if(grid.comm().size()>1)
     {
@@ -225,7 +228,8 @@ BOOST_AUTO_TEST_CASE(distributedLgrFailsVertexGlobalIdsUniquenessWithAddCornerCe
 
 BOOST_AUTO_TEST_CASE(callAdaptWithArgsIsEquivalentToCallAddLgrsUpdateLeafGridViewOnDistributedCoarseGrid)
 {
-    auto [grid, parts]  = createTestCartesianGridAndParts();
+    Dune::CpGrid grid;
+    auto parts = createTestCartesianGridAndParts(grid);
 
     if(grid.comm().size()>1)
     {
@@ -255,7 +259,8 @@ BOOST_AUTO_TEST_CASE(callAdaptWithArgsIsEquivalentToCallAddLgrsUpdateLeafGridVie
 
 BOOST_AUTO_TEST_CASE(callAdaptWithoutArgsOnDistributedCoarseGrid)
 {
-    auto [grid, parts]  = createTestCartesianGridAndParts();
+    Dune::CpGrid grid;
+    auto parts = createTestCartesianGridAndParts(grid);
 
     if(grid.comm().size()>1)
     {

--- a/tests/cpgrid/distribute_level_zero_from_grid_with_lgrs_test.cpp
+++ b/tests/cpgrid/distribute_level_zero_from_grid_with_lgrs_test.cpp
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(distributeLevelZeroFromGridWithOneLgrAndAddSameLgrOnDistrib
     auto grid = createGridAndAddTestLgr();
 
     if (grid.comm().size()>1) {
-        
+
         grid.loadBalance(/*overlapLayers*/ 1,
                          /*partitionMethod*/ Dune::PartitionMethod::zoltanGoG,
                          /*imbalanceTol*/ 1.1,
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(distributeLevelZeroFromGridWithOneLgrAndAddSameLgrOnDistrib
 
         // Add 'the same LGR' in distributed_data_
         grid.switchToDistributedView();
-    
+
 
         grid.addLgrsUpdateLeafView(/*cells_per_dim_vec*/ {{3, 3, 3}},
                                    /*startIJK_vec*/ {{1, 1, 0}},
@@ -158,60 +158,66 @@ BOOST_AUTO_TEST_CASE(distributeLevelZeroFromGridWithOneLgrAndAddSameLgrOnDistrib
 BOOST_AUTO_TEST_CASE(distributeLevelZeroFromGridWithOneLgrWithZoltanOrMetisThrows)
 {
     auto grid = createGridAndAddTestLgr();
-        
-    BOOST_CHECK_THROW( grid.loadBalance(/*overlapLayers*/ 1,
-                                        /*partitionMethod*/ Dune::PartitionMethod::zoltan,
-                                        /*imbalanceTol*/ 1.1,
-                                        /*level*/ 0), std::logic_error);
-   
-    BOOST_CHECK_THROW( grid.loadBalance(/*overlapLayers*/ 1,
-                                        /*partitionMethod*/ Dune::PartitionMethod::metis,
-                                        /*imbalanceTol*/ 1.1,
-                                        /*level*/ 0), std::logic_error);
+
+    if (grid.comm().size()>1) {
+
+        BOOST_CHECK_THROW( grid.loadBalance(/*overlapLayers*/ 1,
+                                            /*partitionMethod*/ Dune::PartitionMethod::zoltan,
+                                            /*imbalanceTol*/ 1.1,
+                                            /*level*/ 0), std::logic_error);
+
+        BOOST_CHECK_THROW( grid.loadBalance(/*overlapLayers*/ 1,
+                                            /*partitionMethod*/ Dune::PartitionMethod::metis,
+                                            /*imbalanceTol*/ 1.1,
+                                            /*level*/ 0), std::logic_error);
+    }
 }
-    
+
 
 BOOST_AUTO_TEST_CASE(distributeRefinedLevelFromGridWithOneLgrThrows)
 {
     auto grid = createGridAndAddTestLgr();
 
-    // Throw for any partition method
-    BOOST_CHECK_THROW( grid.loadBalance(/*overlapLayers*/ 1,
-                                        /*partitionMethod*/ Dune::PartitionMethod::zoltanGoG,
-                                        /*imbalanceTol*/ 1.1,
-                                        /*level*/ 1), std::logic_error);
-    
-    BOOST_CHECK_THROW( grid.loadBalance(/*overlapLayers*/ 1,
-                                        /*partitionMethod*/ Dune::PartitionMethod::zoltan,
-                                        /*imbalanceTol*/ 1.1,
-                                        /*level*/ 1), std::logic_error);
+    if (grid.comm().size()>1) {
+        // Throw for any partition method
+        BOOST_CHECK_THROW( grid.loadBalance(/*overlapLayers*/ 1,
+                                            /*partitionMethod*/ Dune::PartitionMethod::zoltanGoG,
+                                            /*imbalanceTol*/ 1.1,
+                                            /*level*/ 1), std::logic_error);
 
-    BOOST_CHECK_THROW( grid.loadBalance(/*overlapLayers*/ 1,
-                                        /*partitionMethod*/ Dune::PartitionMethod::metis,
-                                        /*imbalanceTol*/ 1.1,
-                                        /*level*/ 1), std::logic_error);
+        BOOST_CHECK_THROW( grid.loadBalance(/*overlapLayers*/ 1,
+                                            /*partitionMethod*/ Dune::PartitionMethod::zoltan,
+                                            /*imbalanceTol*/ 1.1,
+                                            /*level*/ 1), std::logic_error);
+
+        BOOST_CHECK_THROW( grid.loadBalance(/*overlapLayers*/ 1,
+                                            /*partitionMethod*/ Dune::PartitionMethod::metis,
+                                            /*imbalanceTol*/ 1.1,
+                                            /*level*/ 1), std::logic_error);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(distributeLeafGridViewFromGridWithOneLgrThrows)
 {
     auto grid = createGridAndAddTestLgr();
+    if (grid.comm().size()>1) {
+        // Throw with default load balance
+        BOOST_CHECK_THROW(grid.loadBalance(), std::logic_error);
 
-    // Throw with default load balance
-    BOOST_CHECK_THROW(grid.loadBalance(), std::logic_error);
+        // Throw for any partition method. Level equal to -1 represents the leaf grid view.
+        BOOST_CHECK_THROW( grid.loadBalance(/*overlapLayers*/ 1,
+                                            /*partitionMethod*/ Dune::PartitionMethod::zoltanGoG,
+                                            /*imbalanceTol*/ 1.1,
+                                            /*level*/ -1), std::logic_error);
 
-    // Throw for any partition method. Level equal to -1 represents the leaf grid view.
-    BOOST_CHECK_THROW( grid.loadBalance(/*overlapLayers*/ 1,
-                                        /*partitionMethod*/ Dune::PartitionMethod::zoltanGoG,
-                                        /*imbalanceTol*/ 1.1,
-                                        /*level*/ -1), std::logic_error);
-    
-    BOOST_CHECK_THROW( grid.loadBalance(/*overlapLayers*/ 1,
-                                        /*partitionMethod*/ Dune::PartitionMethod::zoltan,
-                                        /*imbalanceTol*/ 1.1,
-                                        /*level*/ -1), std::logic_error);
+        BOOST_CHECK_THROW( grid.loadBalance(/*overlapLayers*/ 1,
+                                            /*partitionMethod*/ Dune::PartitionMethod::zoltan,
+                                            /*imbalanceTol*/ 1.1,
+                                            /*level*/ -1), std::logic_error);
 
-    BOOST_CHECK_THROW( grid.loadBalance(/*overlapLayers*/ 1,
-                                        /*partitionMethod*/ Dune::PartitionMethod::metis,
-                                        /*imbalanceTol*/ 1.1,
-                                        /*level*/ -1), std::logic_error);
+        BOOST_CHECK_THROW( grid.loadBalance(/*overlapLayers*/ 1,
+                                            /*partitionMethod*/ Dune::PartitionMethod::metis,
+                                            /*imbalanceTol*/ 1.1,
+                                            /*level*/ -1), std::logic_error);
+    }
 }


### PR DESCRIPTION
Continuation of #848 to really fix the tests.

:flushed: We have a rather buggy copy constructor in CpGrid it seems. Seems like the pointer current_data_ is just copied nd if the object that we copy from ist destroyed that pointer is dangling.

Another proper fix is upcoming.