### PR TITLE
Return geometry by value (alternative 1)

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1242,7 +1242,7 @@ namespace Dune
         /// \brief Get the Position of a vertex.
         /// \param vertex The index identifying the vertex.
         /// \return The coordinates of the vertex.
-        const Vector& vertexPosition(int vertex) const;
+        Vector vertexPosition(int vertex) const;
 
         /// \brief Get the area of a face.
         /// \param face The index identifying the face.
@@ -1250,12 +1250,12 @@ namespace Dune
 
         /// \brief Get the coordinates of the center of a face.
         /// \param face The index identifying the face.
-        const Vector& faceCentroid(int face) const;
+        Vector faceCentroid(int face) const;
 
         /// \brief Get the unit normal of a face.
         /// \param face The index identifying the face.
         /// \see faceCell
-        const Vector& faceNormal(int face) const;
+        Vector faceNormal(int face) const;
 
         /// \brief Get the volume of the cell.
         /// \param cell The index identifying the cell.
@@ -1263,7 +1263,7 @@ namespace Dune
 
         /// \brief Get the coordinates of the center of a cell.
         /// \param cell The index identifying the face.
-        const Vector& cellCentroid(int cell) const;
+        Vector cellCentroid(int cell) const;
 
         /// \brief An iterator over the centroids of the geometry of the entities.
         /// \tparam codim The co-dimension of the entities.

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1563,7 +1563,7 @@ const Dune::FieldVector<double,3> CpGrid::faceAreaNormalEcl(int face) const
     }
 }
 
-const Dune::FieldVector<double,3>& CpGrid::vertexPosition(int vertex) const
+Dune::FieldVector<double,3> CpGrid::vertexPosition(int vertex) const
 {
     return current_data_->back()->geomVector<3>()[cpgrid::EntityRep<3>(vertex, true)].center();
 }
@@ -1573,12 +1573,12 @@ double CpGrid::faceArea(int face) const
     return current_data_->back()->geomVector<1>()[cpgrid::EntityRep<1>(face, true)].volume();
 }
 
-const Dune::FieldVector<double,3>& CpGrid::faceCentroid(int face) const
+Dune::FieldVector<double,3> CpGrid::faceCentroid(int face) const
 {
     return current_data_->back()->geomVector<1>()[cpgrid::EntityRep<1>(face, true)].center();
 }
 
-const Dune::FieldVector<double,3>& CpGrid::faceNormal(int face) const
+Dune::FieldVector<double,3> CpGrid::faceNormal(int face) const
 {
     return current_data_->back()->face_normals_.get(face);
 }
@@ -1588,7 +1588,7 @@ double CpGrid::cellVolume(int cell) const
     return current_data_->back()->geomVector<0>()[cpgrid::EntityRep<0>(cell, true)].volume();
 }
 
-const Dune::FieldVector<double,3>& CpGrid::cellCentroid(int cell) const
+Dune::FieldVector<double,3> CpGrid::cellCentroid(int cell) const
 {
     return current_data_->back()->geomVector<0>()[cpgrid::EntityRep<0>(cell, true)].center();
 }

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -193,7 +193,7 @@ public:
     }
 
     /// @brief Return the geometry of the entity (does not depend on its orientation).
-    const Geometry& geometry() const;
+    Geometry geometry() const;
 
     /// @brief Return the level of the entity in the grid hierarchy. Level = 0 represents the coarsest grid.
     int level() const;
@@ -422,7 +422,7 @@ unsigned int Entity<codim>::subEntities ( const unsigned int cc ) const
 }
 
 template <int codim>
-const typename Entity<codim>::Geometry& Entity<codim>::geometry() const
+typename Entity<codim>::Geometry Entity<codim>::geometry() const
 {
     return pgrid_->geomVector<codim>()[*this];
 }

--- a/opm/grid/cpgrid/Geometry.hpp
+++ b/opm/grid/cpgrid/Geometry.hpp
@@ -128,7 +128,7 @@ namespace Dune
             }
 
             /// Returns the position of the vertex.
-            const GlobalCoordinate& global(const LocalCoordinate&) const
+            GlobalCoordinate global(const LocalCoordinate&) const
             {
                 return pos_;
             }
@@ -173,7 +173,7 @@ namespace Dune
             }
 
             /// Returns the centroid of the geometry.
-            const GlobalCoordinate& center() const
+            GlobalCoordinate center() const
             {
                 return pos_;
             }
@@ -273,7 +273,7 @@ namespace Dune
             }
 
             /// This method is meaningless for singular geometries.
