### PR TITLE
Fix bug in faceCell().

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1703,7 +1703,14 @@ namespace Dune
         ///
         /// Note that a face here is always oriented. If there are two
         /// neighboring cells then the orientation will be from local_index 0
-        /// to local_index 1
+        /// to local_index 1.
+        /// If there is only one neighbouring cell, meaning that the face is on
+        /// the grid boundary, or a process boundary, then that cell's index will
+        /// be returned for local_index == 0 if the face normal is pointing outwards
+        /// from the cell and for local_index == 1 if the face normal is pointing in.
+        /// The other index will in that case yield -1. Effectively, we return
+        /// element local_index of (c, -1) or (-1, c) depending on face orientation
+        /// with respect to c.
         /// \param face The index identifying the face.
         /// \param local_index The local_index of the cell.
         /// \param level Integer representing the level grid to be considered.


### PR DESCRIPTION
The faceCell() method is expected to return cell indices (or -1 for the outside) in the order implied by the face orientation. The addition of using std::numeric_limits<int>::max() to represent nonexistent cells in some contexts did not properly address this, but could give the wrong order in the output (i.e. orientation) if the first stored connection was the nonexistent one (i.e. r[0]) as that would not have a proper orientation associated with it.

Manual: Fixed a small bug for grid topology that did not affect OPM Flow, but did affect geomechanical codes.