### PR TITLE
Return geometry by value (alternative 2)

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1242,7 +1242,7 @@ namespace Dune
         /// \brief Get the Position of a vertex.
         /// \param vertex The index identifying the vertex.
         /// \return The coordinates of the vertex.
-        const Vector& vertexPosition(int vertex) const;
+        Vector vertexPosition(int vertex) const;
 
         /// \brief Get the area of a face.
         /// \param face The index identifying the face.
@@ -1250,12 +1250,12 @@ namespace Dune
 
         /// \brief Get the coordinates of the center of a face.
         /// \param face The index identifying the face.
-        const Vector& faceCentroid(int face) const;
+        Vector faceCentroid(int face) const;
 
         /// \brief Get the unit normal of a face.
         /// \param face The index identifying the face.
         /// \see faceCell
-        const Vector& faceNormal(int face) const;
+        Vector faceNormal(int face) const;
 
         /// \brief Get the volume of the cell.
         /// \param cell The index identifying the cell.
@@ -1263,7 +1263,7 @@ namespace Dune
 
         /// \brief Get the coordinates of the center of a cell.
         /// \param cell The index identifying the face.
-        const Vector& cellCentroid(int cell) const;
+        Vector cellCentroid(int cell) const;
 
         /// \brief An iterator over the centroids of the geometry of the entities.
         /// \tparam codim The co-dimension of the entities.

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1563,7 +1563,7 @@ const Dune::FieldVector<double,3> CpGrid::faceAreaNormalEcl(int face) const
     }
 }
 
-const Dune::FieldVector<double,3>& CpGrid::vertexPosition(int vertex) const
+Dune::FieldVector<double,3> CpGrid::vertexPosition(int vertex) const
 {
     return current_data_->back()->geomVector<3>()[cpgrid::EntityRep<3>(vertex, true)].center();
 }
@@ -1573,12 +1573,12 @@ double CpGrid::faceArea(int face) const
     return current_data_->back()->geomVector<1>()[cpgrid::EntityRep<1>(face, true)].volume();
 }
 
-const Dune::FieldVector<double,3>& CpGrid::faceCentroid(int face) const
+Dune::FieldVector<double,3> CpGrid::faceCentroid(int face) const
 {
     return current_data_->back()->geomVector<1>()[cpgrid::EntityRep<1>(face, true)].center();
 }
 
-const Dune::FieldVector<double,3>& CpGrid::faceNormal(int face) const
+Dune::FieldVector<double,3> CpGrid::faceNormal(int face) const
 {
     return current_data_->back()->face_normals_.get(face);
 }
@@ -1588,7 +1588,7 @@ double CpGrid::cellVolume(int cell) const
     return current_data_->back()->geomVector<0>()[cpgrid::EntityRep<0>(cell, true)].volume();
 }
 
-const Dune::FieldVector<double,3>& CpGrid::cellCentroid(int cell) const
+Dune::FieldVector<double,3> CpGrid::cellCentroid(int cell) const
 {
     return current_data_->back()->geomVector<0>()[cpgrid::EntityRep<0>(cell, true)].center();
 }

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -536,7 +536,7 @@ struct CellGeometryHandle
             buffer.read(pos[i]);
 
         buffer.read(vol);
-        scatterCont_[t] = Geom(pos, vol, pointGeom_, cell2Points_[t.index()].data());
+        scatterCont_[t] = Geom(pos, vol, pointGeom_.get(), cell2Points_[t.index()].data());
         double isAquifer;
         buffer.read(isAquifer);
         if (isAquifer == 1.0)

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -576,10 +576,9 @@ Dune::cpgrid::Geometry<3,3> Dune::cpgrid::Entity<codim>::geometryInFather() cons
         const auto& auxArr = pgrid_ -> getReferenceRefinedCorners(idx_in_parent_cell, cells_per_dim);
         FieldVector<double, 3> corners_in_father_reference_elem_temp[8] =
             { auxArr[0], auxArr[1], auxArr[2], auxArr[3], auxArr[4], auxArr[5], auxArr[6], auxArr[7]};
-        auto in_father_reference_elem_corners = std::make_shared<EntityVariable<cpgrid::Geometry<0, 3>, 3>>();
-        EntityVariableBase<cpgrid::Geometry<0, 3>>& mutable_in_father_reference_elem_corners = *in_father_reference_elem_corners;
+        EntityVariable<cpgrid::Geometry<0, 3>, 3> in_father_reference_elem_corners;
         // Assign the corners. Make use of the fact that pointers behave like iterators.
