### PR TITLE
[bugfix] Remove raw pointers for the views in CpGrid

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -316,6 +316,11 @@ namespace Dune
         /// @brief Returns either data_ or distributed_data_(if non empty).
         std::vector<std::shared_ptr<Dune::cpgrid::CpGridData>>& currentData();
 
+        /// @brief Returns either data_ or distributed_data_(if non empty).
+        const Dune::cpgrid::CpGridData& currentLeafData() const;
+
+        /// @brief Returns either data_ or distributed_data_(if non empty).
+        Dune::cpgrid::CpGridData& currentLeafData();
         /// @brief
         ///    Extract Cartesian index triplet (i,j,k) of an active cell.
         ///
@@ -1929,12 +1934,10 @@ namespace Dune
          * All the data of all grids are stored there and
          * calls are forwarded to relevant grid.*/
         std::vector<std::shared_ptr<cpgrid::CpGridData>> data_;
-        /** @brief A pointer to data of the current View. */
-        cpgrid::CpGridData* current_view_data_;
         /** @brief The data stored for the distributed grid. */
         std::vector<std::shared_ptr<cpgrid::CpGridData>> distributed_data_;
-        /** @brief A pointer to the current data used. */
-        std::vector<std::shared_ptr<cpgrid::CpGridData>>* current_data_;
+        /** @brief Whether the current view is the distributed version. */
+        bool view_is_distributed_;
         /** @brief To get the level given the lgr-name. Default, {"GLOBAL", 0}. */
         std::map<std::string,int> lgr_names_ = {{"GLOBAL", 0}};
         /**
@@ -2012,7 +2015,7 @@ namespace Dune
     template<class DataHandle>
     void CpGrid::communicate (DataHandle& data, InterfaceType iftype, CommunicationDirection dir) const
     {
-        current_view_data_->communicate(data, iftype, dir);
+        currentLeafData().communicate(data, iftype, dir);
     }
 
 
@@ -2065,8 +2068,8 @@ namespace Dune
         typedef cpgrid::OrientedEntityTable<1,0>::row_type F2C;
 
         const cpgrid::EntityRep<1> f(face, true);
-        const F2C&     f2c = current_view_data_->face_to_cell_[f];
-        const face_tag tag = current_view_data_->face_tag_[f];
+        const F2C&     f2c = currentLeafData().face_to_cell_[f];
+        const face_tag tag = currentLeafData().face_tag_[f];
 
         assert ((f2c.size() == 1) || (f2c.size() == 2));
 

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -697,7 +697,7 @@ public:
     /// \param iftype The interface to use for the communication.
     /// \param dir The direction of the communication along the interface (forward or backward).
     template<class DataHandle>
-    void communicate(DataHandle& data, InterfaceType iftype, CommunicationDirection dir);
+    void communicate(DataHandle& data, InterfaceType iftype, CommunicationDirection dir) const;
 
     void computeCellPartitionType();
 
@@ -831,7 +831,7 @@ private:
     /// \param interface The information about the communication interface
     template<int codim, class DataHandle>
     void communicateCodim(Entity2IndexDataHandle<DataHandle, codim>& data, CommunicationDirection dir,
-                          const Interface& interface);
+                          const Interface& interface) const;
 
     /// \brief Communicates data of a given codimension
     /// \tparam codim The codimension
@@ -843,7 +843,7 @@ private:
     /// \param interface The information about the communication interface
     template<int codim, class DataHandle>
     void communicateCodim(Entity2IndexDataHandle<DataHandle, codim>& data, CommunicationDirection dir,
-                          const InterfaceMap& interface);
+                          const InterfaceMap& interface) const;
 
 #endif
 
@@ -991,8 +991,8 @@ namespace
 /// \param iftype The interface type.
 /// \param interfaces A tuple with the values order by interface type.
 template<class T>
-T& getInterface(InterfaceType iftype,
-                std::tuple<T,T,T,T,T>& interfaces)
+const T& getInterface(InterfaceType iftype,
+                      const std::tuple<T,T,T,T,T>& interfaces)
 {
     switch(iftype)
     {
@@ -1014,14 +1014,14 @@ T& getInterface(InterfaceType iftype,
 
 template<int codim, class DataHandle>
 void CpGridData::communicateCodim(Entity2IndexDataHandle<DataHandle, codim>& data, CommunicationDirection dir,
-                                  const Interface& interface)
+                                  const Interface& interface) const
 {
     this->template communicateCodim<codim>(data, dir, interface.interfaces());
 }
 
 template<int codim, class DataHandle>
 void CpGridData::communicateCodim(Entity2IndexDataHandle<DataHandle, codim>& data_wrapper, CommunicationDirection dir,
-                                  const InterfaceMap& interface)
+                                  const InterfaceMap& interface) const
 {
     Communicator comm(ccobj_, interface);
 
@@ -1034,7 +1034,7 @@ void CpGridData::communicateCodim(Entity2IndexDataHandle<DataHandle, codim>& dat
 
 template<class DataHandle>
 void CpGridData::communicate(DataHandle& data, InterfaceType iftype,
-                             CommunicationDirection dir)
+                             CommunicationDirection dir) const
 {
 #if HAVE_MPI
     if(data.contains(3,0))


### PR DESCRIPTION
This pointers were dangling after a grid was copied and the original one removed. Fortunatley, we did not do this in productive code.

This approach uses a boolean to see whether the current view is distributed or not. This way we can use default copy constructors.

Unfortunately. there are a lot of branches now. Let's see what that costs.