### PR TITLE
Allow distributed wells with partition method `zoltanwell`

### DIFF
--- a/opm/grid/GraphOfGridWrappers.cpp
+++ b/opm/grid/GraphOfGridWrappers.cpp
@@ -564,8 +564,11 @@ zoltanPartitioningWithGraphOfGrid(const Dune::CpGrid& grid,
     assert(gog.size()==0 || !partitionIsEmpty);
     auto wellConnections = partitionIsEmpty || !wells ? Dune::cpgrid::WellConnections()
                                                       : Dune::cpgrid::WellConnections(*wells, possibleFutureConnections, grid);
-    addWellConnections(gog, wellConnections);
-    gog.addNeighboringCellsToWells(layers);
+    if (!allowDistributedWells){
+        // skip cell contraction if wells can be distributed over multiple processes
+        addWellConnections(gog, wellConnections);
+        gog.addNeighboringCellsToWells(layers);
+    }
 
     // call partitioner
     setGraphOfGridZoltanGraphFunctions(zz, gog, partitionIsEmpty);

--- a/opm/grid/GraphOfGridWrappers.cpp
+++ b/opm/grid/GraphOfGridWrappers.cpp
@@ -27,6 +27,7 @@
 #include "GraphOfGridWrappers.hpp"
 #include <opm/grid/common/CommunicationUtils.hpp>
 #include <opm/grid/common/ZoltanPartition.hpp> // function scatterExportInformation
+#include <opm/grid/common/ZoltanGraphFunctions.hpp> // makeImportAndExportLists when allowDistributedWells==true
 
 namespace Opm {
 
@@ -524,6 +525,7 @@ zoltanPartitioningWithGraphOfGrid(const Dune::CpGrid& grid,
                                   Dune::EdgeWeightMethod edgeWeightMethod,
                                   int root,
                                   const double zoltanImbalanceTol,
+                                  bool allowDistributedWells,
                                   const std::map<std::string, std::string>& params,
                                   int level)
 {
@@ -590,30 +592,63 @@ zoltanPartitioningWithGraphOfGrid(const Dune::CpGrid& grid,
     }
 
     // arrange output into tuples and add well cells
-    auto importExportLists = makeImportAndExportLists(gog,
-                                                      cc,
-                                                      wells,
-                                                      wellConnections,
-                                                      root,
-                                                      numExport,
-                                                      numImport,
-                                                      exportLocalGids,
-                                                      exportGlobalGids,
-                                                      exportProcs,
-                                                      importGlobalGids,
-                                                      level);
+    auto prepareIELists = [&]() {
+        if (allowDistributedWells) {
+            // wells can be split among several processes
+            using CombinedGridWellGraph = Dune::cpgrid::CombinedGridWellGraph;
+            std::shared_ptr<CombinedGridWellGraph> gridAndWells;
+            if (wells) {
+                gridAndWells.reset(new CombinedGridWellGraph(grid,
+                                                             wells,
+                                                             possibleFutureConnections,
+                                                             transmissibilities,
+                                                             partitionIsEmpty,
+                                                             edgeWeightMethod));
+            }
+            auto result = makeImportAndExportLists(grid,
+                                                   cc,
+                                                   wells,
+                                                   possibleFutureConnections,
+                                                   gridAndWells.get(),
+                                                   root,
+                                                   numExport,
+                                                   numImport,
+                                                   exportGlobalGids, // function uses Local GIDs that are identical to global GIDs
+                                                   exportGlobalGids,
+                                                   exportProcs,
+                                                   importGlobalGids,
+                                                   allowDistributedWells);
+            std::sort(std::get<2>(result).begin(), std::get<2>(result).end());
+            std::sort(std::get<3>(result).begin(), std::get<3>(result).end());
+            return result;
+        } else {
+            // each well is guaranteed to be on a single process
+            auto partResult = makeImportAndExportLists(gog,
+                                                       cc,
+                                                       wells,
+                                                       wellConnections,
+                                                       root,
+                                                       numExport,
+                                                       numImport,
+                                                       exportLocalGids,
+                                                       exportGlobalGids,
+                                                       exportProcs,
+                                                       importGlobalGids,
+                                                       level);
+            return std::tuple(std::move(std::get<0>(partResult)),
+                              std::move(std::get<1>(partResult)),
+                              std::move(std::get<2>(partResult)),
+                              std::move(std::get<3>(partResult)),
+                              std::move(wellConnections));
+        }
+    };
+    auto importExportLists = prepareIELists();
 
     Zoltan_LB_Free_Part(&exportGlobalGids, &exportLocalGids, &exportProcs, &exportToPart);
     Zoltan_LB_Free_Part(&importGlobalGids, &importLocalGids, &importProcs, &importToPart);
     Zoltan_Destroy(&zz);
 
-    // add wellConnections to the importExportLists and return it
-    auto result = std::tuple(std::move(std::get<0>(importExportLists)),
-                             std::move(std::get<1>(importExportLists)),
-                             std::move(std::get<2>(importExportLists)),
-                             std::move(std::get<3>(importExportLists)),
-                             std::move(wellConnections));
-    return result;
+    return importExportLists;
 }
 
 std::vector<std::vector<int> >
@@ -640,6 +675,7 @@ applySerialZoltan (const Dune::CpGrid& grid,
                    Dune::EdgeWeightMethod edgeWeightMethod,
                    int root,
                    const double zoltanImbalanceTol,
+                   bool allowDistributedWells,
                    const std::map<std::string, std::string>& params)
 {
     int rc = ZOLTAN_OK;
@@ -673,8 +709,11 @@ applySerialZoltan (const Dune::CpGrid& grid,
 
     // prepare graph and contract well cells
     GraphOfGrid gog(grid, transmissibilities, edgeWeightMethod);
-    addWellConnections(gog, wellConnections);
-    gog.addNeighboringCellsToWells(layers);
+    if (!allowDistributedWells){
+        // skip cell contraction if wells can be distributed over multiple processes
+        addWellConnections(gog, wellConnections);
+        gog.addNeighboringCellsToWells(layers);
+    }
 
     // call partitioner
     setGraphOfGridZoltanGraphFunctions(zz, gog, false);
@@ -723,6 +762,7 @@ zoltanSerialPartitioningWithGraphOfGrid(const Dune::CpGrid& grid,
                                         Dune::EdgeWeightMethod edgeWeightMethod,
                                         int root,
                                         const double zoltanImbalanceTol,
+                                        bool allowDistributedWells,
                                         const std::map<std::string, std::string>& params)
 {
     // root process has the whole grid, other ranks nothing
@@ -744,6 +784,7 @@ zoltanSerialPartitioningWithGraphOfGrid(const Dune::CpGrid& grid,
                                                     edgeWeightMethod,
                                                     root,
                                                     zoltanImbalanceTol,
+                                                    allowDistributedWells,
                                                     params);
     }
 
@@ -788,8 +829,15 @@ zoltanSerialPartitioningWithGraphOfGrid(const Dune::CpGrid& grid,
     // get the distribution of wells
     std::vector<std::pair<std::string, bool>> parallel_wells;
     if (wells) {
-        auto wellRanks = getWellRanks(gIDtoRank, wellConnections);
-        parallel_wells = wellsOnThisRank(*wells, wellRanks, cc, root);
+        if (allowDistributedWells) {
+            // wells can be split among several processes
+            auto wellsOnProc = Dune::cpgrid::perforatingWellIndicesOnProc(gIDtoRank, *wells, possibleFutureConnections, grid);
+            parallel_wells = Dune::cpgrid::computeParallelWells(wellsOnProc, *wells, cc, root);
+        } else {
+            // each well is guaranteed to be on a single process
+            auto wellRanks = getWellRanks(gIDtoRank, wellConnections);
+            parallel_wells = wellsOnThisRank(*wells, wellRanks, cc, root);
+        }
     }
 
     return std::make_tuple(std::move(gIDtoRank),

--- a/opm/grid/GraphOfGridWrappers.hpp
+++ b/opm/grid/GraphOfGridWrappers.hpp
@@ -269,6 +269,7 @@ zoltanPartitioningWithGraphOfGrid(const Dune::CpGrid& grid,
                                   Dune::EdgeWeightMethod edgeWeightMethod,
                                   int root,
                                   const double zoltanImbalanceTol,
+                                  bool allowDistributedWells,
                                   const std::map<std::string,std::string>& params,
                                   int level);
 
@@ -298,6 +299,7 @@ zoltanSerialPartitioningWithGraphOfGrid(const Dune::CpGrid& grid,
                                         Dune::EdgeWeightMethod edgeWeightMethod,
                                         int root,
                                         const double zoltanImbalanceTol,
+                                        bool allowDistributedWells,
                                         const std::map<std::string,std::string>& params);
 #endif // HAVE_MPI
 

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -174,7 +174,6 @@ CpGrid::CpGrid()
     current_view_data_ = data_[0].get();
     current_data_ = &data_;
     global_id_set_ptr_ = std::make_shared<cpgrid::GlobalIdSet>(*current_view_data_);
-    
 }
 
 CpGrid::CpGrid(MPIHelper::MPICommunicator comm)
@@ -188,7 +187,6 @@ CpGrid::CpGrid(MPIHelper::MPICommunicator comm)
     current_view_data_ = data_[0].get();
     current_data_ = &data_;
     global_id_set_ptr_ = std::make_shared<cpgrid::GlobalIdSet>(*current_view_data_);
-    
 }
 
 std::vector<int>
@@ -381,8 +379,8 @@ CpGrid::scatterGrid(EdgeWeightMethod method,
 #ifdef HAVE_ZOLTAN
                 std::tie(computedCellPart, wells_on_proc, exportList, importList, wellConnections)
                     = serialPartitioning
-                    ? Opm::zoltanSerialPartitioningWithGraphOfGrid(*this, wells, possibleFutureConnections, transmissibilities, cc, method, 0, imbalanceTol, partitioningParams)
-                    : Opm::zoltanPartitioningWithGraphOfGrid(*this, wells, possibleFutureConnections, transmissibilities, cc, method, 0, imbalanceTol, partitioningParams, level);
+                    ? Opm::zoltanSerialPartitioningWithGraphOfGrid(*this, wells, possibleFutureConnections, transmissibilities, cc, method, 0, imbalanceTol, allowDistributedWells, partitioningParams)
+                    : Opm::zoltanPartitioningWithGraphOfGrid(*this, wells, possibleFutureConnections, transmissibilities, cc, method, 0, imbalanceTol, allowDistributedWells, partitioningParams, level);
 #else
                 OPM_THROW(std::runtime_error, "Parallel runs depend on ZOLTAN if useZoltan is true. Please install!");
 #endif // HAVE_ZOLTAN


### PR DESCRIPTION
The parameter `--allow-distributed-wells` was till this commit ignored, it was always set to `false`. With these changes, the value `true` makes the partitioner completely ignore wells, the partitions are calculated as if there were no wells. It is possible to obtain partitioning that has one or more wells split over multiple subdomains.

Internally, setting `--allow-distributed-wells=true` makes the partitioner skip the vertex contraction step in the graph representation of the grid, where cells of each well were merged to one (which prevented the partitioning algorithm from splitting any well).

Documentation changes: Partitioner `zoltanwell` (default) no longer ignores the `allow-distributed-wells`. This makes its behavior more similar to other partitioners.