-            const GlobalCoordinate& global(const LocalCoordinate&) const
+            GlobalCoordinate global(const LocalCoordinate&) const
             {
                 OPM_THROW(std::runtime_error, "Geometry::global() meaningless on singular geometry.");
             }
@@ -320,20 +320,20 @@ namespace Dune
             }
 
             /// Returns the centroid of the geometry.
-            const GlobalCoordinate& center() const
+            GlobalCoordinate center() const
             {
                 return pos_;
             }
 
             /// This method is meaningless for singular geometries.
-            const FieldMatrix<ctype, mydimension, coorddimension>&
+            FieldMatrix<ctype, mydimension, coorddimension>
             jacobianTransposed(const LocalCoordinate& /* local */) const
             {
                 OPM_THROW(std::runtime_error, "Meaningless to call jacobianTransposed() on singular geometries.");
             }
 
             /// This method is meaningless for singular geometries.
-            const FieldMatrix<ctype, coorddimension, mydimension>&
+            FieldMatrix<ctype, coorddimension, mydimension>
             jacobianInverseTransposed(const LocalCoordinate& /*local*/) const
             {
                 OPM_THROW(std::runtime_error, "Meaningless to call jacobianInverseTransposed() on singular geometries.");
@@ -527,7 +527,7 @@ namespace Dune
             }
 
             /// Returns the centroid of the geometry.
-            const GlobalCoordinate& center() const
+            GlobalCoordinate center() const
             {
                 return pos_;
             }
@@ -538,7 +538,7 @@ namespace Dune
             /// and {u_i} are the reference coordinates.
             /// g = g(u) = (g_1(u), g_2(u), g_3(u)), u=(u_1,u_2,u_3)
             /// g = map from (local) reference domain to global cell
-            const JacobianTransposed
+            JacobianTransposed
             jacobianTransposed(const LocalCoordinate& local_coord) const
             {
                 static_assert(mydimension == 3, "");
@@ -574,7 +574,7 @@ namespace Dune
             }
 
             /// @brief Inverse of Jacobian transposed. \see jacobianTransposed().
-            const JacobianInverseTransposed
+            JacobianInverseTransposed
             jacobianInverseTransposed(const LocalCoordinate& local_coord) const
             {
                 JacobianInverseTransposed Jti = jacobianTransposed(local_coord);

--- a/opm/grid/cpgrid/GridHelpers.cpp
+++ b/opm/grid/cpgrid/GridHelpers.cpp
@@ -147,9 +147,9 @@ beginFaceCentroids(const Dune::CpGrid& grid)
     return FaceCentroidTraits<Dune::CpGrid>::IteratorType(grid, 0);
 }
 
-const double* cellCentroid(const Dune::CpGrid& grid, int cell_index)
+Vector cellCentroid(const Dune::CpGrid& grid, int cell_index)
 {
-    return &(grid.cellCentroid(cell_index)[0]);
+    return grid.cellCentroid(cell_index);
 }
 
 double cellVolume(const  Dune::CpGrid& grid, int cell_index)
@@ -167,8 +167,7 @@ CellVolumeIterator endCellVolumes(const Dune::CpGrid& grid)
     return CellVolumeIterator(grid, numCells(grid));
 }
 
-const FaceCentroidTraits<Dune::CpGrid>::ValueType&
-faceCentroid(const Dune::CpGrid& grid, int face_index)
+Vector faceCentroid(const Dune::CpGrid& grid, int face_index)
 {
     return grid.faceCentroid(face_index);
 }
@@ -190,14 +189,14 @@ face2Vertices(const Dune::CpGrid& grid)
     return Dune::cpgrid::FaceVerticesContainerProxy(&grid);
 }
 
-const double* vertexCoordinates(const Dune::CpGrid& grid, int index)
+Vector vertexCoordinates(const Dune::CpGrid& grid, int index)
 {
-    return &(grid.vertexPosition(index)[0]);
+    return grid.vertexPosition(index);
 }
 
-const double* faceNormal(const Dune::CpGrid& grid, int face_index)
+Vector faceNormal(const Dune::CpGrid& grid, int face_index)
 {
-    return &(grid.faceNormal(face_index)[0]);
+    return grid.faceNormal(face_index);
 }
 
 double faceArea(const Dune::CpGrid& grid, int face_index)

--- a/opm/grid/cpgrid/GridHelpers.hpp
+++ b/opm/grid/cpgrid/GridHelpers.hpp
@@ -328,10 +328,10 @@ struct Cell2FacesTraits<Dune::CpGrid>
     typedef Dune::cpgrid::Cell2FacesContainer Type;
 };
 /// \brief An iterator over the cell volumes.
