### PR TITLE
Uses ADL to resolve geometry reference element

### DIFF
--- a/opm/grid/cpgrid/Geometry.hpp
+++ b/opm/grid/cpgrid/Geometry.hpp
@@ -1124,14 +1124,15 @@ namespace Dune
                 }
             }
         };
+
+        // Reference element for a given geometry
+        template< int mydim, int cdim >
+        auto referenceElement(const cpgrid::Geometry<mydim,cdim>& geo) -> decltype(referenceElement<double,mydim>(geo.type()))
+        {
+            return referenceElement<double,mydim>(geo.type());
+        }
+
     } // namespace cpgrid
-
-    template< int mydim, int cdim >
-    auto referenceElement(const cpgrid::Geometry<mydim,cdim>& geo) -> decltype(referenceElement<double,mydim>(geo.type()))
-    {
-        return referenceElement<double,mydim>(geo.type());
-    }
-
 } // namespace Dune
 
 #endif // OPM_GEOMETRY_HEADER


### PR DESCRIPTION
Use Argument Dependent Lookup (ADL) to resolve the geometry reference element. This change simplifies the selection of the appropriate reference element based on the geometry type. It is also required for the dune grid concepts.

**Discussion**: I am not sure why this was in the `Dune` namespace as this does not overloads the resolution of the `referenceElement` in the dune grid. Note that that one need to provide that implementation as a second argument. See https://gitlab.dune-project.org/core/dune-grid/-/blob/master/dune/grid/common/geometry.hh?ref_type=heads#L585. Technically, this is a breaking change so it would be nice to know why this was added in the first place,