-        mutable_in_father_reference_elem_corners.assign(corners_in_father_reference_elem_temp,
+        in_father_reference_elem_corners.assign(corners_in_father_reference_elem_temp,
                                                         corners_in_father_reference_elem_temp + 8);
         // Compute the center of the 'local-entity'.
         Dune::FieldVector<double, 3> center_in_father_reference_elem = {0., 0.,0.};
@@ -593,7 +592,7 @@ Dune::cpgrid::Geometry<3,3> Dune::cpgrid::Entity<codim>::geometryInFather() cons
         double volume_in_father_reference_elem = double(1)/(cells_per_dim[0]*cells_per_dim[1]*cells_per_dim[2]);
         // Construct (and return) the Geometry<3,3> of 'child-cell in the reference element of its father (unit cube)'.
         return Dune::cpgrid::Geometry<3,3>(center_in_father_reference_elem, volume_in_father_reference_elem,
-                                           in_father_reference_elem_corners, in_father_reference_elem_corner_indices.data());
+                                           std::move(in_father_reference_elem_corners), in_father_reference_elem_corner_indices.data());
     }
     else {
         OPM_THROW(std::logic_error, "Entity has no father.");

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -193,7 +193,7 @@ public:
     }
 
     /// @brief Return the geometry of the entity (does not depend on its orientation).
-    const Geometry& geometry() const;
+    Geometry geometry() const;
 
     /// @brief Return the level of the entity in the grid hierarchy. Level = 0 represents the coarsest grid.
     int level() const;
@@ -422,7 +422,7 @@ unsigned int Entity<codim>::subEntities ( const unsigned int cc ) const
 }
 
 template <int codim>
-const typename Entity<codim>::Geometry& Entity<codim>::geometry() const
+typename Entity<codim>::Geometry Entity<codim>::geometry() const
 {
     return pgrid_->geomVector<codim>()[*this];
 }

--- a/opm/grid/cpgrid/Geometry.hpp
+++ b/opm/grid/cpgrid/Geometry.hpp
@@ -128,7 +128,7 @@ namespace Dune
             }
 
             /// Returns the position of the vertex.
-            const GlobalCoordinate& global(const LocalCoordinate&) const
+            GlobalCoordinate global(const LocalCoordinate&) const
             {
                 return pos_;
             }
@@ -173,7 +173,7 @@ namespace Dune
             }
 
             /// Returns the centroid of the geometry.
-            const GlobalCoordinate& center() const
+            GlobalCoordinate center() const
             {
                 return pos_;
             }
@@ -273,7 +273,7 @@ namespace Dune
             }
 
             /// This method is meaningless for singular geometries.
-            const GlobalCoordinate& global(const LocalCoordinate&) const
+            GlobalCoordinate global(const LocalCoordinate&) const
             {
                 OPM_THROW(std::runtime_error, "Geometry::global() meaningless on singular geometry.");
             }
@@ -320,20 +320,20 @@ namespace Dune
             }
 
             /// Returns the centroid of the geometry.
-            const GlobalCoordinate& center() const
+            GlobalCoordinate center() const
             {
                 return pos_;
             }
 
             /// This method is meaningless for singular geometries.
-            const FieldMatrix<ctype, mydimension, coorddimension>&
+            FieldMatrix<ctype, mydimension, coorddimension>
             jacobianTransposed(const LocalCoordinate& /* local */) const
             {
                 OPM_THROW(std::runtime_error, "Meaningless to call jacobianTransposed() on singular geometries.");
             }
 
             /// This method is meaningless for singular geometries.
-            const FieldMatrix<ctype, coorddimension, mydimension>&
+            FieldMatrix<ctype, coorddimension, mydimension>
             jacobianInverseTransposed(const LocalCoordinate& /*local*/) const
             {
                 OPM_THROW(std::runtime_error, "Meaningless to call jacobianInverseTransposed() on singular geometries.");
@@ -527,7 +527,7 @@ namespace Dune
             }
 
             /// Returns the centroid of the geometry.
-            const GlobalCoordinate& center() const
+            GlobalCoordinate center() const
             {
                 return pos_;
             }
@@ -538,7 +538,7 @@ namespace Dune
             /// and {u_i} are the reference coordinates.
             /// g = g(u) = (g_1(u), g_2(u), g_3(u)), u=(u_1,u_2,u_3)
             /// g = map from (local) reference domain to global cell
