### PR TITLE
Nested refinement for CARFIN keyword

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -38,6 +38,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/grid/cpgrid/Iterators.cpp
   opm/grid/cpgrid/Indexsets.cpp
   opm/grid/cpgrid/LgrHelpers.cpp
+  opm/grid/cpgrid/NestedRefinementUtilities.cpp
   opm/grid/cpgrid/PartitionTypeIndicator.cpp
   opm/grid/cpgrid/processEclipseFormat.cpp
   opm/grid/common/GeometryHelpers.cpp
@@ -93,6 +94,7 @@ list(APPEND TEST_SOURCE_FILES
   tests/cpgrid/lgr/level_and_grid_cartesianIndexMappers_test.cpp
   tests/cpgrid/lgr/lgr_cell_id_sync_test.cpp
   tests/cpgrid/lgr/logicalCartesianSize_and_refinement_test.cpp
+  tests/cpgrid/lgr/nested_refinement_test.cpp
   tests/cpgrid/orientedentitytable_test.cpp
   tests/cpgrid/partition_iterator_test.cpp
   tests/cpgrid/zoltan_test.cpp
@@ -204,6 +206,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/grid/cpgrid/GlobalIdMapping.hpp
   opm/grid/cpgrid/GridHelpers.hpp
   opm/grid/cpgrid/LevelCartesianIndexMapper.hpp
+  opm/grid/cpgrid/NestedRefinementUtilities.hpp
   opm/grid/CpGrid.hpp
   opm/grid/cpgrid/Indexsets.hpp
   opm/grid/cpgrid/Intersection.hpp

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -481,13 +481,15 @@ namespace Dune
         /// Old-corners and old-faces (from coarse grid) lying on the boundary of the patches, get replaced by new-born-equivalent corners
         /// and new-born-faces.
         ///
-        /// @param [in] cells_per_dim_vec      Vector of Number of (refined) cells in each direction that each
-        ///                                    parent cell should be refined to.
-        /// @param [in] startIJK_vec           Vector of Cartesian triplet indices where each patch starts.
-        /// @param [in] endIJK_vec             Vector of Cartesian triplet indices where each patch ends.
-        ///                                    Last cell part of each patch(lgr) will be
-        ///                                    {endIJK_vec[<patch-number>][0]-1, ..., endIJK_vec[<patch-number>][2]-1}.
-        /// @param [in] lgr_name_vec           Names (std::string) for the LGRs/levels.
+        /// @param [in] cells_per_dim_vec         Vector of Number of (refined) cells in each direction that each
+        ///                                       parent cell should be refined to.
+        /// @param [in] startIJK_vec              Vector of Cartesian triplet indices where each patch starts.
+        /// @param [in] endIJK_vec                Vector of Cartesian triplet indices where each patch ends.
+        ///                                       Last cell part of each patch(lgr) will be
+        ///                                       {endIJK_vec[<patch-number>][0]-1, ..., endIJK_vec[<patch-number>][2]-1}.
+        /// @param [in] lgr_name_vec              Names (std::string) for the LGRs/levels.
+        /// @param [in] lgr_parent_grid_name_vec  Names (std::string) for the LGRs/levels parent grids.
+        ///                                       A parent grid may have more than one child LGR.
         void addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_per_dim_vec,
                                    const std::vector<std::array<int,3>>& startIJK_vec,
                                    const std::vector<std::array<int,3>>& endIJK_vec,

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -491,7 +491,8 @@ namespace Dune
         void addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_per_dim_vec,
                                    const std::vector<std::array<int,3>>& startIJK_vec,
                                    const std::vector<std::array<int,3>>& endIJK_vec,
-                                   const std::vector<std::string>& lgr_name_vec);
+                                   const std::vector<std::string>& lgr_name_vec,
+                                   const std::vector<std::string>& lgr_parent_grid_name_vec = std::vector<std::string>{});
 
         /// @brief Global refine the grid with different refinement factors in each direction.
         ///
@@ -630,18 +631,8 @@ namespace Dune
         ///        level zero.
         ///        For nested refinement, we lookup the oldest ancestor, from level zero.
         void computeGlobalCellLeafGridViewWithLgrs(std::vector<int>& global_cell_leaf);
-        
-    private:
-        /// @brief Check if there are non neighboring connections on blocks of cells selected for refinement.
-        ///
-        /// @param [in] startIJK_vec    Vector of ijk values denoting the start of each block of cells selected for refinement.
-        /// @param [in] endIJK_vec      Vector of ijk values denoting the end of each block of cells selected for refinement.
-        ///
-        /// @return True if all blocks of cells do not contain any NNCs (non-neighboring-connection).
-        ///         False if there is a block with at least one cell with a NNC.
-        bool nonNNCsSelectedCellsLGR( const std::vector<std::array<int,3>>& startIJK_vec,
-                                      const std::vector<std::array<int,3>>& endIJK_vec) const;
 
+    private:
         /// @brief Mark selected elements, assign them their corresponding level, and detect active LGRs.
         ///
         /// Given blocks of cells selected for refinement, mark selected elements and assign them their corresponding

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -2721,11 +2721,11 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
         tmp_maxLevel = tmp_maxLevel + startIJK_vec_parent_grid.size(); // Update the maxLevel
 
         //   2. Create the corresponding LGRs. and  3. Update the leaf grid view.
-        adapt(cells_per_dim_vec_parent_grid,
-              assignRefinedLevel,
-              lgr_name_vec_parent_grid,
-              startIJK_vec_parent_grid,
-              endIJK_vec_parent_grid);
+        refineAndUpdateGrid(cells_per_dim_vec_parent_grid,
+                            assignRefinedLevel,
+                            lgr_name_vec_parent_grid,
+                            startIJK_vec_parent_grid,
+                            endIJK_vec_parent_grid);
 
         int non_empty_lgrs = 0;
         for (std::size_t level = 0; level < filtered_startIJK_vec.size(); ++level) {

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -2636,6 +2636,12 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
         return;
     }
 
+    if (!Opm::areParentGridsAvailableBeforeTheirLgrs(getLgrNameToLevel(),
+                                                     filtered_lgr_name_vec,
+                                                     filtered_lgr_parent_grid_name_vec)) {
+        OPM_THROW(std::invalid_argument, "Parent grid (name) must exist before its LGRs.");
+    }
+
     // Refinement proceeds in steps. In each step, for every parent grid:
     //   1. Gather the data of its child LGRs.
     //   2. Create the corresponding LGRs.

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -2636,12 +2636,19 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
         return;
     }
 
+    // Refinement proceeds in steps. In each step, for every parent grid:
+    //   1. Gather the data of its child LGRs.
+    //   2. Create the corresponding LGRs.
+    //   3. Update the leaf grid view.
+    //
+    // To achieve this, we first collect the set of unique parent grid names
+    // (avoiding duplicates).
     std::set<std::string> non_repeated_parent_grid_names(filtered_lgr_parent_grid_name_vec.begin(),
                                                          filtered_lgr_parent_grid_name_vec.end());
     int tmp_maxLevel = this->maxLevel();
 
     for (const auto& parent_grid_name : non_repeated_parent_grid_names) {
-
+        //   1. Gather the data of its child LGRs.
         auto [cells_per_dim_vec_parent_grid,
               startIJK_vec_parent_grid,
               endIJK_vec_parent_grid,
@@ -2706,7 +2713,8 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
             }
         }
         tmp_maxLevel = tmp_maxLevel + startIJK_vec_parent_grid.size(); // Update the maxLevel
-        // Refine
+
+        //   2. Create the corresponding LGRs. and  3. Update the leaf grid view.
         adapt(cells_per_dim_vec_parent_grid,
               assignRefinedLevel,
               lgr_name_vec_parent_grid,

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -2627,11 +2627,11 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
                 filtered_startIJK_vec,
                 filtered_endIJK_vec,
                 filtered_lgr_name_vec,
-                filtered_lgr_parent_grid_name_vec] = Opm::Lgr::filterUndesiredNumberOfSubdivisions(cells_per_dim_vec,
-                                                                                                   startIJK_vec,
-                                                                                                   endIJK_vec,
-                                                                                                   lgr_name_vec,
-                                                                                                   parent_grid_names);
+                filtered_lgr_parent_grid_name_vec] = Opm::Lgr::excludeFakeSubdivisions(cells_per_dim_vec,
+                                                                                       startIJK_vec,
+                                                                                       endIJK_vec,
+                                                                                       lgr_name_vec,
+                                                                                       parent_grid_names);
     if (allUndesired) { // if all LGRs expect 1 child per direction, then no refinement will be done.
         return;
     }

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -1754,43 +1754,6 @@ bool CpGridData::hasNNCs(const std::vector<int>& cellIndices) const
     return hasNNC;
 }
 
