### PR TITLE
Make consistent the vertex order in face_to_point for CpGrid with LGRs

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -112,6 +112,7 @@ list(APPEND TEST_SOURCE_FILES
   tests/cpgrid/lgr/addLgrs_in_allActiveCartesianGrid_test.cpp
   tests/cpgrid/lgr/addLgrsOnDistributedGrid_test.cpp
   tests/cpgrid/lgr/autoRefine_test.cpp
+  tests/cpgrid/lgr/consistent_vertex_order_in_face_test.cpp
   tests/cpgrid/lgr/global_refine_test.cpp
   tests/cpgrid/lgr/id_entity_entityrep_test.cpp
   tests/cpgrid/lgr/level_and_grid_cartesianIndexMappers_test.cpp

--- a/opm/grid/cpgrid/Geometry.hpp
+++ b/opm/grid/cpgrid/Geometry.hpp
@@ -811,9 +811,9 @@ namespace Dune
                                 // with the {edge_indix[0], edge_index[1]} for each edge of the refined face.
                                 std::vector<std::array<int,2>> refined_face_to_edges = {
                                     { face_to_point[0], face_to_point[1] },
-                                    { face_to_point[0], face_to_point[2] },
-                                    { face_to_point[1], face_to_point[3] },
-                                    { face_to_point[2], face_to_point[3] }
+                                    { face_to_point[1], face_to_point[2] },
+                                    { face_to_point[2], face_to_point[3] },
+                                    { face_to_point[3], face_to_point[0] }
                                 };
                                 // Calculate the AREA of each face of a global refined face,
                                 // by adding the 4 areas of the triangles partitioning each face.
@@ -1058,6 +1058,10 @@ namespace Dune
             /// @param [out] refined_face_tag            I_FACE, J_FACE, K_FACE
             /// @param [out] refined_face_index          Face index of a refined cell 'lmn' generated with "refine()".
             /// @param [out] refined_face_to_point       Four corner indices of the corners of the refined face 'lmn'.
+            ///                                          Vertex order 
+            ///                                          for I_FACE:  jk, (j+1)k, (j+1)(k+1), j(k+1)
+            ///                                          for J_FACE:  (i+1)k, ik,  i(k+1), (i+1)(k+1)
+            ///                                          for K_FACE:  ij, (i+1)j, (i+1)(j+1), (i+1)(j+1)
             /// @param [out] refined_face_to_cell        For each face, the (at most 2) neighboring cells (used in "face_to_cell").
             /// @param [out] refined_face_centroid       Local centroid of the face of refined cell 'lmn' of the unit cube.
             const std::tuple< enum face_tag, int,
@@ -1079,11 +1083,12 @@ namespace Dune
                         neighboring_cells_of_one_face.push_back({ (l*cells_per_dim[0]*cells_per_dim[1])
                                 + (m*cells_per_dim[0]) + n, false});
                     }
