### PR TITLE
Refactor adapt_cpgrid_test, add global_refine_test

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -88,6 +88,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/cpgrid/entityrep_test.cpp
   tests/cpgrid/entity_test.cpp
   tests/cpgrid/facetag_test.cpp
+  tests/cpgrid/global_refine_test.cpp
   tests/cpgrid/grid_global_id_set_test.cpp
   tests/cpgrid/lgr_cell_id_sync_test.cpp
   tests/cpgrid/orientedentitytable_test.cpp

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -484,7 +484,8 @@ namespace Dune
         ///        Need to be called after elements have been marked for refinement.
         bool preAdapt();
 
-        /// @brief Triggers the grid refinement process
+        /// @brief Triggers the grid refinement process.
+        ///        Returns true if the grid has changed, false otherwise.
         bool adapt();
 
         /// @brief Triggers the grid refinement process, allowing to select diffrent refined level grids.
@@ -496,10 +497,6 @@ namespace Dune
         ///                                  the marked elements belong. In each entry, the refined level grid where the
         ///                                  refined entities of the (parent) marked element should belong is stored.
         /// @param [in] lgr_name_vector      Each refined level grid name, e.g. {"LGR1", "LGR2"}.
-        /// @param [in] isCARFIN             Default false. The keyword CARFIN implies that the selected cells to be refined form a block,
-        ///                                  which can be edscribed via startIJK and endIJK Cartesian indices. This bool
-        ///                                  is used to define logical_cartesian_size_ of the refined level grids according
-        ///                                  to this block shape.
         /// @param [in] startIJK_vec         Default empty vector. When isCARFIN, the starting ijk Cartesian index of each
         ///                                  block of cells to be refined.
         /// @param [in] endIJK_vec           Default empty vector. When isCARFIN, the final ijk Cartesian index of each
@@ -507,7 +504,6 @@ namespace Dune
         bool adapt(const std::vector<std::array<int,3>>& cells_per_dim_vec,
                    const std::vector<int>& assignRefinedLevel,
                    const std::vector<std::string>& lgr_name_vec,
-                   bool isCARFIN = false,
                    const std::vector<std::array<int,3>>& startIJK_vec = std::vector<std::array<int,3>>{},
                    const std::vector<std::array<int,3>>& endIJK_vec = std::vector<std::array<int,3>>{});
 
@@ -518,7 +514,7 @@ namespace Dune
     private:
 
         /// --------------- Auxiliary methods to support Adaptivity (begin) ---------------
-        
+
         /// @brief Refine each marked element and establish relationships between corners, faces, and cells marked for refinement,
         ///        with the refined corners, refined faces, and refined cells.
         ///

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -96,15 +96,6 @@ template<int> class EntityRep;
 }
 }
 
-
-void markAndAdapt_check(Dune::CpGrid&,
-                        const std::array<int,3>&,
-                        const std::vector<int>&,
-                        Dune::CpGrid&,
-                        bool,
-                        bool,
-                        bool);
-
 void refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,
                       const std::array<int, 3>&,
                       bool);
@@ -151,15 +142,6 @@ class CpGridData
     friend class Dune::cpgrid::IndexSet;
     friend class Dune::cpgrid::IdSet;
     friend class Dune::cpgrid::LevelGlobalIdSet;