-template<const Dune::FieldVector<double, 3>& (Dune::CpGrid::*Method)(int)const>
+template<Dune::FieldVector<double, 3> (Dune::CpGrid::*Method)(int)const>
 class CpGridCentroidIterator
     : public Dune::RandomAccessIteratorFacade<CpGridCentroidIterator<Method>, Dune::FieldVector<double, 3>,
-                                              const Dune::FieldVector<double, 3>&, int>
+                                              Dune::FieldVector<double, 3>, int>
 {
 public:
     /// \brief Creates an iterator.
@@ -341,7 +341,7 @@ public:
         : grid_(&grid), cell_index_(cell_index)
     {}
 
-    const Dune::FieldVector<double, 3>& dereference() const
+    Dune::FieldVector<double, 3> dereference() const
     {
         return std::mem_fn(Method)(*grid_, cell_index_);
     }
@@ -349,7 +349,7 @@ public:
     {
         ++cell_index_;
     }
-    const Dune::FieldVector<double, 3>& elementAt(int n) const
+    Dune::FieldVector<double, 3> elementAt(int n) const
     {
         return  std::mem_fn(Method)(*grid_, n);
     }
@@ -430,7 +430,7 @@ double cellCentroidCoordinate(const Dune::CpGrid& grid, int cell_index,
 /// \brief Get the centroid of a cell.
 /// \param grid The grid whose cell centroid we query.
 /// \param cell_index The index of the corresponding cell.
-const double* cellCentroid(const Dune::CpGrid& grid, int cell_index);
+Vector cellCentroid(const Dune::CpGrid& grid, int cell_index);
 
 /// \brief Get vertical position of cell center ("zcorn" average).
 /// \brief grid The grid.
@@ -531,8 +531,7 @@ beginFaceCentroids(const Dune::CpGrid& grid);
 /// \param grid The grid.
 /// \param face_index The index of the specific face.
 /// \param coordinate The coordinate index.
-const FaceCentroidTraits<Dune::CpGrid>::ValueType&
-faceCentroid(const Dune::CpGrid& grid, int face_index);
+Vector faceCentroid(const Dune::CpGrid& grid, int face_index);
 
 template<>
 struct FaceCellTraits<Dune::CpGrid>
@@ -559,9 +558,9 @@ face2Vertices(const Dune::CpGrid& grid);
 /// \brief Get the coordinates of a vertex of the grid.
 /// \param grid The grid the vertex is part of.
 /// \param index The index identifying the vertex.
-const double* vertexCoordinates(const Dune::CpGrid& grid, int index);
+Vector vertexCoordinates(const Dune::CpGrid& grid, int index);
 
-const double* faceNormal(const Dune::CpGrid& grid, int face_index);
+Vector faceNormal(const Dune::CpGrid& grid, int face_index);
 
 double faceArea(const Dune::CpGrid& grid, int face_index);
 

--- a/opm/grid/cpgrid/Intersection.hpp
+++ b/opm/grid/cpgrid/Intersection.hpp
@@ -158,7 +158,7 @@ namespace Dune
             /// @brief
             /// @todo Doc me!
             /// @return
-            const LocalGeometry& geometryInInside() const
+            LocalGeometry geometryInInside() const
             {
                 OPM_THROW(std::runtime_error, "This intersection class does not support geometryInInside().");
             }
@@ -168,7 +168,7 @@ namespace Dune
             /// @brief
             /// @todo Doc me!
             /// @return
-            const LocalGeometry& geometryInOutside() const
+            LocalGeometry geometryInOutside() const
             {
                 if (boundary()) {
                     OPM_THROW(std::runtime_error, "Cannot access geometryInOutside(), intersection is at a boundary.");

--- a/opm/grid/transmissibility/TransTpfa_impl.hpp
+++ b/opm/grid/transmissibility/TransTpfa_impl.hpp
@@ -87,7 +87,7 @@ tpfa_htrans_compute(const Grid* G, const double *perm, double *htrans)
             s = 2.0*(face_cells(*f, 0) == c) - 1.0;
             n = faceNormal(*G, *f);
             const double* nn=multiplyFaceNormalWithArea(*G, *f, n);
-            const double* fc = &(faceCentroid(*G, *f)[0]);
+            const auto fc = faceCentroid(*G, *f);
             dgemv_("No Transpose", &nrows, &ncols,
                    &a1, K, &ldA, nn, &incx, &a2, &Kn[0], &incy);
             maybeFreeFaceNormal(*G, nn);


### PR DESCRIPTION
This is to conform with the dune interface.

Note that this is possible since the introduction of shared pointers into the geometry. On the other hand, because copying shared pointer can cause performance problems I also propose an alternative #884 and compare them with the benchmarks.
