### PR TITLE
Improve interface compatibility with DUNE grid

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -334,7 +334,7 @@ namespace Dune
         /// Set whether we want to have unique boundary ids.
         /// \param uids if true, each boundary intersection will have a unique boundary id.
         void setUniqueBoundaryIds(bool uids);
-       
+
 
         // --- Dune interface below ---
 
@@ -345,7 +345,7 @@ namespace Dune
         /// It's the same as the class name.
         /// What did you expect, something funny?
         std::string name() const;
-        
+
         /// Return maximum level defined in this grid. Levels are 0 and 1,  maxlevel = 1 (not counting leafview), 0 = the coarsest level.
         int maxLevel() const;
 
@@ -355,7 +355,7 @@ namespace Dune
         /// one past the end on this level
         template<int codim>
         typename Traits::template Codim<codim>::LevelIterator lend (int level) const;
-        
+
         /// Iterator to first entity of given codim on level and PartitionIteratorType
         template<int codim, PartitionIteratorType PiType>
         typename Traits::template Codim<codim>::template Partition<PiType>::LevelIterator lbegin (int level) const;
@@ -394,7 +394,7 @@ namespace Dune
 
         /// \brief Access to the LocalIdSet
         const Traits::LocalIdSet& localIdSet() const;
-        
+
         /// \brief Access to the LevelIndexSets
         const Traits::LevelIndexSet& levelIndexSet(int level) const;
 
@@ -626,10 +626,10 @@ namespace Dune
                                                                              const int& cell_count) const;
 
         /// @brief Define refined level grid cells indices and leaf grid view (or adapted grid) cells indices relations. Namely, level_to_leaf_cells_ for each new
-        ///        refined level grid, and leaf_to_level_cells_ for the updated leaf grid view. 
+        ///        refined level grid, and leaf_to_level_cells_ for the updated leaf grid view.
         ///
         /// @param [in] elemLgrAndElemLgrCell_to_refinedLevelAdRefinedCell:  Each marked element has been refined in its "own elemLgr". Refined entities should be stored in
-        ///                                                                  the corresponding assigned refined level grid. To keep track of the cell index relation, we 
+        ///                                                                  the corresponding assigned refined level grid. To keep track of the cell index relation, we
         ///                                                                  associate each
         ///                                                                  { marked element index ("elemLgr"), refined cell index in the auxiliary single-cell-refinement } with
         ///                                                                  { refined level grid assigned for the marked element, refined cell index in refined level grid }.
@@ -761,7 +761,7 @@ namespace Dune
         /// @param [out] adaptedFace_to_elemLgrAndElemLgrFace: Each marked element has been refined in its "own elemLgr". Refined corners should be stored in
         ///                                                    the corresponding assigned refined level grid. To keep track of the face index relation, we associate each
         ///                                                    face index in the leaf grid view (or adapted grid) with
-        ///                                                    { marked element index ("elemLgr"), refined corner index in the auxiliary single-cell-refinement }. 
+        ///                                                    { marked element index ("elemLgr"), refined corner index in the auxiliary single-cell-refinement }.
         /// @param [out] face_count:                           Total amount of faces on the leaf grid view (or adapted grid).
         /// @param [in] markedElem_to_itsLgr
         /// @param [in] assignRefinedLevel
@@ -1087,7 +1087,7 @@ namespace Dune
         int getParentFaceWhereNewRefinedFaceLiesOn(const std::array<int,3>& cells_per_dim, int faceIdxInLgr,
                                                    const std::shared_ptr<cpgrid::CpGridData>& elemLgr_ptr,
                                                    int elemLgr)  const;
-        
+
         /// --------------- Auxiliary methods to support Adaptivity (end) ---------------
 
         /// @brief Check if there are non neighboring connections on blocks of cells selected for refinement.
@@ -1712,7 +1712,7 @@ namespace Dune
         /// cell due the face being part of the grid boundary or the
         /// cell being stored on another process.
         int faceCell(int face, int local_index, int level = -1) const;
-      
+
         /// \brief Get the sum of all faces attached to all cells.
         ///
         /// Each face identified by a unique index is counted as often

--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -90,9 +90,7 @@ public:
     // the official DUNE names
     typedef Entity    EntitySeed;
 
