### PR TITLE
Add missing reference element method on entities

### DIFF
--- a/opm/grid/cpgrid/Entity.hpp
+++ b/opm/grid/cpgrid/Entity.hpp
@@ -39,6 +39,7 @@
 
 #include <dune/common/version.hh>
 #include <dune/geometry/type.hh>
+#include <dune/geometry/referenceelements.hh>
 #include <dune/grid/common/gridenums.hh>
 
 #include "PartitionTypeIndicator.hpp"
@@ -292,6 +293,14 @@ public:
 protected:
     const CpGridData* pgrid_;
 };
+
+// Reference element for a given entity
+template <int codim>
+auto referenceElement(const Entity<codim>&)
+{
+    return Dune::referenceElement<double,3-codim>(Dune::GeometryTypes::cube(3-codim));
+}
+
 
 } // namespace cpgrid
 } // namespace Dune

--- a/tests/cpgrid/entity_test.cpp
+++ b/tests/cpgrid/entity_test.cpp
@@ -70,12 +70,22 @@ BOOST_AUTO_TEST_CASE(entity)
     BOOST_CHECK(e2 != e3);
     BOOST_CHECK(e2 != e4);
     BOOST_CHECK(e3 != e4);
+
+
     BOOST_CHECK_EQUAL(e1.level(), 0);
     // BOOST_CHECK(e1.type().isSingular()); // Our new type
     BOOST_CHECK(e1.type().isCube());
+    BOOST_CHECK(e1.type().dim() == 3);
+    using Dune::referenceElement;
+    BOOST_CHECK_EQUAL(referenceElement(e4).type(), e4.type());
+    BOOST_CHECK_EQUAL(referenceElement(e4.geometry()).type(), e4.type());
     BOOST_CHECK_EQUAL(e1.partitionType(), InteriorEntity);
+
     cpgrid::Entity<3> e5(g, 0, true);
+    BOOST_CHECK_EQUAL(e5.level(), 0);
     BOOST_CHECK(e5.type().isCube());
+    BOOST_CHECK_EQUAL(referenceElement(e5).type(), e5.type());
+    BOOST_CHECK_EQUAL(referenceElement(e5.geometry()).type(), e5.type());
 
     // Cannot check other members without a real grid.
     // Put in more checks when it is possible to construct


### PR DESCRIPTION
The DUNE grid interface requires that entities are able to give a reference element directly from the entity and without necessarily going through the geometry.