### PR TITLE
Make well edge weight equal to sum of grid edges instead of limits::max

### DIFF
--- a/opm/grid/common/MetisPartition.cpp
+++ b/opm/grid/common/MetisPartition.cpp
@@ -277,7 +277,7 @@ metisSerialGraphPartitionGridOnRoot(const CpGrid& cpgrid,
         {
             idx_t weWeight = 0;
             for (int edge = 0; edge<cpgrid.numFaces(); ++edge) {
-                weWeight += gridAndWells.transmissibility[edge];
+                weWeight += gridAndWells->transmissibility(edge);
             }
             if (weWeight == std::numeric_limits<idx_t>::infinity()) {
                 weWeight = std::numeric_limits<idx_t>::max();

--- a/opm/grid/common/MetisPartition.cpp
+++ b/opm/grid/common/MetisPartition.cpp
@@ -275,12 +275,15 @@ metisSerialGraphPartitionGridOnRoot(const CpGrid& cpgrid,
 
         if( wells )
         {
+            // weight of edges between well connections is set to the sum of all grid edges
             idx_t weWeight = 0;
             for (int edge = 0; edge<cpgrid.numFaces(); ++edge) {
-                weWeight += gridAndWells->transmissibility(edge);
-            }
-            if (weWeight == std::numeric_limits<idx_t>::infinity()) {
-                weWeight = std::numeric_limits<idx_t>::max();
+                const auto& addend = gridAndWells->transmissibility(edge);
+                if (weWeight >= std::numeric_limits<idx_t>::max()-addend) {
+                    weWeight = std::numeric_limits<idx_t>::max();
+                    break;
+                }
+                weWeight += addend;
             }
 
             int neighborCounter = 0;

--- a/opm/grid/common/MetisPartition.cpp
+++ b/opm/grid/common/MetisPartition.cpp
@@ -275,10 +275,18 @@ metisSerialGraphPartitionGridOnRoot(const CpGrid& cpgrid,
 
         if( wells )
         {
+            idx_t weWeight = 0;
+            for (int edge = 0; edge<cpgrid.numFaces(); ++edge) {
+                weWeight += gridAndWells.transmissibility[edge];
+            }
+            if (weWeight == std::numeric_limits<idx_t>::infinity()) {
+                weWeight = std::numeric_limits<idx_t>::max();
+            }
+
             int neighborCounter = 0;
             for( int cell = 0; cell < n;  cell++ )
             {
-                fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(*gridAndWells, lids[cell], gids, neighborCounter, adjncy, adjwgt);
+                fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(*gridAndWells, lids[cell], gids, neighborCounter, adjncy, adjwgt, weWeight);
             }
         }
         else

--- a/opm/grid/common/MetisPartition.cpp
+++ b/opm/grid/common/MetisPartition.cpp
@@ -275,16 +275,8 @@ metisSerialGraphPartitionGridOnRoot(const CpGrid& cpgrid,
 
         if( wells )
         {
-            // weight of edges between well connections is set to the sum of all grid edges
-            idx_t weWeight = 0;
-            for (int edge = 0; edge<cpgrid.numFaces(); ++edge) {
-                const auto& addend = gridAndWells->transmissibility(edge);
-                if (weWeight >= std::numeric_limits<idx_t>::max()-addend) {
-                    weWeight = std::numeric_limits<idx_t>::max();
-                    break;
-                }
-                weWeight += addend;
-            }
+            // well edge weight for partitioning, big enough that wells should not get split
+            idx_t weWeight = sumOfGridEdges<idx_t>(cpgrid, *gridAndWells);
 
             int neighborCounter = 0;
             for( int cell = 0; cell < n;  cell++ )

--- a/opm/grid/common/ZoltanGraphFunctions.cpp
+++ b/opm/grid/common/ZoltanGraphFunctions.cpp
@@ -245,14 +245,14 @@ void getCpGridEdgeList(void *cpGridPointer, int sizeGID, int sizeLID,
 #endif
 }
 template<typename ID, typename weightType>
-void fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(const CombinedGridWellGraph& graph, const int localCellId, ID globalID, int& neighborCounter, ID& nborGID, weightType *ewgts) {
+void fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(const CombinedGridWellGraph& graph, const int localCellId, ID globalID, int& neighborCounter, ID& nborGID, weightType *ewgts, const weightType& weWeight) {
     const Dune::CpGrid&  grid = graph.getGrid();
     // First the strong edges of the well completions.
     auto wellEdges = graph.getWellsGraph()[localCellId];
     for( auto edge : wellEdges)
     {
         nborGID[neighborCounter] = edge;
-        ewgts[neighborCounter++] = std::numeric_limits<weightType>::max();
+        ewgts[neighborCounter++] = weWeight;
     }
 
     // Now the ones of the grid that are not handled by the well completions
@@ -308,9 +308,19 @@ void getCpGridWellsEdgeList(void *graphPointer, int sizeGID, int sizeLID,
 #endif
     int neighborCounter = 0;
 
+    // well edge weight for partitioning, big enough that wells should not get split
+    float weWeight = 0; // type of ewgts even though transmissibility is double
+    for (int edge=0; edge<grid.numFaces(); ++edge) {
+        // assumes that transmissibility is positive (too obvious to leave an assert)
+        weWeight += graph.transmissibility(edge);
+    }
+    if (weWeight == std::numeric_limits<float>::infinity()) {
+        weWeight = std::numeric_limits<float>::max();
+    }
+
     for( int cell = 0; cell < numCells;  cell++ )
     {
-        fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(graph, localID[cell], globalID, neighborCounter, nborGID, ewgts);
+        fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(graph, localID[cell], globalID, neighborCounter, nborGID, ewgts, weWeight);
 #ifndef NDEBUG
         assert(neighborCounter-oldNeighborCounter==numEdges[cell]);
         oldNeighborCounter = neighborCounter;
@@ -416,12 +426,12 @@ void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz,
 template
 void fillNBORGIDForSpecificCellAndIncrementNeighborCounter(const Dune::CpGrid&, int, int*, int&, int*& nborGID);
 template
-void fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(const CombinedGridWellGraph&, const int, int*, int&, int*&, int*);
+void fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(const CombinedGridWellGraph&, const int, int*, int&, int*&, int*, const int&);
 
 template
 void fillNBORGIDForSpecificCellAndIncrementNeighborCounter(Dune::CpGrid const&, int, long*, int&, long*&);
 template
-void fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(Dune::cpgrid::CombinedGridWellGraph const&, int, long*, int&, long*&, long*);
+void fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(Dune::cpgrid::CombinedGridWellGraph const&, int, long*, int&, long*&, long*, const long&);
 
 #endif
 

--- a/opm/grid/common/ZoltanGraphFunctions.cpp
+++ b/opm/grid/common/ZoltanGraphFunctions.cpp
@@ -179,6 +179,23 @@ void getNullEdgeList(void *cpGridPointer, int sizeGID, int sizeLID,
     *err = ZOLTAN_OK;
 }
 
+template <typename EdgeWeightType>
+EdgeWeightType sumOfGridEdges(const Dune::CpGrid& grid,
+                              const CombinedGridWellGraph& graph)
+{
+    EdgeWeightType weWeight = 0;
+    for (int edge=0; edge<grid.numFaces(); ++edge) {
+        // assumes that transmissibility is positive (too obvious to leave an assert)
+        const auto& addend = graph.transmissibility(edge);
+        if (weWeight >= std::numeric_limits<EdgeWeightType>::max()-addend) {
+            weWeight = std::numeric_limits<EdgeWeightType>::max();
+            break;
+        }
+        weWeight += graph.transmissibility(edge);
+    }
+    return weWeight;
+}
+
 template<typename ID>
 void fillNBORGIDForSpecificCellAndIncrementNeighborCounter(const Dune::CpGrid& grid, int localCellId, ID globalID, int& neighborCounter, ID& nborGID) {
     for ( int local_face = 0 ; local_face < grid.numCellFaces(localCellId); ++local_face )
@@ -309,14 +326,7 @@ void getCpGridWellsEdgeList(void *graphPointer, int sizeGID, int sizeLID,
     int neighborCounter = 0;
 
     // well edge weight for partitioning, big enough that wells should not get split
-    float weWeight = 0; // type of ewgts even though transmissibility is double
-    for (int edge=0; edge<grid.numFaces(); ++edge) {
-        // assumes that transmissibility is positive (too obvious to leave an assert)
-        weWeight += graph.transmissibility(edge);
-    }
-    if (weWeight == std::numeric_limits<float>::infinity()) {
-        weWeight = std::numeric_limits<float>::max();
-    }
+    float weWeight = sumOfGridEdges<float>(grid, graph);
 
     for( int cell = 0; cell < numCells;  cell++ )
     {
@@ -427,11 +437,15 @@ template
 void fillNBORGIDForSpecificCellAndIncrementNeighborCounter(const Dune::CpGrid&, int, int*, int&, int*& nborGID);
 template
 void fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(const CombinedGridWellGraph&, const int, int*, int&, int*&, int*, const int&);
+template
+int sumOfGridEdges(const Dune::CpGrid& grid, const CombinedGridWellGraph& graph);
 
 template
 void fillNBORGIDForSpecificCellAndIncrementNeighborCounter(Dune::CpGrid const&, int, long*, int&, long*&);
 template
 void fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(Dune::cpgrid::CombinedGridWellGraph const&, int, long*, int&, long*&, long*, const long&);
+template
+long sumOfGridEdges(const Dune::CpGrid& grid, const CombinedGridWellGraph& graph);
 
 #endif
 

--- a/opm/grid/common/ZoltanGraphFunctions.hpp
+++ b/opm/grid/common/ZoltanGraphFunctions.hpp
@@ -246,7 +246,7 @@ int getNumberOfEdgesForSpecificCellForGridWithWells(const CombinedGridWellGraph&
 
 /// \brief Get the list of edges and weights for one cell of a grid with wells
 template<typename ID, typename weightType>
-void fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(const CombinedGridWellGraph& graph, const int localCellId, ID globalID, int& neighborCounter, ID& nborGID, weightType *ewgts);
+void fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(const CombinedGridWellGraph& graph, const int localCellId, ID globalID, int& neighborCounter, ID& nborGID, weightType *ewgts, const weightType& weWeight);
 
 #ifdef HAVE_ZOLTAN
 /// \brief Sets up the call-back functions for ZOLTAN's graph partitioning.

--- a/opm/grid/common/ZoltanGraphFunctions.hpp
+++ b/opm/grid/common/ZoltanGraphFunctions.hpp
@@ -244,6 +244,13 @@ private:
 /// \brief Get the number of edges of the graph of the grid and the wells for one cell
 int getNumberOfEdgesForSpecificCellForGridWithWells(const CombinedGridWellGraph& graph, int localCellId);
 
+/// \brief Iterate over the grid and get the sum of all edge weights
+///
+/// Used as a weight for edges between cells of a well
+template <typename EdgeWeightType>
+EdgeWeightType sumOfGridEdges(const Dune::CpGrid& grid,
+                              const CombinedGridWellGraph& graph);
+
 /// \brief Get the list of edges and weights for one cell of a grid with wells
 template<typename ID, typename weightType>
 void fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(const CombinedGridWellGraph& graph, const int localCellId, ID globalID, int& neighborCounter, ID& nborGID, weightType *ewgts, const weightType& weWeight);


### PR DESCRIPTION
The partitioners metis and zoltan (not the default zoltanwell) uses std::numeric_limits::max for the weights of well edges (plus considers all cells perforated by one well to be pairwise neighboring). This PR lowers the constant to the sum of all transmissibilities of the grid. This induces an extra cost, we have to iterate over all transmissibilities first.

Testing showed that the algorithm with new weights yields partitioning that is as good as previous version, and in several cases the improvement is significant. The best observed result was 50% faster. (The computation on 12 ranks was the same. Splitting onto 16 ranks hurt the computation and increased the time by 16% with the updated weights whereas older version increased the time by 168%.) The updated algorithm is more robust and reaches the breaking point later.

We explain the improvement by giving better information to the partitioning algorithm. Lowering the gap between the weights between well connections and weights of other edges reduces the risk of losing information to rounding errors.