-bool CpGridData::compatibleSubdivisions(const std::vector<std::array<int,3>>& cells_per_dim_vec,
-                                        const std::vector<std::array<int,3>>& startIJK_vec,
-                                        const std::vector<std::array<int,3>>& endIJK_vec) const
-{
-    bool compatibleSubdivisions = true;
-    if (startIJK_vec.size() > 1) {
-        bool notAllowedYet = false;
-        for (std::size_t level = 0; level < startIJK_vec.size(); ++level) {
-            for (std::size_t otherLevel = level+1; otherLevel < startIJK_vec.size(); ++otherLevel) {
-                const auto& sharedFaceTag = Opm::Lgr::sharedFaceTag({startIJK_vec[level], startIJK_vec[otherLevel]},
-                                                                    {endIJK_vec[level],endIJK_vec[otherLevel]},
-                                                                    this->logicalCartesianSize());
-                if(sharedFaceTag == -1){
-                    break; // Go to the next "other patch"
-                }
-                if (sharedFaceTag == 0 ) {
-                    notAllowedYet = notAllowedYet ||
-                        ((cells_per_dim_vec[level][1] != cells_per_dim_vec[otherLevel][1]) || (cells_per_dim_vec[level][2] != cells_per_dim_vec[otherLevel][2]));
-                }
-                if (sharedFaceTag == 1) {
-                    notAllowedYet = notAllowedYet ||
-                        ((cells_per_dim_vec[level][0] != cells_per_dim_vec[otherLevel][0]) || (cells_per_dim_vec[level][2] != cells_per_dim_vec[otherLevel][2]));
-                }
-                if (sharedFaceTag == 2) {
-                    notAllowedYet = notAllowedYet ||
-                        ((cells_per_dim_vec[level][0] != cells_per_dim_vec[otherLevel][0]) || (cells_per_dim_vec[level][1] != cells_per_dim_vec[otherLevel][1]));
-                }
-                if (notAllowedYet){
-                    compatibleSubdivisions = false;
-                    break;
-                }
-            } // end-otherLevel-for-loop
-        } // end-level-for-loop
-    }// end-if-patchesShareFace
-    return compatibleSubdivisions;
-}
-
 std::tuple< const std::shared_ptr<CpGridData>,
             const std::vector<std::array<int,2>>,                // parent_to_refined_corners(~boundary_old_to_new_corners)
             const std::vector<std::tuple<int,std::vector<int>>>, // parent_to_children_faces (~boundary_old_to_new_faces)

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -434,25 +434,6 @@ public:
     void postAdapt();
 
 private:
-    /// @brief Check compatibility of number of subdivisions of neighboring LGRs.
-    ///
-    /// Check shared faces on boundaries of LGRs. Not optimal since the code below does not take into account
-    /// active/inactive cells, instead, relies on "ijk-computations".
-    ///
-    /// @param [in]  cells_per_dim_vec    Vector of expected subdivisions per cell, per direction, in each LGR.
-    /// @param [in]  startIJK_vec         Vector of Cartesian triplet indices where each patch starts.
-    /// @param [in]  endIJK_vec           Vector of Cartesian triplet indices where each patch ends.
-    ///                                   Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
-    /// @return True if all block of cells either do not share faces on their boundaries, or they may share faces with compatible
-    ///         subdivisions. Example: block1 and block2 share an I_FACE, then number of subdivisions NY NZ should coincide, i.e.
-    ///         if block1, block2 cells_per_dim values are {NX1, NY1, NZ1}, {NX2, NY2, NZ2}, respectively, then NY1 == NY2 and
-    ///         NZ1 == NZ2.
-    ///         False if at least two blocks share a face and their subdivions are not compatible. In the example above,
-    ///         if NY1 != NY2 or NZ1 != NZ2.
-    bool compatibleSubdivisions(const std::vector<std::array<int,3>>& cells_per_dim_vec,
-                                const std::vector<std::array<int,3>>& startIJK_vec,
-                                const std::vector<std::array<int,3>>& endIJK_vec) const;
-
     std::array<Dune::FieldVector<double,3>,8> getReferenceRefinedCorners(int idx_in_parent_cell, const std::array<int,3>& cells_per_dim) const;
 
 public:
@@ -853,7 +834,6 @@ private:
     std::vector<int> cell_to_idxInParentCell_;
     /** To keep track of refinement processes */
     int refinement_max_level_{0};
-
 
     /// \brief Object for collective communication operations.
     Communication ccobj_;

--- a/opm/grid/cpgrid/LgrHelpers.cpp
+++ b/opm/grid/cpgrid/LgrHelpers.cpp
@@ -2150,11 +2150,11 @@ std::tuple<bool,
            std::vector<std::array<int,3>>,
            std::vector<std::string>,
            std::vector<std::string>>
