### PR TITLE
Fixes for NVCC

### DIFF
--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -96,7 +96,7 @@ public:
     template <int cd>
     struct Codim
     {
-        typedef cpgrid::Entity<cd> Entity;
+        using Entity = ::Dune::cpgrid::Entity<cd>;
     };
 
 


### PR DESCRIPTION
It seems like NVCC complains about `Entity` being defined twice, this PR fixes that issue.