-    /// @brief
-    /// @todo Doc me!
-    /// @tparam
+    /** \brief Export supported entity types */
     template <int cd>
     struct Codim
     {

--- a/opm/grid/cpgrid/Indexsets.cpp
+++ b/opm/grid/cpgrid/Indexsets.cpp
@@ -49,7 +49,7 @@ IndexSet::IndexType IndexSet::subIndex(const cpgrid::Entity<0>& e, int i, unsign
     switch(cc) {
     case 0: return index(e.subEntity<0>(i));
     case 1: return index(e.subEntity<1>(i));
-    case 2: return index(e.subEntity<2>(i));
+    // case 2: return index(e.subEntity<2>(i)); // Not supported in this grid
     case 3: return index(e.subEntity<3>(i));
     default: OPM_THROW(std::runtime_error,
                        "Codimension " + std::to_string(cc) + " not supported.");
@@ -61,7 +61,7 @@ IdSet::IdType IdSet::subId(const cpgrid::Entity<0>& e, int i, int cc) const
     switch (cc) {
     case 0: return id(e.subEntity<0>(i));
     case 1: return id(e.subEntity<1>(i));
-    case 2: return id(e.subEntity<2>(i));
+    // case 2: return id(e.subEntity<2>(i)); // Not supported in this grid
     case 3: return id(e.subEntity<3>(i));
     default: OPM_THROW(std::runtime_error,
                        "Cannot get subId of codimension " + std::to_string(cc));

--- a/opm/grid/cpgrid/Intersection.hpp
+++ b/opm/grid/cpgrid/Intersection.hpp
@@ -69,6 +69,7 @@ namespace Dune
             /// @todo Doc me!
             enum { dimension = 3 };
             enum { dimensionworld = 3 };
+            enum { mydimension = 2 };
             /// @brief
             /// @todo Doc me!
             typedef cpgrid::Entity<0> Entity;
@@ -300,6 +301,13 @@ namespace Dune
                 return *this;
             }
 
+            IntersectionIterator operator++(int)
+            {
+                IntersectionIterator tmp(*this);
+                ++(*this);
+                return tmp;
+            }
+
             const Intersection* operator->() const
             {
                 assert(!Intersection::isAtEnd());
@@ -320,5 +328,20 @@ namespace Dune
 
     } // namespace cpgrid
 } // namespace Dune
+
+namespace std
+{
+    template<>
+    struct iterator_traits< Dune::cpgrid::IntersectionIterator >
+    {
+        typedef Dune::cpgrid::IntersectionIterator          Iterator;
+        typedef ptrdiff_t                                   difference_type;
+        typedef typename Iterator::Intersection             value_type;
+        typedef value_type*                                 pointer;
+        typedef value_type&                                 reference;
+        typedef forward_iterator_tag                        iterator_category;
+    };
+
+} // namespace std
 
 #endif // OPM_INTERSECTION_HEADER

--- a/opm/grid/cpgrid/Iterators.hpp
+++ b/opm/grid/cpgrid/Iterators.hpp
@@ -65,6 +65,8 @@ namespace Dune
             /// @param
             Iterator(const CpGridData& grid, int index, bool orientation);
 
+            Iterator() = default;
+
             /// Increment operator.
             /// Implementation note: This class is a friend of
             /// \see EntityRep (which is a private base class of
@@ -80,6 +82,14 @@ namespace Dune
                     EntityRep<cd>::increment();
                 return *this;
             }
+
+            Iterator operator++(int)
+            {
+                Iterator tmp(*this);
+                ++(*this);
+                return tmp;
+            }
+
             /// Const member by pointer operator.
             const Entity<cd>* operator->() const
             {
@@ -116,6 +126,8 @@ namespace Dune
                 : virtualEntity_(grid, EntityRep<0>::InvalidIndex, true )
             {
             }
+
+            explicit HierarchicIterator() = default;
 
             // Constructor with Entity<0> target and maxLevel (begin iterator).
             HierarchicIterator(Entity<0> target, int maxLevel)


### PR DESCRIPTION
* ~~Add entity capability for codimension 1~~
* ~~Export Codim only for valid codimensions~~
* Implement the `id<codim>(e)` and `index<codim>(e)` methods
* Make iterators conform to forward iterator concept