-            const JacobianTransposed
+            JacobianTransposed
             jacobianTransposed(const LocalCoordinate& local_coord) const
             {
                 static_assert(mydimension == 3, "");
@@ -574,7 +574,7 @@ namespace Dune
             }
 
             /// @brief Inverse of Jacobian transposed. \see jacobianTransposed().
-            const JacobianInverseTransposed
+            JacobianInverseTransposed
             jacobianInverseTransposed(const LocalCoordinate& local_coord) const
             {
                 JacobianInverseTransposed Jti = jacobianTransposed(local_coord);

--- a/opm/grid/cpgrid/Geometry.hpp
+++ b/opm/grid/cpgrid/Geometry.hpp
@@ -38,11 +38,13 @@
 #define OPM_GEOMETRY_HEADER
 
 #include <cmath>
+#include <variant>
 
 // Warning suppression for Dune includes.
 #include <opm/grid/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
+#include <dune/common/overloadset.hh>
 #include <dune/geometry/referenceelements.hh>
 #include <dune/grid/common/geometry.hh>
 
@@ -406,6 +408,10 @@ namespace Dune
 
             /// @brief Construct from center, volume (1- and 0-moments) and
             ///        corners.
+            /// @warning This constructor does not own the corners or indices,
+            ///         thus, the pointers must remain valid for the lifetime of
+            ///         the Geometry object.
+            ///
             /// @param pos the centroid of the entity
             /// @param vol the volume(area) of the entity
             /// @param allcorners_ptr pointer of all corner positions in the grid
@@ -414,17 +420,34 @@ namespace Dune
             ///                       by (kji), i.e. i running fastest.
             Geometry(const GlobalCoordinate& pos,
                      ctype vol,
-                     std::shared_ptr<const EntityVariable<cpgrid::Geometry<0, 3>, 3>> allcorners_ptr,
+                     EntityVariable<cpgrid::Geometry<0, 3>, 3> const * allcorners_view,
                      const int* corner_indices)
-                : pos_(pos), vol_(vol),
-                  allcorners_(allcorners_ptr), cor_idx_(corner_indices)
+                : pos_(pos), vol_(vol), cor_idx_(corner_indices),
+                  allcorners_(allcorners_view)
             {
-                assert(allcorners_ && corner_indices);
+                assert(allcorners_view && corner_indices);
             }
+
+            /// @brief Construct from center, volume (1- and 0-moments) and
+            ///        corners.
+            ///
+            /// @param pos the centroid of the entity
+            /// @param vol the volume(area) of the entity
+            /// @param allcorners pointer of all corner positions in the grid
+            /// @param corner_indices array of 8 indices into allcorners. The
+            ///                       indices must be given in lexicographical order
+            ///                       by (kji), i.e. i running fastest.
+            Geometry(const GlobalCoordinate& pos,
+                     ctype vol,
+                     const EntityVariable<cpgrid::Geometry<0, 3>, 3>& allcorners_storage,
+                     const int* corner_indices)
+                : pos_(pos), vol_(vol), cor_idx_(corner_indices),
+                  allcorners_(allcorners_storage)
+            {}
 
             /// Default constructor, giving a non-valid geometry.
             Geometry()
-                : pos_(0.0), vol_(0.0), allcorners_(0), cor_idx_(0)
+                : pos_(0.0), vol_(0.0), cor_idx_(nullptr), allcorners_(nullptr)
             {
             }
 
@@ -512,8 +535,16 @@ namespace Dune
             /// @brief Get the cor-th of 8 corners of the hexahedral base cell.
             GlobalCoordinate corner(int cor) const
             {
-                assert(allcorners_ && cor_idx_);
-                return (allcorners_->data())[cor_idx_[cor]].center();
+                return std::visit(
+                    Dune::overload(
+                        [](const EntityVariable<Geometry<0, 3>, 3>& corners) -> const EntityVariable<Geometry<0, 3>, 3>& {
+                            return corners;
+                        },
+                        [](EntityVariable<Geometry<0, 3>, 3> const * corners) -> const EntityVariable<Geometry<0, 3>, 3>& {
+                            return *corners;
+                        }
+                    ), allcorners_
+                ).data()[cor_idx_[cor]].center();
             }
 
             /// Cell volume.
@@ -1023,7 +1054,7 @@ namespace Dune
                             refined_cells[refined_cell_idx] =
                                 Geometry<3,cdim>(refined_cell_center,
                                                  refined_cell_volume,
-                                                 all_geom.geomVector(std::integral_constant<int,3>()),
+                                                 all_geom.geomVector(std::integral_constant<int,3>()).get(),
                                                  indices_storage_ptr);
                         } // end i-for-loop
                     }  // end j-for-loop
