### PR TITLE
Partitioning: lower the well edge weights to the sum of all grid edges

### DIFF
--- a/opm/grid/common/ZoltanGraphFunctions.cpp
+++ b/opm/grid/common/ZoltanGraphFunctions.cpp
@@ -251,9 +251,11 @@ void fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithW
     auto wellEdges = graph.getWellsGraph()[localCellId];
     for( auto edge : wellEdges)
     {
-        nborGID[neighborCounter] = edge;
-        ewgts[neighborCounter++] = std::numeric_limits<weightType>::max();
+        nborGID[neighborCounter++] = edge;
     }
+    // fill edge weights of wells later when we know the sum of other grid faces
+    int nrWellEdges = neighborCounter;
+    weightType edgeSum = 0;
 
     // Now the ones of the grid that are not handled by the well completions
     for ( int local_face = 0 ; local_face < grid.numCellFaces(localCellId); ++local_face )
@@ -274,6 +276,7 @@ void fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithW
                 {
                     nborGID[neighborCounter] = globalID[otherCell];
                     ewgts[neighborCounter++] = graph.edgeWeight(face);
+                    edgeSum += graph.edgeWeight(face);
                 }
                 continue;
             }
@@ -282,8 +285,15 @@ void fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithW
         {
             nborGID[neighborCounter] = globalID[otherCell];
             ewgts[neighborCounter++] = graph.edgeWeight(face);
+            edgeSum += graph.edgeWeight(face);
         }
     }
+
+    // set well edge weight to the weight of the whole grid
+    if (edgeSum == std::numeric_limits<weightType>::infinity()) {
+        edgeSum = std::numeric_limits<weightType>::max();
+    }
+    std::for_each(ewgts, ewgts + nrWellEdges, [&edgeSum](weightType& e) { e = edgeSum; });
 }
 
 void getCpGridWellsEdgeList(void *graphPointer, int sizeGID, int sizeLID,


### PR DESCRIPTION
The partitioners metis and zoltan (not the default zoltanwell) uses std::numeric_limits::max for the weights of well edges (plus considers all cells perforated by one well to be pairwise neighboring). This PR lowers the constant to the sum of all transmissibilities of the grid.

We hope that this will make the partitioning better for hard cases when some wells get split. Lowering the gap between the weights between well connections and weights of other edges reduces the risk of losing information to rounding errors.