-filterUndesiredNumberOfSubdivisions(const std::vector<std::array<int,3>>& cells_per_dim_vec,
-                                    const std::vector<std::array<int,3>>& startIJK_vec,
-                                    const std::vector<std::array<int,3>>& endIJK_vec,
-                                    const std::vector<std::string>& lgr_name_vec,
-                                    const std::vector<std::string>& lgr_parent_grid_name_vec)
+excludeFakeSubdivisions(const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                        const std::vector<std::array<int,3>>& startIJK_vec,
+                        const std::vector<std::array<int,3>>& endIJK_vec,
+                        const std::vector<std::string>& lgr_name_vec,
+                        const std::vector<std::string>& lgr_parent_grid_name_vec)
 {
     // Assume all vector sizes are equal
     const std::size_t size = cells_per_dim_vec.size();

--- a/opm/grid/cpgrid/LgrHelpers.cpp
+++ b/opm/grid/cpgrid/LgrHelpers.cpp
@@ -2148,11 +2148,13 @@ std::tuple<bool,
            std::vector<std::array<int,3>>,
            std::vector<std::array<int,3>>,
            std::vector<std::array<int,3>>,
+           std::vector<std::string>,
            std::vector<std::string>>
 filterUndesiredNumberOfSubdivisions(const std::vector<std::array<int,3>>& cells_per_dim_vec,
                                     const std::vector<std::array<int,3>>& startIJK_vec,
                                     const std::vector<std::array<int,3>>& endIJK_vec,
-                                    const std::vector<std::string>& lgr_name_vec)
+                                    const std::vector<std::string>& lgr_name_vec,
+                                    const std::vector<std::string>& lgr_parent_grid_name_vec)
 {
     // Assume all vector sizes are equal
     const std::size_t size = cells_per_dim_vec.size();
@@ -2161,11 +2163,13 @@ filterUndesiredNumberOfSubdivisions(const std::vector<std::array<int,3>>& cells_
     std::vector<std::array<int,3>> filtered_startIJK_vec{};
     std::vector<std::array<int,3>> filtered_endIJK_vec{};
     std::vector<std::string> filtered_lgr_name_vec{};
+    std::vector<std::string> filtered_lgr_parent_grid_name_vec{};
     
     filtered_cells_per_dim_vec.reserve(size);
     filtered_startIJK_vec.reserve(size);
     filtered_endIJK_vec.reserve(size);
     filtered_lgr_name_vec.reserve(size);
+    filtered_lgr_parent_grid_name_vec.reserve(size);
 
     bool allUndesired = true;
     for (std::size_t i = 0; i < size; ++i)
@@ -2177,6 +2181,7 @@ filterUndesiredNumberOfSubdivisions(const std::vector<std::array<int,3>>& cells_
             filtered_startIJK_vec.push_back(startIJK_vec[i]);
             filtered_endIJK_vec.push_back(endIJK_vec[i]);
             filtered_lgr_name_vec.push_back(lgr_name_vec[i]);
+            filtered_lgr_parent_grid_name_vec.push_back(lgr_parent_grid_name_vec[i]);
             allUndesired = false;
         }
         else {
@@ -2187,7 +2192,46 @@ filterUndesiredNumberOfSubdivisions(const std::vector<std::array<int,3>>& cells_
                            std::move(filtered_cells_per_dim_vec),
                            std::move(filtered_startIJK_vec),
                            std::move(filtered_endIJK_vec),
-                           std::move(filtered_lgr_name_vec));
+                           std::move(filtered_lgr_name_vec),
+                           std::move(filtered_lgr_parent_grid_name_vec));
+}
+
+bool compatibleSubdivisions(const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                            const std::vector<std::array<int,3>>& startIJK_vec,
+                            const std::vector<std::array<int,3>>& endIJK_vec,
+                            const std::array<int,3>& logicalCartesianSize)
+{
+    bool compatibleSubdivisions = true;
+    if (startIJK_vec.size() > 1) {
+        bool notAllowedYet = false;
+        for (std::size_t level = 0; level < startIJK_vec.size(); ++level) {
+            for (std::size_t otherLevel = level+1; otherLevel < startIJK_vec.size(); ++otherLevel) {
+                const int sharedTag = sharedFaceTag({startIJK_vec[level], startIJK_vec[otherLevel]},
+                                                          {endIJK_vec[level],endIJK_vec[otherLevel]},
+                                                          logicalCartesianSize);
+                if(sharedTag == -1){
+                    break; // Go to the next "other patch"
+                }
+                if (sharedTag == 0 ) {
+                    notAllowedYet = notAllowedYet ||
+                        ((cells_per_dim_vec[level][1] != cells_per_dim_vec[otherLevel][1]) || (cells_per_dim_vec[level][2] != cells_per_dim_vec[otherLevel][2]));
+                }
+                if (sharedTag == 1) {
+                    notAllowedYet = notAllowedYet ||
+                        ((cells_per_dim_vec[level][0] != cells_per_dim_vec[otherLevel][0]) || (cells_per_dim_vec[level][2] != cells_per_dim_vec[otherLevel][2]));
+                }
+                if (sharedTag == 2) {
+                    notAllowedYet = notAllowedYet ||
+                        ((cells_per_dim_vec[level][0] != cells_per_dim_vec[otherLevel][0]) || (cells_per_dim_vec[level][1] != cells_per_dim_vec[otherLevel][1]));
+                }
+                if (notAllowedYet){
+                    compatibleSubdivisions = false;
+                    break;
+                }
+            } // end-otherLevel-for-loop
+        } // end-level-for-loop
+    }// end-if-patchesShareFace
+    return compatibleSubdivisions;
 }
 
 void containsEightDifferentCorners(const std::array<int,8>& cell_to_point)

--- a/opm/grid/cpgrid/LgrHelpers.hpp
+++ b/opm/grid/cpgrid/LgrHelpers.hpp
@@ -725,11 +725,34 @@ std::tuple<bool,
            std::vector<std::array<int,3>>,
            std::vector<std::array<int,3>>,
            std::vector<std::array<int,3>>,
+           std::vector<std::string>,
            std::vector<std::string>>
 filterUndesiredNumberOfSubdivisions(const std::vector<std::array<int, 3>>& cells_per_dim_vec,
                                     const std::vector<std::array<int, 3>>& startIJK_vec,
                                     const std::vector<std::array<int, 3>>& endIJK_vec,
-                                    const std::vector<std::string>& lgr_name_vec);
+                                    const std::vector<std::string>& lgr_name_vec,
+                                    const std::vector<std::string>& lgr_parent_grid_name_vec);
+
+/// @brief Check compatibility of number of subdivisions of neighboring LGRs.
+///
+/// Check shared faces on boundaries of LGRs. Not optimal since the code below does not take into account
+/// active/inactive cells, instead, relies on "ijk-computations".
+///
+/// @param [in]  cells_per_dim_vec    Vector of expected subdivisions per cell, per direction, in each LGR.
+/// @param [in]  startIJK_vec         Vector of Cartesian triplet indices where each patch starts.
+/// @param [in]  endIJK_vec           Vector of Cartesian triplet indices where each patch ends.
+///                                   Last cell part of the lgr will be {endIJK_vec[patch][0]-1, ..., endIJK_vec[patch][2]-1}.
+/// @parem [in]  logicalCartesianSize From the level grid where the cell blocks were selected.
+/// @return True if all block of cells either do not share faces on their boundaries, or they may share faces with compatible
+///         subdivisions. Example: block1 and block2 share an I_FACE, then number of subdivisions NY NZ should coincide, i.e.
+///         if block1, block2 cells_per_dim values are {NX1, NY1, NZ1}, {NX2, NY2, NZ2}, respectively, then NY1 == NY2 and
+///         NZ1 == NZ2.
+///         False if at least two blocks share a face and their subdivions are not compatible. In the example above,
+///         if NY1 != NY2 or NZ1 != NZ2.
+bool compatibleSubdivisions(const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                            const std::vector<std::array<int,3>>& startIJK_vec,
+                            const std::vector<std::array<int,3>>& endIJK_vec,
+                            const std::array<int,3>& logicalCartesianSize);
 
 void containsEightDifferentCorners(const std::array<int,8>& cell_to_point);
 

--- a/opm/grid/cpgrid/LgrHelpers.hpp
+++ b/opm/grid/cpgrid/LgrHelpers.hpp
@@ -711,9 +711,11 @@ int sharedFaceTag(const std::vector<std::array<int,3>>& startIJK_2Patches,
 ///
 /// A warning is logged for each excluded LGR name.
 ///
-/// @param [in] startIJK_vec          Vector of Cartesian triplet indices where each patch starts.
-/// @param [in] endIJK_vec            Vector of Cartesian triplet indices where each patch ends.
-/// @param [in] lgr_name_vec          Names (std::string) for the LGRs/levels.
+/// @param [in] startIJK_vec              Vector of Cartesian triplet indices where each patch starts.
+/// @param [in] endIJK_vec                Vector of Cartesian triplet indices where each patch ends.
+/// @param [in] lgr_name_vec              Names (std::string) for the LGRs/levels.
+/// @param [in] lgr_parent_grid_name_vec  Names (std::string) for the LGRs/levels parent grids.
+///                                       A parent grid may have more than one child LGR.
 ///
 /// @return A tuple containing a bool and the filtered vectors:
 ///         - allUndesired         True if all LGRs have cells_per_dim_ = {1,1,1}
@@ -721,17 +723,18 @@ int sharedFaceTag(const std::vector<std::array<int,3>>& startIJK_2Patches,
 ///         - startIJK_vec
 ///         - endIJK_vec
 ///         - lgr_name_vec
+///         - lgr_parent_grid_name_vec
 std::tuple<bool,
            std::vector<std::array<int,3>>,
            std::vector<std::array<int,3>>,
            std::vector<std::array<int,3>>,
            std::vector<std::string>,
            std::vector<std::string>>
-filterUndesiredNumberOfSubdivisions(const std::vector<std::array<int, 3>>& cells_per_dim_vec,
-                                    const std::vector<std::array<int, 3>>& startIJK_vec,
-                                    const std::vector<std::array<int, 3>>& endIJK_vec,
-                                    const std::vector<std::string>& lgr_name_vec,
-                                    const std::vector<std::string>& lgr_parent_grid_name_vec);
+excludeFakeSubdivisions(const std::vector<std::array<int, 3>>& cells_per_dim_vec,
+                        const std::vector<std::array<int, 3>>& startIJK_vec,
+                        const std::vector<std::array<int, 3>>& endIJK_vec,
+                        const std::vector<std::string>& lgr_name_vec,
+                        const std::vector<std::string>& lgr_parent_grid_name_vec);
 
 /// @brief Check compatibility of number of subdivisions of neighboring LGRs.
 ///

--- a/opm/grid/cpgrid/NestedRefinementUtilities.cpp
+++ b/opm/grid/cpgrid/NestedRefinementUtilities.cpp
@@ -23,6 +23,8 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
+#include <map>
 #include <set>
 #include <stdexcept>
 #include <string>
@@ -87,6 +89,32 @@ filterLgrDataPerParentGridName(const std::vector<std::array<int,3>>& cells_per_d
         filtered_lgr_name_vec.push_back(lgr_name_vec[lgr_idx]);
     }
     return std::make_tuple(filtered_cells_per_dim_vec, filtered_startIJK_vec, filtered_endIJK_vec, filtered_lgr_name_vec);
+}
+
+bool areParentGridsAvailableBeforeTheirLgrs(const std::map<std::string,int>& existing_grid_names,
+                                            const std::vector<std::string>& new_lgr_names,
+                                            const std::vector<std::string>& new_lgrs_parent_grid_names)
+{
+    assert(new_lgr_names.size() == new_lgrs_parent_grid_names.size());
+
+    for (std::size_t i = 0; i < new_lgrs_parent_grid_names.size(); ++i) {
+        const std::string& parent = new_lgrs_parent_grid_names[i];
+
+        // Case 1: Parent already exists
+        if (existing_grid_names.find(parent) != existing_grid_names.end()) {
+            continue;
+        }
+
+        // Case 2: Parent must appear earlier among the new LGRs
+        bool foundEarlier = std::find(new_lgr_names.begin(),
+                                      new_lgr_names.begin() + i,
+                                      parent) != new_lgr_names.begin() + i;
+
+        if (!foundEarlier) {
+            return false; // parent not found before child
+        }
+    }
+    return true; // all parent grids valid (exist before their LGRs)
 }
 
 } // namespace Opm

