### PR TITLE
Remove face parent container in return refineSingleCell

### DIFF
--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -1782,9 +1782,10 @@ bool CpGridData::hasNNCs(const std::vector<int>& cellIndices) const
 }
 
 std::tuple< const std::shared_ptr<CpGridData>,
-            const std::vector<std::array<int,2>>,                 // parent_to_refined_corners(~boundary_old_to_new_corners)
-            const std::vector<std::tuple<int,std::vector<int>>> > // parent_to_children_faces (~boundary_old_to_new_faces)
-CpGridData::refineSingleCell(const std::array<int,3>& cells_per_dim, const int& parent_idx) const
+            const std::vector<std::array<int,2>>>               // parent_to_refined_corners(~boundary_old_to_new_corners)
+CpGridData::refineSingleCell(const std::array<int,3>& cells_per_dim,
+                             const int& parent_idx,
+                             std::vector<std::vector<std::pair<int, std::vector<int>>>>& faceInMarkedElemAndRefinedFaces) const
 {
     // To store the LGR/refined-grid.
     std::vector<std::shared_ptr<CpGridData>> refined_data;
@@ -1797,15 +1798,17 @@ CpGridData::refineSingleCell(const std::array<int,3>& cells_per_dim, const int& 
     cpgrid::OrientedEntityTable<1,0>& refined_face_to_cell = refined_grid.face_to_cell_;
     cpgrid::EntityVariable<enum face_tag,1>& refined_face_tags = refined_grid.face_tag_;
     cpgrid::SignedEntityVariable<Dune::FieldVector<double,3>,1>& refined_face_normals = refined_grid.face_normals_;
-    // Get parent cell
-    const cpgrid::Geometry<3,3>& parent_cell = (*(geometry_.geomVector(std::integral_constant<int,0>())))[EntityRep<0>(parent_idx, true)];
-    // Get parent cell corners.
+   
     const auto& parent_to_point = this->cell_to_point_[parent_idx];
-    Opm::Lgr::containsEightDifferentCorners(parent_to_point);
+    Opm::Lgr::containsEightDifferentCorners(parent_to_point); // refinement supported only for hexahedron
+    
     // Refine parent cell
-    parent_cell.refineCellifiedPatch(cells_per_dim, refined_geometries, refined_cell_to_point, refined_cell_to_face,
-                                     refined_face_to_point, refined_face_to_cell, refined_face_tags, refined_face_normals,
-                                     {1,1,1}, /*widthX, lengthY, heightZ*/ {1.}, {1.}, {1.});
+    const auto parentCellElem = Entity<0>(*this, parent_idx, true);
+    const cpgrid::Geometry<3,3>& parentCellGeom = (*(geometry_.geomVector(std::integral_constant<int,0>())))[parentCellElem];
+    parentCellGeom.refineCellifiedPatch(cells_per_dim, refined_geometries, refined_cell_to_point, refined_cell_to_face,
+                                        refined_face_to_point, refined_face_to_cell, refined_face_tags, refined_face_normals,
+                                        {1,1,1}, /*widthX, lengthY, heightZ*/ {1.}, {1.}, {1.});
+    
     const std::vector<std::array<int,2>>& parent_to_refined_corners{
         // corIdx (J*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (I*(cells_per_dim[2]+1)) +K
         // replacing parent-cell corner '0' {0,0,0}
@@ -1825,8 +1828,8 @@ CpGridData::refineSingleCell(const std::array<int,3>& cells_per_dim, const int& 
         // replacing parent-cell corner '7' {cells_per_dim[0], cells_per_dim[1], cells_per_dim[2]}
         {parent_to_point[7], (cells_per_dim[1]*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (cells_per_dim[0]*(cells_per_dim[2]+1))
          + cells_per_dim[2]}};
-    // Get parent_cell_to_face = { {face, orientation}, {another face, its orientation}, ...}.
-    const auto& parent_cell_to_face = (this-> cell_to_face_[EntityRep<0>(parent_idx, true)]);
+   
+    const auto& parent_cell_to_face = (this-> cell_to_face_[parentCellElem]);
     // To store relation old-face to new-born-faces (children faces).
     std::vector<std::tuple<int,std::vector<int>>>  parent_to_children_faces;
     parent_to_children_faces.reserve(6);
@@ -1882,9 +1885,9 @@ CpGridData::refineSingleCell(const std::array<int,3>& cells_per_dim, const int& 
                 } // k-for-loop
             } // i-for-loop
         } // if-J_FACE
-        parent_to_children_faces.push_back(std::make_tuple(face.index(), children_faces));
+        faceInMarkedElemAndRefinedFaces[face.index()].push_back(std::make_pair(parentCellElem.index(), children_faces));
     }
-    return {refined_grid_ptr, parent_to_refined_corners, parent_to_children_faces};
+    return {refined_grid_ptr, parent_to_refined_corners};
 }
 
 bool CpGridData::mark(int refCount, const cpgrid::Entity<0>& element, bool throwOnFailure)

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -498,8 +498,11 @@ public:
     /// parent-to-new-born entities are buil, as well as, new-born-to-parent. Maps(<int,bool>) to detect parent
     /// faces or cells are also provided. (Cell with 6 faces required).
     ///
