### PR TITLE
[refactor] adapt_cpgrid_test

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -88,6 +88,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/cpgrid/entityrep_test.cpp
   tests/cpgrid/entity_test.cpp
   tests/cpgrid/facetag_test.cpp
+  tests/cpgrid/global_refine_test.cpp
   tests/cpgrid/grid_global_id_set_test.cpp
   tests/cpgrid/orientedentitytable_test.cpp
   tests/cpgrid/partition_iterator_test.cpp

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -498,7 +498,7 @@ namespace Dune
         ///                                  refined entities of the (parent) marked element should belong is stored.
         /// @param [in] lgr_name_vector      Each refined level grid name, e.g. {"LGR1", "LGR2"}.
         /// @param [in] isCARFIN             Default false. The keyword CARFIN implies that the selected cells to be refined form a block,
-        ///                                  which can be edscribed via startIJK and endIJK Cartesian indices. This bool
+        ///                                  which can be described via startIJK and endIJK Cartesian indices. This bool
         ///                                  is used to define logical_cartesian_size_ of the refined level grids according
         ///                                  to this block shape.
         /// @param [in] startIJK_vec         Default empty vector. When isCARFIN, the starting ijk Cartesian index of each
@@ -519,7 +519,7 @@ namespace Dune
     private:
 
         /// --------------- Auxiliary methods to support Adaptivity (begin) ---------------
-        
+
         /// @brief Refine each marked element and establish relationships between corners, faces, and cells marked for refinement,
         ///        with the refined corners, refined faces, and refined cells.
         ///

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -484,7 +484,8 @@ namespace Dune
         ///        Need to be called after elements have been marked for refinement.
         bool preAdapt();
 
-        /// @brief Triggers the grid refinement process
+        /// @brief Triggers the grid refinement process.
+        ///        Returns true if the grid has changed, false otherwise.
         bool adapt();
 
         /// @brief Triggers the grid refinement process, allowing to select diffrent refined level grids.

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1955,6 +1955,15 @@ template cpgrid::Entity<1> createEntity(const CpGrid&, int, bool); // needed in 
 
 bool CpGrid::mark(int refCount, const cpgrid::Entity<0>& element)
 {
+    // Throw if element has a neighboring cell from a different level.
+    // E.g., a coarse cell touching the boundary of an LGR, or
+    // a refined cell with a coarser/finner neighboring cell. 
+    const auto& intersections = Dune::intersections(leafGridView(), element);
+    for (const auto& intersection : intersections){
+        if (intersection.neighbor() && (intersection.outside().level() != element.level()))
+             OPM_THROW(std::logic_error, "Refinement of cells at LGR boundaries is not supported, yet.");
+    }
+    
     // For serial run, mark elements also in the level they were born.
     if(currentData().size()>1) {
         // Mark element in its level

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -96,15 +96,6 @@ template<int> class EntityRep;
 }
 }
 
-
-void markAndAdapt_check(Dune::CpGrid&,
-                        const std::array<int,3>&,
-                        const std::vector<int>&,
-                        Dune::CpGrid&,
-                        bool,
-                        bool,
-                        bool);
-
 void refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,
                       const std::array<int, 3>&,
                       bool);
@@ -151,15 +142,6 @@ class CpGridData
     friend class Dune::cpgrid::IndexSet;
     friend class Dune::cpgrid::IdSet;
     friend class Dune::cpgrid::LevelGlobalIdSet;
-
-    friend
-    void ::markAndAdapt_check(Dune::CpGrid&,
-                              const std::array<int,3>&,
-                              const std::vector<int>&,
-                              Dune::CpGrid&,
-                              bool,
-                              bool,
-                              bool);
 
     friend
     void ::refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,