--- a/opm/grid/cpgrid/NestedRefinementUtilities.cpp
+++ b/opm/grid/cpgrid/NestedRefinementUtilities.cpp
@@ -1,0 +1,92 @@
+/*
+  Copyright 2025 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <algorithm>
+#include <array>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <tuple>
+
+namespace Opm
+{
+
+bool isNameInTheList(const std::vector<std::string>& lgr_parent_grid_names,
+                     const std::string& parent_grid_name)
+{
+    return (std::find(lgr_parent_grid_names.begin(), lgr_parent_grid_names.end(),
+                      parent_grid_name) != lgr_parent_grid_names.end());
+}
+
+std::vector<int> collectIndicesWithSameParentGridName(const std::vector<std::string>& lgr_parent_grid_names,
+                                                      const std::string& parent_grid_name)
+{
+    if (!isNameInTheList(lgr_parent_grid_names, parent_grid_name)) {
+        throw std::invalid_argument("Parent grid name does not exist.\n");
+    }
+
+    std::vector<int> indices;
+
+    for (size_t i = 0; i < lgr_parent_grid_names.size(); ++i) {
+        if (lgr_parent_grid_names[i] == parent_grid_name) {
+            indices.push_back(i);
+        }
+    }
+    return indices;
+}
+
+std::tuple<std::vector<std::array<int,3>>,
+           std::vector<std::array<int,3>>,
+           std::vector<std::array<int,3>>,
+           std::vector<std::string>>
+filterLgrDataPerParentGridName(const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                               const std::vector<std::array<int,3>>& startIJK_vec,
+                               const std::vector<std::array<int,3>>& endIJK_vec,
+                               const std::vector<std::string>& lgr_name_vec,
+                               const std::vector<std::string>& lgr_parent_grid_name_vec,
+                               const std::string& parent_grid_name)
+{
+    const auto lgrs_with_given_parent_grid = collectIndicesWithSameParentGridName(lgr_parent_grid_name_vec,
+                                                                                  parent_grid_name);
+    // Assume all vector sizes are equal
+    const auto& size =  lgrs_with_given_parent_grid.size();
+    std::vector<std::array<int,3>> filtered_cells_per_dim_vec{};
+    std::vector<std::array<int,3>> filtered_startIJK_vec{};
+    std::vector<std::array<int,3>> filtered_endIJK_vec{};
+    std::vector<std::string> filtered_lgr_name_vec{};
+    filtered_cells_per_dim_vec.reserve(size);
+    filtered_startIJK_vec.reserve(size);
+    filtered_endIJK_vec.reserve(size);
+    filtered_lgr_name_vec.reserve(size);
+
+    for (const auto& lgr_idx : lgrs_with_given_parent_grid) {
+        filtered_cells_per_dim_vec.push_back(cells_per_dim_vec[lgr_idx]);
+        filtered_startIJK_vec.push_back(startIJK_vec[lgr_idx]);
+        filtered_endIJK_vec.push_back(endIJK_vec[lgr_idx]);
+        filtered_lgr_name_vec.push_back(lgr_name_vec[lgr_idx]);
+    }
+    return std::make_tuple(filtered_cells_per_dim_vec, filtered_startIJK_vec, filtered_endIJK_vec, filtered_lgr_name_vec);
+}
+
+} // namespace Opm

--- a/opm/grid/cpgrid/NestedRefinementUtilities.cpp
+++ b/opm/grid/cpgrid/NestedRefinementUtilities.cpp
@@ -33,14 +33,14 @@ namespace Opm
 {
 
 bool isNameInTheList(const std::vector<std::string>& lgr_parent_grid_names,
-                     const std::string& parent_grid_name)
+                     const std::string& grid_name)
 {
     return (std::find(lgr_parent_grid_names.begin(), lgr_parent_grid_names.end(),
-                      parent_grid_name) != lgr_parent_grid_names.end());
+                      grid_name) != lgr_parent_grid_names.end());
 }
 
-std::vector<int> collectIndicesWithSameParentGridName(const std::vector<std::string>& lgr_parent_grid_names,
-                                                      const std::string& parent_grid_name)
+std::vector<int> getLgrDataIndicesByParentGrid(const std::vector<std::string>& lgr_parent_grid_names,
+                                               const std::string& parent_grid_name)
 {
     if (!isNameInTheList(lgr_parent_grid_names, parent_grid_name)) {
         throw std::invalid_argument("Parent grid name does not exist.\n");
@@ -48,7 +48,7 @@ std::vector<int> collectIndicesWithSameParentGridName(const std::vector<std::str
 
     std::vector<int> indices;
 
-    for (size_t i = 0; i < lgr_parent_grid_names.size(); ++i) {
+    for (std::size_t i = 0; i < lgr_parent_grid_names.size(); ++i) {
         if (lgr_parent_grid_names[i] == parent_grid_name) {
             indices.push_back(i);
         }
@@ -67,8 +67,8 @@ filterLgrDataPerParentGridName(const std::vector<std::array<int,3>>& cells_per_d
                                const std::vector<std::string>& lgr_parent_grid_name_vec,
                                const std::string& parent_grid_name)
 {
-    const auto lgrs_with_given_parent_grid = collectIndicesWithSameParentGridName(lgr_parent_grid_name_vec,
-                                                                                  parent_grid_name);
+    const auto lgrs_with_given_parent_grid = getLgrDataIndicesByParentGrid(lgr_parent_grid_name_vec,
+                                                                           parent_grid_name);
     // Assume all vector sizes are equal
     const auto& size =  lgrs_with_given_parent_grid.size();
     std::vector<std::array<int,3>> filtered_cells_per_dim_vec{};

--- a/opm/grid/cpgrid/NestedRefinementUtilities.hpp
+++ b/opm/grid/cpgrid/NestedRefinementUtilities.hpp
@@ -1,0 +1,50 @@
+/*
+  Copyright 2025 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_NESTEDREFINEMENTUTILITIES_HEADER_INCLUDED
+#define OPM_NESTEDREFINEMENTUTILITIES_HEADER_INCLUDED
+
+#include <array>
+#include <string>
+#include <vector>
+
+namespace Opm
+{
+
+bool isNameInTheList(const std::vector<std::string>& lgr_parent_grid_names,
+                     const std::string& parent_grid_name);
+
+std::vector<int>
+collectIndicesWithSameParentGridName(const std::vector<std::string>& lgr_parent_grid_names,
+                                     const std::string& parent_grid_name);
+
+std::tuple<std::vector<std::array<int,3>>,
+           std::vector<std::array<int,3>>,
+           std::vector<std::array<int,3>>,
+           std::vector<std::string>>
+filterLgrDataPerParentGridName(const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                               const std::vector<std::array<int,3>>& startIJK_vec,
+                               const std::vector<std::array<int,3>>& endIJK_vec,
+                               const std::vector<std::string>& lgr_name_vec,
+                               const std::vector<std::string>& lgr_parent_grid_name_vec,
+                               const std::string& parent_grid_name);
+    
+} // namespace Opm
+
+#endif // OPM_NESTEDREFINEMENTUTILITIES_HEADER_INCLUDED

--- a/opm/grid/cpgrid/NestedRefinementUtilities.hpp
+++ b/opm/grid/cpgrid/NestedRefinementUtilities.hpp
@@ -27,13 +27,49 @@
 namespace Opm
 {
 
+/// @brief Check whether a grid name exists in a list of parent grid names.
+///
+/// @param [in] lgr_parent_grid_names  List of parent grid names (std::string) 
+///                                    used for refinement.
+/// @param [in] grid_name              Grid name to search for.
+/// @return true if grid_name is found in lgr_parent_grid_names, 
+///         false otherwise.
 bool isNameInTheList(const std::vector<std::string>& lgr_parent_grid_names,
-                     const std::string& parent_grid_name);
+                     const std::string& grid_name);
 
+/// @brief Group LGRs by their parent grid, identified through indices.
+///
+/// @param [in] lgr_parent_grid_names  List of parent grid names (std::string)
+///                                    used for refinement.
+/// @param [in] parent_grid_name       Parent grid name to match.
+/// @return A vector of indices corresponding to LGRs associated with the
+///         given parent grid. These indices can be used to access LGR data
+///         and trigger refinement.
 std::vector<int>
-collectIndicesWithSameParentGridName(const std::vector<std::string>& lgr_parent_grid_names,
-                                     const std::string& parent_grid_name);
+getLgrDataIndicesByParentGrid(const std::vector<std::string>& lgr_parent_grid_names,
+                              const std::string& parent_grid_name);
 
+/// @brief Retrieve LGR data associated with a specific parent grid.
+///
+/// Filters LGR information (cell refinements, block bounds, and LGR names) 
+/// based on the given parent grid name.
+///
+/// @param [in] cells_per_dim_vec        Vector of triplets specifying the number of 
+///                                      refined cells in each dimension for each patch.
+/// @param [in] startIJK_vec             Vector of triplets specifying the starting 
+///                                      Cartesian indices of each patch.
+/// @param [in] endIJK_vec               Vector of triplets specifying the ending 
+///                                      Cartesian indices of each patch.
+/// @param [in] lgr_name_vec             Vector of LGR/level names.
+/// @param [in] lgr_parent_grid_name_vec Vector of parent grid names corresponding 
+///                                      to each LGR.
+/// @param [in] parent_grid_name         Parent grid name to filter by.
+/// @return A tuple containing:
+///         - Vector of cell refinement triplets (cells per dimension),
+///         - Vector of starting index triplets,
+///         - Vector of ending index triplets,
+///         - Vector of LGR names,
+///         all restricted to the specified parent grid.
 std::tuple<std::vector<std::array<int,3>>,
            std::vector<std::array<int,3>>,
            std::vector<std::array<int,3>>,

--- a/opm/grid/cpgrid/NestedRefinementUtilities.hpp
+++ b/opm/grid/cpgrid/NestedRefinementUtilities.hpp
@@ -80,7 +80,20 @@ filterLgrDataPerParentGridName(const std::vector<std::array<int,3>>& cells_per_d
                                const std::vector<std::string>& lgr_name_vec,
                                const std::vector<std::string>& lgr_parent_grid_name_vec,
                                const std::string& parent_grid_name);
-    
+
+/// @brief Check whether each parent grid exists before its child LGRs.
+///
+/// Ensures that a parent grid is either already present in the set of existing
+/// grids or appears earlier in the list of new LGRs, before its children.
+///
+/// @param [in] existing_grid_names         Map of existing grid names.
+/// @param [in] new_lgr_names               Names of new LGRs to be created.
+/// @param [in] new_lgrs_parent_grid_names  Corresponding parent grid names for each LGR.
+/// @return true if all parent grids exist before their child LGRs, false otherwise.
+bool areParentGridsAvailableBeforeTheirLgrs(const std::map<std::string,int>& existing_grid_names,
+                                            const std::vector<std::string>& new_lgr_names,
+                                            const std::vector<std::string>& new_lgrs_parent_grid_names);
+
 } // namespace Opm
 
 #endif // OPM_NESTEDREFINEMENTUTILITIES_HEADER_INCLUDED

--- a/tests/cpgrid/lgr/LgrChecks.hpp
+++ b/tests/cpgrid/lgr/LgrChecks.hpp
@@ -48,8 +48,7 @@ namespace Opm
 {
 
 void checkReferenceElemParentCellVolume(Dune::cpgrid::HierarchicIterator it,
-                                        const Dune::cpgrid::HierarchicIterator& endIt,
-                                        bool isNested);
+                                        const Dune::cpgrid::HierarchicIterator& endIt);
 
 void checkReferenceElemParentCellCenter(Dune::cpgrid::HierarchicIterator it,
                                         const Dune::cpgrid::HierarchicIterator& endIt,
@@ -174,8 +173,7 @@ void checkMarksAfterPostAdapt(const Dune::CpGrid& grid,
 } // namespace Opm
 
 void Opm::checkReferenceElemParentCellVolume(Dune::cpgrid::HierarchicIterator it,
-                                             const Dune::cpgrid::HierarchicIterator& endIt,
-                                             bool isNested)
+                                             const Dune::cpgrid::HierarchicIterator& endIt)
 {
     double reference_elem_parent_cell_volume = std::accumulate(it, endIt, 0.0,
                                                                [](double sum, const Dune::cpgrid::Entity<0>& child) {

--- a/tests/cpgrid/lgr/LgrChecks.hpp
+++ b/tests/cpgrid/lgr/LgrChecks.hpp
@@ -48,7 +48,8 @@ namespace Opm
 {
 
 void checkReferenceElemParentCellVolume(Dune::cpgrid::HierarchicIterator it,
-                                        const Dune::cpgrid::HierarchicIterator& endIt);
+                                        const Dune::cpgrid::HierarchicIterator& endIt,
+                                        bool isNested);
 
 void checkReferenceElemParentCellCenter(Dune::cpgrid::HierarchicIterator it,
                                         const Dune::cpgrid::HierarchicIterator& endIt,
@@ -173,7 +174,8 @@ void checkMarksAfterPostAdapt(const Dune::CpGrid& grid,
 } // namespace Opm
 
 void Opm::checkReferenceElemParentCellVolume(Dune::cpgrid::HierarchicIterator it,
-                                             const Dune::cpgrid::HierarchicIterator& endIt)
+                                             const Dune::cpgrid::HierarchicIterator& endIt,
+                                             bool isNested)
 {
     double reference_elem_parent_cell_volume = std::accumulate(it, endIt, 0.0,
                                                                [](double sum, const Dune::cpgrid::Entity<0>& child) {
@@ -270,7 +272,7 @@ void Opm::checkFatherAndSiblings(const Dune::cpgrid::Entity<0>& element,
     const auto& father = element.father();
     const auto& fatherLevelData =  grid.currentData()[father.level()];
     BOOST_CHECK( father.level() <= element.level() );
-
+    
     BOOST_CHECK_EQUAL( originLevelData->getMark(origin), 1);
     BOOST_CHECK_EQUAL( fatherLevelData->getMark(father), 1);
 

--- a/tests/cpgrid/lgr/nested_refinement_test.cpp
+++ b/tests/cpgrid/lgr/nested_refinement_test.cpp
@@ -45,16 +45,16 @@ BOOST_GLOBAL_FIXTURE(Fixture);
 
 BOOST_AUTO_TEST_CASE(ifNonParentGridNameProvidedDefaultIsAllChildGridsFromGlobal) {
 
-    const std::vector<std::array<int,3>> cells_per_dim_vec = {{3,3,1}, {3,3,1}};
-    const std::vector<std::array<int,3>> startIJK_vec = {{1,1,0}, {2,2,0}};
-    const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1}, {3,3,1}};
-    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2"};
+    const std::vector<std::array<int,3>>  cells_per_dim_vec = {{3,3,1},  {2,4,3}};
+    const std::vector<std::array<int,3>>       startIJK_vec = {{1,1,0},  {2,2,0}};
+    const std::vector<std::array<int,3>>         endIJK_vec = {{2,2,1},  {3,3,1}};
+    const std::vector<std::string>             lgr_name_vec = { "LGR1",   "LGR2"};
     const std::vector<std::string> lgr_parent_grid_name_vec = {"GLOBAL", "GLOBAL"};
 
     //   GLOBAL            The grids are stored: GLOBAL,
     //   |    |                                  LGR1, LGR2 (child grids from GLOBAL),
     // LGR1  LGR2                                leaf grid view (without name).
-    
+
     Dune::CpGrid grid, equiv_grid;
     grid.createCartesian(/* grid_dim = */ {3,3,1}, /* cell_sizes = */ {1.0, 1.0, 1.0});
     equiv_grid.createCartesian(/* grid_dim = */ {3,3,1}, /* cell_sizes = */ {1.0, 1.0, 1.0});