-    /// @param [in] cells_per_dim                 Number of (refined) cells in each direction that each parent cell should be refined to.
-    /// @param [in] parent_idx                    Parent cell index, cell to be refined.
+    /// @param [in] cells_per_dim                      Number of (refined) cells in each direction that each parent cell should be refined to.
+    /// @param [in] parent_idx                         Parent cell index, cell to be refined.
+    /// @param [out] faceInMarkedElemAndRefinedFaces   For each original (parent grid) face, stores marked element indices where it appears
+    ///                                                (<=2) and their refined face indices in each single-cell-refinement (of each parent
+    ///                                                cell where the face/intersection appears).
     ///
     /// @return refined_grid_ptr                  Shared pointer pointing at refined_grid.
     /// @return parent_to_refined_corners         For each corner of the parent cell, we store the index of the
@@ -509,12 +512,11 @@ public:
     ///                                                      2---3   |   | TOP FACE
     ///                                                      |   |   4---5
     ///                                                      0---1 BOTTOM FACE
-    /// @return parent_to_children_faces          For each parent face, we store its child-face indices.
-    ///                                           {parent face index in coarse level, {indices of its children in refined level}}
     std::tuple< const std::shared_ptr<CpGridData>,
-                const std::vector<std::array<int,2>>,                  // parent_to_refined_corners(~boundary_old_to_new_corners)
-                const std::vector<std::tuple<int,std::vector<int>>> >  // parent_to_children_faces (~boundary_old_to_new_faces)
-    refineSingleCell(const std::array<int,3>& cells_per_dim, const int& parent_idx) const;
+                const std::vector<std::array<int,2>>>                  // parent_to_refined_corners(~boundary_old_to_new_corners)
+    refineSingleCell(const std::array<int,3>& cells_per_dim,
+                     const int& parent_idx,
+                     std::vector<std::vector<std::pair<int, std::vector<int>>>>& faceInMarkedElemAndRefinedFaces) const;
 
     // @breif Compute center of an entity/element/cell in the Eclipse way:
     //        - Average of the 4 corners of the bottom face.