@@ -1044,8 +1075,9 @@ namespace Dune
         private:
             GlobalCoordinate pos_;
             double vol_;
-            std::shared_ptr<const EntityVariable<Geometry<0, 3>,3>> allcorners_; // For dimension 3 only
-            const int* cor_idx_; // For dimension 3 only
+            int const * cor_idx_; // For dimension 3 only
+            // store either a (view) pointer or the variable itself. For dimension 3 only
+            std::variant<EntityVariable<Geometry<0, 3>,3> const *, EntityVariable<Geometry<0, 3>,3>> allcorners_;
 
             /// @brief
             ///   Auxiliary function to get refined_face information: tag, index, face_to_point_, face_to_cell, face centroid,
@@ -1058,7 +1090,7 @@ namespace Dune
             /// @param [out] refined_face_tag            I_FACE, J_FACE, K_FACE
             /// @param [out] refined_face_index          Face index of a refined cell 'lmn' generated with "refine()".
             /// @param [out] refined_face_to_point       Four corner indices of the corners of the refined face 'lmn'.
-            ///                                          Vertex order 
+            ///                                          Vertex order
             ///                                          for I_FACE:  jk, (j+1)k, (j+1)(k+1), j(k+1)
             ///                                          for J_FACE:  (i+1)k, ik,  i(k+1), (i+1)(k+1)
             ///                                          for K_FACE:  ij, (i+1)j, (i+1)(j+1), (i+1)(j+1)

--- a/opm/grid/cpgrid/GridHelpers.cpp
+++ b/opm/grid/cpgrid/GridHelpers.cpp
@@ -147,9 +147,9 @@ beginFaceCentroids(const Dune::CpGrid& grid)
     return FaceCentroidTraits<Dune::CpGrid>::IteratorType(grid, 0);
 }
 
-const double* cellCentroid(const Dune::CpGrid& grid, int cell_index)
+Vector cellCentroid(const Dune::CpGrid& grid, int cell_index)
 {
-    return &(grid.cellCentroid(cell_index)[0]);
+    return grid.cellCentroid(cell_index);
 }
 
 double cellVolume(const  Dune::CpGrid& grid, int cell_index)
@@ -167,8 +167,7 @@ CellVolumeIterator endCellVolumes(const Dune::CpGrid& grid)
     return CellVolumeIterator(grid, numCells(grid));
 }
 
-const FaceCentroidTraits<Dune::CpGrid>::ValueType&
-faceCentroid(const Dune::CpGrid& grid, int face_index)
+Vector faceCentroid(const Dune::CpGrid& grid, int face_index)
 {
     return grid.faceCentroid(face_index);
 }
@@ -190,14 +189,14 @@ face2Vertices(const Dune::CpGrid& grid)
     return Dune::cpgrid::FaceVerticesContainerProxy(&grid);
 }
 
-const double* vertexCoordinates(const Dune::CpGrid& grid, int index)
+Vector vertexCoordinates(const Dune::CpGrid& grid, int index)
 {
-    return &(grid.vertexPosition(index)[0]);
+    return grid.vertexPosition(index);
 }
 
-const double* faceNormal(const Dune::CpGrid& grid, int face_index)
+Vector faceNormal(const Dune::CpGrid& grid, int face_index)
 {
-    return &(grid.faceNormal(face_index)[0]);
+    return grid.faceNormal(face_index);
 }
 
 double faceArea(const Dune::CpGrid& grid, int face_index)

--- a/opm/grid/cpgrid/GridHelpers.hpp
+++ b/opm/grid/cpgrid/GridHelpers.hpp
@@ -328,10 +328,10 @@ struct Cell2FacesTraits<Dune::CpGrid>
     typedef Dune::cpgrid::Cell2FacesContainer Type;
 };
 /// \brief An iterator over the cell volumes.
-template<const Dune::FieldVector<double, 3>& (Dune::CpGrid::*Method)(int)const>
+template<Dune::FieldVector<double, 3> (Dune::CpGrid::*Method)(int)const>
 class CpGridCentroidIterator
     : public Dune::RandomAccessIteratorFacade<CpGridCentroidIterator<Method>, Dune::FieldVector<double, 3>,
