### PR TITLE
Avoid copying CpGrid in LgrCheck methods

### DIFF
--- a/tests/cpgrid/LgrChecks.hpp
+++ b/tests/cpgrid/LgrChecks.hpp
@@ -81,18 +81,20 @@ void checkVertexAndFaceIndexAreNonNegative(const Dune::CpGrid& grid);
 void checkFaceHas4VerticesAndMax2NeighboringCells(const Dune::CpGrid& grid,
                                                   const std::vector<std::shared_ptr<Dune::cpgrid::CpGridData>>& data);
 
-Dune::CpGrid createGridAndAddLgrs(const std::string& deck_string,
-                                  const std::vector<std::array<int, 3>>& cells_per_dim_vec,
-                                  const std::vector<std::array<int, 3>>& startIJK_vec,
-                                  const std::vector<std::array<int, 3>>& endIJK_vec,
-                                  const std::vector<std::string>& lgr_name_vec);
+void createGridAndAddLgrs(Dune::CpGrid& grid,
+                          const std::string& deck_string,
+                          const std::vector<std::array<int, 3>>& cells_per_dim_vec,
+                          const std::vector<std::array<int, 3>>& startIJK_vec,
+                          const std::vector<std::array<int, 3>>& endIJK_vec,
+                          const std::vector<std::string>& lgr_name_vec);
 
-Dune::CpGrid createGridAndAddLgrs(const std::array<double, 3>& cell_sizes,
-                                  const std::array<int, 3>& grid_dim,
-                                  const std::vector<std::array<int, 3>>& cells_per_dim_vec,
-                                  const std::vector<std::array<int, 3>>& startIJK_vec,
-                                  const std::vector<std::array<int, 3>>& endIJK_vec,
-                                  const std::vector<std::string>& lgr_name_vec);
+void createGridAndAddLgrs(Dune::CpGrid& grid,
+                          const std::array<double, 3>& cell_sizes,
+                          const std::array<int, 3>& grid_dim,
+                          const std::vector<std::array<int, 3>>& cells_per_dim_vec,
+                          const std::vector<std::array<int, 3>>& startIJK_vec,
+                          const std::vector<std::array<int, 3>>& endIJK_vec,
+                          const std::vector<std::string>& lgr_name_vec);
 
 void checkExpectedVertexGlobalIdsCount(const Dune::CpGrid& grid,
                                        const std::vector<int>& expected_vertex_ids_per_lgr,
@@ -401,13 +403,13 @@ void Opm::checkFaceHas4VerticesAndMax2NeighboringCells(const Dune::CpGrid& grid,
     }
 }
 
