### PR TITLE
Skip NNCs created by PINCH if one of the cells is collapsed.

### DIFF
--- a/opm/grid/MinpvProcessor.cpp
+++ b/opm/grid/MinpvProcessor.cpp
@@ -57,6 +57,13 @@ double MinpvProcessor::computeGap(const std::array<double,8>& coord_above,
     return min_val;
 }
 
+/// \brief Whether top and bottom plane coincide
+bool isCollapsed(const std::array<double,8>& coord)
+{
+    return coord[0] == coord[4] && coord[1] == coord[5] &&
+        coord[2] == coord[6] && coord[3] == coord[7];
+}
+
 MinpvProcessor::Result
 MinpvProcessor::process(const std::vector<double>& thickness,
                         const double z_tolerance,
@@ -293,8 +300,11 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                         option4ALLZero = option4ALLZero || (!permz.empty() && permz[c_above] == 0.0) || multz(c_above) == 0.0;
                         nnc_allowed = nnc_allowed && (computeGap(cz_above, cz_below) < max_gap) && (!pinchOption4ALL || !option4ALLZero) ;
 
+                        // Note that collapsed cells become inactive in preprocess.c
+                        // We treat them as a barrier preventing NNCs here.
                         if ( nnc_allowed &&
                              (actnum.empty() || (actnum[c_above] && actnum[c_below])) &&
+                             !isCollapsed(cz_below) && !isCollapsed(cz_above) &&
                              pv[c_above] > minpvv[c_above] && pv[c_below] > minpvv[c_below]) {
                             result.add_nnc(c_above, c_below);
                         }
@@ -323,7 +333,10 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                                     <= tolerance_unique_points;
                             }
 
-                            if (!vertically_connected && computeGap(cz, cz_below) < max_gap) {
+                            // Note that collapsed cells become inactive in preprocess.c
+                            // We treat them as a barrier preventing NNCs here.
+                            if (!vertically_connected && computeGap(cz, cz_below) < max_gap &&
+                                !isCollapsed(cz) && !isCollapsed(cz_below) ) {
                                 result.add_nnc(c, c_below);
                             }
                         }

--- a/tests/test_minpvprocessor.cpp
+++ b/tests/test_minpvprocessor.cpp
@@ -123,6 +123,37 @@ BOOST_AUTO_TEST_CASE(Pinch4ALL)
                                fill_removed_cells, z1.data(), pinch_no_gap,
                                option4all, permz, multz);
     BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 1);
+
+    std::vector<double> zcorn_collapsed1 = { 0, 0, 0, 0,
+                                             2, 2, 2, 2,
+                                             2, 2, 2, 2,
+                                             2.5, 2.5, 2.5, 2.5,
+                                             2.5, 2.5, 2.5, 2.5,
+                                             3.5, 3.5, 3.5, 3.5,
+                                             3.5, 3.5, 3.5, 3.5,
+                                             3.5, 3.5, 3.5, 3.5 };
+
+    permz = {2, 2, 1, 2.5}; // Should not create an NNC because bottom cell is collapsed and will be neglected in grid
+    minpv_result = mp1.process(thickness, z_threshold, 1e20, pv, minpvv, actnum,
+                               fill_removed_cells, zcorn_collapsed1.data(), pinch_no_gap,
+                               option4all, permz, multz);
+    BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 0);
+
+    std::vector<double> zcorn_collapsed2 = { 2, 2, 2, 2,
+                                             2, 2, 2, 2,
+                                             2, 2, 2, 2,
+                                             2.5, 2.5, 2.5, 2.5,
+                                             2.5, 2.5, 2.5, 2.5,
+                                             3.5, 3.5, 3.5, 3.5,
+                                             3.5, 3.5, 3.5, 3.5,
+                                             6, 6, 6, 6 };
+
+    permz = {2, 2, 1, 2.5}; // Should not create an NNC because top cell is collapsed and will be neglected in grid
+    minpv_result = mp1.process(thickness, z_threshold, 1e20, pv, minpvv, actnum,
+                               fill_removed_cells, zcorn_collapsed2.data(), pinch_no_gap,
+                               option4all, permz, multz);
+    BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 0);
+
     auto multz2 = [](int i){ if (i==2) return 0.0; else return 1.0;};
 
     minpv_result = mp1.process(thickness, z_threshold, 1e20, pv, minpvv, actnum,
@@ -136,6 +167,9 @@ BOOST_AUTO_TEST_CASE(Pinch4ALL)
 			       option4all, permz, multz3);
     BOOST_CHECK_EQUAL(minpv_result.nnc.size(), 0);
 }
+
+
+
 BOOST_AUTO_TEST_CASE(Pinch)
 {
     // Set up a simple example.


### PR DESCRIPTION
Collapsed here means that the points of the top and lower plane on the same pillar coincide.
Later those cells will be treated as inactive in [preprocess.c](/OPM/opm-grid/blob/6a456765a4f2d55182738df4dd6cf690b357a42f/opm/grid/cpgpreprocess/preprocess.c#L380-L388) and will not be part of the grid. when we create the grid topology. They would present numerical problems later anyway.

Note that this means that these cells (collapsed but PORV larger than MINPVV) will now be present a barrier preventing creation of a PINCH NNC.

Fixes the assertion:
```
flow: ./opm/grid/cpgrid/EntityRep.hpp:121: void Dune::cpgrid::EntityRep<codim>::setValue(int, bool) [with int codim = 0]: Assertion `index_arg >= 0' failed.
```
Closes #505 