### PR TITLE
Revert entity test with geometry

### DIFF
--- a/tests/cpgrid/entity_test.cpp
+++ b/tests/cpgrid/entity_test.cpp
@@ -78,14 +78,12 @@ BOOST_AUTO_TEST_CASE(entity)
     BOOST_CHECK(e1.type().dim() == 3);
     using Dune::referenceElement;
     BOOST_CHECK_EQUAL(referenceElement(e4).type(), e4.type());
-    BOOST_CHECK_EQUAL(referenceElement(e4.geometry()).type(), e4.type());
     BOOST_CHECK_EQUAL(e1.partitionType(), InteriorEntity);
 
     cpgrid::Entity<3> e5(g, 0, true);
     BOOST_CHECK_EQUAL(e5.level(), 0);
     BOOST_CHECK(e5.type().isCube());
     BOOST_CHECK_EQUAL(referenceElement(e5).type(), e5.type());
-    BOOST_CHECK_EQUAL(referenceElement(e5.geometry()).type(), e5.type());
 
     // Cannot check other members without a real grid.
     // Put in more checks when it is possible to construct


### PR DESCRIPTION
The entity has no knowledge of the grid, hence, it cannot create a geometry so it segfaults. This test may work when the compiler manages to figure out that the geometry object is not really needed and can create the geometry on the fly. This may explain why this was not trigger in the CI.

This produces failures in other PRs like #885 #884 and #891 