-Dune::CpGrid Opm::createGridAndAddLgrs(const std::string& deck_string,
-                                       const std::vector<std::array<int, 3>>& cells_per_dim_vec,
-                                       const std::vector<std::array<int, 3>>& startIJK_vec,
-                                       const std::vector<std::array<int, 3>>& endIJK_vec,
-                                       const std::vector<std::string>& lgr_name_vec)
+void Opm::createGridAndAddLgrs(Dune::CpGrid& grid,
+                               const std::string& deck_string,
+                               const std::vector<std::array<int, 3>>& cells_per_dim_vec,
+                               const std::vector<std::array<int, 3>>& startIJK_vec,
+                               const std::vector<std::array<int, 3>>& endIJK_vec,
+                               const std::vector<std::string>& lgr_name_vec)
 {
-    Dune::CpGrid grid;
     Opm::Parser parser;
     const auto deck = parser.parseString(deck_string);
     Opm::EclipseState ecl_state(deck);
@@ -416,20 +418,18 @@ Dune::CpGrid Opm::createGridAndAddLgrs(const std::string& deck_string,
     grid.processEclipseFormat(&eclipse_grid, &ecl_state, false, false, false);
 
     grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
-    return grid;
 }
 
-Dune::CpGrid Opm::createGridAndAddLgrs(const std::array<double, 3>& cell_sizes,
-                                       const std::array<int, 3>& grid_dim,
-                                       const std::vector<std::array<int, 3>>& cells_per_dim_vec,
-                                       const std::vector<std::array<int, 3>>& startIJK_vec,
-                                       const std::vector<std::array<int, 3>>& endIJK_vec,
-                                       const std::vector<std::string>& lgr_name_vec)
+void Opm::createGridAndAddLgrs(Dune::CpGrid& grid,
+                               const std::array<double, 3>& cell_sizes,
+                               const std::array<int, 3>& grid_dim,
+                               const std::vector<std::array<int, 3>>& cells_per_dim_vec,
+                               const std::vector<std::array<int, 3>>& startIJK_vec,
+                               const std::vector<std::array<int, 3>>& endIJK_vec,
+                               const std::vector<std::string>& lgr_name_vec)
 {
-    Dune::CpGrid grid;
     grid.createCartesian(grid_dim, cell_sizes);
     grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
-    return grid;
 }
 
 void Opm::checkExpectedVertexGlobalIdsCount(const Dune::CpGrid& grid,

--- a/tests/cpgrid/lgrIJK_test.cpp
+++ b/tests/cpgrid/lgrIJK_test.cpp
@@ -69,22 +69,22 @@ struct Fixture {
 BOOST_GLOBAL_FIXTURE(Fixture);
 
 // Create a grid and add one test LGR with dimension 6x6x3.
-Dune::CpGrid
-createGridAndAddTestLgr(const std::string& deck_string)
+void createGridAndAddTestLgr(Dune::CpGrid& grid,
+                             const std::string& deck_string)
 {
-    return Opm::createGridAndAddLgrs(deck_string,
-                                     {{3, 3, 3}}, // 3x3x3 child cells in x-,y-, and z-direction per ACTIVE parent cell
-                                     {{1, 1, 0}}, // starts at (1,1,0) in coarse grid - equivalent to (I1-1, J1-1, K1-1) from its CARFIN block
-                                     {{3, 3, 1}}, // ends at (3,3,1) in coarse grid - equivalent to (I2, J2, K2) from its CARFIN block
-                                     {"LGR1"});
+    Opm::createGridAndAddLgrs(grid,
+                              deck_string,
+                              {{3, 3, 3}}, // 3x3x3 child cells in x-,y-, and z-direction per ACTIVE parent cell
+                              {{1, 1, 0}}, // starts at (1,1,0) in coarse grid - equivalent to (I1-1, J1-1, K1-1) from its CARFIN block
+                              {{3, 3, 1}}, // ends at (3,3,1) in coarse grid - equivalent to (I2, J2, K2) from its CARFIN block
+                              {"LGR1"});
 }
 
-void
-checkExpectedSize(const int& expected_elements,
-                  const std::size_t& numLgrCells,
-                  const std::size_t& cellIdxToLgrCartesianIdxSize,
-                  const std::size_t& lgrCartesianIdxToCellIdxSize,
-                  const std::size_t& lgr1IJKSize)
+void checkExpectedSize(const int& expected_elements,
+                       const std::size_t& numLgrCells,
+                       const std::size_t& cellIdxToLgrCartesianIdxSize,
+                       const std::size_t& lgrCartesianIdxToCellIdxSize,
+                       const std::size_t& lgr1IJKSize)
 {
     BOOST_CHECK_EQUAL(numLgrCells, expected_elements);
     BOOST_CHECK_EQUAL(cellIdxToLgrCartesianIdxSize, expected_elements);
@@ -138,7 +138,8 @@ SOLUTION
 SCHEDULE
 )";
 
-    const auto grid = createGridAndAddTestLgr(deck_string);
+    Dune::CpGrid grid;
+    createGridAndAddTestLgr(grid, deck_string);
 
     const auto [lgrCartesianIdxToCellIdx, lgr1IJK] = Opm::lgrIJK(grid, "LGR1");
 
@@ -281,7 +282,8 @@ SOLUTION
 SCHEDULE
 )";
 
-    const auto grid = createGridAndAddTestLgr(deck_string);
+    Dune::CpGrid grid;
+    createGridAndAddTestLgr(grid, deck_string);
 
     // Note: k = 0, indicating a single-layer grid with dimensions 3x3x1.
     // ACTNUM represents the active cell indicator for the parent grid of the LGR (Local Grid Refinement).
@@ -412,7 +414,8 @@ REGIONS
 SOLUTION
 SCHEDULE
 )";
-    const auto grid = createGridAndAddTestLgr(deck_string);
+    Dune::CpGrid grid;
+    createGridAndAddTestLgr(grid, deck_string);
 
     // Note: k = 0, indicating a single-layer grid with dimensions 3x3x1.
     // ACTNUM represents the active cell indicator for the parent grid of the LGR (Local Grid Refinement).

--- a/tests/cpgrid/lgr_coord_zcorn_test.cpp
+++ b/tests/cpgrid/lgr_coord_zcorn_test.cpp
@@ -69,14 +69,15 @@ struct Fixture {
 BOOST_GLOBAL_FIXTURE(Fixture);
 
 // Create a grid and add one test LGR with dimension 6x6x3.
-Dune::CpGrid
-createGridAndAddTestLgr(const std::string& deck_string)
+void createGridAndAddTestLgr(Dune::CpGrid& grid,
+                             const std::string& deck_string)
 {
-    return Opm::createGridAndAddLgrs(deck_string,
-                                     {{3, 3, 3}}, // 3x3x3 child cells in x-,y-, and z-direction per ACTIVE parent cell
-                                     {{1, 1, 0}}, // starts at (1,1,0) in coarse grid - equivalent to (I1-1, J1-1, K1-1) from its CARFIN block
-                                     {{3, 3, 1}}, // ends at (3,3,1) in coarse grid - equivalent to (I2, J2, K2) from its CARFIN block
-                                     {"LGR1"});
+    Opm::createGridAndAddLgrs(grid,
+                              deck_string,
+                              {{3, 3, 3}}, // 3x3x3 child cells in x-,y-, and z-direction per ACTIVE parent cell
+                              {{1, 1, 0}}, // starts at (1,1,0) in coarse grid - equivalent to (I1-1, J1-1, K1-1) from its CARFIN block
+                              {{3, 3, 1}}, // ends at (3,3,1) in coarse grid - equivalent to (I2, J2, K2) from its CARFIN block
+                              {"LGR1"});
 }
 
 BOOST_AUTO_TEST_CASE(fullActiveParentCellsBlock)
@@ -124,7 +125,8 @@ SOLUTION
 SCHEDULE
 )";
 
-    const auto grid = createGridAndAddTestLgr(deck_string);
+    Dune::CpGrid grid;
+    createGridAndAddTestLgr(grid, deck_string);
 
     const auto [lgrCartesianIdxToCellIdx, lgr1IJK] = Opm::lgrIJK(grid, "LGR1");
 
@@ -318,7 +320,8 @@ SOLUTION
 SCHEDULE
 )";
 