--- a/opm/grid/cpgrid/LgrHelpers.cpp
+++ b/opm/grid/cpgrid/LgrHelpers.cpp
@@ -122,9 +122,10 @@ void refineAndProvideMarkedRefinedRelations(const Dune::CpGrid& grid, /* Marked 
             const auto& shiftedLevel = markedElemLevel - preAdaptMaxLevel-1;
             // Build auxiliary LGR for the refinement of this element
             const auto& [elemLgr_ptr,
-                         parentCorners_to_equivalentRefinedCorners,
-                         parentFace_to_itsRefinedFaces]
-                = grid.currentLeafData().refineSingleCell(cells_per_dim_vec[shiftedLevel], element.index());
+                         parentCorners_to_equivalentRefinedCorners]
+                = grid.currentLeafData().refineSingleCell(cells_per_dim_vec[shiftedLevel],
+                                                          element.index(),
+                                                          faceInMarkedElemAndRefinedFaces);
             markedElem_to_itsLgr[ element.index() ] = elemLgr_ptr;
 
             const int childrenCount = cells_per_dim_vec[shiftedLevel][0]*cells_per_dim_vec[shiftedLevel][1]*cells_per_dim_vec[shiftedLevel][2];
@@ -149,9 +150,6 @@ void refineAndProvideMarkedRefinedRelations(const Dune::CpGrid& grid, /* Marked 
             for (const auto& [markedCorner, lgrEquivCorner] : parentCorners_to_equivalentRefinedCorners) {
                 cornerInMarkedElemWithEquivRefinedCorner[markedCorner].push_back({element.index(), lgrEquivCorner});
                 markedElemAndEquivRefinedCorn_to_corner[ {element.index(), lgrEquivCorner}] = markedCorner;
-            }
-            for (const auto& [markedFace, itsRefinedFaces] : parentFace_to_itsRefinedFaces) {
-                faceInMarkedElemAndRefinedFaces[markedFace].push_back({element.index(), itsRefinedFaces});
             }
         } // end-if-elemMark==1
     } // end-elem-for-loop

--- a/tests/cpgrid/lgr/replace_lgr1_corner_idx_by_lgr2_corner_idx_test.cpp
+++ b/tests/cpgrid/lgr/replace_lgr1_corner_idx_by_lgr2_corner_idx_test.cpp
@@ -66,11 +66,13 @@ const std::shared_ptr<Dune::cpgrid::CpGridData> createSingleCellGridAndRefine(co
     const std::array<int,3>& coarse_grid_dim = {1,1,1};
     lgr.createCartesian(coarse_grid_dim, cell_sizes);
 
+    std::vector<std::vector<std::pair<int, std::vector<int>>>> faceInMarkedElemAndRefinedFaces{};
+    faceInMarkedElemAndRefinedFaces.resize(6);
+
     // Single-cell-refinement for the only cell contained in lgr grid.
     const auto& [lgr_ptr,
-                 lgr_parentCorners_to_equivalentRefinedCorners,
-                 lgr_parentFace_to_itsRefinedFaces]
-        = lgr.currentLeafData().refineSingleCell(lgr_dim, 0);
+                 lgr_parentCorners_to_equivalentRefinedCorners]
+        = lgr.currentLeafData().refineSingleCell(lgr_dim, 0, faceInMarkedElemAndRefinedFaces);
     return lgr_ptr;
 }
 

--- a/tests/cpgrid/lgr/replace_lgr1_face_idx_by_lgr2_face_idx_test.cpp
+++ b/tests/cpgrid/lgr/replace_lgr1_face_idx_by_lgr2_face_idx_test.cpp
@@ -65,11 +65,13 @@ const std::shared_ptr<Dune::cpgrid::CpGridData> createSingleCellGridAndRefine(co
     const std::array<int,3>& coarse_grid_dim = {1,1,1};
     lgr.createCartesian(coarse_grid_dim, cell_sizes);
 
+    std::vector<std::vector<std::pair<int, std::vector<int>>>> faceInMarkedElemAndRefinedFaces{};
+    faceInMarkedElemAndRefinedFaces.resize(6);
+
     // Single-cell-refinement for the only cell contained in lgr grid.
     const auto& [lgr_ptr,
-                 lgr_parentCorners_to_equivalentRefinedCorners,
-                 lgr_parentFace_to_itsRefinedFaces]
-        = lgr.currentLeafData().refineSingleCell(lgr_dim, 0);
+                 lgr_parentCorners_to_equivalentRefinedCorners]
+        = lgr.currentLeafData().refineSingleCell(lgr_dim, 0, faceInMarkedElemAndRefinedFaces);
     return lgr_ptr;
 }
 


### PR DESCRIPTION
The refinement strategy is implemented by constructing auxiliary single-cell refinement CpGridData objects. Geometries are then grouped and stored per grid level, avoiding duplication caused by shared vertices or intersections.

This PR removes an intermediate auxiliary container that mapped parent cell face indices to the corresponding refined faces generated during single-cell refinement.