@@ -74,9 +74,9 @@ BOOST_AUTO_TEST_CASE(ifNonParentGridNameProvidedDefaultIsAllChildGridsFromGlobal
                                        equiv_grid);
 
     BOOST_CHECK_EQUAL(grid.maxLevel(), 2);
-    BOOST_CHECK_EQUAL(grid.levelGridView(1).size(0), 9); // 1 parent cell from GLOBAL, refined into 3x3x1 children
-    BOOST_CHECK_EQUAL(grid.levelGridView(2).size(0), 9); // 1 parent cell from LGR1, refined into 3x3x1 children
-    BOOST_CHECK_EQUAL(grid.leafGridView().size(0), 25); // 3x3x1 level zero - 1 parent cell + 9 LGR1 - 1 LGR1-parent + 9 LGR2 = 25
+    BOOST_CHECK_EQUAL(grid.levelGridView(1).size(0),  9); // level 1 -> LGR1. 1 parent cell from GLOBAL, refined into 3x3x1 children
+    BOOST_CHECK_EQUAL(grid.levelGridView(2).size(0), 24); // level 2 -> LGR2. 1 parent cell from GLOBAL, refined into 2x4x3 children
+    BOOST_CHECK_EQUAL(grid.leafGridView().size(0), 40);   // 3x3x1 level zero - 2 parent cells + 9 LGR1 + 24 LGR2 = 40
 
     for (int level = 1; level <=2; ++level) { // unique parent grid = "GLOBAL"->level zero
         for (const auto& element : Dune::elements(grid.levelGridView(1))) {
@@ -85,8 +85,8 @@ BOOST_AUTO_TEST_CASE(ifNonParentGridNameProvidedDefaultIsAllChildGridsFromGlobal
     }
 
     Opm::checkGridWithLgrs(grid,
-                           /* cells_per_dim_vec = */ {{3,3,1}, {3,3,1}},
-                           /* lgr_name_vec = */ {"LGR1", "LGR2"},
+                           /* cells_per_dim_vec = */ {{3,3,1}, {2,4,3}},
+                           /* lgr_name_vec = */      { "LGR1",  "LGR2"},
                            /* gridHasBeenGlobalRefined = */ false,
                            /* preRefineMaxLevel = */ 0,
                            /* isNested = */ false);
@@ -94,11 +94,11 @@ BOOST_AUTO_TEST_CASE(ifNonParentGridNameProvidedDefaultIsAllChildGridsFromGlobal
 
 BOOST_AUTO_TEST_CASE(nestedRefinementOnly) {
 
-    const std::vector<std::array<int,3>> cells_per_dim_vec = {{3,3,1}, {3,3,1}, {3,3,1}, {3,3,1}};
-    const std::vector<std::array<int,3>> startIJK_vec = {{1,1,0},{1,1,0}, {1,1,0}, {1,1,0}};
-    const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1},{2,2,1}, {2,2,1}, {2,2,1}};
-    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3", "LGR4"};
-    const std::vector<std::string> lgr_parent_grid_name_vec = {"GLOBAL","LGR1","LGR2","LGR3"};
+    const std::vector<std::array<int,3>>  cells_per_dim_vec = {{3,2,2}, {2,2,2}, {2,2,1}, {3,4,2}};
+    const std::vector<std::array<int,3>>       startIJK_vec = {{1,1,0}, {1,1,0}, {1,1,0}, {1,1,0}};
+    const std::vector<std::array<int,3>>         endIJK_vec = {{2,2,1}, {2,2,1}, {2,2,1}, {2,2,1}};
+    const std::vector<std::string>             lgr_name_vec = { "LGR1",  "LGR2",  "LGR3",  "LGR4"};
+    const std::vector<std::string> lgr_parent_grid_name_vec = {"GLOBAL", "LGR1",  "LGR2",  "LGR3"};
 
     // GLOBAL            The grids are stored: GLOBAL,
     //  |                                      LGR1 (child grid from GLOBAL),
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(nestedRefinementOnly) {
     //  |                                      LGR3 (child grid from LGR2),
     // LGR2                                    LGR4 (child grid from LGR3),
     //  |                                      leaf grid view (without name).
-    // LGR3                                    
+    // LGR3
     //  |
     // LGR4
     Dune::CpGrid grid;
@@ -119,12 +119,12 @@ BOOST_AUTO_TEST_CASE(nestedRefinementOnly) {
                                lgr_parent_grid_name_vec);
 
     BOOST_CHECK_EQUAL(grid.maxLevel(), 4);
-    BOOST_CHECK_EQUAL(grid.levelGridView(1).size(0), 9); // 1 parent cell from GLOBAL, refined into 3x3x1 children
-    BOOST_CHECK_EQUAL(grid.levelGridView(2).size(0), 9); // 1 parent cell from LGR1, refined into 3x3x1 children
-    BOOST_CHECK_EQUAL(grid.levelGridView(3).size(0), 9); // 1 parent cell from GLOBAL, refined into 3x3x1 children
-    BOOST_CHECK_EQUAL(grid.levelGridView(4).size(0), 9); // 1 parent cell from LGR1, refined into 3x3x1 children
-    BOOST_CHECK_EQUAL(grid.leafGridView().size(0), 41);
-    // 3x3x1 level zero - 1 parent cell + 9 LGR1 - 1 LGR1-parent + 9 LGR2 - 1 l0-parent-cell + 9 LGR3 - 1 LGR-parent + 9 LGR4 = 41
+    BOOST_CHECK_EQUAL(grid.levelGridView(1).size(0), 12); // level 1 -> LGR1. 1 parent cell from GLOBAL, refined into 3x2x2 children
+    BOOST_CHECK_EQUAL(grid.levelGridView(2).size(0), 8);  // level 2 -> LGR2. 1 parent cell from   LGR1, refined into 2x2x2 children
+    BOOST_CHECK_EQUAL(grid.levelGridView(3).size(0), 4);  // level 3 -> LGR3. 1 parent cell from   LGR2, refined into 2x2x1 children
+    BOOST_CHECK_EQUAL(grid.levelGridView(4).size(0), 24); // level 4 -> LGR4. 1 parent cell from   LGR3, refined into 3x4x2 children
+    BOOST_CHECK_EQUAL(grid.leafGridView().size(0), 53);
+    // 3x3x1 level zero - 1 parent cell + 12 LGR1 - 1 LGR1-parent + 8 LGR2 - 1 LGR2-parent-cell + 4 LGR3 - 1 LGR3-parent + 24 LGR4 = 53
 
     for (const auto& element : Dune::elements(grid.levelGridView(1))) {
         BOOST_CHECK_EQUAL( element.father().level(), 0);
@@ -143,8 +143,8 @@ BOOST_AUTO_TEST_CASE(nestedRefinementOnly) {
     }
 
     Opm::checkGridWithLgrs(grid,
-                           /* cells_per_dim_vec = */ {{3,3,1}, {3,3,1}, {3,3,1}, {3,3,1}},
-                           /* lgr_name_vec = */ {"LGR1", "LGR2", "LGR3", "LGR4"},
+                           /* cells_per_dim_vec = */ {{3,2,2}, {2,2,2}, {2,2,1}, {3,4,2}},
+                           /* lgr_name_vec = */      { "LGR1",  "LGR2",  "LGR3",  "LGR4"},
                            /* gridHasBeenGlobalRefined = */ false,
                            /* preRefineMaxLevel = */ 0,
                            /* isNested = */ true);
@@ -152,11 +152,11 @@ BOOST_AUTO_TEST_CASE(nestedRefinementOnly) {
 
 BOOST_AUTO_TEST_CASE(mixNameOrderAndNestedRefinement){
 
-    const std::vector<std::array<int,3>> cells_per_dim_vec = {{3,3,1}, {3,3,1}, {3,3,1}, {3,3,1}};
-    const std::vector<std::array<int,3>> startIJK_vec = {{1,1,0},{0,0,0}, {0,0,0}, {1,1,0}};
-    const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1},{1,1,1}, {1,1,1}, {2,2,1}};
-    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3", "LGR4"};
-    const std::vector<std::string> lgr_parent_grid_name_vec = {"GLOBAL","LGR1","GLOBAL","LGR3"};
+    const std::vector<std::array<int,3>>  cells_per_dim_vec = { {3,2,2}, {2,2,2}, {2,2,1}, {3,4,2}};
+    const std::vector<std::array<int,3>>       startIJK_vec = { {1,1,0}, {0,0,0}, {0,0,0}, {1,1,0}};
+    const std::vector<std::array<int,3>>         endIJK_vec = { {2,2,1}, {1,1,1}, {1,1,1}, {2,2,1}};
+    const std::vector<std::string>             lgr_name_vec = {  "LGR1", "LGR2",   "LGR3", "LGR4"};
+    const std::vector<std::string> lgr_parent_grid_name_vec = {"GLOBAL", "LGR1", "GLOBAL", "LGR3"};
 
     //   GLOBAL            The grids are stored: GLOBAL,
     //   |    |                                  LGR1, LGR3 (child grid from GLOBAL),
@@ -174,16 +174,16 @@ BOOST_AUTO_TEST_CASE(mixNameOrderAndNestedRefinement){
 
     BOOST_CHECK_EQUAL(grid.maxLevel(), 4);
     BOOST_CHECK_EQUAL(grid.levelGridView(0).size(0), 9);
-    BOOST_CHECK_EQUAL(grid.levelGridView(1).size(0), 9); // 1 parent cell from GLOBAL, refined into 3x3x1 children
-    BOOST_CHECK_EQUAL(grid.levelGridView(2).size(0), 9); // 2 parent cell from LGR1, refined into 3x3x1 children
-    BOOST_CHECK_EQUAL(grid.levelGridView(3).size(0), 9); // 1 parent cell from LGR2, refined into 3x3x1 children
-    BOOST_CHECK_EQUAL(grid.levelGridView(4).size(0), 9); // 1 parent cell from LGR2, refined into 3x3x1 children
-    BOOST_CHECK_EQUAL(grid.leafGridView().size(0), 41);
-    // 3x3x1 level zero - 2 parent cells + 9 LGR1 - 1 LGR1-parent + 9 LGR2 - 1 l0-parent-cell + 9 LGR3 - 1 LGR-parent + 9 LGR4 = 41
-    
+    BOOST_CHECK_EQUAL(grid.levelGridView(1).size(0), 12); // level 1 -> LGR1. 1 parent cell from GLOBAL, refined into 3x2x2 children
+    BOOST_CHECK_EQUAL(grid.levelGridView(2).size(0), 4);  // level 2 -> LGR3. 1 parent cell from GLOBAL, refined into 2x2x1 children
+    BOOST_CHECK_EQUAL(grid.levelGridView(3).size(0), 8);  // level 3 -> LGR2. 1 parent cell from   LGR1, refined into 2x2x2 children
+    BOOST_CHECK_EQUAL(grid.levelGridView(4).size(0), 24); // level 4 -> LGR4. 1 parent cell from   LGR3, refined into 3x4x2 children
+    BOOST_CHECK_EQUAL(grid.leafGridView().size(0), 53);
+    // 3x3x1 level zero - 2 parent cells + 12 LGR1 - 1 LGR1-parent + 8 LGR2 + 4 LGR3 - 1 LGR2-parent + 24 LGR4 = 53
+
     Opm::checkGridWithLgrs(grid,
-                           /* cells_per_dim_vec = */ {{3,3,1}, {3,3,1}, {3,3,1}, {3,3,1}},
-                           /* lgr_name_vec = */ {"LGR1", "LGR3", "LGR2", "LGR4"},
+                           /* cells_per_dim_vec = */ { {3,2,2}, {2,2,1}, {2,2,2}, {3,4,2}},
+                           /* lgr_name_vec = */      {  "LGR1",  "LGR3",  "LGR2",  "LGR4"},
                            /* gridHasBeenGlobalRefined = */ false,
                            /* preRefineMaxLevel = */ 0,
                            /* isNested = */ true);
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(mixNameOrderAndNestedRefinement){
         BOOST_CHECK_EQUAL( element.father().level(), 0); // LGR1 parent grid is GLOBAL
     }
 
-    for (const auto& element : Dune::elements(grid.levelGridView(2))) { // LGR3 
+    for (const auto& element : Dune::elements(grid.levelGridView(2))) { // LGR3
         BOOST_CHECK_EQUAL( element.father().level(), 0); // LGR3 parent grid is GLOBAL
     }
 

--- a/tests/cpgrid/lgr/nested_refinement_test.cpp
+++ b/tests/cpgrid/lgr/nested_refinement_test.cpp
@@ -204,3 +204,22 @@ BOOST_AUTO_TEST_CASE(mixNameOrderAndNestedRefinement){
         BOOST_CHECK_EQUAL( element.father().level(), 2); // LGR4 parent grid is LGR3-> grid index 2
     }
 }
+
+BOOST_AUTO_TEST_CASE(throwIfParentGridNameDoesNotExitBeforeItsLgrs){
+
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{3,3,1}, {2,2,2}, {3,2,1}, {3,4,1}};
+    const std::vector<std::array<int,3>> startIJK_vec = {{1,1,0},{0,0,0}, {0,0,0}, {1,1,0}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1},{1,1,1}, {1,1,1}, {2,2,1}};
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3", "LGR4"};
+    const std::vector<std::string> lgr_parent_grid_name_vec = {"GLOBAL","LGR3","GLOBAL","LGR1"};
+
+    Dune::CpGrid grid;
+    grid.createCartesian(/* grid_dim = */ {3,3,1}, /* cell_sizes = */ {1.0, 1.0, 1.0});
+
+    BOOST_CHECK_THROW( grid.addLgrsUpdateLeafView(cells_per_dim_vec,
+                                                  startIJK_vec,
+                                                  endIJK_vec,
+                                                  lgr_name_vec,
+                                                  lgr_parent_grid_name_vec), std::invalid_argument);
+}
+

--- a/tests/cpgrid/lgr/nested_refinement_test.cpp
+++ b/tests/cpgrid/lgr/nested_refinement_test.cpp
@@ -1,0 +1,206 @@
+/*
+  Copyright 2025 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#define BOOST_TEST_MODULE NestedRefinementTests
+#include <boost/test/unit_test.hpp>
+
+#include <opm/grid/CpGrid.hpp>
+#include <tests/cpgrid/lgr/LgrChecks.hpp>
+
+
+#include <array>
+#include <string>
+#include <vector>
+
+struct Fixture
+{
+    Fixture()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        Dune::MPIHelper::instance(m_argc, m_argv);
+        Opm::OpmLog::setupSimpleDefaultLogging();
+    }
+};
+
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+
+BOOST_AUTO_TEST_CASE(ifNonParentGridNameProvidedDefaultIsAllChildGridsFromGlobal) {
+
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{3,3,1}, {3,3,1}};
+    const std::vector<std::array<int,3>> startIJK_vec = {{1,1,0}, {2,2,0}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1}, {3,3,1}};
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2"};
+    const std::vector<std::string> lgr_parent_grid_name_vec = {"GLOBAL", "GLOBAL"};
+
+    //   GLOBAL            The grids are stored: GLOBAL,
+    //   |    |                                  LGR1, LGR2 (child grids from GLOBAL),
+    // LGR1  LGR2                                leaf grid view (without name).
+    
+    Dune::CpGrid grid, equiv_grid;
+    grid.createCartesian(/* grid_dim = */ {3,3,1}, /* cell_sizes = */ {1.0, 1.0, 1.0});
+    equiv_grid.createCartesian(/* grid_dim = */ {3,3,1}, /* cell_sizes = */ {1.0, 1.0, 1.0});
+
+    grid.addLgrsUpdateLeafView(cells_per_dim_vec,
+                               startIJK_vec,
+                               endIJK_vec,
+                               lgr_name_vec,
+                               lgr_parent_grid_name_vec);
+    
+    equiv_grid.addLgrsUpdateLeafView(cells_per_dim_vec,
+                                     startIJK_vec,
+                                     endIJK_vec,
+                                     lgr_name_vec);
+
+    Opm::checkLeafGridGeometryEquality(grid,
+                                       equiv_grid);
+
+    BOOST_CHECK_EQUAL(grid.maxLevel(), 2);
+    BOOST_CHECK_EQUAL(grid.levelGridView(1).size(0), 9); // 1 parent cell from GLOBAL, refined into 3x3x1 children
+    BOOST_CHECK_EQUAL(grid.levelGridView(2).size(0), 9); // 1 parent cell from LGR1, refined into 3x3x1 children
+    BOOST_CHECK_EQUAL(grid.leafGridView().size(0), 25); // 3x3x1 level zero - 1 parent cell + 9 LGR1 - 1 LGR1-parent + 9 LGR2 = 25
+
+    for (int level = 1; level <=2; ++level) { // unique parent grid = "GLOBAL"->level zero
+        for (const auto& element : Dune::elements(grid.levelGridView(1))) {
+            BOOST_CHECK_EQUAL( element.father().level(), 0);
+        }
+    }
+
+    Opm::checkGridWithLgrs(grid,
+                           /* cells_per_dim_vec = */ {{3,3,1}, {3,3,1}},
+                           /* lgr_name_vec = */ {"LGR1", "LGR2"},
+                           /* gridHasBeenGlobalRefined = */ false,
+                           /* preRefineMaxLevel = */ 0,
+                           /* isNested = */ false);
+}
+
+BOOST_AUTO_TEST_CASE(nestedRefinementOnly) {
+
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{3,3,1}, {3,3,1}, {3,3,1}, {3,3,1}};
+    const std::vector<std::array<int,3>> startIJK_vec = {{1,1,0},{1,1,0}, {1,1,0}, {1,1,0}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1},{2,2,1}, {2,2,1}, {2,2,1}};
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3", "LGR4"};
+    const std::vector<std::string> lgr_parent_grid_name_vec = {"GLOBAL","LGR1","LGR2","LGR3"};
+
+    // GLOBAL            The grids are stored: GLOBAL,
+    //  |                                      LGR1 (child grid from GLOBAL),
+    // LGR1                                    LGR2 (child grid from LGR1),
+    //  |                                      LGR3 (child grid from LGR2),
+    // LGR2                                    LGR4 (child grid from LGR3),
+    //  |                                      leaf grid view (without name).
+    // LGR3                                    
+    //  |
+    // LGR4
+    Dune::CpGrid grid;
+    grid.createCartesian(/* grid_dim = */ {3,3,1}, /* cell_sizes = */ {1.0, 1.0, 1.0});
+
+    grid.addLgrsUpdateLeafView(cells_per_dim_vec,
+                               startIJK_vec,
+                               endIJK_vec,
+                               lgr_name_vec,
+                               lgr_parent_grid_name_vec);
+
+    BOOST_CHECK_EQUAL(grid.maxLevel(), 4);
+    BOOST_CHECK_EQUAL(grid.levelGridView(1).size(0), 9); // 1 parent cell from GLOBAL, refined into 3x3x1 children
+    BOOST_CHECK_EQUAL(grid.levelGridView(2).size(0), 9); // 1 parent cell from LGR1, refined into 3x3x1 children
+    BOOST_CHECK_EQUAL(grid.levelGridView(3).size(0), 9); // 1 parent cell from GLOBAL, refined into 3x3x1 children
+    BOOST_CHECK_EQUAL(grid.levelGridView(4).size(0), 9); // 1 parent cell from LGR1, refined into 3x3x1 children
+    BOOST_CHECK_EQUAL(grid.leafGridView().size(0), 41);
+    // 3x3x1 level zero - 1 parent cell + 9 LGR1 - 1 LGR1-parent + 9 LGR2 - 1 l0-parent-cell + 9 LGR3 - 1 LGR-parent + 9 LGR4 = 41
+
+    for (const auto& element : Dune::elements(grid.levelGridView(1))) {
+        BOOST_CHECK_EQUAL( element.father().level(), 0);
+    }
+
+    for (const auto& element : Dune::elements(grid.levelGridView(2))) { 
+        BOOST_CHECK_EQUAL( element.father().level(), 1);
+    }
+
+    for (const auto& element : Dune::elements(grid.levelGridView(3))) {
+        BOOST_CHECK_EQUAL( element.father().level(), 2);
+    }
+
+    for (const auto& element : Dune::elements(grid.levelGridView(4))) {
+        BOOST_CHECK_EQUAL( element.father().level(), 3);
+    }
+
+    Opm::checkGridWithLgrs(grid,
+                           /* cells_per_dim_vec = */ {{3,3,1}, {3,3,1}, {3,3,1}, {3,3,1}},
+                           /* lgr_name_vec = */ {"LGR1", "LGR2", "LGR3", "LGR4"},
+                           /* gridHasBeenGlobalRefined = */ false,
+                           /* preRefineMaxLevel = */ 0,
+                           /* isNested = */ true);
+}
+
+BOOST_AUTO_TEST_CASE(mixNameOrderAndNestedRefinement){
+
+    const std::vector<std::array<int,3>> cells_per_dim_vec = {{3,3,1}, {3,3,1}, {3,3,1}, {3,3,1}};
+    const std::vector<std::array<int,3>> startIJK_vec = {{1,1,0},{0,0,0}, {0,0,0}, {1,1,0}};
+    const std::vector<std::array<int,3>> endIJK_vec = {{2,2,1},{1,1,1}, {1,1,1}, {2,2,1}};
+    const std::vector<std::string> lgr_name_vec = {"LGR1", "LGR2", "LGR3", "LGR4"};
+    const std::vector<std::string> lgr_parent_grid_name_vec = {"GLOBAL","LGR1","GLOBAL","LGR3"};
+
+    //   GLOBAL            The grids are stored: GLOBAL,
+    //   |    |                                  LGR1, LGR3 (child grid from GLOBAL),
+    // LGR1  LGR3                                LGR2 (child grid from LGR1),
+    //   |    |                                  LGR4 (child grid from LGR3),
+    // LGR2  LGR4                                leaf grid view (without name).
+    Dune::CpGrid grid;
+    grid.createCartesian(/* grid_dim = */ {3,3,1}, /* cell_sizes = */ {1.0, 1.0, 1.0});
+
+    grid.addLgrsUpdateLeafView(cells_per_dim_vec,
+                               startIJK_vec,
+                               endIJK_vec,
+                               lgr_name_vec,
+                               lgr_parent_grid_name_vec);
+
+    BOOST_CHECK_EQUAL(grid.maxLevel(), 4);
+    BOOST_CHECK_EQUAL(grid.levelGridView(0).size(0), 9);
+    BOOST_CHECK_EQUAL(grid.levelGridView(1).size(0), 9); // 1 parent cell from GLOBAL, refined into 3x3x1 children
+    BOOST_CHECK_EQUAL(grid.levelGridView(2).size(0), 9); // 2 parent cell from LGR1, refined into 3x3x1 children
+    BOOST_CHECK_EQUAL(grid.levelGridView(3).size(0), 9); // 1 parent cell from LGR2, refined into 3x3x1 children
+    BOOST_CHECK_EQUAL(grid.levelGridView(4).size(0), 9); // 1 parent cell from LGR2, refined into 3x3x1 children
+    BOOST_CHECK_EQUAL(grid.leafGridView().size(0), 41);
+    // 3x3x1 level zero - 2 parent cells + 9 LGR1 - 1 LGR1-parent + 9 LGR2 - 1 l0-parent-cell + 9 LGR3 - 1 LGR-parent + 9 LGR4 = 41
+    
+    Opm::checkGridWithLgrs(grid,
+                           /* cells_per_dim_vec = */ {{3,3,1}, {3,3,1}, {3,3,1}, {3,3,1}},
+                           /* lgr_name_vec = */ {"LGR1", "LGR3", "LGR2", "LGR4"},
+                           /* gridHasBeenGlobalRefined = */ false,
+                           /* preRefineMaxLevel = */ 0,
+                           /* isNested = */ true);
+
+    for (const auto& element : Dune::elements(grid.levelGridView(1))) { // LGR1
+        BOOST_CHECK_EQUAL( element.father().level(), 0); // LGR1 parent grid is GLOBAL
+    }
+
+    for (const auto& element : Dune::elements(grid.levelGridView(2))) { // LGR3 
+        BOOST_CHECK_EQUAL( element.father().level(), 0); // LGR3 parent grid is GLOBAL
+    }
+
+    for (const auto& element : Dune::elements(grid.levelGridView(3))) { // LGR2
+        BOOST_CHECK_EQUAL( element.father().level(), 1); // LGR2 parent grid is LGR1
+    }
+
+    for (const auto& element : Dune::elements(grid.levelGridView(4))) { // LGR4
+        BOOST_CHECK_EQUAL( element.father().level(), 2); // LGR4 parent grid is LGR3-> grid index 2
+    }
+}


### PR DESCRIPTION
This PR updates addLgrsUpdateLeafView to support nested refinement.

Previously, each LGR could only refine cells directly from the global grid. With this change, an LGR can now specify another LGR as its parent, enabling hierarchical/nested refinements.

Each LGR entry in the input file may now include an additional string indicating the parent grid from which its cells should be refined.

This allows definitions such as:
CARFIN
--   I1  I2   J1  J2   K1  K2   NX  NY  NZ   GRID NAME

LGR1  1   4   1   4   1   3   8   8   6   GLOBAL
LGR2  1   4   1   4   1   6   8   8  12   LGR1
ENDFIN

Here, LGR2 refines cells from LGR1, rather than from the global grid.

Added a test case (serial only for now) to validate nested refinement behavior.