-
-    friend
-    void ::markAndAdapt_check(Dune::CpGrid&,
-                              const std::array<int,3>&,
-                              const std::vector<int>&,
-                              Dune::CpGrid&,
-                              bool,
-                              bool,
-                              bool);
 
     friend
     void ::refine_and_check(const Dune::cpgrid::Geometry<3, 3>&,

--- a/tests/cpgrid/global_refine_test.cpp
+++ b/tests/cpgrid/global_refine_test.cpp
@@ -1,0 +1,156 @@
+//===========================================================================
+/*
+  Copyright 2024 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#define BOOST_TEST_MODULE GlobalRefineTests
+#include <boost/test/unit_test.hpp>
+
+#include <opm/grid/CpGrid.hpp>
+#include <tests/cpgrid/LgrChecks.hpp>
+
+#include <numeric>
+#include <vector>
+
+struct Fixture
+{
+    Fixture()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        Dune::MPIHelper::instance(m_argc, m_argv);
+        Opm::OpmLog::setupSimpleDefaultLogging();
+    }
+};
+
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+
+BOOST_AUTO_TEST_CASE(globalRefineWithParamZeroDoesNothingToTheGrid)
+{
+    Dune::CpGrid grid;
+    grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
+    grid.globalRefine(0);
+
+    BOOST_CHECK_EQUAL( grid.maxLevel(), 0);
+    BOOST_CHECK_EQUAL( grid.leafGridView().size(0), grid.levelGridView(0).size(0));
+}
+
+BOOST_AUTO_TEST_CASE(globalRefineWithNegativeParamThrows)
+{
+    Dune::CpGrid grid;
+    BOOST_CHECK_THROW(grid.globalRefine(-5), std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE(globalRefineAgridWithCoarseAndRefinedCellsThrows)
+{
+    Dune::CpGrid grid;
+    grid.createCartesian(/* grid_dim = */ {4,3,3}, /* cell_sizes = */ {1.0, 1.0, 1.0});
+    grid.addLgrsUpdateLeafView(/* cells_per_dim_vec = */ {{2,2,2}},
+                               /* startIJK_vec = */ {{2,0,0}},
+                               /* endIJK_vec = */ {{4,1,1}},
+                               /* lgr_name_vec = */ {"LGR1"});
+
+    BOOST_CHECK_THROW(grid.globalRefine(1), std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE(adaptAGridThatHadBeenGlobalRefinedIsSupported)
+{
+    Dune::CpGrid grid;
+    grid.createCartesian(/* grid_dim = */ {2,2,1}, /* cell_sizes = */ {2.0, 2.0, 2.0});
+    grid.globalRefine(1);
+
+    Opm::adaptGrid(grid, /* markedCells = */ {0,4,10,11});
+
+    // Create equivalent grid for comparison.
+    Dune::CpGrid equivalent_grid;
+    equivalent_grid.createCartesian(/* grid_dim = */ {4,4,2}, /* cell_sizes = */ {1.0, 1.0, 1.0});
+    // -> Equivalent to grid after calling globalRefine(1) and before calling adapt() with marked
+    // cells {0,4,10,11}
+    equivalent_grid.addLgrsUpdateLeafView(/* cells_per_dim_vec = */ {{2,2,2}, {2,2,2}},
+                                          /* startIJK_vec = */ {{0,0,0}, {2,1,0}},
+                                          /* endIJK_vec = */ {{1,1,2}, {4,2,1}},
+                                          /* lgr_name_vec = */ {"LGR1", "LGR2"});
+    // LGR1 parent cells = {0,4}
+    // LGR2 parent cells = {10,11}
+    // -> Equivalent to grid after calling globalRefine(1) AND adapt() with marked cells {0,4,10,11}.
+
+    Opm::checkLeafGridGeometryEquality(grid, equivalent_grid);
+}
+
+BOOST_AUTO_TEST_CASE(globalRefineWithPositiveParamIsSupported)
+{
+    Dune::CpGrid grid;
+    grid.createCartesian(/* grid_dim = */ {2,2,1}, /* cell_sizes = */ {8.0, 8.0, 4.0});
+    grid.globalRefine(3);
+    // Note: default subdivisions per cell is 2x2x2 in globalRefine().
+    // Starting grid dimensions {2,2,1} -1stGR-> {4,4,2} -2ndGR-> {8,8,4} -3rdGR-> {16,16,8}.
+
+    // Create other grid for comparison, equivalent to "grid.globalRefine(2)". Mark all elements
+    // and adapt.
+    Dune::CpGrid equivalent_grid;
+    equivalent_grid.createCartesian(/* grid_dim = */ {8,8,4}, /* cell_sizes = */ {2.0, 2.0, 1.0});
+    std::vector<int> markedCells(256); // 256 = 8x8x4
+    std::iota(markedCells.begin(), markedCells.end(), 0);
+    Opm::adaptGrid(equivalent_grid, markedCells);
+
+    Opm::checkLeafGridGeometryEquality(grid, equivalent_grid);
+}
+
+BOOST_AUTO_TEST_CASE(multipleGlobalRefineCallsAreSupported)
+{
+    Dune::CpGrid grid;
+    grid.createCartesian(/* grid_dim = */ {2,2,1}, /* cell_sizes = */ {8.0, 8.0, 4.0});
+    grid.globalRefine(1);
+    grid.globalRefine(1);
+    grid.globalRefine(1);
+    // Note: default subdivisions per cell is 2x2x2 in globalRefine().
+    // Starting grid dimensions {2,2,1} -1stGR-> {4,4,2} -2ndGR-> {8,8,4} -3rdGR-> {16,16,8}.
+
+    // Create other grid for comparison, equivalent to "grid.globalRefine(2)". Mark all elements
+    // and adapt.
+    Dune::CpGrid equivalent_grid;
+    equivalent_grid.createCartesian(/* grid_dim = */ {8,8,4}, /* cell_sizes = */ {2.0, 2.0, 1.0});
+    std::vector<int> markedCells(256); // 256 = 8x8x4
+    std::iota(markedCells.begin(), markedCells.end(), 0);
+    Opm::adaptGrid(equivalent_grid, markedCells);
+
+    Opm::checkLeafGridGeometryEquality(grid, equivalent_grid);
+}
+
+
+BOOST_AUTO_TEST_CASE(multipleRefineCallsWithDifferentPositivParamsAreSupported)
+{
+    Dune::CpGrid grid;
+    grid.createCartesian(/* grid_dim = */ {2,2,1}, /* cell_sizes = */ {8.0, 8.0, 4.0});
+    grid.globalRefine(2);
+    grid.globalRefine(1);
+    // Note: default subdivisions per cell is 2x2x2 in globalRefine().
+    // Starting grid dimensions {2,2,1} -1stGR-> {4,4,2} -2ndGR-> {8,8,4} -3rdGR-> {16,16,8}.
+
+    // Create other grid for comparison, equivalent to "grid.globalRefine(2)". Mark all elements
+    // and adapt.
+    Dune::CpGrid equivalent_grid;
+    equivalent_grid.createCartesian(/* grid_dim = */ {8,8,4}, /* cell_sizes = */ {2.0, 2.0, 1.0});
+    std::vector<int> markedCells(256); // 256 = 8x8x4
+    std::iota(markedCells.begin(), markedCells.end(), 0);
+    Opm::adaptGrid(equivalent_grid, markedCells);
+
+    Opm::checkLeafGridGeometryEquality(grid, equivalent_grid);
+}


### PR DESCRIPTION
This PR refactors and improves adapt_cpgrid_test.cpp. Previously, the test took ~13 seconds and included checks for globalRefine(). Now, adapt_cpgrid_test.cpp takes less than a second and a separate test has been introduced specifically for globalRefine().

Additionally, redundant test cases that exhibited similar behavior to existing tests have been removed. The test names have also been cleaned up and improved, with emphasis on describing behavior clearly.

Not relevant for the Reference Manual.