### PR TITLE
Rename adapt(...)->refineAndUpdateGrid(...)

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -573,11 +573,11 @@ namespace Dune
         ///                                  block of cells to be refined.
         /// @param [in] endIJK_vec           Default empty vector. When isCARFIN, the final ijk Cartesian index of each
         ///                                  block of cells to be refined.
-        bool adapt(const std::vector<std::array<int,3>>& cells_per_dim_vec,
-                   const std::vector<int>& assignRefinedLevel,
-                   const std::vector<std::string>& lgr_name_vec,
-                   const std::vector<std::array<int,3>>& startIJK_vec = std::vector<std::array<int,3>>{},
-                   const std::vector<std::array<int,3>>& endIJK_vec = std::vector<std::array<int,3>>{});
+        bool refineAndUpdateGrid(const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                 const std::vector<int>& assignRefinedLevel,
+                                 const std::vector<std::string>& lgr_name_vec,
+                                 const std::vector<std::array<int,3>>& startIJK_vec = std::vector<std::array<int,3>>{},
+                                 const std::vector<std::array<int,3>>& endIJK_vec = std::vector<std::array<int,3>>{});
 
         /// @brief Clean up refinement markers - set every element to the mark 0 which represents 'doing nothing'
         void postAdapt();

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -1063,7 +1063,7 @@ void CpGrid::globalRefine (int refCount)
             }
 
             preAdapt();
-            adapt(/* cells_per_dim_vec = */ {{2,2,2}}, assignRefinedLevel, lgr_name_vec, {{0,0,0}}, {endIJK});
+            refineAndUpdateGrid(/* cells_per_dim_vec = */ {{2,2,2}}, assignRefinedLevel, lgr_name_vec, {{0,0,0}}, {endIJK});
             postAdapt();
         }
     }
@@ -1870,16 +1870,16 @@ bool CpGrid::adapt()
         // Rewrite the lgr name (GR stands for GLOBAL REFINEMET)
         lgr_name_vec = { "GR" + std::to_string(preAdaptMaxLevel +1) };
         const std::array<int,3>& endIJK = currentData().back()->logicalCartesianSize();
-        return this->adapt(cells_per_dim_vec, assignRefinedLevel, lgr_name_vec, {{0,0,0}}, {endIJK});
+        return this->refineAndUpdateGrid(cells_per_dim_vec, assignRefinedLevel, lgr_name_vec, {{0,0,0}}, {endIJK});
     }
-    return this-> adapt(cells_per_dim_vec, assignRefinedLevel, lgr_name_vec);
+    return this-> refineAndUpdateGrid(cells_per_dim_vec, assignRefinedLevel, lgr_name_vec);
 }
 
-bool CpGrid::adapt(const std::vector<std::array<int,3>>& cells_per_dim_vec,
-                   const std::vector<int>& assignRefinedLevel,
-                   const std::vector<std::string>& lgr_name_vec,
-                   const std::vector<std::array<int,3>>& startIJK_vec,
-                   const std::vector<std::array<int,3>>& endIJK_vec)
+bool CpGrid::refineAndUpdateGrid(const std::vector<std::array<int,3>>& cells_per_dim_vec,
+                                 const std::vector<int>& assignRefinedLevel,
+                                 const std::vector<std::string>& lgr_name_vec,
+                                 const std::vector<std::array<int,3>>& startIJK_vec,
+                                 const std::vector<std::array<int,3>>& endIJK_vec)
 {
     // To do: support coarsening.
     assert( static_cast<int>(assignRefinedLevel.size()) == current_view_data_->size(0));
@@ -2714,7 +2714,7 @@ void CpGrid::addLgrsUpdateLeafView(const std::vector<std::array<int,3>>& cells_p
     }
 
     // Refine
-    adapt(filtered_cells_per_dim_vec, assignRefinedLevel, filtered_lgr_name_vec, filtered_startIJK_vec, filtered_endIJK_vec);
+    refineAndUpdateGrid(filtered_cells_per_dim_vec, assignRefinedLevel, filtered_lgr_name_vec, filtered_startIJK_vec, filtered_endIJK_vec);
 
     // Print total refined level grids and total cells on the leaf grid view
     Opm::OpmLog::info(std::to_string(non_empty_lgrs) + " (new) refined level grid(s) (in " + std::to_string(comm().rank()) + " rank).\n");

--- a/tests/cpgrid/lgr/LgrChecks.hpp
+++ b/tests/cpgrid/lgr/LgrChecks.hpp
@@ -774,7 +774,7 @@ void Opm::adaptGridWithParams(Dune::CpGrid& grid,
     bool preAdapt = grid.preAdapt();
     checkMarksAfterPreAdapt(grid, preAdapt);
 
-    grid.adapt({cells_per_dim}, assignRefinedLevel, {"LGR"+std::to_string(grid.maxLevel() +1)});
+    grid.refineAndUpdateGrid({cells_per_dim}, assignRefinedLevel, {"LGR"+std::to_string(grid.maxLevel() +1)});
 
     grid.postAdapt();
     checkMarksAfterPostAdapt(grid, preAdaptMaxLevel);

--- a/tests/cpgrid/lgr/addLgrsOnDistributedGrid_test.cpp
+++ b/tests/cpgrid/lgr/addLgrsOnDistributedGrid_test.cpp
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(distributedLgrFailsVertexGlobalIdsUniquenessWithAddCornerCe
     }
 }
 
-BOOST_AUTO_TEST_CASE(callAdaptWithArgsIsEquivalentToCallAddLgrsUpdateLeafGridViewOnDistributedCoarseGrid)
+BOOST_AUTO_TEST_CASE(callRefineAndUpdateGridOnDistributedCoarseGrid)
 {
     Dune::CpGrid grid;
     auto parts = createTestCartesianGridAndParts(grid);
@@ -209,11 +209,11 @@ BOOST_AUTO_TEST_CASE(callAdaptWithArgsIsEquivalentToCallAddLgrsUpdateLeafGridVie
         for (const auto& idx : marked_elemIdx)
             assignRefinedLevel[idx] = 1;
 
-        grid.adapt(cells_per_dim_vec,
-                   assignRefinedLevel,
-                   {"LGR1"} /*lgr_name_vec*/,
-                   startIJK_vec,
-                   endIJK_vec);
+        grid.refineAndUpdateGrid(cells_per_dim_vec,
+                                 assignRefinedLevel,
+                                 {"LGR1"} /*lgr_name_vec*/,
+                                 startIJK_vec,
+                                 endIJK_vec);
 
         Opm::checkGridWithLgrs(grid, cells_per_dim_vec, {"LGR1"}, /* isGlobalRefined = */ false);
     }


### PR DESCRIPTION
To avoid confusion with DUNE’s CpGrid::adapt() interface method, we are renaming CpGrid::adapt(with arguments) to CpGrid::refineAndUpdateGrid(with arguments).

The new name more accurately reflects the current behavior: the method only supports refinement, not coarsening. This reduces the risk of misinterpretation.

 