-                                              const Dune::FieldVector<double, 3>&, int>
+                                              Dune::FieldVector<double, 3>, int>
 {
 public:
     /// \brief Creates an iterator.
@@ -341,7 +341,7 @@ public:
         : grid_(&grid), cell_index_(cell_index)
     {}
 
-    const Dune::FieldVector<double, 3>& dereference() const
+    Dune::FieldVector<double, 3> dereference() const
     {
         return std::mem_fn(Method)(*grid_, cell_index_);
     }
@@ -349,7 +349,7 @@ public:
     {
         ++cell_index_;
     }
-    const Dune::FieldVector<double, 3>& elementAt(int n) const
+    Dune::FieldVector<double, 3> elementAt(int n) const
     {
         return  std::mem_fn(Method)(*grid_, n);
     }
@@ -430,7 +430,7 @@ double cellCentroidCoordinate(const Dune::CpGrid& grid, int cell_index,
 /// \brief Get the centroid of a cell.
 /// \param grid The grid whose cell centroid we query.
 /// \param cell_index The index of the corresponding cell.
-const double* cellCentroid(const Dune::CpGrid& grid, int cell_index);
+Vector cellCentroid(const Dune::CpGrid& grid, int cell_index);
 
 /// \brief Get vertical position of cell center ("zcorn" average).
 /// \brief grid The grid.
@@ -531,8 +531,7 @@ beginFaceCentroids(const Dune::CpGrid& grid);
 /// \param grid The grid.
 /// \param face_index The index of the specific face.
 /// \param coordinate The coordinate index.
-const FaceCentroidTraits<Dune::CpGrid>::ValueType&
-faceCentroid(const Dune::CpGrid& grid, int face_index);
+Vector faceCentroid(const Dune::CpGrid& grid, int face_index);
 
 template<>
 struct FaceCellTraits<Dune::CpGrid>
@@ -559,9 +558,9 @@ face2Vertices(const Dune::CpGrid& grid);
 /// \brief Get the coordinates of a vertex of the grid.
 /// \param grid The grid the vertex is part of.
 /// \param index The index identifying the vertex.
-const double* vertexCoordinates(const Dune::CpGrid& grid, int index);
+Vector vertexCoordinates(const Dune::CpGrid& grid, int index);
 
-const double* faceNormal(const Dune::CpGrid& grid, int face_index);
+Vector faceNormal(const Dune::CpGrid& grid, int face_index);
 
 double faceArea(const Dune::CpGrid& grid, int face_index);
 

--- a/opm/grid/cpgrid/Intersection.hpp
+++ b/opm/grid/cpgrid/Intersection.hpp
@@ -158,7 +158,7 @@ namespace Dune
             /// @brief
             /// @todo Doc me!
             /// @return
-            const LocalGeometry& geometryInInside() const
+            LocalGeometry geometryInInside() const
             {
                 OPM_THROW(std::runtime_error, "This intersection class does not support geometryInInside().");
             }
@@ -168,7 +168,7 @@ namespace Dune
             /// @brief
             /// @todo Doc me!
             /// @return
-            const LocalGeometry& geometryInOutside() const
+            LocalGeometry geometryInOutside() const
             {
                 if (boundary()) {
                     OPM_THROW(std::runtime_error, "Cannot access geometryInOutside(), intersection is at a boundary.");

--- a/opm/grid/cpgrid/LgrHelpers.cpp
+++ b/opm/grid/cpgrid/LgrHelpers.cpp
@@ -1426,7 +1426,7 @@ void populateRefinedCells(const Dune::cpgrid::CpGridData& current_data,
 
             // Create a pointer to the first element of "refined_cell_to_point" (required as the fourth argement to construct a Geometry<3,3> type object).
             int* indices_storage_ptr = refined_cell_to_point_vec[shiftedLevel][cell].data();
-            refined_cells_vec[shiftedLevel][cell] = Dune::cpgrid::Geometry<3,3>(elemLgrGeom.center(), elemLgrGeom.volume(), allLevelCorners, indices_storage_ptr);
+            refined_cells_vec[shiftedLevel][cell] = Dune::cpgrid::Geometry<3,3>(elemLgrGeom.center(), elemLgrGeom.volume(), allLevelCorners.get(), indices_storage_ptr);
         } // refined_cells
         // Refined face to cell.
         refined_cell_to_face_vec[shiftedLevel].makeInverseRelation(refined_face_to_cell_vec[shiftedLevel]);
@@ -1722,7 +1722,7 @@ void populateLeafGridCells(const Dune::cpgrid::CpGridData& current_data,
 
         // Create a pointer to the first element of "adapted_cell_to_point" (required as the fourth argement to construct a Geometry<3,3> type object).
         int* indices_storage_ptr = adapted_cell_to_point[cell].data();
-        adapted_cells[cell] = Dune::cpgrid::Geometry<3,3>(cellGeom.center(), cellGeom.volume(), allCorners, indices_storage_ptr);
+        adapted_cells[cell] = Dune::cpgrid::Geometry<3,3>(cellGeom.center(), cellGeom.volume(), allCorners.get(), indices_storage_ptr);
     } // adapted_cells
 
     // Adapted/Leaf-grid-view face to cell.
@@ -2287,7 +2287,7 @@ void filterMarkedAquiferCellsAndConnections(Dune::CpGrid& grid,
                 } else {
                     grid.mark(0, elem);
                 }
-            }  
+            }
         }
     };
 

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -1296,7 +1296,7 @@ namespace cpgrid
                                                       double vol,
                                                       const std::array<int,8>& corner_indices)
             {
-                return cpgrid::Geometry<3, 3>(pos, vol, allcorners_, &corner_indices[0]);
+                return cpgrid::Geometry<3, 3>(pos, vol, allcorners_.get(), &corner_indices[0]);
             }
         };
 