-                    return { face_tag::K_FACE, (l*cells_per_dim[0]*cells_per_dim[1]) + (m*cells_per_dim[0]) + n,
+                    return { face_tag::K_FACE,
+                             (l*cells_per_dim[0]*cells_per_dim[1]) + (m*cells_per_dim[0]) + n,
                              {(m*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (n*(cells_per_dim[2]+1)) +l,
                               (m*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + ((n+1)*(cells_per_dim[2]+1)) +l,
-                              ((m+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (n*(cells_per_dim[2]+1)) +l,
-                              ((m+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + ((n+1)*(cells_per_dim[2]+1)) +l},
+                              ((m+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + ((n+1)*(cells_per_dim[2]+1)) +l,
+                               ((m+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (n*(cells_per_dim[2]+1)) +l},
                              neighboring_cells_of_one_face,
                              {(.5 + n)/cells_per_dim[0], (.5 + m)/cells_per_dim[1], double(l)/cells_per_dim[2]}};
                 case 1:  // {l,m,n} = {i,k,j}, constant in the x-direction
@@ -1097,12 +1102,13 @@ namespace Dune
                         neighboring_cells_of_one_face.push_back({ (m*cells_per_dim[0]*cells_per_dim[1])
                                 + (n*cells_per_dim[0]) + l, false});
                     }
-                    return { face_tag::I_FACE, (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1))
+                    return { face_tag::I_FACE,
+                             (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2]+1))
                         + (l*cells_per_dim[1]*cells_per_dim[2]) + (m*cells_per_dim[1]) + n,
                              {(n*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (l*(cells_per_dim[2]+1)) +m,
                               ((n+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (l*(cells_per_dim[2]+1)) +m,
-                              (n*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (l*(cells_per_dim[2]+1)) +m+1,
-                              ((n+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (l*(cells_per_dim[2]+1)) +m+1},
+                              ((n+1)*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (l*(cells_per_dim[2]+1)) +m+1,
+                              (n*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (l*(cells_per_dim[2]+1)) +m+1},
                              neighboring_cells_of_one_face,
                              { double(l)/cells_per_dim[0], (.5 + n)/cells_per_dim[1], (.5 + m)/cells_per_dim[2]}};
                 case 2: // {l,m,n} = {j,i,k}, constant in the y-direction
@@ -1116,13 +1122,14 @@ namespace Dune
                         neighboring_cells_of_one_face.push_back({(n*cells_per_dim[0]*cells_per_dim[1])
                                 + (l*cells_per_dim[0]) + m, false});
                     }
-                    return { face_tag::J_FACE, (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2] +1))
+                    return { face_tag::J_FACE,
+                             (cells_per_dim[0]*cells_per_dim[1]*(cells_per_dim[2] +1))
                         + ((cells_per_dim[0]+1)*cells_per_dim[1]*cells_per_dim[2])
                         + (l*cells_per_dim[0]*cells_per_dim[2]) + (m*cells_per_dim[2]) + n,
                              {(l*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (m*(cells_per_dim[2]+1)) +n,
                               (l*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + ((m+1)*(cells_per_dim[2]+1)) +n,
-                              (l*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (m*(cells_per_dim[2]+1)) +n+1,
-                              (l*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + ((m+1)*(cells_per_dim[2]+1)) +n+1},
+                              (l*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + ((m+1)*(cells_per_dim[2]+1)) +n+1,
+                              (l*(cells_per_dim[0]+1)*(cells_per_dim[2]+1)) + (m*(cells_per_dim[2]+1)) +n+1},
                              neighboring_cells_of_one_face,
                              {(.5 + m)/cells_per_dim[0], double(l)/cells_per_dim[1], (.5 + n)/cells_per_dim[2]}};
                 default:

--- a/tests/cpgrid/lgr/consistent_vertex_order_in_face_test.cpp
+++ b/tests/cpgrid/lgr/consistent_vertex_order_in_face_test.cpp
@@ -1,0 +1,138 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#define BOOST_TEST_MODULE FaultFullyInLgrTest
+#include <boost/test/unit_test.hpp>
+
+#include <opm/grid/CpGrid.hpp>
+#include <opm/grid/cpgrid/CpGridData.hpp>
+
+#include <tests/cpgrid/lgr/LgrChecks.hpp>
+
+struct Fixture
+{
+    Fixture()
+    {
+        int m_argc = boost::unit_test::framework::master_test_suite().argc;
+        char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+        Dune::MPIHelper::instance(m_argc, m_argv);
+        Opm::OpmLog::setupSimpleDefaultLogging();
+    }
+};
+
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+void checkConsistentVertexOrderInFaceToPoint(const Dune::cpgrid::CpGridData& gridData,
+                                             const Dune::cpgrid::Entity<0>& element)
+{
+    const auto& cellToFace = gridData.cellToFace(element.index());
+
+    for (const auto& face : cellToFace) {
+
+        const auto& faceToPoint = gridData.faceToPoint(face.index());
+
+        const auto& vertex0 =  Dune::cpgrid::Entity<3>(gridData, faceToPoint[0], true).geometry().center();
+        const auto& vertex1 =  Dune::cpgrid::Entity<3>(gridData, faceToPoint[1], true).geometry().center();
+        const auto& vertex2 =  Dune::cpgrid::Entity<3>(gridData, faceToPoint[2], true).geometry().center();
+        const auto& vertex3 =  Dune::cpgrid::Entity<3>(gridData, faceToPoint[3], true).geometry().center();
+
+        const auto& faceTag = gridData.faceTag(face.index());
+
+        if (faceTag == 0) {
+            BOOST_CHECK( vertex0[1] == vertex3[1]);
+            BOOST_CHECK( vertex1[1] == vertex2[1]);
+
+            BOOST_CHECK( vertex0[2] == vertex1[2]);
+            BOOST_CHECK( vertex2[2] == vertex3[2]);
+        }
+        else if (faceTag == 1) {
+            BOOST_CHECK( vertex0[0] == vertex3[0]);
+            BOOST_CHECK( vertex1[0] == vertex2[0]);
+
+            BOOST_CHECK( vertex0[2] == vertex1[2]);
+            BOOST_CHECK( vertex2[2] == vertex3[2]);
+        }
+        else if (faceTag == 2) {
+            BOOST_CHECK( vertex0[0] == vertex3[0]);
+            BOOST_CHECK( vertex1[0] == vertex2[0]);
+
+            BOOST_CHECK( vertex0[1] == vertex1[1]);
+            BOOST_CHECK( vertex2[1] == vertex3[1]);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(consistentVertexOrderInFaceToPointBeforeAndAfterRefinement)
+{
+    // Level zero grid dims = 1x1x1
+    //
+    // cell 0
+    // bottom face corners (0,0,0), (2,0,0), (0,2,0), (2,2,0)
+    //    top face corners (0,0,2), (2,0,2), (0,2,2), (2,2,2)
+    const std::string deckString =
+        R"(
+RUNSPEC
+DIMENS
+ 1 1 1 /
+
+GRID
+
+COORD
+ 0 0 0     0 0 2
+ 2 0 0     2 0 2
+
+ 0 2 0     0 2 2
+ 2 2 0     2 2 2
+/
+
+ZCORN
+ 0 0 0 0  2 2 2 2
+/
+
+ACTNUM
+ 1
+/
+
+PORO
+0.15
+/
+)";
+
+    Dune::CpGrid grid;
+    Opm::createGridAndAddLgrs(grid,
+                              deckString,
+                              /* cells_per_dim_vec */ {{2,2,2}},
+                              /* startIJK_vec */ {{0,0,0}},
+                              /* endIJK_vec */ {{1,1,1}},
+                              /* lgr_name_vec */ {"LGR1"});
+
+    for (const auto& element : Dune::elements(grid.levelGridView(0))) {
+        checkConsistentVertexOrderInFaceToPoint(*grid.currentData().front(), element);
+    }
+    
+    for (const auto& element : Dune::elements(grid.levelGridView(1))) {
+        checkConsistentVertexOrderInFaceToPoint(*grid.currentData()[1], element);
+    }
+    
+    for (const auto& element : Dune::elements(grid.leafGridView())) {
+        checkConsistentVertexOrderInFaceToPoint(grid.currentLeafData(), element);
+    }    
+}
+


### PR DESCRIPTION
Previously, the ordering of vertex indices in face_to_point_ for each CpGridData object, whether representing a level grid or the leaf grid view, was not important. However, to facilitate the computation of edge intersections between coarse and refined face edges (not included in this PR), it is more convenient to enforce a consistent ordering.

Vertex order 
            I_FACE:  jk, (j+1)k, (j+1)(k+1), j(k+1)
            J_FACE:  (i+1)k, ik,  i(k+1), (i+1)(k+1)
            K_FACE:  ij, (i+1)j, (i+1)(j+1), (i+1)(j+1)