--- a/tests/cpgrid/LgrChecks.hpp
+++ b/tests/cpgrid/LgrChecks.hpp
@@ -111,11 +111,6 @@ void checkCellBlockRefinements(const Dune::CpGrid& coarse_grid,
 template<typename T>
 bool areClose(const T& cont1, const T& cont2);
 
-void compareGrids(const Dune::CpGrid& grid,
-                  const Dune::CpGrid& equivalent_grid,
-                  bool gridLgrsHaveBlockShape,
-                  bool gridHasBeenGlobalRefined);
-
 void adaptGridWithParams(Dune::CpGrid& grid,
                          const std::array<int,3>& cells_per_dim,
                          const std::vector<int>& markedCells);
@@ -528,7 +523,7 @@ void Opm::checkVertexGlobalIds(const Dune::CpGrid& grid, int expected_vertex_ids
 }
 
 template<typename T>
-bool Opm::areClose(const T& cont1, const T& cont2) 
+bool Opm::areClose(const T& cont1, const T& cont2)
 {
     return (std::abs(cont1[0] - cont2[0]) < 1e-12) && (std::abs(cont1[1] - cont2[1]) < 1e-12) && (std::abs(cont1[2] - cont2[2])< 1e-12);
 }
@@ -539,18 +534,70 @@ void Opm::checkLeafGridGeometryEquality(const Dune::CpGrid& grid, const Dune::Cp
     const auto& grid_view = grid.leafGridView();
     const auto& equiv_grid_view = other_grid.leafGridView();
 
-    for(const auto& element: elements(grid_view)) {
-        BOOST_CHECK( element.getOrigin().level() == 0);
-        auto equiv_element_iter = equiv_grid_view.begin<0>();
-        bool closeCenter = Opm::areClose(element.geometry().center(), equiv_element_iter->geometry().center());
-        while ((equiv_element_iter != equiv_grid_view.end<0>()) && (!closeCenter)) {
-            ++equiv_element_iter;
-            closeCenter = Opm::areClose(element.geometry().center(), equiv_element_iter->geometry().center());
+    // Check sizes
+    BOOST_CHECK_EQUAL(grid_view.size(3), equiv_grid_view.size(3));
+    BOOST_CHECK_EQUAL(grid_view.size(0),  equiv_grid_view.size(0));
+
+    BOOST_CHECK_EQUAL(grid.numFaces(), other_grid.numFaces());
+    BOOST_CHECK_EQUAL(grid.numCells(), other_grid.numCells());
+    BOOST_CHECK_EQUAL(grid.size(3), other_grid.size(3));
+    BOOST_CHECK_EQUAL(grid.size(0), other_grid.size(0));
+
+    const auto& grid_vertices =  Dune::vertices(grid.leafGridView());
+    const auto& other_grid_vertices =  Dune::vertices(other_grid.leafGridView());
+
+    for(const auto& grid_vertex : grid_vertices) {
+        // find matching vertex (needed as ordering is allowed to be different
+        bool matching_vertex_found = false;
+        for (const auto& other_grid_vertex : other_grid_vertices) {
+            if (!Opm::areClose(grid_vertex.geometry().center(), other_grid_vertex.geometry().center() ))
+                continue;
+            for(const auto& coord: grid_vertex.geometry().center()) {
+                BOOST_TEST(std::isfinite(coord));
+            }
+            matching_vertex_found = true;
         }
-        for(const auto& intersection: intersections(grid_view, element)) {
+        BOOST_CHECK(matching_vertex_found);
+    }
+
+    const auto& grid_elements =  Dune::elements(grid.leafGridView());
+    for(const auto& element : grid_elements) {
+        // find matching element (needed as ordering is allowed to be different
+        bool matching_elem_found = false;
+
+        // Iterate over other_grid elements until an element's center is close enough to element.geometry().center()
+        auto equiv_element_iter = equiv_grid_view.begin<0>();
+        
+        const auto& elem_geo = element.geometry();
+        
+        bool closeCenter = Opm::areClose(elem_geo.center(), equiv_element_iter->geometry().center());
+        while ( (equiv_element_iter != equiv_grid_view.end<0>()) && (!closeCenter) ) {
+            ++equiv_element_iter;
+            closeCenter = Opm::areClose(elem_geo.center(), equiv_element_iter->geometry().center());
+        }
+        matching_elem_found = true;
+
+        for(const auto& coord : elem_geo.center()) {
+            BOOST_TEST(std::isfinite(coord));
+        }
+        BOOST_CHECK_CLOSE(elem_geo.volume(), equiv_element_iter->geometry().volume(), 1e-8);
+
+        const int elemNumFaces = grid.numCellFaces(element.index());
+        const int equivElemNumFaces = other_grid.numCellFaces(equiv_element_iter->index());
+        BOOST_CHECK_EQUAL( elemNumFaces, equivElemNumFaces);
+
+        // For coarse cells with more than 6 faces, this is the case when they touch lgr boundaries, finding matching
+        // intersections is not implemented yet.
+        if (elemNumFaces>6) {
+            continue;
+        }
+
+        const auto& elemIntersections = Dune::intersections(grid_view, element);
+        for(const auto& intersection: elemIntersections) {
             // find matching intersection (needed as ordering is allowed to be different
             bool matching_intersection_found = false;
-            for(auto& intersection_match: intersections(equiv_grid_view, *equiv_element_iter)) {
+            const auto& equivElemIntersections = intersections(equiv_grid_view, *equiv_element_iter);
+            for(const auto& intersection_match : equivElemIntersections) {
                 if(intersection_match.indexInInside() == intersection.indexInInside()) {
                     BOOST_CHECK(intersection_match.neighbor() == intersection.neighbor());
 
@@ -559,7 +606,7 @@ void Opm::checkLeafGridGeometryEquality(const Dune::CpGrid& grid, const Dune::Cp
                     }
 
                     BOOST_CHECK( Opm::areClose(intersection_match.centerUnitOuterNormal(), intersection.centerUnitOuterNormal()) );
-                  
+
                     const auto& geom_match = intersection_match.geometry();
                     BOOST_TEST(0.0 == 1e-11, boost::test_tools::tolerance(1e-8));
                     const auto& geom =  intersection.geometry();
@@ -567,6 +614,7 @@ void Opm::checkLeafGridGeometryEquality(const Dune::CpGrid& grid, const Dune::Cp
                     if (!closeGeomCenter) {
                         break; // Check next intersection_match
                     }
+
                     BOOST_CHECK_CLOSE(geom_match.volume(), geom.volume(), 1e-6);
                     BOOST_CHECK( Opm::areClose(geom_match.center(), geom.center()) );
                     BOOST_CHECK(geom_match.corners() == geom.corners());
@@ -584,6 +632,7 @@ void Opm::checkLeafGridGeometryEquality(const Dune::CpGrid& grid, const Dune::Cp
             } // end-for-loop-intersection_match
             BOOST_CHECK(matching_intersection_found);
         }
+        BOOST_CHECK(matching_elem_found);
     }
 }
 
@@ -591,7 +640,6 @@ void Opm::checkCellBlockRefinements(const Dune::CpGrid& grid,
                                     const Dune::CpGrid& other_grid)
 {
     const auto& leafGrid = grid.currentData().back();
-    // For a mixed grid that gets refined a second time, isBlockShape == false, even though the marked elements form a block.
     const auto& leafOtherGrid = other_grid.currentData().back();
 
     // Check sizes
@@ -603,20 +651,6 @@ void Opm::checkCellBlockRefinements(const Dune::CpGrid& grid,
     BOOST_CHECK_EQUAL(grid.numCells(), other_grid.numCells());
     BOOST_CHECK_EQUAL(grid.size(3), other_grid.size(3));
     BOOST_CHECK_EQUAL(grid.size(0), other_grid.size(0));
-
-    BOOST_CHECK_EQUAL(grid.size(1,0), other_grid.size(1,0)); // equal amount of cells in level 1
-    BOOST_CHECK_EQUAL(grid.numCells(1), other_grid.numCells(1));
-    BOOST_CHECK_EQUAL(grid.size(1,3), other_grid.size(1,3)); // equal amount of corners in level 1
-    BOOST_CHECK_EQUAL(grid.numFaces(1), other_grid.numFaces(1));  // equal amount of faces in level 1
-
-
-    //   BOOST_CHECK_EQUAL(adapted_leaf.face_to_cell_.size(), blockRefinement_leaf.face_to_cell_.size());
-    //  BOOST_CHECK_EQUAL(adapted_leaf.face_to_point_.size(), blockRefinement_leaf.face_to_point_.size());
-    //  BOOST_CHECK_EQUAL(adapted_leaf.face_normals_.size(), blockRefinement_leaf.face_normals_.size());
-    //  BOOST_CHECK_EQUAL(adapted_leaf.face_tag_.size(), blockRefinement_leaf.face_tag_.size());
-    //   BOOST_CHECK_EQUAL(adapted_leaf.cell_to_point_.size(), blockRefinement_leaf.cell_to_point_.size());
-    //   BOOST_CHECK_EQUAL(adapted_leaf.cell_to_face_.size(), blockRefinement_leaf.cell_to_face_.size());
-
 
     const auto& grid_vertices =  Dune::vertices(grid.leafGridView());
     const auto& other_grid_vertices =  Dune::vertices(other_grid.leafGridView());
@@ -652,21 +686,6 @@ void Opm::checkCellBlockRefinements(const Dune::CpGrid& grid,
             matching_elem_found = true;
         }
         BOOST_CHECK(matching_elem_found);
-    }
-}
-
-void Opm::compareGrids(const Dune::CpGrid& grid,
-                       const Dune::CpGrid& equivalent_grid,
-                       bool gridLgrsHaveBlockShape,
-                       bool gridHasBeenGlobalRefined)
-{
-    if(gridLgrsHaveBlockShape) { // For a mixed grid that gets refined more than once,
-        // gridLgrsHaveBlockShape == false, even though the marked elements form a block.
-        Opm::checkCellBlockRefinements(grid, equivalent_grid);
-
-        if (gridHasBeenGlobalRefined) {
-            Opm::checkLeafGridGeometryEquality(grid, equivalent_grid);
-        }
     }
 }
 

--- a/tests/cpgrid/LgrChecks.hpp
+++ b/tests/cpgrid/LgrChecks.hpp
@@ -65,8 +65,7 @@ void checkFatherAndSiblings(const Dune::cpgrid::Entity<0>& element,
 
 void checkGridBasicHiearchyInfo(const Dune::CpGrid& grid,
                                 const std::vector<std::array<int,3>>& cells_per_dim_vec,
-                                bool gridHadBeenRefinedAtLeastOnce,
-                                int preAdaptMaxLevel);
+                                int preAdaptMaxLevel = 0);
 
 void checkLocalIndicesMatchMapper(const Dune::CpGrid& grid);
 
@@ -200,8 +199,7 @@ void Opm::checkFatherAndSiblings(const Dune::cpgrid::Entity<0>& element,
 
 void Opm::checkGridBasicHiearchyInfo(const Dune::CpGrid& grid,
                                      const std::vector<std::array<int,3>>& cells_per_dim_vec,
-                                     bool gridHadBeenRefinedAtLeastOnce = false,
-                                     int preAdaptMaxLevel = 0)
+                                     int preAdaptMaxLevel)
 {
     const int maxLevel = grid.maxLevel(); // Leaf Grid View has index maxLevel +1
     for (int level = preAdaptMaxLevel+1; level <= maxLevel+1; ++level) {

--- a/tests/cpgrid/LgrChecks.hpp
+++ b/tests/cpgrid/LgrChecks.hpp
@@ -104,6 +104,8 @@ void checkExpectedVertexGlobalIdsCount(const Dune::CpGrid& grid,
 
 void checkVertexGlobalIds(const Dune::CpGrid& grid, int expected_vertex_ids, int levelOrLeaf);
 
+void checkEqualVertexFaceCellSizes(const Dune::CpGrid& grid, const Dune::CpGrid& other_grid);
+
 void checkLeafGridGeometryEquality(const Dune::CpGrid& grid, const Dune::CpGrid& other_grid);
 
 template<typename T>
@@ -526,21 +528,21 @@ bool Opm::areClose(const T& cont1, const T& cont2)
     return (std::abs(cont1[0] - cont2[0]) < 1e-12) && (std::abs(cont1[1] - cont2[1]) < 1e-12) && (std::abs(cont1[2] - cont2[2])< 1e-12);
 }
 
+void Opm::checkEqualVertexFaceCellSizes(const Dune::CpGrid& grid, const Dune::CpGrid& other_grid)
+{
+    BOOST_CHECK_EQUAL(grid.size(3), other_grid.size(3));
+    BOOST_CHECK_EQUAL(grid.numFaces(), other_grid.numFaces());
+    BOOST_CHECK_EQUAL(grid.size(0), other_grid.size(0));
+}
+
 void Opm::checkLeafGridGeometryEquality(const Dune::CpGrid& grid, const Dune::CpGrid& other_grid)
 {
-
+    Opm::checkEqualVertexFaceCellSizes(grid, other_grid);
+    
     const auto& grid_view = grid.leafGridView();
     const auto& equiv_grid_view = other_grid.leafGridView();
 
-    // Check sizes
-    BOOST_CHECK_EQUAL(grid_view.size(3), equiv_grid_view.size(3));
-    BOOST_CHECK_EQUAL(grid_view.size(0),  equiv_grid_view.size(0));
-
-    BOOST_CHECK_EQUAL(grid.numFaces(), other_grid.numFaces());
-    BOOST_CHECK_EQUAL(grid.numCells(), other_grid.numCells());
-    BOOST_CHECK_EQUAL(grid.size(3), other_grid.size(3));
-    BOOST_CHECK_EQUAL(grid.size(0), other_grid.size(0));
-
+    
     const auto& grid_vertices =  Dune::vertices(grid.leafGridView());
     const auto& other_grid_vertices =  Dune::vertices(other_grid.leafGridView());
 
@@ -589,7 +591,7 @@ void Opm::checkLeafGridGeometryEquality(const Dune::CpGrid& grid, const Dune::Cp
             for(const auto& intersection: elemIntersections) {
                 // find matching intersection (needed as ordering is allowed to be different
                 bool matching_intersection_found = false;
-                const auto& equivElemIntersections = intersections(equiv_grid_view, other_grid_elem); //*equiv_element_iter);
+                const auto& equivElemIntersections = intersections(equiv_grid_view, other_grid_elem); 
                 for(const auto& intersection_match : equivElemIntersections) {
                     if(intersection_match.indexInInside() == intersection.indexInInside()) {
                         BOOST_CHECK(intersection_match.neighbor() == intersection.neighbor());

--- a/tests/cpgrid/LgrChecks.hpp
+++ b/tests/cpgrid/LgrChecks.hpp
@@ -111,6 +111,11 @@ void checkCellBlockRefinements(const Dune::CpGrid& coarse_grid,
 template<typename T>
 bool areClose(const T& cont1, const T& cont2);
 
+void compareGrids(const Dune::CpGrid& grid,
+                  const Dune::CpGrid& equivalent_grid,
+                  bool gridLgrsHaveBlockShape,
+                  bool gridHasBeenGlobalRefined);
+
 } // namespace Opm
 
 
@@ -643,6 +648,20 @@ void Opm::checkCellBlockRefinements(const Dune::CpGrid& grid,
     }
 }
 
+void Opm::compareGrids(const Dune::CpGrid& grid,
+                       const Dune::CpGrid& equivalent_grid,
+                       bool gridLgrsHaveBlockShape,
+                       bool gridHasBeenGlobalRefined)
+{
+    if(gridLgrsHaveBlockShape) { // For a mixed grid that gets refined more than once,
+        // gridLgrsHaveBlockShape == false, even though the marked elements form a block.
+        Opm::checkCellBlockRefinements(grid, equivalent_grid);
+
+        if (gridHasBeenGlobalRefined) {
+            Opm::checkLeafGridGeometryEquality(grid, equivalent_grid);
+        }
+    }
+}
 
 #endif // OPM_LGRCHECKS_HEADER_INCLUDED
 

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -39,6 +39,7 @@
 
 #include <algorithm>
 #include <array>
+#include <numeric>
 #include <vector>
 
 struct Fixture
@@ -73,7 +74,7 @@ void checkAdaptedGrid(Dune::CpGrid& grid,
     }
 }
 
-BOOST_AUTO_TEST_CASE(emptyMarkedElemForRefinementSetDoesNothingToTheGrid)
+BOOST_AUTO_TEST_CASE(markNoElemForRefinementDoesNothingToTheGrid)
 {
     Dune::CpGrid grid;
     grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
@@ -190,7 +191,7 @@ BOOST_AUTO_TEST_CASE(callAdaptMultipleTimesAsLongAsCoarseMarkedElementsAreNotAtL
     Opm::compareGrids(grid, equivalent_grid, /* lgrsHaveBlockShape = */ false, /* gridHasBeenGlobalRefined = */ false);
 }
 
-BOOST_AUTO_TEST_CASE(refinedCoarseOrRefinedCellsOnLgrBoundaryInAGridWithLgrsThrows)
+BOOST_AUTO_TEST_CASE(refineCoarseOrRefinedCellsOnLgrBoundaryInAGridWithLgrsThrows)
 {
     Dune::CpGrid grid;
     grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -182,10 +182,10 @@ BOOST_AUTO_TEST_CASE(markCellBlockForRefinementIsEquivalentToCallAddLgrsUpdateLe
     Dune::CpGrid equivalent_grid;
     equivalent_grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
     equivalent_grid.addLgrsUpdateLeafView( /* cells_per_dim = */ {{2,2,2}},
-                                      /* startIJK = */ {{1,1,1}},
-                                      /* endIJK = */  {{3,2,2}}, // block cell indices = {17, 18}
-                                      /* lgr_name = */  {"LGR1"});
-    
+                                           /* startIJK = */ {{1,1,1}},
+                                           /* endIJK = */  {{3,2,2}}, // block cell indices = {17, 18}
+                                           /* lgr_name = */  {"LGR1"});
+
     compareGrids(grid, equivalent_grid, /* lgrsHaveBlockShape = */ true, /* gridHasBeenGlobalRefined = */ false);
 }
 
@@ -196,12 +196,12 @@ BOOST_AUTO_TEST_CASE(refinementOfCellsNotFormingABlockIsSupported)
     std::vector<int> markedCells = {0,4,5,17,18,30,31,35};
 
     // level zero grid view - cells marked for refinement are denoted with (/*index*/).
-    // k = 0   8  9  10  11 | k = 1  20   21   22  23 | k = 2  32 33  34  (35) | 
+    // k = 0   8  9  10  11 | k = 1  20   21   22  23 | k = 2  32 33  34  (35) |
     //       (4) (5)  6   7 |        16  (17) (18) 19 |        28 29 (30) (31) |
     //       (0)  1   2   3 |        12   13   14  15 |        24 25   26   27 |
 
     adaptGridWithParams(grid, /* cells_per_dim = */ {2,3,4}, markedCells);
-  
+
     checkAdaptedGrid(grid,
                      /* cells_per_dim = */ {2,3,4},
                      /* lgrsHaveBlockShape = */ false,
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(callAdaptMultipleTimesAsLongAsCoarseMarkedElementsAreNotAtL
     adaptGrid(equivalent_grid, markedCells1);
     adaptGrid(equivalent_grid, markedCells2);
     adaptGrid(equivalent_grid, markedCells3);
-    
+
     compareGrids(grid, equivalent_grid, /* lgrsHaveBlockShape = */ false, /* gridHasBeenGlobalRefined = */ false);
 }
 
@@ -243,7 +243,7 @@ BOOST_AUTO_TEST_CASE(refinedCoarseOrRefinedCellsOnLgrBoundaryInAGridWithLgrsThro
     grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
 
     // level zero grid view - cells marked for refinement are denoted with (/*index*/).
-    // k = 0  8   9  10  11 | k = 1  20  21   22  23 | k = 2  32 33 34 35 | 
+    // k = 0  8   9  10  11 | k = 1  20  21   22  23 | k = 2  32 33 34 35 |
     //        4   5   6   7 |        16 (17) (18) 19 |        28 29 30 31 |
     //        0   1   2   3 |        12  13   14  15 |        24 25 26 27 |
     grid.addLgrsUpdateLeafView( /* cells_per_dim = */ {{3,3,3}},
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE(refinedCoarseOrRefinedCellsOnLgrBoundaryInAGridWithLgrsThro
     //        17  18  19  | 44  45  46 |
 
     // leaf grid view
-    // k = 0  8   9  10  11 | k = 1  72  73   74  75 | k = 2  84 85 86 87 | 
+    // k = 0  8   9  10  11 | k = 1  72  73   74  75 | k = 2  84 85 86 87 |
     //        4   5   6   7 |        16  ()* ()** 71 |        80 81 82 83 |
     //        0   1   2   3 |        12  13   14  15 |        76 77 78 79 |
     // *  indices 17, 18, ..., 43 (children of parent cell with index 17 in level zero grid)
@@ -298,7 +298,7 @@ BOOST_AUTO_TEST_CASE(refineCoarseCellsNotTouchingLgrBoundaryInAGridWithLgrsIsSup
     grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
 
     // level zero grid - cells marked for refinement are denoted with (/*index*/).
-    // k = 0  8   9  10  11 | k = 1  20  21   22  23 | k = 2  32 33 34 35 | 
+    // k = 0  8   9  10  11 | k = 1  20  21   22  23 | k = 2  32 33 34 35 |
     //        4   5   6   7 |        16  17   18  19 |        28 29 30 31 |
     //        0   1   2  (3)|        12  13   14  15 |        24 25 26 27 |
     grid.addLgrsUpdateLeafView(/* cells_per_dim_vec = */ { {2,2,2}},
@@ -307,15 +307,15 @@ BOOST_AUTO_TEST_CASE(refineCoarseCellsNotTouchingLgrBoundaryInAGridWithLgrsIsSup
                                /* lgr_name_vec = */ {"LGR1"});
 
     // leaf grid view (after adding LGR1 and before calling adapt with parameters).
-    // k = 0 [15]  16  17  18 | k = 1  27  28   29  30 | k = 2  39 40 41 42 | 
+    // k = 0 [15]  16  17  18 | k = 1  27  28   29  30 | k = 2  39 40 41 42 |
     //       [11]  12  13  14 |        23  24   25  26 |        35 36 37 38 |
     //        [0]  [1]  2  ()*|        19  20   21  22 |        31 32 33 34 |
     //* indices 3-10 of refined cells (children of parent cell with index 3 in level zero grid).
     // [/*index*/] coarse marked cells for refinement, (not forming a block) not touching the lgr boundary.
-    
-    std::vector<int> markedCells = {0,1,11,15}; 
+
+    std::vector<int> markedCells = {0,1,11,15};
     adaptGridWithParams(grid, /* cells_per_dim = */ {2,3,4}, markedCells);
-    
+
     checkAdaptedGrid(grid,
                      /* cells_per_dim = */ {2,3,4},
                      /* lgrsHaveBlockShape = */ false,
@@ -329,7 +329,7 @@ BOOST_AUTO_TEST_CASE(refineRefinedCellsInTheInteriorOfAnLgrIsSupported)
     grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
 
     // level zero grid view - cells marked for refinement are denoted with (/*index*/).
-    // k = 0  8   9  10  11 | k = 1  20  21   22  23 | k = 2  32 33 34 35 | 
+    // k = 0  8   9  10  11 | k = 1  20  21   22  23 | k = 2  32 33 34 35 |
     //        4   5   6   7 |        16 (17) (18) 19 |        28 29 30 31 |
     //        0   1   2   3 |        12  13   14  15 |        24 25 26 27 |
 
@@ -372,11 +372,11 @@ BOOST_AUTO_TEST_CASE(refineCoarseAndRefinedCellsAwayFromLgrBondaryIsSupported) {
     grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
 
     // level zero grid view - cells marked for refinement are denoted with (/*index*/).
-    // k = 0  8   9  10  11 | k = 1  20  21   22  23 | k = 2  32 33 34 35 | 
+    // k = 0  8   9  10  11 | k = 1  20  21   22  23 | k = 2  32 33 34 35 |
     //        4   5   6   7 |        16 (17) (18) 19 |        28 29 30 31 |
     //        0   1   2   3 |        12  13   14  15 |        24 25 26 27 |
-  
-   // LGR1 marked elements with elemIdx = 17 and 18, refined into 27 children cells each,
+
+    // LGR1 marked elements with elemIdx = 17 and 18, refined into 27 children cells each,
     // with leaf indices 17+0,...,17+26 = 43 (children {level 0, cell index 17}),44,...,70 (children {level 0, cell index 18}).
     grid.addLgrsUpdateLeafView( /* cells_per_dim = */ {{3,3,3}},
                                 /* startIJK_vec = */ {{1,1,1}},
@@ -401,13 +401,13 @@ BOOST_AUTO_TEST_CASE(refineCoarseAndRefinedCellsAwayFromLgrBondaryIsSupported) {
 
 
     // leaf grid view
-    // k = 0  8  9 10 11 | k = 1  72  73   74  75 | k = 2  84 85 [86][87]| 
+    // k = 0  8  9 10 11 | k = 1  72  73   74  75 | k = 2  84 85 [86][87]|
     //        4  5  6  7 |        16  ()* ()** 71 |        80 81  82  83 |
     //       [0][1] 2  3 |        12  13   14  15 |        76 77  78  79 |
     //
     // *  indices 17, 18, ..., 43 (children of parent cell with index 17 in level zero grid)
     // ** indices 44, 45, ..., 70 (children of parent cell with index 18 in level zero grid)
-   
+
     // - Cells 30, 31, 56, and 57 are refined cells, located in the interior of the refined-level-grid-1 (lgr 1 / level 1).
     // Therefore, cell_to_face_ for all of them has size 6. (Their faces have all 2 refined neigboring cells - (not one coarse cell, and one refined)).
     // - Cells 0,1,2,86, and 87 are coarse cells, not touching the boundary of the LGR1 (cell 86 shares corners with LGR1 but do not share
@@ -423,59 +423,61 @@ BOOST_AUTO_TEST_CASE(refineCoarseAndRefinedCellsAwayFromLgrBondaryIsSupported) {
 }
 
 
-/*BOOST_AUTO_TEST_CASE(refineMixedCells_in_multiLevelGrid) {
-// Create a grid
-    Dune::CpGrid coarse_grid;
-    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim = {3,3,3};
-    coarse_grid.createCartesian(grid_dim, cell_sizes);
+BOOST_AUTO_TEST_CASE(refineCoarseAndRefinedCellsAwayFromMultipleLgrBondaryIsSupported) {
 
-    // LGR1: element with elemIdx = 17, refined into 27 children cells with leaf indices 17+0,...,17+26 = 43 (children {level 0, cell index 17}).
-    // LGR2: element with elemIdx = 18, refined into 27 children cells with leaf indices 44,...,70 (children {level 0, cell index 18}).
-    const std::vector<std::array<int, 3>> startIJK_vec = {{1,1,1}, {2,1,1}};
-    const std::vector<std::array<int, 3>> endIJK_vec = {{2,2,2}, {3,2,2}};
-    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2"};
-    coarse_grid.addLgrsUpdateLeafView({cells_per_dim, cells_per_dim}, startIJK_vec, endIJK_vec, lgr_name_vec);
+    Dune::CpGrid grid;
+    grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
 
-    // - Cells 30, 31, 56, and 57 are refined cells, located in the interior of the refined-level-grid-1 (lgr 1 / level 1).
-    // Therefore, cell_to_face_ for all of them has size 6. (Their faces have all 2 refined neigboring cells - (not one coarse cell, and one refined)).
-    // - Cells 0,1,2,12, and 15 are coarse cells, not touching the boundary of the LGR1 (cells 12 and 15 do share corners with LGR1 but do not share
-    // any face. Therefore, the faces of cells 0,1,2,12,and 15 have all 1 or 2 neighboring coarse cells).
-    std::vector<int> markedCells = {0,1,2,12,15,30,31,56,57};
-    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, true, false);
-}
-
-
-BOOST_AUTO_TEST_CASE(refineMixedCells_in_mixedGrid_II)
-{
-    // Create a grid
-    Dune::CpGrid coarse_grid;
-    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim = {3,3,3};
-    coarse_grid.createCartesian(grid_dim, cell_sizes);
+    // level zero grid view - cells marked for refinement are denoted with (/*index*/).
+    // k = 0  8   9  10  11 | k = 1  20  21   22  23 | k = 2  32 33 34 35 |
+    //        4   5   6   7 |        16 (17) (18) 19 |        28 29 30 31 |
+    //        0   1   2   3 |        12  13   14  15 |        24 25 26 27 |
 
     // LGR1 marked elements with elemIdx = 17 and 18, refined into 27 children cells each,
     // with leaf indices 17+0,...,17+26 = 43 (children {level 0, cell index 17}),44,...,70 (children {level 0, cell index 18}).
-    const std::array<int, 3> startIJK = {1,1,1};
-    const std::array<int, 3> endIJK = {3,2,2};
-    const std::string lgr_name = {"LGR1"};
-    coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+    // LGR2 marked elements with elemIdx = 34 and 35, refined into 27 children cells each,
+    // with leaf indices 86,...,86+26 = 112  (children {level 0, cell index 34}), 113,...,139 (children {level 0, cell index 35}).
+    grid.addLgrsUpdateLeafView( /* cells_per_dim = */ {{3,3,3}, {3,3,3}},
+                                /* startIJK_vec = */ {{1,1,1}, {2,2,2}},
+                                /* endIJK_vec = */ {{3,2,2}, {4,3,3}},
+                                /* lgr_name_vec = */ {"LGR1", "LGR2"});
 
-    // - Cells 72 (in level 0 with cell index 20) and 84 (in level 0 with cell index 32) are coarse cells,
-    // sharing one K_FACE, that do not share faces with LGR1 (they do share corners).
-    // - Cells 25,34,43 are refined cells, children of {level 0, cell index 17}, forming a collum.
-    // - Cells 50,59,68 are refined cells, children of {level 0, cell index 18}, forming a collum.
-    // Cells 25 and 50, 34 and 59, 43 and 68, share a face (the collums are next to each other).
-    std::vector<int> markedCells = {25,34,43,50,59,68, 72, 84};
-    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, true, true, false);
+    // level 1 grid view, dimension 6x6x3 (leaf cell indices).       level 2 grid view, dimension 6x6x3 (leaf cell indices).
+    // k = 2  41  42  43  | 68  69  70 |                             k = 2  ...       112  | ...       139 |
+    //        38  39  40  | 65  66  67 |                                    ...            | ...           |
+    //        35  36  37  | 62  63  64 |                                    104 ..         | 131 ...       |
+    // ---------------------------------                             --------------------------------------
+    // k = 1  32  33  34  | 59  60  61 |                             k = 1  101  102  103  |...        130 |
+    //        29 [30][31] |[56][57] 58 |                                     98 [99] [100] |[125][126] 127 |
+    //        26  27  28  | 53  54  55 |                                     95   96  97   | 122 ...       |
+    // ---------------------------------                             ---------------------------------------
+    // k = 0  23  24  25  | 50  51  52 |                             k = 0   92   93   94  | ...       121 |
+    //        20  21  22  | 47  48  49 |                                     89   90   91  | ...           |
+    //        17  18  19  | 44  45  46 |                                     86   87   88  | 113 ...       |
+    //
+    // Cells 30, 31, 56, and 57 are refined cells, located in the interior of the refined-level-grid-1 (lgr 1 / level 1).
+    // Therefore, cell_to_face_ for all of them has size 6. (Their faces have all 2 refined neigboring cells - (not one coarse cell, and one refined)).
+
+
+    // leaf grid view
+    // k = 0  8  9 10 11 | k = 1  72  73   74  75 | k = 2  84 85  []* []**|
+    //        4  5  6  7 |        16  ()* ()** 71 |        80 81  82  83  |
+    //       [0][1] 2  3 |        12  13   14  15 |        76 77  78  79  |
+    //
+    // ()*  indices 17, 18, ..., 43 (children of parent cell with index 17 in level zero grid)
+    // ()** indices 44, 45, ..., 70 (children of parent cell with index 18 in level zero grid)
+    // ()*  indices 86, 87, ..., 112 (children of parent cell with index 34 in level zero grid)
+    // ()** indices 113, 114, ..., 139 (children of parent cell with index 35 in level zero grid)
+
+    // - Cells 30, 31, 56, and 57 are refined cells, located in the interior of the refined-level-grid-1 (lgr 1 / level 1).
+    // - Cells 99, 100, 125, and 126 are refined cells, located in the interior of the refined-level-grid-1 (lgr 1 / level 1).
+    // - Cells 0 and 1  are coarse cells, not touching the LGRs boundary.
+    std::vector<int> markedCells = {0,1,2,30,31,56,57,99,100,125,126};
+    adaptGridWithParams(grid, /* cells_per_dim = */ {2,3,4}, markedCells);
+
+    checkAdaptedGrid(grid,
+                     /* cells_per_dim = */ {2,3,4},
+                     /* lgrsHaveBlockShape = */ false,
+                     /* gridHasBeenGlobalRefined = */ false,
+                     /* preAdaptMaxLevel = */ 2);
 }
-*/
-
-
-
-
-

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -69,28 +69,22 @@ void adaptGridWithParams(Dune::CpGrid& grid,
         BOOST_CHECK( elem.mightVanish() == true);
     }
     grid.preAdapt();
-    if( grid.preAdapt() ) { // markedCells can be empty
-        grid.adapt({cells_per_dim}, assignRefinedLevel, {"LGR"+std::to_string(grid.maxLevel() +1)});
-        grid.postAdapt();
-    }
+    grid.adapt({cells_per_dim}, assignRefinedLevel, {"LGR"+std::to_string(grid.maxLevel() +1)});
+    grid.postAdapt();
 }
 
 void adaptGrid(Dune::CpGrid& grid,
                const std::vector<int>& markedCells)
 {
     const auto& leafGridView = grid.currentData().back();
-    std::cout<< "empty: " << markedCells.empty()<< std::endl;
     for (const auto& elemIdx : markedCells)
     {
-        std::cout<< "hola: " << markedCells.empty()<< std::endl;
         const auto& elem =  Dune::cpgrid::Entity<0>(*leafGridView, elemIdx, true);
         grid.mark(1, elem);
     }
     grid.preAdapt();
-    if( grid.preAdapt() ) { // markedCells can be empty
-        grid.adapt();
-        grid.postAdapt();
-    }
+    grid.adapt();
+    grid.postAdapt();
 }
 
 void compareGrids(const Dune::CpGrid& grid,
@@ -151,10 +145,10 @@ BOOST_AUTO_TEST_CASE(emptyMarkedElemForRefinementSetDoesNothingToTheGrid)
     adaptGrid(grid, /* markedCells = */ {});
 
     BOOST_CHECK_EQUAL( grid.maxLevel(), 0);
-    BOOST_CHECK_EQUAL( grid.numCells(), grid.levelGridView(0).size(0));
+    BOOST_CHECK_EQUAL( grid.preAdapt(), false);
+    BOOST_CHECK_EQUAL( grid.adapt(), false);
+    BOOST_CHECK_EQUAL( grid.leafGridView().size(0), grid.levelGridView(0).size(0));
 }
-
-
 
 BOOST_AUTO_TEST_CASE(markAllElementsForRefinementIsEquivalentToCallGlobalRefinementWithOne)
 {

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -59,7 +59,7 @@ BOOST_GLOBAL_FIXTURE(Fixture);
 void checkAdaptedGrid(Dune::CpGrid& grid,
                       const std::array<int,3>& cells_per_dim,
                       bool lgrsHaveBlockShape,
-                      [[maybe_unused]] bool gridHasBeenGlobalRefined,
+                      bool gridHasBeenGlobalRefined,
                       int preAdaptMaxLevel)
 {
     const auto& data = grid.currentData();
@@ -68,10 +68,7 @@ void checkAdaptedGrid(Dune::CpGrid& grid,
     Opm::checkVertexAndFaceIndexAreNonNegative(grid);
     Opm::checkGridBasicHiearchyInfo(grid, {cells_per_dim}, preAdaptMaxLevel);
     Opm::checkGridLocalAndGlobalIdConsistency(grid, data);
-
-    if (lgrsHaveBlockShape) {
-        Opm::checkGlobalCellBounds(grid, data);
-    }
+    Opm::checkGlobalCellBounds(grid, data, lgrsHaveBlockShape, gridHasBeenGlobalRefined);
 }
 
 BOOST_AUTO_TEST_CASE(markNoElemForRefinementDoesNothingToTheGrid)
@@ -102,7 +99,7 @@ BOOST_AUTO_TEST_CASE(markAllElementsForRefinementIsEquivalentToCallGlobalRefinem
     // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells..
     checkAdaptedGrid(grid,
                      /* cells_per_dim = */ {2,2,2},
-                     /* lgrsHaveBlockShape = */ false,
+                     /* lgrsHaveBlockShape = */ true,
                      /* gridHasBeenGlobalRefined = */ true,
                      /* preAdaptMaxLevel = */ 0);
 

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -91,7 +91,6 @@ void compareGrids(const Dune::CpGrid& grid,
                   const Dune::CpGrid& equivalent_grid,
                   bool gridLgrsHaveBlockShape,
                   bool gridHasBeenGlobalRefined,
-                  bool gridHadBeenRefinedAtLeastOnce = false,
                   int gridPreAdaptMaxLevel = 0)
 {
     if(gridLgrsHaveBlockShape) { // For a mixed grid that gets refined a second time, isBlockShape == false, even though the marked elements form a block.
@@ -107,14 +106,13 @@ void checkAdaptedGrid(Dune::CpGrid& grid,
                       const std::array<int,3>& cells_per_dim,
                       bool lgrsHaveBlockShape,
                       bool gridHasBeenGlobalRefined,
-                      bool gridHadBeenRefinedAtLeastOnce = false,
                       int preAdaptMaxLevel = 0)
 {
     const auto& data = grid.currentData();
     BOOST_CHECK(static_cast<int>(data.size()) == grid.maxLevel() +2);
 
     Opm::checkVertexAndFaceIndexAreNonNegative(grid);
-    Opm::checkGridBasicHiearchyInfo(grid, {cells_per_dim}, gridHadBeenRefinedAtLeastOnce, preAdaptMaxLevel);
+    Opm::checkGridBasicHiearchyInfo(grid, {cells_per_dim}, preAdaptMaxLevel);
     Opm::checkGridLocalAndGlobalIdConsistency(grid, data);
 
     if (lgrsHaveBlockShape) {
@@ -280,7 +278,7 @@ BOOST_AUTO_TEST_CASE(refineCoarseCellsNotTouchingLgrBoundaryInAGridWithLgrsIsSup
     adaptGridWithParams(grid, /* cells_per_dim = */ {2,2,2}, markedCells);
     
     checkAdaptedGrid(grid, /* cells_per_dim = */ {2,3,4}, /* lgrsHaveBlockShape = */ false, /* gridHasBeenGlobalRefined = */ false,
-                     /* hadBeenRefinedAtLeastOnce = */ true, /* preAdaptMaxLevel = */ 1);
+                     /* preAdaptMaxLevel = */ 1);
 }
 
 /*BOOST_AUTO_TEST_CASE(refineInteriorRefinedCells_in_mixedGrid) {

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -473,66 +473,52 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
     } // end-if-preAdapt
 }
 
-BOOST_AUTO_TEST_CASE(doNothing)
+BOOST_AUTO_TEST_CASE(emptyMarkedElementsForRefinementSetDoesNothingToTheGrid)
 {
-    // Create a grid
-    Dune::CpGrid coarse_grid;
-    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim = {2,2,2};
-    std::vector<int> markedCells;
-    coarse_grid.createCartesian(grid_dim, cell_sizes);
-    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, true, false, true);
+    Dune::CpGrid grid;
+    grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
+   
+    // The last three bool arguments represent:, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(grid, /* cells_per_dim = */ {2,2,2}, /* markedCells = */ {}, grid, /* isBlockShape = */ true, false, true);
 }
 
-BOOST_AUTO_TEST_CASE(globalRefinement)
+
+BOOST_AUTO_TEST_CASE(emptyMarkedElementsForRefinementSetIsEquivalentToCallGlobalRefineWithZero)
 {
-    // Create a grid
-    Dune::CpGrid coarse_grid;
-    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim = {2,2,2};
-    std::vector<int> markedCells(36);
-    std::iota(markedCells.begin(), markedCells.end(), 0);
-    coarse_grid.createCartesian(grid_dim, cell_sizes);
+    Dune::CpGrid grid;
+    grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
 
     // Create other grid for comparison
     Dune::CpGrid other_grid;
-    other_grid.createCartesian(grid_dim, cell_sizes);
-
-    const std::array<int, 3> startIJK = {0,0,0};
-    const std::array<int, 3> endIJK = {4,3,3};
-    const std::string lgr_name = {"LGR1"};
-    other_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
-
-    // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
-    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, false, false, true);
-}
-
-
-BOOST_AUTO_TEST_CASE(doNothing_calling_globalRefine)
-{
-    // Create a grid
-    Dune::CpGrid coarse_grid;
-    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim = {2,2,2};
-    std::vector<int> markedCells;
-    coarse_grid.createCartesian(grid_dim, cell_sizes);
-
-    // Create another grid
-    Dune::CpGrid other_grid;
-    other_grid.createCartesian(grid_dim, cell_sizes);
+    other_grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
     other_grid.globalRefine(0);
 
     // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
     // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, true, false, true);
+    markAndAdapt_check(grid,  /* cells_per_dim = */ {2,2,2}, /*markedCells = */ {}, other_grid, true, false, true);
 }
 
-BOOST_AUTO_TEST_CASE(globalRefinement_calling_globalRefine)
+
+BOOST_AUTO_TEST_CASE(allElementsMarkedForRefinementIsEquivalentToCallGlobalRefinementWithOne)
+{
+    Dune::CpGrid grid;
+    grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
+    std::vector<int> markedCells(36);
+    std::iota(markedCells.begin(), markedCells.end(), 0);
+   
+
+    // Create other grid for comparison
+    Dune::CpGrid other_grid;
+    other_grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
+    other_grid.globalRefine(1);
+
+    // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(grid, /* cells_per_dim = */ {2,2,2}, markedCells, other_grid, false, false, true);
+}
+
+
+/*BOOST_AUTO_TEST_CASE(globalRefinement_calling_globalRefine)
 {
     // Create a grid
     Dune::CpGrid coarse_grid;
@@ -922,3 +908,4 @@ BOOST_AUTO_TEST_CASE(cellTouchesLgrBoundary_throw)
     // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
     BOOST_CHECK_THROW(markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, true, true, false), std::logic_error);
 }
+*/

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -112,11 +112,8 @@ BOOST_AUTO_TEST_CASE(markAllElementsForRefinementIsEquivalentToCallGlobalRefinem
     equivalent_grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
     equivalent_grid.globalRefine(1);
 
-    // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
-    Opm::compareGrids(grid,
-                      equivalent_grid,
-                      /* lgrsHaveBlockShape = */ false,
-                      /* gridHasBeenGlobalRefined = */ true);
+    Opm::checkLeafGridGeometryEquality(grid, equivalent_grid);
+     Opm::checkCellBlockRefinements(grid, equivalent_grid);
 }
 
 BOOST_AUTO_TEST_CASE(markCellBlockForRefinementIsEquivalentToCallAddLgrsUpdateLeafView)
@@ -140,7 +137,8 @@ BOOST_AUTO_TEST_CASE(markCellBlockForRefinementIsEquivalentToCallAddLgrsUpdateLe
                                            /* endIJK = */  {{3,2,2}}, // block cell indices = {17, 18}
                                            /* lgr_name = */  {"LGR1"});
 
-    Opm::compareGrids(grid, equivalent_grid, /* lgrsHaveBlockShape = */ true, /* gridHasBeenGlobalRefined = */ false);
+    Opm::checkLeafGridGeometryEquality(grid, equivalent_grid);
+    Opm::checkCellBlockRefinements(grid, equivalent_grid);
 }
 
 BOOST_AUTO_TEST_CASE(refinementOfCellsNotFormingABlockIsSupported)
@@ -188,7 +186,8 @@ BOOST_AUTO_TEST_CASE(callAdaptMultipleTimesAsLongAsCoarseMarkedElementsAreNotAtL
     Opm::adaptGrid(equivalent_grid, markedCells2);
     Opm::adaptGrid(equivalent_grid, markedCells3);
 
-    Opm::compareGrids(grid, equivalent_grid, /* lgrsHaveBlockShape = */ false, /* gridHasBeenGlobalRefined = */ false);
+    Opm::checkLeafGridGeometryEquality(grid, equivalent_grid);
+     Opm::checkCellBlockRefinements(grid, equivalent_grid);
 }
 
 BOOST_AUTO_TEST_CASE(refineCoarseOrRefinedCellsOnLgrBoundaryThrows)

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -73,12 +73,25 @@ struct Fixture
 
 BOOST_GLOBAL_FIXTURE(Fixture);
 
-#define CHECK_COORDINATES(c1, c2)                                       \
-    for (int c = 0; c < 3; c++) {                                       \
-        BOOST_TEST(c1[c] == c2[c], boost::test_tools::tolerance(1e-12)); \
-    }
+std::vector<int> markElemsForRefinementAndGetAssignedLevels(Dune::CpGrid& grid,
+                                   const std::vector<int>& markedCells)
+{
+    const int startingGridIdx = grid.currentData().size() -1; // size before calling adapt
 
-void markAndAdapt_check(Dune::CpGrid& coarse_grid,
+    std::vector<int> assignRefinedLevel(grid.currentData()[startingGridIdx]->size(0));
+
+    for (const auto& elemIdx : markedCells)
+    {
+        const auto& elem =  Dune::cpgrid::Entity<0>(*(grid.currentData()[startingGridIdx]), elemIdx, true);
+        grid.mark(1, elem);
+        assignRefinedLevel[elemIdx] = grid.maxLevel() + 1;
+        BOOST_CHECK( grid.getMark(elem) == 1);
+        BOOST_CHECK( elem.mightVanish() == true);
+    }
+    return assignRefinedLevel;
+}
+
+void markAndAdapt_check(Dune::CpGrid& grid,
                         const std::array<int,3>& cells_per_dim,
                         const std::vector<int>& markedCells,
                         Dune::CpGrid& other_grid,
@@ -86,306 +99,50 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
                         bool hasBeenRefinedAtLeastOnce,
                         bool isGlobalRefinement)
 {
-    const int startingGridIdx = coarse_grid.currentData().size() -1; // size before calling adapt
-
-    std::vector<int> assignRefinedLevel(coarse_grid.currentData()[startingGridIdx]->size(0));
-
-    for (const auto& elemIdx : markedCells)
-    {
-        const auto& elem =  Dune::cpgrid::Entity<0>(*(coarse_grid.currentData()[startingGridIdx]), elemIdx, true);
-        coarse_grid.mark(1, elem);
-        assignRefinedLevel[elemIdx] = coarse_grid.maxLevel() + 1;
-        BOOST_CHECK( coarse_grid.getMark(elem) == 1);
-        BOOST_CHECK( elem.mightVanish() == true);
-    }
-    bool preAdapt = coarse_grid.preAdapt();
-    const auto& data = coarse_grid.currentData();
+    const auto assignRefinedLevel = markElemsForRefinementAndGetAssignedLevels(grid, markedCells);
+    
+    bool preAdapt = grid.preAdapt();
+    const auto& data = grid.currentData();
     if(preAdapt) {
-        coarse_grid.adapt({cells_per_dim}, assignRefinedLevel, {"LGR"+std::to_string(coarse_grid.maxLevel() +1)});
-        coarse_grid.postAdapt();
-        BOOST_CHECK(static_cast<int>(data.size()) == coarse_grid.maxLevel() +2);
-        const auto& leafGridIdx = coarse_grid.maxLevel() +1;
-        const auto& adapted_leaf = *data[leafGridIdx];
+        
+        grid.adapt({cells_per_dim}, assignRefinedLevel, {"LGR"+std::to_string(grid.maxLevel() +1)});
+        grid.postAdapt();
+        
+        BOOST_CHECK(static_cast<int>(data.size()) == grid.maxLevel() +2);
+        //const auto& leafGridIdx = coarse_grid.maxLevel() +1;
 
         if(isBlockShape) { // For a mixed grid that gets refined a second time, isBlockShape == false, even though the marked elements form a block.
-            const auto& blockRefinement_data = other_grid.currentData();
-            const auto& blockRefinement_leaf = *blockRefinement_data.back();
-
-            // Check the container sizes
-            BOOST_CHECK_EQUAL(adapted_leaf.geomVector<3>().size(), blockRefinement_leaf.geomVector<3>().size());
-            BOOST_CHECK_EQUAL(adapted_leaf.face_to_cell_.size(), blockRefinement_leaf.face_to_cell_.size());
-            BOOST_CHECK_EQUAL(adapted_leaf.face_to_point_.size(), blockRefinement_leaf.face_to_point_.size());
-            BOOST_CHECK_EQUAL(adapted_leaf.face_normals_.size(), blockRefinement_leaf.face_normals_.size());
-            BOOST_CHECK_EQUAL(adapted_leaf.face_tag_.size(), blockRefinement_leaf.face_tag_.size());
-            BOOST_CHECK_EQUAL(adapted_leaf.cell_to_point_.size(), blockRefinement_leaf.cell_to_point_.size());
-            BOOST_CHECK_EQUAL(adapted_leaf.cell_to_face_.size(), blockRefinement_leaf.cell_to_face_.size());
-            BOOST_CHECK_EQUAL(coarse_grid.size(3), other_grid.size(3));
-            BOOST_CHECK_EQUAL(coarse_grid.size(0), other_grid.size(0));
-            BOOST_CHECK_EQUAL(coarse_grid.size(1,0), other_grid.size(1,0)); // equal amount of cells in level 1
-            BOOST_CHECK_EQUAL(coarse_grid.size(1,3), other_grid.size(1,3)); // equal amount of corners in level 1
-
-
-            for(const auto& point: adapted_leaf.geomVector<3>()){
-                auto equiv_point_iter = blockRefinement_leaf.geomVector<3>().begin();
-                while ((equiv_point_iter != blockRefinement_leaf.geomVector<3>().end()) && (point.center() != equiv_point_iter->center())) {
-                    ++equiv_point_iter;
-                }
-                CHECK_COORDINATES(point.center(), equiv_point_iter->center());
-                for(const auto& coord: point.center())
-                    BOOST_TEST(std::isfinite(coord));
-
-            }
-            for(const auto& cell: adapted_leaf.geomVector<3>()) {
-                auto equiv_cell_iter = blockRefinement_leaf.geomVector<3>().begin();
-                while ((equiv_cell_iter != blockRefinement_leaf.geomVector<3>().end()) && (cell.center() != equiv_cell_iter->center())) {
-                    ++equiv_cell_iter;
-                }
-                CHECK_COORDINATES(cell.center(), equiv_cell_iter->center());
-                for(const auto& coord: cell.center())
-                    BOOST_TEST(std::isfinite(coord));
-                BOOST_CHECK_CLOSE(cell.volume(), equiv_cell_iter->volume(), 1e-24);
-            }
-
-            /////  THE FOLLOWING CODE WOULD FIT FOR TESTING GLOBAL REFINEMENT
+            Opm::checkCellBlockRefinements(grid, other_grid);
+            
             if (isGlobalRefinement) {
-                const auto& grid_view = coarse_grid.leafGridView();
-                const auto& equiv_grid_view = other_grid.leafGridView();
+                Opm::checkLeafGridGeometryEquality(grid, other_grid);
+            }
+        }
 
-                for(const auto& element: elements(grid_view)) {
-                    BOOST_CHECK( element.getOrigin().level() == 0);
-                    auto equiv_element_iter = equiv_grid_view.begin<0>();
-                    bool closedCenter =  (std::abs(element.geometry().center()[0] - equiv_element_iter->geometry().center()[0]) < 1e-12) &&
-                        (std::abs(element.geometry().center()[1] - equiv_element_iter->geometry().center()[1]) < 1e-12) &&
-                        (std::abs(element.geometry().center()[2] - equiv_element_iter->geometry().center()[2])< 1e-12);
-
-                    while ((equiv_element_iter != equiv_grid_view.end<0>()) && (!closedCenter)) {
-                        ++equiv_element_iter;
-                        closedCenter = (std::abs(element.geometry().center()[0] - equiv_element_iter->geometry().center()[0]) < 1e-12) &&
-                            (std::abs(element.geometry().center()[1] - equiv_element_iter->geometry().center()[1]) < 1e-12) &&
-                            (std::abs(element.geometry().center()[2] - equiv_element_iter->geometry().center()[2])< 1e-12);
-                    }
-                    for(const auto& intersection: intersections(grid_view, element)) {
-                        // find matching intersection (needed as ordering is allowed to be different
-                        bool matching_intersection_found = false;
-                        for(auto& intersection_match: intersections(equiv_grid_view, *equiv_element_iter)) {
-                            if(intersection_match.indexInInside() == intersection.indexInInside()) {
-                                BOOST_CHECK(intersection_match.neighbor() == intersection.neighbor());
-
-                                if(intersection.neighbor()) {
-                                    BOOST_CHECK(intersection_match.indexInOutside() == intersection.indexInOutside());
-                                }
-
-                                CHECK_COORDINATES(intersection_match.centerUnitOuterNormal(), intersection.centerUnitOuterNormal());
-                                const auto& geom_match = intersection_match.geometry();
-                                BOOST_TEST(0.0 == 1e-11, boost::test_tools::tolerance(1e-8));
-                                const auto& geom =  intersection.geometry();
-                                bool closedGeomCenter =  (std::abs(geom_match.center()[0] - geom.center()[0]) < 1e-12) &&
-                                    (std::abs(geom_match.center()[1] - geom.center()[1]) < 1e-12) &&
-                                    (std::abs(geom_match.center()[2] - geom.center()[2])< 1e-12);
-                                if (!closedGeomCenter) {
-                                    break; // Check next intersection_match
-                                }
-                                BOOST_CHECK_CLOSE(geom_match.volume(), geom.volume(), 1e-6);
-                                CHECK_COORDINATES(geom_match.center(), geom.center());
-                                BOOST_CHECK(geom_match.corners() == geom.corners());
-
-                                decltype(geom.corner(0)) sum_match{}, sum{};
-
-                                for(int cor = 0; cor < geom.corners(); ++cor) {
-                                    sum += geom.corner(cor);
-                                    sum_match += geom_match.corner(1);
-                                }
-                                CHECK_COORDINATES(sum, sum_match);
-                                matching_intersection_found = true;
-                                break;
-                            }
-                        } // end-for-loop-intersection_match
-                        BOOST_CHECK(matching_intersection_found);
-                    }
-                }
-            } // end-if-isGlobalRefinement
-        } // end-if-isBlockShape
-
-        const auto& grid_view = coarse_grid.leafGridView();
+        const auto& grid_view = grid.leafGridView();
         Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LeafGridView> adaptMapper(grid_view, Dune::mcmgElementLayout());
 
-        // Opm::checkGlobalCellBounds(coarse_grid, data);
+        Opm::checkVertexAndFaceIndexAreNonNegative(grid);
+        Opm::checkGridBasicHiearchyInfo(grid, {cells_per_dim});
         
-        auto itMin = std::min_element((data.back() -> global_cell_).begin(),  (data.back()-> global_cell_).end());
-        auto itMax = std::max_element((data.back() -> global_cell_).begin(),  (data.back() -> global_cell_).end());
-        BOOST_CHECK_EQUAL( *itMin, 0);
-        const auto& maxCartesianIdx = coarse_grid.logicalCartesianSize()[0]*coarse_grid.logicalCartesianSize()[1]*coarse_grid.logicalCartesianSize()[2] -1;
-        BOOST_CHECK_EQUAL( *itMax, maxCartesianIdx);
-
-        for(const auto& element: elements(grid_view)) {
-            // postAdapt() has been called, therefore every element gets marked with 0
-            BOOST_CHECK( coarse_grid.getMark(element) == 0);
-            BOOST_CHECK(  adapted_leaf.cell_to_point_[element.index()].size() == 8);
-            for (int i = 0; i < 8; ++i) {
-                BOOST_CHECK(  adapted_leaf.cell_to_point_[element.index()][i] != -1);
-            }
-            for (int i = 0; i <  adapted_leaf.cell_to_face_[element].size(); ++i) {
-                BOOST_CHECK(  adapted_leaf.cell_to_face_[element][i].index() != -1);
-            }
-            const auto& child_to_parent =  adapted_leaf.child_to_parent_cells_[element.index()];
-            const auto& level_cellIdx =  adapted_leaf.leaf_to_level_cells_[element.index()];
-            auto it = element.hbegin(level_cellIdx[0] /*level*/);//coarse_grid.maxLevel());
-            auto endIt = element.hend(level_cellIdx[0] /*level*/); //coarse_grid.maxLevel());
-            BOOST_CHECK(element.isLeaf());
-            BOOST_CHECK(it == endIt);
-            if (element.hasFather()){
-                BOOST_CHECK( element.isNew() == true);
-                BOOST_CHECK_CLOSE(element.geometryInFather().volume(), 1./(cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]), 1e-6);
-                if (hasBeenRefinedAtLeastOnce){
-                    BOOST_CHECK(element.father().level() <= startingGridIdx);
-                    BOOST_CHECK( element.getOrigin().level() <= startingGridIdx);
-                    BOOST_CHECK( data[element.father().level()] ->mark_[element.father().index()] == 1);
-                }
-                else {
-                    BOOST_CHECK(element.father().level() == 0);
-                    BOOST_CHECK( element.getOrigin().level() == 0);
-                    BOOST_CHECK_EQUAL( (std::find(markedCells.begin(), markedCells.end(), element.father().index()) == markedCells.end()), false);
-                }
-                BOOST_CHECK(child_to_parent[0] != -1);
-                BOOST_CHECK_EQUAL( child_to_parent[0], element.father().level());
-                BOOST_CHECK_EQUAL( child_to_parent[1], element.father().index());
-                BOOST_CHECK( element.father() == element.getOrigin());
-
-                BOOST_CHECK( std::get<0>(data[element.father().level()]->parent_to_children_cells_[element.father().index()]) == element.level());
-                // Check amount of children cells of the parent cell
-                BOOST_CHECK_EQUAL(std::get<1>(data[element.father().level()]->parent_to_children_cells_[child_to_parent[1]]).size(),
-                                  (*data[element.level()]).cells_per_dim_[0]*(*data[element.level()]).cells_per_dim_[1]*(*data[element.level()]).cells_per_dim_[2]);
-                if(!hasBeenRefinedAtLeastOnce)
-                {
-                    BOOST_CHECK( element.father().isLeaf() == false);
-                }
-                BOOST_CHECK( (element.level() > 0) || (element.level() < coarse_grid.maxLevel() +1));
-                BOOST_CHECK( level_cellIdx[0] == element.level());
-                BOOST_CHECK(element.index() == adaptMapper.index(element));
-                BOOST_CHECK(element.index() == adaptMapper.index(element));
-                /** Not ideal to define this for each element. Remove?*/
-                const auto& preAdapt_view = coarse_grid.levelGridView(element.father().level());
-                Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LevelGridView> preAdaptMapper(preAdapt_view, Dune::mcmgElementLayout());
-                BOOST_CHECK(element.father().index() == preAdaptMapper.index(element.father()));
-            }
-            else{
-                BOOST_CHECK_THROW(element.father(), std::logic_error);
-                BOOST_CHECK_THROW(element.geometryInFather(), std::logic_error);
-                BOOST_CHECK_EQUAL(child_to_parent[0], -1);
-                BOOST_CHECK_EQUAL(child_to_parent[1], -1);
-                if (hasBeenRefinedAtLeastOnce){
-                    BOOST_CHECK( level_cellIdx[0] == element.level());
-                    BOOST_CHECK( element.level() <= startingGridIdx);
-                    BOOST_CHECK( element.getOrigin().level() <= startingGridIdx);
-                }
-                else  {
-                    BOOST_CHECK( level_cellIdx[0] == 0);
-                    BOOST_CHECK( element.level() == 0);
-                    BOOST_CHECK( element.getOrigin().level() == 0);
-                }
-                BOOST_CHECK( std::get<0>(data[element.level()]-> parent_to_children_cells_[level_cellIdx[1]]) == -1);
-                BOOST_CHECK( std::get<1>(data[element.level()]->parent_to_children_cells_[level_cellIdx[1]]).empty());
-                // Get index of the cell in level 0
-                const auto& entityOldIdx =   adapted_leaf.leaf_to_level_cells_[element.index()][1];
-                BOOST_CHECK( element.getOrigin().index() == entityOldIdx);
-                BOOST_CHECK( element.getOrigin().level() == 0);
-                BOOST_CHECK( element.isNew() == false);
-            }
-            BOOST_CHECK( element.mightVanish() == false); // marks get rewrtitten and set to 0 via postAdapt call
-        } // end-element-for-loop
-
-
-
-        if (startingGridIdx == 0) {
-            const auto& preAdapt_view = coarse_grid.levelGridView(startingGridIdx);
-            Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LevelGridView> preAdaptMapper(preAdapt_view, Dune::mcmgElementLayout());
-            //  const auto& preAdapt_idSet = (*data[startingGridIdx+1]).local_id_set_;
-            // Some checks on the preAdapt grid
-            for(const auto& element: elements(preAdapt_view)) {
-
-                BOOST_CHECK( element.hasFather() == false);
-                BOOST_CHECK_THROW(element.father(), std::logic_error);
-                BOOST_CHECK_THROW(element.geometryInFather(), std::logic_error);
-                BOOST_CHECK( element.getOrigin() ==  element);
-                BOOST_CHECK( element.getOrigin().level() == startingGridIdx);
-                BOOST_CHECK( element.isNew() == false);
-                auto it = element.hbegin(coarse_grid.maxLevel()); // With element.level(), fails
-                auto endIt = element.hend(coarse_grid.maxLevel());
-                const auto& [lgr, childrenList] = (*data[startingGridIdx]).parent_to_children_cells_[element.index()];
-                if (std::find(markedCells.begin(), markedCells.end(), element.index()) == markedCells.end()){
-                    BOOST_CHECK_EQUAL(lgr, -1);
-                    BOOST_CHECK(childrenList.empty());
-                    BOOST_CHECK( element.isLeaf() == true);
-                    // If it == endIt, then entity.isLeaf() true (when dristibuted_data_ is empty)
-                    BOOST_CHECK( it == endIt);
-                    BOOST_CHECK( element.mightVanish() == false);
-                }
-                else{
-                    BOOST_CHECK(lgr != -1);
-                    BOOST_CHECK(static_cast<int>(childrenList.size()) == cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]);
-                    // If it != endIt, then entity.isLeaf() false (when dristibuted_data_ is empty)
-                    BOOST_CHECK_EQUAL( it == endIt, false);
-                    BOOST_CHECK( element.mightVanish() == true);
-                    BOOST_CHECK( element.isNew() == false);
-                    BOOST_CHECK_EQUAL( element.isLeaf(), false); // parent cells do not appear in the LeafView
-
-                    // Auxiliary int to check amount of children
-                    double referenceElemOneParent_volume = 0.;
-                    std::array<double,3> referenceElem_entity_center = {0.,0.,0.}; // Expected {.5,.5,.5}
-                    for (const auto& child : childrenList) {
-                        BOOST_CHECK( child != -1);
-                        BOOST_CHECK( data[startingGridIdx+1]-> child_to_parent_cells_[child][0] == startingGridIdx);  //
-                        BOOST_CHECK( data[startingGridIdx+1]-> child_to_parent_cells_[child][1] == element.index());
-
-                        const auto& childElem =  Dune::cpgrid::Entity<0>(*data[startingGridIdx+1], child, true);
-                        BOOST_CHECK(childElem.hasFather() == true);
-                        BOOST_CHECK(childElem.level() == lgr);
-                        referenceElemOneParent_volume += childElem.geometryInFather().volume();
-                        for (int c = 0; c < 3; ++c)  {
-                            referenceElem_entity_center[c] += (childElem.geometryInFather().center())[c];
-                        }
-                    }
-                    /// Auxiliary int to check amount of children
-                    double referenceElemOneParent_volume_it = 0.;
-                    std::array<double,3> referenceElem_entity_center_it = {0.,0.,0.}; // Expected {.5,.5,.5}
-                    for (; it != endIt; ++it)
-                    {
-                        BOOST_CHECK(it ->hasFather() == true);
-                        BOOST_CHECK(it ->level() == lgr);
-                        referenceElemOneParent_volume_it += it-> geometryInFather().volume();
-                        for (int c = 0; c < 3; ++c)
-                        {
-                            referenceElem_entity_center_it[c] += (it-> geometryInFather().center())[c];
-                        }
-                    }
-                    for (int c = 0; c < 3; ++c) {
-                        referenceElem_entity_center[c] /= cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2];
-                        referenceElem_entity_center_it[c] /= cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2];
-                    }
-                    BOOST_CHECK_CLOSE(referenceElemOneParent_volume, 1, 1e-13);
-                    BOOST_CHECK_CLOSE(referenceElem_entity_center[0], .5, 1e-13);
-                    BOOST_CHECK_CLOSE(referenceElem_entity_center[1], .5, 1e-13);
-                    BOOST_CHECK_CLOSE(referenceElem_entity_center[2], .5, 1e-13);
-
-                    BOOST_CHECK_CLOSE(referenceElemOneParent_volume_it, 1, 1e-13);
-                    BOOST_CHECK_CLOSE(referenceElem_entity_center_it[0], .5, 1e-13);
-                    BOOST_CHECK_CLOSE(referenceElem_entity_center_it[1], .5, 1e-13);
-                    BOOST_CHECK_CLOSE(referenceElem_entity_center_it[2], .5, 1e-13);
-                }
-                BOOST_CHECK( element.level() == 0);
-            } // end-preAdaptElements-for-loop
-        } // end-startingGridIdx==0
-
-        for (int level = 1; level < coarse_grid.maxLevel(); ++level)
+        /* for (int level = 1; level < coarse_grid.maxLevel(); ++level)
         {
             auto itMinLevel = std::min_element((data[level] -> global_cell_).begin(),  (data[level] -> global_cell_).end());
             auto itMaxLevel = std::max_element((data[level] -> global_cell_).begin(),  (data[level] -> global_cell_).end());
             BOOST_CHECK_EQUAL( *itMinLevel, 0);
             const auto& maxCartesianIdxLevel = data[level]->logical_cartesian_size_[0]*data[level]->logical_cartesian_size_[1]* data[level]->logical_cartesian_size_[2] -1;
             BOOST_CHECK_EQUAL( *itMaxLevel, maxCartesianIdxLevel);
-        }
+            }*/
 
-        Opm::checkGridLocalAndGlobalIdConsistency(coarse_grid, data);
+        //Opm::checkGlobalCellBounds(coarse_grid, data);
+        
+         /* auto itMin = std::min_element((data.back() -> global_cell_).begin(),  (data.back()-> global_cell_).end());
+        auto itMax = std::max_element((data.back() -> global_cell_).begin(),  (data.back() -> global_cell_).end());
+        BOOST_CHECK_EQUAL( *itMin, 0);
+        const auto& maxCartesianIdx = coarse_grid.logicalCartesianSize()[0]*coarse_grid.logicalCartesianSize()[1]*coarse_grid.logicalCartesianSize()[2] -1;
+        BOOST_CHECK_EQUAL( *itMax, maxCartesianIdx);*/
+
+        Opm::checkGridLocalAndGlobalIdConsistency(grid, data);
     } // end-if-preAdapt
 }
 
@@ -434,7 +191,7 @@ BOOST_AUTO_TEST_CASE(allElementsMarkedForRefinementIsEquivalentToCallGlobalRefin
 }
 
 
-/*BOOST_AUTO_TEST_CASE(globalRefinement_calling_globalRefine)
+BOOST_AUTO_TEST_CASE(globalRefinement_calling_globalRefine)
 {
     // Create a grid
     Dune::CpGrid coarse_grid;
@@ -534,6 +291,7 @@ BOOST_AUTO_TEST_CASE(throw_globalRefine_of_mixed_grid)
 
     BOOST_CHECK_THROW(grid.globalRefine(1), std::logic_error);
 }
+
 
 BOOST_AUTO_TEST_CASE(mark2consequtiveCells)
 {
@@ -684,7 +442,10 @@ BOOST_AUTO_TEST_CASE(callAdaptMultipleTimes)
     markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, false, false, false);
 }
 
-BOOST_AUTO_TEST_CASE(refineCoarseCells_in_mixedGrid) {
+
+// Nested cases
+
+/*BOOST_AUTO_TEST_CASE(refineCoarseCells_in_mixedGrid) {
     // Create a grid
     Dune::CpGrid coarse_grid;
     const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
@@ -801,6 +562,7 @@ BOOST_AUTO_TEST_CASE(refineMixedCells_in_mixedGrid_II)
     // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
     markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, true, true, false);
 }
+*/
 
 BOOST_AUTO_TEST_CASE(cellTouchesLgrBoundary_throw)
 {
@@ -824,4 +586,4 @@ BOOST_AUTO_TEST_CASE(cellTouchesLgrBoundary_throw)
     // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
     BOOST_CHECK_THROW(markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, true, true, false), std::logic_error);
 }
-*/
+

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -88,20 +88,6 @@ void adaptGrid(Dune::CpGrid& grid,
     grid.postAdapt();
 }
 
-void compareGrids(const Dune::CpGrid& grid,
-                  const Dune::CpGrid& equivalent_grid,
-                  bool gridLgrsHaveBlockShape,
-                  bool gridHasBeenGlobalRefined)
-{
-    if(gridLgrsHaveBlockShape) { // For a mixed grid that gets refined a second time, isBlockShape == false, even though the marked elements form a block.
-        Opm::checkCellBlockRefinements(grid, equivalent_grid);
-
-        if (gridHasBeenGlobalRefined) {
-            Opm::checkLeafGridGeometryEquality(grid, equivalent_grid);
-        }
-    }
-}
-
 void checkAdaptedGrid(Dune::CpGrid& grid,
                       const std::array<int,3>& cells_per_dim,
                       bool lgrsHaveBlockShape,
@@ -159,10 +145,10 @@ BOOST_AUTO_TEST_CASE(markAllElementsForRefinementIsEquivalentToCallGlobalRefinem
     equivalent_grid.globalRefine(1);
 
     // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
-    compareGrids(grid,
-                 equivalent_grid,
-                 /* lgrsHaveBlockShape = */ false,
-                 /* gridHasBeenGlobalRefined = */ true);
+    Opm::compareGrids(grid,
+                      equivalent_grid,
+                      /* lgrsHaveBlockShape = */ false,
+                      /* gridHasBeenGlobalRefined = */ true);
 }
 
 BOOST_AUTO_TEST_CASE(markCellBlockForRefinementIsEquivalentToCallAddLgrsUpdateLeafView)
@@ -186,7 +172,7 @@ BOOST_AUTO_TEST_CASE(markCellBlockForRefinementIsEquivalentToCallAddLgrsUpdateLe
                                            /* endIJK = */  {{3,2,2}}, // block cell indices = {17, 18}
                                            /* lgr_name = */  {"LGR1"});
 
-    compareGrids(grid, equivalent_grid, /* lgrsHaveBlockShape = */ true, /* gridHasBeenGlobalRefined = */ false);
+    Opm::compareGrids(grid, equivalent_grid, /* lgrsHaveBlockShape = */ true, /* gridHasBeenGlobalRefined = */ false);
 }
 
 BOOST_AUTO_TEST_CASE(refinementOfCellsNotFormingABlockIsSupported)
@@ -234,7 +220,7 @@ BOOST_AUTO_TEST_CASE(callAdaptMultipleTimesAsLongAsCoarseMarkedElementsAreNotAtL
     adaptGrid(equivalent_grid, markedCells2);
     adaptGrid(equivalent_grid, markedCells3);
 
-    compareGrids(grid, equivalent_grid, /* lgrsHaveBlockShape = */ false, /* gridHasBeenGlobalRefined = */ false);
+    Opm::compareGrids(grid, equivalent_grid, /* lgrsHaveBlockShape = */ false, /* gridHasBeenGlobalRefined = */ false);
 }
 
 BOOST_AUTO_TEST_CASE(refinedCoarseOrRefinedCellsOnLgrBoundaryInAGridWithLgrsThrows)

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -113,7 +113,6 @@ BOOST_AUTO_TEST_CASE(markAllElementsForRefinementIsEquivalentToCallGlobalRefinem
     equivalent_grid.globalRefine(1);
 
     Opm::checkLeafGridGeometryEquality(grid, equivalent_grid);
-     Opm::checkCellBlockRefinements(grid, equivalent_grid);
 }
 
 BOOST_AUTO_TEST_CASE(markCellBlockForRefinementIsEquivalentToCallAddLgrsUpdateLeafView)
@@ -138,7 +137,6 @@ BOOST_AUTO_TEST_CASE(markCellBlockForRefinementIsEquivalentToCallAddLgrsUpdateLe
                                            /* lgr_name = */  {"LGR1"});
 
     Opm::checkLeafGridGeometryEquality(grid, equivalent_grid);
-    Opm::checkCellBlockRefinements(grid, equivalent_grid);
 }
 
 BOOST_AUTO_TEST_CASE(refinementOfCellsNotFormingABlockIsSupported)
@@ -187,7 +185,6 @@ BOOST_AUTO_TEST_CASE(callAdaptMultipleTimesAsLongAsCoarseMarkedElementsAreNotAtL
     Opm::adaptGrid(equivalent_grid, markedCells3);
 
     Opm::checkLeafGridGeometryEquality(grid, equivalent_grid);
-     Opm::checkCellBlockRefinements(grid, equivalent_grid);
 }
 
 BOOST_AUTO_TEST_CASE(refineCoarseOrRefinedCellsOnLgrBoundaryThrows)

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -33,25 +33,12 @@
 
 #define BOOST_TEST_MODULE AdaptTests
 #include <boost/test/unit_test.hpp>
-#include <boost/version.hpp>
-#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
-#include <boost/test/floating_point_comparison.hpp>
-#else
-#include <boost/test/tools/floating_point_comparison.hpp>
-#endif
+
 #include <opm/grid/CpGrid.hpp>
-#include <opm/grid/cpgrid/CpGridData.hpp>
-#include <opm/grid/cpgrid/DefaultGeometryPolicy.hpp>
-#include <opm/grid/cpgrid/Entity.hpp>
-#include <opm/grid/cpgrid/EntityRep.hpp>
-#include <opm/grid/cpgrid/Geometry.hpp>
-#include <opm/grid/LookUpData.hh>
 #include <tests/cpgrid/LgrChecks.hpp>
 
-#include <dune/grid/common/mcmgmapper.hh>
-
-#include <sstream>
-#include <iostream>
+#include <array>
+#include <vector>
 
 struct Fixture
 {
@@ -62,20 +49,13 @@ struct Fixture
         Dune::MPIHelper::instance(m_argc, m_argv);
         Opm::OpmLog::setupSimpleDefaultLogging();
     }
-
-    static int rank()
-    {
-        int m_argc = boost::unit_test::framework::master_test_suite().argc;
-        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
-        return Dune::MPIHelper::instance(m_argc, m_argv).rank();
-    }
 };
 
 BOOST_GLOBAL_FIXTURE(Fixture);
 
 void adaptGridWithParams(Dune::CpGrid& grid,
-               const std::array<int,3>& cells_per_dim,
-               const std::vector<int>& markedCells)
+                         const std::array<int,3>& cells_per_dim,
+                         const std::vector<int>& markedCells)
 {
     const int startingGridIdx = grid.currentData().size() -1; // size before calling adapt
     std::vector<int> assignRefinedLevel(grid.currentData()[startingGridIdx]->size(0));
@@ -162,7 +142,7 @@ BOOST_AUTO_TEST_CASE(emptyMarkedElemForRefinementSetDoesNothingToTheGrid)
     grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
     adaptGridWithParams(grid, /* cells_per_dim = */ {2,2,2}, /* markedCells = */ {});
 
-     // Create other grid for comparison
+    // Create other grid for comparison
     Dune::CpGrid other_grid;
     other_grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
 
@@ -198,7 +178,7 @@ BOOST_AUTO_TEST_CASE(markAllElementsForRefinementIsEquivalentToCallGlobalRefinem
     // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
     //  isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
     checkAdaptedGrid(grid, /* cells_per_dim = */ {2,2,2}, false, false, true);
-   
+
 
     // Create other grid for comparison
     Dune::CpGrid other_grid;
@@ -219,7 +199,7 @@ BOOST_AUTO_TEST_CASE(markCellBlockForRefinementIsEquivalentToCallAddLgrsUpdateLe
     adaptGridWithParams(grid, /* cells_per_dim = */ {2,2,2}, markedCells);
 
     checkAdaptedGrid(grid, /* cells_per_dim = */ {2,2,2}, true, false, false);
-    
+
     // Create other grid for comparison
     Dune::CpGrid other_grid;
     other_grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
@@ -228,9 +208,9 @@ BOOST_AUTO_TEST_CASE(markCellBlockForRefinementIsEquivalentToCallAddLgrsUpdateLe
                                       /* endIJK = */  {{3,2,2}}, // block cell indices = {17, 18}
                                       /* lgr_name = */  {"LGR1"});
 
-    
+
     // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-     compareGrids(grid, other_grid, true, false, false);
+    compareGrids(grid, other_grid, true, false, false);
 }
 
 BOOST_AUTO_TEST_CASE(markCellsNotFormingABlock)
@@ -244,39 +224,39 @@ BOOST_AUTO_TEST_CASE(markCellsNotFormingABlock)
     //       (0)  1   2   3 |        12   13   14  15 |        24 25   26   27 |
 
     adaptGridWithParams(grid, /* cells_per_dim = */ {2,3,4}, markedCells);
-     // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
     checkAdaptedGrid(grid, /* cells_per_dim = */ {2,3,4}, false, false, false);
 }
 
 /*BOOST_AUTO_TEST_CASE(markNonBlockCells_compareAdapt)
-{
-    // Create a grid
-    Dune::CpGrid coarse_grid;
-    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim = {3,3,3}; // WHY THIS DOES NOT FAIL??
-    std::vector<int> markedCells = {1,4,6,9,17,22,28,32,33};
-    coarse_grid.createCartesian(grid_dim, cell_sizes);
+  {
+  // Create a grid
+  Dune::CpGrid coarse_grid;
+  const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+  const std::array<int, 3> grid_dim = {4,3,3};
+  const std::array<int, 3> cells_per_dim = {3,3,3}; // WHY THIS DOES NOT FAIL??
+  std::vector<int> markedCells = {1,4,6,9,17,22,28,32,33};
+  coarse_grid.createCartesian(grid_dim, cell_sizes);
 
-    // Create a grid
-    Dune::CpGrid other_grid;
-    other_grid.createCartesian(grid_dim, cell_sizes);
-    for (const auto& elemIdx : markedCells)
-    {
-        const auto& elem =  Dune::cpgrid::Entity<0>(*(other_grid.currentData()[0]), elemIdx, true);
-        other_grid.mark(1, elem);
-    }
-    other_grid.preAdapt();
-    other_grid.adapt();
-    other_grid.postAdapt();
+  // Create a grid
+  Dune::CpGrid other_grid;
+  other_grid.createCartesian(grid_dim, cell_sizes);
+  for (const auto& elemIdx : markedCells)
+  {
+  const auto& elem =  Dune::cpgrid::Entity<0>(*(other_grid.currentData()[0]), elemIdx, true);
+  other_grid.mark(1, elem);
+  }
+  other_grid.preAdapt();
+  other_grid.adapt();
+  other_grid.postAdapt();
 
-    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, false, false, false);
-    }*/
+  // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+  markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, false, false, false);
+  }*/
 
 BOOST_AUTO_TEST_CASE(callAdaptMultipleTimes)
 {
-    
+
     Dune::CpGrid grid;
     grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
     std::vector<int> markedCells = {1,4,6,17,22,28,32};
@@ -285,8 +265,8 @@ BOOST_AUTO_TEST_CASE(callAdaptMultipleTimes)
     // k = 0  8   9  10  11 | k = 1  20  21  (22) 23 | k = 2  (32) 33 34 35 |
     //       (4)  5  (6)  7 |        16 (17)  18  19 |        (28) 29 30 31 |
     //        0  (1)  2   3 |        12  13   14  15 |          24 25 26 27 |
-     
-   
+
+
     std::vector<int> markedCells1 = {1,4,6};
     std::vector<int> markedCells2 = {38, 43}; // Equivalent cells to level 0 cells with indices {17,22};
     std::vector<int> markedCells3 = {63, 67}; // Equivalent cells to level 0 cells with indices {28,32};
@@ -297,107 +277,107 @@ BOOST_AUTO_TEST_CASE(callAdaptMultipleTimes)
     adaptGrid(other_grid, markedCells1);
     adaptGrid(other_grid, markedCells2);
     adaptGrid(other_grid, markedCells3);
-     
+
     // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
     // INFO ABOUR GRID (NOT OTHER_GRID)
     compareGrids(grid, other_grid, false, false, false);
 }
 
 /*BOOST_AUTO_TEST_CASE(markCoarseCellsOnLgrBoundaryOfGridWithLgrsThrows)
-{
-    // Create a grid
-    Dune::CpGrid coarse_grid;
-    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim = {3,3,3};
-    coarse_grid.createCartesian(grid_dim, cell_sizes);
+  {
+  // Create a grid
+  Dune::CpGrid coarse_grid;
+  const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+  const std::array<int, 3> grid_dim = {4,3,3};
+  const std::array<int, 3> cells_per_dim = {3,3,3};
+  coarse_grid.createCartesian(grid_dim, cell_sizes);
 
-    // LGR1 marked elements with elemIdx = 17 and 18, refined into 27 children cells each,
-    // with leaf indices 17+0,...,17+26 = 43 (children {level 0, cell index 17}),44,...,70 (children {level 0, cell index 18}).
-    const std::array<int, 3> startIJK = {1,1,1};
-    const std::array<int, 3> endIJK = {3,2,2};
-    const std::string lgr_name = {"LGR1"};
-    coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+  // LGR1 marked elements with elemIdx = 17 and 18, refined into 27 children cells each,
+  // with leaf indices 17+0,...,17+26 = 43 (children {level 0, cell index 17}),44,...,70 (children {level 0, cell index 18}).
+  const std::array<int, 3> startIJK = {1,1,1};
+  const std::array<int, 3> endIJK = {3,2,2};
+  const std::string lgr_name = {"LGR1"};
+  coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
 
-    // - Coarse cells touching the LGR1 on its boundary.
-    // Cell 5, 14, 16, 71, 73, and 82, touching the bottom, front, left, right, back, and the top of LGR1, respectively.
-    std::vector<int> markedCells = {5,14,16,71,73,82};
-    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-    BOOST_CHECK_THROW(markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, true, true, false), std::logic_error);
-    }*/
+  // - Coarse cells touching the LGR1 on its boundary.
+  // Cell 5, 14, 16, 71, 73, and 82, touching the bottom, front, left, right, back, and the top of LGR1, respectively.
+  std::vector<int> markedCells = {5,14,16,71,73,82};
+  // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+  BOOST_CHECK_THROW(markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, true, true, false), std::logic_error);
+  }*/
 
 
-// Nested cases - 
+// Nested cases -
 
 /*BOOST_AUTO_TEST_CASE(refineCoarseCells_in_mixedGrid_notTouchingLgrBoundary) {
-    // Create a grid
-    Dune::CpGrid coarse_grid;
-    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim = {2,2,2};
-    coarse_grid.createCartesian(grid_dim, cell_sizes);
+// Create a grid
+Dune::CpGrid coarse_grid;
+const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+const std::array<int, 3> grid_dim = {4,3,3};
+const std::array<int, 3> cells_per_dim = {2,2,2};
+coarse_grid.createCartesian(grid_dim, cell_sizes);
 
-    // LGR1 marked element with elemIdx = 3, refined into 8 children cells with leaf indices 3,...,10.
-    const std::array<int, 3> startIJK = {3,0,0};
-    const std::array<int, 3> endIJK = {4,1,1};
-    const std::string lgr_name = {"LGR1"};
-    coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+// LGR1 marked element with elemIdx = 3, refined into 8 children cells with leaf indices 3,...,10.
+const std::array<int, 3> startIJK = {3,0,0};
+const std::array<int, 3> endIJK = {4,1,1};
+const std::string lgr_name = {"LGR1"};
+coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
 
-    std::vector<int> markedCells = {0,1,11,15}; // coarse cells (in level 0 grid, this cell has index 8)
-    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, true, false);
+std::vector<int> markedCells = {0,1,11,15}; // coarse cells (in level 0 grid, this cell has index 8)
+// The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, true, false);
 }
 
 BOOST_AUTO_TEST_CASE(refineInteriorRefinedCells_in_mixedGrid) {
-    // Create a grid
-    Dune::CpGrid coarse_grid;
-    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim = {3,3,3};
-    coarse_grid.createCartesian(grid_dim, cell_sizes);
+// Create a grid
+Dune::CpGrid coarse_grid;
+const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+const std::array<int, 3> grid_dim = {4,3,3};
+const std::array<int, 3> cells_per_dim = {3,3,3};
+coarse_grid.createCartesian(grid_dim, cell_sizes);
 
-    // LGR1 marked elements with elemIdx = 17 and 18, refined into 27 children cells each,
-    // with leaf indices 17+0,...,17+26 = 43 (children {level 0, cell index 17}),44,...,70 (children {level 0, cell index 18}).
-    const std::array<int, 3> startIJK = {1,1,1};
-    const std::array<int, 3> endIJK = {3,2,2};
-    const std::string lgr_name = {"LGR1"};
-    coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+// LGR1 marked elements with elemIdx = 17 and 18, refined into 27 children cells each,
+// with leaf indices 17+0,...,17+26 = 43 (children {level 0, cell index 17}),44,...,70 (children {level 0, cell index 18}).
+const std::array<int, 3> startIJK = {1,1,1};
+const std::array<int, 3> endIJK = {3,2,2};
+const std::string lgr_name = {"LGR1"};
+coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
 
-    // Cells 30, 31, 56, and 57 are refined cells, located in the interior of the refined-level-grid-1 (lgr 1 / level 1).
-    // Therefore, cell_to_face_ for all of them has size 6. (Their faces have all 2 refined neigboring cells - (not one coarse cell, and one refined)).
-    std::vector<int> markedCells = {30,31, 56,57};
-    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, true, false);
+// Cells 30, 31, 56, and 57 are refined cells, located in the interior of the refined-level-grid-1 (lgr 1 / level 1).
+// Therefore, cell_to_face_ for all of them has size 6. (Their faces have all 2 refined neigboring cells - (not one coarse cell, and one refined)).
+std::vector<int> markedCells = {30,31, 56,57};
+// The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, true, false);
 }
 
 
 BOOST_AUTO_TEST_CASE(refineMixedCells_in_mixedGrid) {
-    // Create a grid
-    Dune::CpGrid coarse_grid;
-    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim = {3,3,3};
-    coarse_grid.createCartesian(grid_dim, cell_sizes);
+// Create a grid
+Dune::CpGrid coarse_grid;
+const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+const std::array<int, 3> grid_dim = {4,3,3};
+const std::array<int, 3> cells_per_dim = {3,3,3};
+coarse_grid.createCartesian(grid_dim, cell_sizes);
 
-    // LGR1 marked elements with elemIdx = 17 and 18, refined into 27 children cells each,
-    // with leaf indices 17+0,...,17+26 = 43 (children {level 0, cell index 17}),44,...,70 (children {level 0, cell index 18}).
-    const std::array<int, 3> startIJK = {1,1,1};
-    const std::array<int, 3> endIJK = {3,2,2};
-    const std::string lgr_name = {"LGR1"};
-    coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+// LGR1 marked elements with elemIdx = 17 and 18, refined into 27 children cells each,
+// with leaf indices 17+0,...,17+26 = 43 (children {level 0, cell index 17}),44,...,70 (children {level 0, cell index 18}).
+const std::array<int, 3> startIJK = {1,1,1};
+const std::array<int, 3> endIJK = {3,2,2};
+const std::string lgr_name = {"LGR1"};
+coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
 
-    // - Cells 30, 31, 56, and 57 are refined cells, located in the interior of the refined-level-grid-1 (lgr 1 / level 1).
-    // Therefore, cell_to_face_ for all of them has size 6. (Their faces have all 2 refined neigboring cells - (not one coarse cell, and one refined)).
-    // - Cells 0,1,2,12, and 15 are coarse cells, not touching the boundary of the LGR1 (cells 12 and 15 do share corners with LGR1 but do not share
-    // any face. Therefore, the faces of cells 0,1,2,12,and 15 have all 1 or 2 neighboring coarse cells).
-    std::vector<int> markedCells = {0,1,2,12,15,30,31,56,57};
-    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, true, false);
+// - Cells 30, 31, 56, and 57 are refined cells, located in the interior of the refined-level-grid-1 (lgr 1 / level 1).
+// Therefore, cell_to_face_ for all of them has size 6. (Their faces have all 2 refined neigboring cells - (not one coarse cell, and one refined)).
+// - Cells 0,1,2,12, and 15 are coarse cells, not touching the boundary of the LGR1 (cells 12 and 15 do share corners with LGR1 but do not share
+// any face. Therefore, the faces of cells 0,1,2,12,and 15 have all 1 or 2 neighboring coarse cells).
+std::vector<int> markedCells = {0,1,2,12,15,30,31,56,57};
+// The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, true, false);
 }
 
 
 BOOST_AUTO_TEST_CASE(refineMixedCells_in_multiLevelGrid) {
-    // Create a grid
+// Create a grid
     Dune::CpGrid coarse_grid;
     const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
     const std::array<int, 3> grid_dim = {4,3,3};

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -146,7 +146,7 @@ void markAndAdapt_check(Dune::CpGrid& grid,
     } // end-if-preAdapt
 }
 
-BOOST_AUTO_TEST_CASE(emptyMarkedElementsForRefinementSetDoesNothingToTheGrid)
+BOOST_AUTO_TEST_CASE(emptyMarkedElemForRefinementSetDoesNothingToTheGrid)
 {
     Dune::CpGrid grid;
     grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(emptyMarkedElementsForRefinementSetDoesNothingToTheGrid)
 }
 
 
-BOOST_AUTO_TEST_CASE(emptyMarkedElementsForRefinementSetIsEquivalentToCallGlobalRefineWithZero)
+BOOST_AUTO_TEST_CASE(markNoElemForRefinementIsEquivalentToCallGlobalRefineWithZero)
 {
     Dune::CpGrid grid;
     grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
@@ -172,11 +172,11 @@ BOOST_AUTO_TEST_CASE(emptyMarkedElementsForRefinementSetIsEquivalentToCallGlobal
 }
 
 
-BOOST_AUTO_TEST_CASE(allElementsMarkedForRefinementIsEquivalentToCallGlobalRefinementWithOne)
+BOOST_AUTO_TEST_CASE(markAllElementsForRefinementIsEquivalentToCallGlobalRefinementWithOne)
 {
     Dune::CpGrid grid;
     grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
-    std::vector<int> markedCells(36);
+    std::vector<int> markedCells(36); // 36 = 4x3x3
     std::iota(markedCells.begin(), markedCells.end(), 0);
    
 
@@ -190,190 +190,46 @@ BOOST_AUTO_TEST_CASE(allElementsMarkedForRefinementIsEquivalentToCallGlobalRefin
     markAndAdapt_check(grid, /* cells_per_dim = */ {2,2,2}, markedCells, other_grid, false, false, true);
 }
 
-
-BOOST_AUTO_TEST_CASE(globalRefinement_calling_globalRefine)
+BOOST_AUTO_TEST_CASE(markCellBlockForRefinementIsEquivalentToCallAddLgrsUpdateLeafView)
 {
-    // Create a grid
-    Dune::CpGrid coarse_grid;
-    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int, 3> grid_dim = {4,3,3};
-    coarse_grid.createCartesian(grid_dim, cell_sizes);
-
-    std::vector<int> markedCells(36);
-    std::iota(markedCells.begin(), markedCells.end(), 0);
-
-    // Create other grid for comparison
-    Dune::CpGrid other_grid;
-    other_grid.createCartesian(grid_dim, cell_sizes);
-    other_grid.globalRefine(1);
-
-    const std::array<int, 3> cells_per_dim = {2,2,2};
-
-    // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
-    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, false, false, true);
-}
-
-BOOST_AUTO_TEST_CASE(calling_globalRefine_with_2)
-{
-    // Create a grid
-    Dune::CpGrid equiv_fine_grid;
-    const std::array<double, 3> cell_sizes = {0.5, 0.5, 0.5};
-    const std::array<int, 3> grid_dim = {8,6,6};
-    equiv_fine_grid.createCartesian(grid_dim, cell_sizes);
-
-    std::vector<int> markedCells(288);
-    std::iota(markedCells.begin(), markedCells.end(), 0);
-
-    // Create other grid for comparison
-    Dune::CpGrid other_grid;
-    const std::array<double, 3> other_cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int, 3> other_grid_dim = {4,3,3};
-    other_grid.createCartesian(other_grid_dim, other_cell_sizes);
-    other_grid.globalRefine(2);
-
-    const std::array<int, 3> cells_per_dim = {2,2,2};
-
-    // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
-    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-    markAndAdapt_check(equiv_fine_grid, cells_per_dim, markedCells, other_grid, false, false, true);
-}
-
-BOOST_AUTO_TEST_CASE(calling_globalRefine_with_3)
-{
-    // Create a grid
-    Dune::CpGrid equiv_fine_grid;
-    const std::array<double, 3> cell_sizes = {0.25, 0.25, 0.25};
-    const std::array<int, 3> grid_dim = {16,12,12};
-    equiv_fine_grid.createCartesian(grid_dim, cell_sizes);
-
-    std::vector<int> markedCells(2304);
-    std::iota(markedCells.begin(), markedCells.end(), 0);
-
-    // Create other grid for comparison
-    Dune::CpGrid other_grid;
-    const std::array<double, 3> other_cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int, 3> other_grid_dim = {4,3,3};
-    other_grid.createCartesian(other_grid_dim, other_cell_sizes);
-    other_grid.globalRefine(3);
-
-    const std::array<int, 3> cells_per_dim = {2,2,2};
-
-    // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
-    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-    markAndAdapt_check(equiv_fine_grid, cells_per_dim, markedCells, other_grid, false, false, true);
-}
-
-BOOST_AUTO_TEST_CASE(throw_globalRefine_with_negative_int)
-{
-    // Create a grid
     Dune::CpGrid grid;
-    const std::array<double, 3> cell_sizes = {0.25, 0.25, 0.25};
-    const std::array<int, 3> grid_dim = {16,12,12};
-    grid.createCartesian(grid_dim, cell_sizes);
-
-    BOOST_CHECK_THROW(grid.globalRefine(-5), std::logic_error);
-}
-
-BOOST_AUTO_TEST_CASE(throw_globalRefine_of_mixed_grid)
-{
-    // Create a grid
-    Dune::CpGrid grid;
-    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int, 3> grid_dim = {4,3,3};
-    grid.createCartesian(grid_dim, cell_sizes);
-
-    const std::array<int, 3> cells_per_dim = {2,2,2};
-    const std::array<int, 3> startIJK = {2,0,0};
-    const std::array<int, 3> endIJK = {4,1,1};  // -> marked elements 2 and 3
-    const std::string lgr_name = {"LGR1"};
-    grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
-
-    BOOST_CHECK_THROW(grid.globalRefine(1), std::logic_error);
-}
-
-
-BOOST_AUTO_TEST_CASE(mark2consequtiveCells)
-{
-    // Create a grid
-    Dune::CpGrid coarse_grid;
-    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim = {2,2,2};
-    coarse_grid.createCartesian(grid_dim, cell_sizes);
-
-
-    // Create other grid for comparison
-    Dune::CpGrid other_grid;
-    other_grid.createCartesian(grid_dim, cell_sizes);
-
-    const std::array<int, 3> startIJK = {2,0,0};
-    const std::array<int, 3> endIJK = {4,1,1};  // -> marked elements 2 and 3
-    const std::string lgr_name = {"LGR1"};
-    other_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
-
-    std::vector<int> markedCells = {2,3};
-    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, true, false, false);
-}
-
-BOOST_AUTO_TEST_CASE(mark2InteriorConsequtiveCells)
-{
-    // Create a grid
-    Dune::CpGrid coarse_grid;
-    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim = {2,2,2};
-    coarse_grid.createCartesian(grid_dim, cell_sizes);
-
-
-    // Create other grid for comparison
-    Dune::CpGrid other_grid;
-    other_grid.createCartesian(grid_dim, cell_sizes);
-
-    const std::array<int, 3> startIJK = {1,1,1};
-    const std::array<int, 3> endIJK = {3,2,2};  // -> marked elements 17 and 18
-    const std::string lgr_name = {"LGR1"};
-    other_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
-
+    grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
     std::vector<int> markedCells = {17,18};
+    
+    // Create other grid for comparison
+    Dune::CpGrid other_grid;
+    other_grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
+    other_grid.addLgrsUpdateLeafView( /* cells_per_dim = */ {{2,2,2}},
+                                      /* startIJK = */ {{1,1,1}},
+                                      /* endIJK = */  {{3,2,2}}, // block cell indices = {17, 18}
+                                      /* lgr_name = */  {"LGR1"});
+
+    
     // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, true, false, false);
+    markAndAdapt_check(grid, /* cells_per_dim = */ {2,2,2}, markedCells, other_grid, true, false, false);
 }
 
-BOOST_AUTO_TEST_CASE(markNonBlockShapeCells)
+BOOST_AUTO_TEST_CASE(markCellsNotFormingABlock)
+{
+    Dune::CpGrid grid;
+    grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
+    std::vector<int> markedCells = {0,4,5,17,18,30,31,35};
+
+    // k = 0  8  9 10 11 | k = 1  20 21 22 23 | k = 2  32 33 34 35 |
+    //        4  5  6  7 |        16 17 18 19 |        28 29 30 31 |
+    //        0  1  2  3 |        12 13 14 15 |        24 25 26 27 |
+    
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(grid, /* cells_per_dim = */{2,3,4}, markedCells, grid, false, false, false);
+}
+
+/*BOOST_AUTO_TEST_CASE(markNonBlockCells_compareAdapt)
 {
     // Create a grid
     Dune::CpGrid coarse_grid;
     const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
     const std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim = {2,2,2};
-    std::vector<int> markedCells = {0}; //,1,2,5,13};
-    coarse_grid.createCartesian(grid_dim, cell_sizes);
-    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, false, false);
-}
-
-BOOST_AUTO_TEST_CASE(markNonBlockShapeCells_II)
-{
-    // Create a grid
-    Dune::CpGrid coarse_grid;
-    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim = {2,3,4};
-    std::vector<int> markedCells = {1,4,6,9,17,22,28,32,33};
-    coarse_grid.createCartesian(grid_dim, cell_sizes);
-    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-    markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, false, false, false);
-}
-
-BOOST_AUTO_TEST_CASE(markNonBlockCells_compareAdapt)
-{
-    // Create a grid
-    Dune::CpGrid coarse_grid;
-    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
-    const std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim = {3,3,3};
+    const std::array<int, 3> cells_per_dim = {3,3,3}; // WHY THIS DOES NOT FAIL??
     std::vector<int> markedCells = {1,4,6,9,17,22,28,32,33};
     coarse_grid.createCartesian(grid_dim, cell_sizes);
 
@@ -391,7 +247,7 @@ BOOST_AUTO_TEST_CASE(markNonBlockCells_compareAdapt)
 
     // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
     markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, false, false, false);
-}
+    }*/
 
 BOOST_AUTO_TEST_CASE(callAdaptMultipleTimes)
 {
@@ -442,10 +298,33 @@ BOOST_AUTO_TEST_CASE(callAdaptMultipleTimes)
     markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, other_grid, false, false, false);
 }
 
+BOOST_AUTO_TEST_CASE(markCoarseCellsOnLgrBoundaryOfGridWithLgrsThrows)
+{
+    // Create a grid
+    Dune::CpGrid coarse_grid;
+    const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> grid_dim = {4,3,3};
+    const std::array<int, 3> cells_per_dim = {3,3,3};
+    coarse_grid.createCartesian(grid_dim, cell_sizes);
 
-// Nested cases
+    // LGR1 marked elements with elemIdx = 17 and 18, refined into 27 children cells each,
+    // with leaf indices 17+0,...,17+26 = 43 (children {level 0, cell index 17}),44,...,70 (children {level 0, cell index 18}).
+    const std::array<int, 3> startIJK = {1,1,1};
+    const std::array<int, 3> endIJK = {3,2,2};
+    const std::string lgr_name = {"LGR1"};
+    coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
 
-/*BOOST_AUTO_TEST_CASE(refineCoarseCells_in_mixedGrid) {
+    // - Coarse cells touching the LGR1 on its boundary.
+    // Cell 5, 14, 16, 71, 73, and 82, touching the bottom, front, left, right, back, and the top of LGR1, respectively.
+    std::vector<int> markedCells = {5,14,16,71,73,82};
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    BOOST_CHECK_THROW(markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, true, true, false), std::logic_error);
+}
+
+
+// Nested cases - 
+
+/*BOOST_AUTO_TEST_CASE(refineCoarseCells_in_mixedGrid_notTouchingLgrBoundary) {
     // Create a grid
     Dune::CpGrid coarse_grid;
     const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
@@ -564,26 +443,83 @@ BOOST_AUTO_TEST_CASE(refineMixedCells_in_mixedGrid_II)
 }
 */
 
-BOOST_AUTO_TEST_CASE(cellTouchesLgrBoundary_throw)
+
+
+
+
+
+
+// Move to global_refine test??
+
+/*BOOST_AUTO_TEST_CASE(calling_globalRefine_with_2)
+{
+    Dune::CpGrid equiv_fine_grid;
+    const std::array<double, 3> cell_sizes = {0.5, 0.5, 0.5};
+    const std::array<int, 3> grid_dim = {8,6,6};
+    equiv_fine_grid.createCartesian(grid_dim, cell_sizes);
+
+    std::vector<int> markedCells(288);
+    std::iota(markedCells.begin(), markedCells.end(), 0);
+
+    // Create other grid for comparison
+    Dune::CpGrid other_grid;
+    const std::array<double, 3> other_cell_sizes = {1.0, 1.0, 1.0};
+    const std::array<int, 3> other_grid_dim = {4,3,3};
+    other_grid.createCartesian(other_grid_dim, other_cell_sizes);
+    other_grid.globalRefine(2);
+
+    const std::array<int, 3> cells_per_dim = {2,2,2};
+
+    // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(equiv_fine_grid, cells_per_dim, markedCells, other_grid, false, false, true);
+    }*/
+
+// Move to global_refine test 
+BOOST_AUTO_TEST_CASE(calling_globalRefine_with_3)
+{
+    Dune::CpGrid grid;
+    grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
+    grid.globalRefine(3);
+
+    // Create other grid for comparison. Note: default subdivisions per cell is 2x2x2.
+    Dune::CpGrid equiv_fine_grid;
+    equiv_fine_grid.createCartesian(/* grid_dim = */ {16,12,12}, /* cell_sizes = */ {0.25, 0.25, 0.25});
+    std::vector<int> markedCells(2304); // 2304 = 16x12x12
+    std::iota(markedCells.begin(), markedCells.end(), 0);
+
+    // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
+    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
+    markAndAdapt_check(equiv_fine_grid, /* cells_per_dim = */ {2,2,2}, markedCells, grid, false, false, true);
+}
+
+// Move to global_refine test
+BOOST_AUTO_TEST_CASE(throw_globalRefine_with_negative_int)
 {
     // Create a grid
-    Dune::CpGrid coarse_grid;
+    Dune::CpGrid grid;
+    //  grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
+
+    BOOST_CHECK_THROW(grid.globalRefine(-5), std::logic_error);
+}
+
+// Move to global_refine test
+BOOST_AUTO_TEST_CASE(throw_globalRefine_of_mixed_grid)
+{
+    // Create a grid
+    Dune::CpGrid grid;
     const std::array<double, 3> cell_sizes = {1.0, 1.0, 1.0};
     const std::array<int, 3> grid_dim = {4,3,3};
-    const std::array<int, 3> cells_per_dim = {3,3,3};
-    coarse_grid.createCartesian(grid_dim, cell_sizes);
+    grid.createCartesian(grid_dim, cell_sizes);
 
-    // LGR1 marked elements with elemIdx = 17 and 18, refined into 27 children cells each,
-    // with leaf indices 17+0,...,17+26 = 43 (children {level 0, cell index 17}),44,...,70 (children {level 0, cell index 18}).
-    const std::array<int, 3> startIJK = {1,1,1};
-    const std::array<int, 3> endIJK = {3,2,2};
+    const std::array<int, 3> cells_per_dim = {2,2,2};
+    const std::array<int, 3> startIJK = {2,0,0};
+    const std::array<int, 3> endIJK = {4,1,1};  // -> marked elements 2 and 3
     const std::string lgr_name = {"LGR1"};
-    coarse_grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
+    grid.addLgrsUpdateLeafView({cells_per_dim}, {startIJK}, {endIJK}, {lgr_name});
 
-    // - Coarse cells touching the LGR1 on its boundary.
-    // Cell 5, 14, 16, 71, 73, and 82, touching the bottom, front, left, right, back, and the top of LGR1, respectively.
-    std::vector<int> markedCells = {5,14,16,71,73,82};
-    // The last three bool arguments represent: isBlockShape, hasBeenRefinedAtLeastOnce, isGlobalRefinement.
-    BOOST_CHECK_THROW(markAndAdapt_check(coarse_grid, cells_per_dim, markedCells, coarse_grid, true, true, false), std::logic_error);
+    BOOST_CHECK_THROW(grid.globalRefine(1), std::logic_error);
 }
+
+
 

--- a/tests/cpgrid/adapt_cpgrid_test.cpp
+++ b/tests/cpgrid/adapt_cpgrid_test.cpp
@@ -46,6 +46,7 @@
 #include <opm/grid/cpgrid/EntityRep.hpp>
 #include <opm/grid/cpgrid/Geometry.hpp>
 #include <opm/grid/LookUpData.hh>
+#include <tests/cpgrid/LgrChecks.hpp>
 
 #include <dune/grid/common/mcmgmapper.hh>
 
@@ -208,6 +209,8 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
         const auto& grid_view = coarse_grid.leafGridView();
         Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LeafGridView> adaptMapper(grid_view, Dune::mcmgElementLayout());
 
+        // Opm::checkGlobalCellBounds(coarse_grid, data);
+        
         auto itMin = std::min_element((data.back() -> global_cell_).begin(),  (data.back()-> global_cell_).end());
         auto itMax = std::max_element((data.back() -> global_cell_).begin(),  (data.back() -> global_cell_).end());
         BOOST_CHECK_EQUAL( *itMin, 0);
@@ -382,94 +385,7 @@ void markAndAdapt_check(Dune::CpGrid& coarse_grid,
             BOOST_CHECK_EQUAL( *itMaxLevel, maxCartesianIdxLevel);
         }
 
-        std::set<int> allIds_set;
-        std::vector<int> allIds_vec;
-        allIds_vec.reserve(data.back()->size(0) + data.back()->size(3));
-        for (const auto& element: elements(grid_view)){
-            const auto& localId = data.back()->localIdSet().id(element);
-            const auto& globalId = data.back()->globalIdSet().id(element);
-            // In serial run, local and global id coincide:
-            BOOST_CHECK_EQUAL(localId, globalId);
-            allIds_set.insert(localId);
-            allIds_vec.push_back(localId);
-            // Check that the global_id_set_ptr_ has the correct id (id from the level where the entity was born).
-            BOOST_CHECK_EQUAL( coarse_grid.globalIdSet().id(element), data[element.level()]->localIdSet().id(element.getLevelElem()));
-        }
-        // Check injectivity of the map local_id_set_ (and, indirectly, global_id_set_) after adding cell ids.
-        BOOST_CHECK( allIds_set.size() == allIds_vec.size());
-
-        for (const auto& point: vertices(grid_view)){
-            const auto& localId = data.back()->localIdSet().id(point);
-            const auto& globalId = data.back()->globalIdSet().id(point);
-            BOOST_CHECK_EQUAL(localId, globalId);
-            allIds_set.insert(localId);
-            allIds_vec.push_back(localId);
-        }
-        // Check injectivity of the map local_id_set_ (and, indirectly, global_id_set_) after adding point ids.
-        BOOST_CHECK( allIds_set.size() == allIds_vec.size());
-        // CpGrid supports only elements (cells) and vertices (corners). Total amount of ids for the leaf grid view should coincide
-        // with the total amount of cells and corners on the leaf grid view.
-        BOOST_CHECK( static_cast<int>(allIds_set.size()) == (data.back()->size(0) + data.back()->size(3)));
-        
-
-        // Local/Global id sets for level grids (level 0, 1, ..., maxLevel)
-        for (int level = 0; level < coarse_grid.maxLevel() +1; ++level)
-        {
-            std::set<int> levelIds_set;
-            std::vector<int> levelIds_vec;
-            levelIds_vec.reserve(data[level]->size(0) + data[level]->size(3));
-
-            for (const auto& element: elements(coarse_grid.levelGridView(level))){
-                const auto& localId = data[level]->localIdSet().id(element);
-                const auto& globalId = data[level]->globalIdSet().id(element);
-                // In serial run, local and global id coincide:
-                BOOST_CHECK_EQUAL(localId, globalId);
-                levelIds_set.insert(localId);
-                levelIds_vec.push_back(localId);
-                // The following check is commented even though all the test cases pass it. However, runnning this file
-                // with it (uncommented) takes ~2.5 minutes.
-                // Search in the leaf grid view elements for the element with the same id, if it exists.
-                /*if (auto itIsLeaf = std::find_if( elements(coarse_grid.leafGridView()).begin(),
-                  elements(coarse_grid.leafGridView()).end(),
-                  [localId, data](const Dune::cpgrid::Entity<0>& leafElem)
-                  { return (localId == data.back()->localIdSet().id(leafElem)); });
-                  itIsLeaf != elements(coarse_grid.leafGridView()).end()) {
-                  BOOST_CHECK( itIsLeaf->getLevelElem() == element);
-                  }*/
-                if (element.isLeaf()) { // Check that the id of a cell not involved in any further refinement appears on the IdSet of the leaf grid view.
-                    BOOST_CHECK( std::find(allIds_set.begin(), allIds_set.end(), localId) != allIds_set.end());
-                }
-                else { // Check that the id of a cell that vanished during refinement does not appear on the IdSet of the leaf grid view.
-                    BOOST_CHECK( std::find(allIds_set.begin(), allIds_set.end(), localId) == allIds_set.end());
-                }
-                const auto& idx = data[level]->indexSet().index(element);
-                // In serial run, local and global id coincide:
-                BOOST_CHECK_EQUAL(idx, element.index());
-            }
-
-            for (const auto& point : vertices(coarse_grid.levelGridView(level))) {
-                const auto& localId = data[level]->localIdSet().id(point);
-                const auto& globalId = data[level]->globalIdSet().id(point);
-                BOOST_CHECK_EQUAL(localId, globalId);
-                levelIds_set.insert(localId);
-                levelIds_vec.push_back(localId);
-                // The following check is commented even though all the test cases pass it. However, runnning this file
-                // with it (uncommented) takes ~2.5 minutes.
-                /* // Search in the leaf grid view elements for the element with the same id, if it exists.
-                   if (auto itIsLeaf = std::find_if( vertices(coarse_grid.leafGridView()).begin(),
-                   vertices(coarse_grid.leafGridView()).end(),
-                   [localId, data](const Dune::cpgrid::Entity<3>& leafPoint)
-                   { return (localId == data.back()->localIdSet().id(leafPoint)); });
-                   itIsLeaf != vertices(coarse_grid.leafGridView()).end()) {
-                   BOOST_CHECK( (*itIsLeaf).geometry().center() == point.geometry().center() );
-                   }*/
-            }
-            // Check injectivity of the map local_id_set_ (and, indirectly, global_id_set_)
-            BOOST_CHECK( levelIds_set.size() == levelIds_vec.size());
-            // CpGrid supports only elements (cells) and vertices (corners). Total amount of ids for each level grid should coincide
-            // with the total amount of cells and corners on that level grid.
-            BOOST_CHECK( static_cast<int>(levelIds_set.size()) == (data[level]->size(0) + data[level]->size(3)));
-        }
+        Opm::checkGridLocalAndGlobalIdConsistency(coarse_grid, data);
     } // end-if-preAdapt
 }
 

--- a/tests/cpgrid/addLgrsOnDistributedGrid_test.cpp
+++ b/tests/cpgrid/addLgrsOnDistributedGrid_test.cpp
@@ -66,7 +66,8 @@ BOOST_GLOBAL_FIXTURE(Fixture);
 
 void check(const Dune::CpGrid& grid,
            const std::vector<std::array<int,3>>& cells_per_dim_vec,
-           const std::vector<std::string>& lgr_name_vec)
+           const std::vector<std::string>& lgr_name_vec,
+           bool isGlobalRefined)
 {
     const auto& data = grid.currentData(); // what data current_view_data_ is pointing at (data_ or distributed_data_)
 
@@ -75,7 +76,7 @@ void check(const Dune::CpGrid& grid,
     Opm::checkFaceHas4VerticesAndMax2NeighboringCells(grid, data);
     Opm::checkLocalIndicesMatchMapper(grid); // Decide if it's worth to keep it
     Opm::checkGridBasicHiearchyInfo(grid, cells_per_dim_vec);
-    Opm::checkGlobalCellBounds(grid, data);
+    Opm::checkGlobalCellBounds(grid, data, /* lgrsHaveBlockShape = */ true, isGlobalRefined);
     Opm::checkCellGlobalIdUniquenessForInteriorCells(grid, data);
     Opm::checkGridLocalAndGlobalIdConsistency(grid, data);
 
@@ -121,7 +122,7 @@ BOOST_AUTO_TEST_CASE(fullyInteriorLgrsHaveUniqueVertexGlobalIds)
         const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3", "LGR4"};
         grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
 
-        check(grid, cells_per_dim_vec, lgr_name_vec);
+        check(grid, cells_per_dim_vec, lgr_name_vec, /* isGlobalRefined = */ false);
 
         // LGR1 dim 2x4x2 -> 3x5x3 = 45 points
         // LGR2 dim 3x3x3 -> 4x4x4 = 64 points
@@ -152,7 +153,7 @@ BOOST_AUTO_TEST_CASE(interiorLgrWithOverlapNeighborHasUniqueVertexGlobalIdsIfAdd
         const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3", "LGR4"};
         grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
 
-        check(grid, cells_per_dim_vec, lgr_name_vec);
+        check(grid, cells_per_dim_vec, lgr_name_vec, /* isGlobalRefined = */ false);
 
         // LGR1 dim 2x4x2 -> 3x5x3 = 45 points
         // LGR2 dim 3x3x3 -> 4x4x4 = 64 points
@@ -181,7 +182,7 @@ BOOST_AUTO_TEST_CASE(distributedLgrHasUniqueVertexGlobalIdsIfAddCornerCellsTrue)
         // LGR1 element indices = 8,9 (rank 0), 10 (rank 2). Total 24 refined cells, 63 points (63-16 = 47 with new global id).
         grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
 
-        check(grid, cells_per_dim_vec, lgr_name_vec);
+        check(grid, cells_per_dim_vec, lgr_name_vec, /* isGlobalRefined = */ false);
 
         // Check global id is not duplicated for points for each LGR
         // LGR1 dim 6x2x2 -> 7x3x3 = 63 points
@@ -207,7 +208,7 @@ BOOST_AUTO_TEST_CASE(distributedLgrFailsVertexGlobalIdsUniquenessWithAddCornerCe
         // LGR1 element indices = {1,2,5,6,13,14,17,18} where
         // 1,5 are interior in rank 0, 13,17 in rank 1, 2,6,18 in rank 2, 14 in rank 3.
         grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgr_name_vec);
-        check(grid, cells_per_dim_vec, lgr_name_vec);
+        check(grid, cells_per_dim_vec, lgr_name_vec, /* isGlobalRefined = */ false);
 
         // Check global id is not duplicated for points for each LGR
         // LGR1 dim 4x4x4 -> 5x5x5 = 125 points
@@ -253,7 +254,7 @@ BOOST_AUTO_TEST_CASE(callAdaptWithArgsIsEquivalentToCallAddLgrsUpdateLeafGridVie
                    startIJK_vec,
                    endIJK_vec);
 
-        check(grid, cells_per_dim_vec, {"LGR1"});
+        check(grid, cells_per_dim_vec, {"LGR1"}, /* isGlobalRefined = */ false);
     }
 }
 
@@ -275,7 +276,7 @@ BOOST_AUTO_TEST_CASE(callAdaptWithoutArgsOnDistributedCoarseGrid)
         grid.adapt();
         grid.postAdapt();
 
-        check(grid, {{2,2,2}} /*cells_per_dim_vec*/, {"GR1"} /*lgr_name_vec (GR: GLOBAL REFINEMENT)*/);
+        check(grid, {{2,2,2}} /*cells_per_dim_vec*/, {"GR1"} /*lgr_name_vec (GR: GLOBAL REFINEMENT)*/,  /* isGlobalRefined = */ true);
     }
 }
 
@@ -289,6 +290,6 @@ BOOST_AUTO_TEST_CASE(callGlobalRefineOnceOnDistributedCoarseGrid)
         grid.loadBalance();
         grid.globalRefine(1);
 
-        check(grid,  {{2,2,2}} /*cells_per_dim_vec*/, {"GR1"} /*lgr_name_vec (GR: GLOBAL REFINEMENT)*/);
+        check(grid,  {{2,2,2}} /*cells_per_dim_vec*/, {"GR1"} /*lgr_name_vec (GR: GLOBAL REFINEMENT)*/,  /* isGlobalRefined = */ true);
     }
 }

--- a/tests/cpgrid/global_refine_test.cpp
+++ b/tests/cpgrid/global_refine_test.cpp
@@ -25,8 +25,7 @@
 #include <opm/grid/CpGrid.hpp>
 #include <tests/cpgrid/LgrChecks.hpp>
 
-#include <algorithm>
-#include <array>
+#include <numeric>
 #include <vector>
 
 struct Fixture

--- a/tests/cpgrid/global_refine_test.cpp
+++ b/tests/cpgrid/global_refine_test.cpp
@@ -1,0 +1,95 @@
+//===========================================================================
+/*
+  Copyright 2024 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#define BOOST_TEST_MODULE GlobalRefineTests
+#include <boost/test/unit_test.hpp>
+
+#include <opm/grid/CpGrid.hpp>
+#include <tests/cpgrid/LgrChecks.hpp>
+
+#include <algorithm>
+#include <array>
+#include <vector>
+
+struct Fixture
+{
+    Fixture()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        Dune::MPIHelper::instance(m_argc, m_argv);
+        Opm::OpmLog::setupSimpleDefaultLogging();
+    }
+};
+
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+
+BOOST_AUTO_TEST_CASE(globalRefineWithParamZeroDoesNothingToTheGrid)
+{
+    Dune::CpGrid grid;
+    grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
+    grid.globalRefine(0);
+
+    BOOST_CHECK_EQUAL( grid.maxLevel(), 0);
+    BOOST_CHECK_EQUAL( grid.leafGridView().size(0), grid.levelGridView(0).size(0));
+}
+
+BOOST_AUTO_TEST_CASE(globalRefineWithNegativeParamThrows)
+{
+    Dune::CpGrid grid;
+    BOOST_CHECK_THROW(grid.globalRefine(-5), std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE(globalRefineAgridWithCoarseAndRefinedCellsThrows)
+{
+    Dune::CpGrid grid;
+    grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
+    grid.addLgrsUpdateLeafView(/* cells_per_dim_vec = */ {{2,2,2}},
+                               /* startIJK_vec = */ {{2,0,0}},
+                               /* endIJK_vec = */ {{4,1,1}},
+                               /* lgr_name_vec = */ {"LGR1"});
+
+    BOOST_CHECK_THROW(grid.globalRefine(1), std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE(globalRefineWithPositiveParamIsSupported)
+{
+    Dune::CpGrid grid;
+    grid.createCartesian(/* grid_dim = */ {2,2,1}, /* cell_sizes = */ {8.0, 8.0, 4.0});
+    grid.globalRefine(3);
+    // Note: default subdivisions per cell is 2x2x2 in globalRefine().
+    // Starting grid dimensions {2,2,1} -1stGR-> {4,4,2} -2ndGR-> {8,8,4} -3rdGR-> {16,16,8}.
+
+    // Create other grid for comparison, equivalent to "grid.globalRefine(2)". Mark all elements
+    // and adapt.
+    Dune::CpGrid equivalent_grid;
+    equivalent_grid.createCartesian(/* grid_dim = */ {8,8,4}, /* cell_sizes = */ {2.0, 2.0, 1.0});
+    std::vector<int> markedCells(256); // 256 = 8x8x4
+    std::iota(markedCells.begin(), markedCells.end(), 0);
+    Opm::adaptGrid(equivalent_grid, markedCells);
+
+    // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
+    Opm::compareGrids(grid,
+                      equivalent_grid,
+                      /* lgrsHaveBlockShape = */ false,
+                      /* gridHasBeenGlobalRefined = */ true);
+}

--- a/tests/cpgrid/global_refine_test.cpp
+++ b/tests/cpgrid/global_refine_test.cpp
@@ -91,10 +91,7 @@ BOOST_AUTO_TEST_CASE(adaptAGridThatHadBeenGlobalRefinedIsSupported)
     // LGR2 parent cells = {10,11}
     // -> Equivalent to grid after calling globalRefine(1) AND adapt() with marked cells {0,4,10,11}.
 
-    Opm::compareGrids(grid,
-                      equivalent_grid,
-                      /* lgrsHaveBlockShape = */ false,
-                      /* gridHasBeenGlobalRefined = */ true);
+    Opm::checkLeafGridGeometryEquality(grid, equivalent_grid);
 }
 
 BOOST_AUTO_TEST_CASE(globalRefineWithPositiveParamIsSupported)
@@ -113,9 +110,5 @@ BOOST_AUTO_TEST_CASE(globalRefineWithPositiveParamIsSupported)
     std::iota(markedCells.begin(), markedCells.end(), 0);
     Opm::adaptGrid(equivalent_grid, markedCells);
 
-    // We set isBlockShape as false, even though global-refinement implies refinement of a block of cells.
-    Opm::compareGrids(grid,
-                      equivalent_grid,
-                      /* lgrsHaveBlockShape = */ false,
-                      /* gridHasBeenGlobalRefined = */ true);
+    Opm::checkLeafGridGeometryEquality(grid, equivalent_grid);
 }


### PR DESCRIPTION
This PR refactors and improves adapt_cpgrid_test.cpp. Previously, the test took ~13 seconds and included checks for globalRefine(). Now,  adapt_cpgrid_test.cpp takes less than a second and a separate test has been introduced specifically for globalRefine().

Additionally, redundant test cases that exhibited similar behavior to existing tests have been removed. The test names have also been cleaned up and improved, with emphasis on describing behavior clearly.

Not relevant for the Reference Manual. 