--- a/opm/grid/transmissibility/TransTpfa_impl.hpp
+++ b/opm/grid/transmissibility/TransTpfa_impl.hpp
@@ -87,7 +87,7 @@ tpfa_htrans_compute(const Grid* G, const double *perm, double *htrans)
             s = 2.0*(face_cells(*f, 0) == c) - 1.0;
             n = faceNormal(*G, *f);
             const double* nn=multiplyFaceNormalWithArea(*G, *f, n);
-            const double* fc = &(faceCentroid(*G, *f)[0]);
+            const auto fc = faceCentroid(*G, *f);
             dgemv_("No Transpose", &nrows, &ncols,
                    &a1, K, &ldA, nn, &incx, &a2, &Kn[0], &incy);
             maybeFreeFaceNormal(*G, nn);

--- a/tests/cpgrid/geometry_test.cpp
+++ b/tests/cpgrid/geometry_test.cpp
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(cellgeom)
     }
 
     int cor_idx[8] = { 0, 1, 2, 3, 4, 5, 6, 7 };
-    Geometry g(c, v, pg, cor_idx);
+    Geometry g(c, v, pg.get(), cor_idx);
 
     // Verification of properties.
     BOOST_CHECK(g.type().isCube());
@@ -207,7 +207,7 @@ BOOST_AUTO_TEST_CASE(cellgeom)
     {
         (*pg1).push_back(cpgrid::Geometry<0, 3>(crn));
     }
-    g = Geometry(c, v, pg1, cor_idx);
+    g = Geometry(c, v, pg1.get(), cor_idx);
 
     // Verification of properties.
     BOOST_CHECK(g.type().isCube());
@@ -524,7 +524,7 @@ BOOST_AUTO_TEST_CASE(refine_simple_cube)
     }
 
     int cor_idx[8] = {0, 1, 2, 3, 4, 5, 6, 7};
-    Geometry g(c, v, pg, cor_idx);
+    Geometry g(c, v, pg.get(), cor_idx);
 
     refine_and_check(g, {1, 1, 1}, true);
     refine_and_check(g, {2, 3, 4}, true);
@@ -566,7 +566,7 @@ BOOST_AUTO_TEST_CASE(refine_distorted_cube)
     }
 
     int cor_idx[8] = {0, 1, 2, 3, 4, 5, 6, 7};
-    Geometry g(center, v, pg, cor_idx);
+    Geometry g(center, v, pg.get(), cor_idx);
     refine_and_check(g, {1, 1, 1});
     refine_and_check(g, {2, 3, 4});
 


### PR DESCRIPTION
To avoid copying a shared pointer, which is rather costly, the geometry now stores a variant holding either the ownership or a non-owning view to the entity variable. In the case of entity variables owned by the grid, a non-owning storage is fine as the geometry should not outlive the grid. On grid refinement the grid points are only owned by the geometry, so a move into the geometry is preferred.

Note that this PR is based on #885 which fixes all the lifetime issues of the geometry objects.