-    const auto grid = createGridAndAddTestLgr(deck_string);
+    Dune::CpGrid grid;
+    createGridAndAddTestLgr(grid, deck_string);
 
     // Note: k = 0, indicating a single-layer grid with dimensions 3x3x1.
     // ACTNUM represents the active cell indicator for the parent grid of the LGR (Local Grid Refinement).
@@ -391,7 +394,8 @@ REGIONS
 SOLUTION
 SCHEDULE
 )";
-    const auto grid = createGridAndAddTestLgr(deck_string);
+    Dune::CpGrid grid;
+    createGridAndAddTestLgr(grid, deck_string);
 
     // Note: k = 0, indicating a single-layer grid with dimensions 3x3x1.
     // ACTNUM represents the active cell indicator for the parent grid of the LGR (Local Grid Refinement).


### PR DESCRIPTION
This PR refactors createGridAndAddLgrs(...) to eliminate unnecessary CpGrid copies, preventing potential issues in parallel settings.

While this change does not introduce direct improvements, it addresses a potential risk similar to the one reported in [OPM/opm-grid#845](https://github.com/OPM/opm-grid/issues/845), where using copied CpGrid instances in a parallel context could lead to unexpected behavior.

This refactor reduces the risk of such issues in the future and allows reusing existing code.

Not relevant for the Reference Manual.