### PR TITLE
Add CpGrid support for loading unstructured grids from external files

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -170,6 +170,7 @@ list(APPEND TEST_DATA_FILES
 # originally generated with the command:
 # find tutorials examples -name '*.c*' -printf '\t%p\n' | sort
 list(APPEND EXAMPLE_SOURCE_FILES
+  examples/export_grid.cpp
   examples/finitevolume/finitevolume.cc
   examples/griditer.cpp
 )

--- a/examples/export_grid.cpp
+++ b/examples/export_grid.cpp
@@ -1,0 +1,236 @@
+#include <config.h>
+
+#include <opm/grid/CpGrid.hpp>
+#include <opm/grid/cpgrid/GridHelpers.hpp>
+
+#if HAVE_OPM_COMMON
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/input/eclipse/Parser/InputErrorAction.hpp>
+#include <opm/input/eclipse/Parser/ParseContext.hpp>
+#include <opm/input/eclipse/Parser/Parser.hpp>
+#endif
+
+#include <fstream>
+#include <filesystem>
+#include <iomanip>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+#if HAVE_OPM_COMMON
+Opm::ParseContext makeFlowLikeParseContext()
+{
+    return Opm::ParseContext({
+        {Opm::ParseContext::PARSE_RANDOM_SLASH, Opm::InputErrorAction::IGNORE},
+        {Opm::ParseContext::PARSE_MISSING_DIMS_KEYWORD, Opm::InputErrorAction::WARN},
+        {Opm::ParseContext::SUMMARY_UNKNOWN_WELL, Opm::InputErrorAction::WARN},
+        {Opm::ParseContext::SUMMARY_UNKNOWN_GROUP, Opm::InputErrorAction::WARN},
+    });
+}
+#endif
+
+void writeGridFromCpGrid(const Dune::CpGrid& grid, const std::string& output_file)
+{
+    const int ndims = 3;
+    const int ncells = grid.numCells();
+    const int nfaces = grid.numFaces();
+    const int nnodes = grid.numVertices();
+    const int ncellfaces = grid.numCellFaces();
+
+    int nfacenodes = 0;
+    std::vector<int> face_nodepos;
+    std::vector<int> face_nodes;
+    face_nodepos.reserve(nfaces + 1);
+    face_nodes.reserve(4 * nfaces);
+    face_nodepos.push_back(0);
+    for (int f = 0; f < nfaces; ++f) {
+        const int nv = grid.numFaceVertices(f);
+        for (int lv = 0; lv < nv; ++lv) {
+            face_nodes.push_back(grid.faceVertex(f, lv));
+        }
+        nfacenodes += nv;
+        face_nodepos.push_back(nfacenodes);
+    }
+
+    std::vector<int> face_cells;
+    face_cells.reserve(2 * nfaces);
+    for (int f = 0; f < nfaces; ++f) {
+        face_cells.push_back(grid.faceCell(f, 0));
+        face_cells.push_back(grid.faceCell(f, 1));
+    }
+
+    std::vector<int> cell_facepos;
+    std::vector<int> cell_faces;
+    std::vector<int> cell_facetag;
+    cell_facepos.reserve(ncells + 1);
+    cell_faces.reserve(ncellfaces);
+    cell_facetag.reserve(ncellfaces);
+    cell_facepos.push_back(0);
+    const auto c2f = Opm::UgGridHelpers::cell2Faces(grid);
+    for (int c = 0; c < ncells; ++c) {
+        const auto row = c2f[c];
+        for (auto it = row.begin(); it != row.end(); ++it) {
+            const int face = *it;
+            cell_faces.push_back(face);
+
+            // Export the exact CpGrid face tag used by transmissibility logic
+            const int tag = Opm::UgGridHelpers::faceTag(grid, it);
+            cell_facetag.push_back(tag);
+        }
+        cell_facepos.push_back(static_cast<int>(cell_faces.size()));
+    }
+
+    if (static_cast<int>(cell_faces.size()) != ncellfaces) {
+        throw std::runtime_error("Internal inconsistency: numCellFaces() total mismatch");
+    }
+
+    std::ofstream out(output_file);
+    if (!out) {
+        throw std::runtime_error("Failed to open output file: " + output_file);
+    }
+
+    out << std::setprecision(17) << std::fixed;
+
+    const int has_tag = 1;
+    const int has_indexmap = 1;
+    out << ndims << ' ' << ncells << ' ' << nfaces << ' '
+        << nnodes << ' ' << nfacenodes << ' ' << ncellfaces << ' '
+        << has_tag << ' ' << has_indexmap << '\n';
+
+    const auto cartdims = grid.logicalCartesianSize();
+    out << cartdims[0] << ' ' << cartdims[1] << ' ' << cartdims[2] << '\n';
+
+    for (int v = 0; v < nnodes; ++v) {
+        const auto& p = grid.vertexPosition(v);
+        out << p[0] << ' ' << p[1] << ' ' << p[2] << ' ';
+    }
+    out << '\n';
+
+    for (const int value : face_nodepos) {
+        out << value << ' ';
+    }
+    out << '\n';
+
+    for (const int value : face_nodes) {
+        out << value << ' ';
+    }
+    out << '\n';
+
+    for (const int value : face_cells) {
+        out << value << ' ';
+    }
+    out << '\n';
+
+    for (int f = 0; f < nfaces; ++f) {
+        out << grid.faceArea(f) << ' ';
+    }
+    out << '\n';
+
+    for (int f = 0; f < nfaces; ++f) {
+        const auto& c = grid.faceCentroid(f);
+        out << c[0] << ' ' << c[1] << ' ' << c[2] << ' ';
+    }
+    out << '\n';
+
+    for (int f = 0; f < nfaces; ++f) {
+        const auto& n = grid.faceNormal(f);
+        out << n[0] << ' ' << n[1] << ' ' << n[2] << ' ';
+    }
+    out << '\n';
+
+    for (const int value : cell_facepos) {
+        out << value << ' ';
+    }
+    out << '\n';
+
+    for (std::size_t i = 0; i < cell_faces.size(); ++i) {
+        out << cell_faces[i] << ' ' << cell_facetag[i] << ' ';
+    }
+    out << '\n';
+
+    const auto& global_cell = grid.globalCell();
+    for (const int value : global_cell) {
+        out << value << ' ';
+    }
+    out << '\n';
+
+    for (int c = 0; c < ncells; ++c) {
+        out << grid.cellVolume(c) << ' ';
+    }
+    out << '\n';
+
+    for (int c = 0; c < ncells; ++c) {
+        const auto& cc = grid.cellCentroid(c);
+        out << cc[0] << ' ' << cc[1] << ' ' << cc[2] << ' ';
+    }
+    out << '\n';
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+
+#if !HAVE_OPM_COMMON
+    std::cerr << "export_grid requires HAVE_OPM_COMMON to parse .DATA files." << std::endl;
+    return 2;
+#else
+    if (argc != 3) {
+        std::cerr << "Usage: " << argv[0] << " <case.DATA> <output.grid>" << std::endl;
+        return 1;
+    }
+
+    const std::string data_file = argv[1];
+    const std::string output_file = argv[2];
+
+    try {
+        Dune::CpGrid cpgrid;
+        bool built_from_data = false;
+
+        try {
+            Opm::Parser parser;
+            const auto deck = parser.parseFile(data_file, makeFlowLikeParseContext());
+
+            Opm::EclipseGrid eclipse_grid(deck);
+            Opm::EclipseState ecl_state(deck);
+
+            cpgrid.processEclipseFormat(&eclipse_grid, &ecl_state, false);
+            built_from_data = true;
+        } catch (const std::exception& e) {
+            const std::filesystem::path data_path(data_file);
+            const std::filesystem::path egrid_path =
+                data_path.parent_path() / (data_path.stem().string() + ".EGRID");
+            if (!std::filesystem::exists(egrid_path)) {
+                throw std::runtime_error(
+                    std::string("Failed to parse DATA and no EGRID fallback found. DATA error: ") + e.what());
+            }
+
+            std::cerr << "Warning: failed to build grid directly from DATA (" << e.what() << ")\n"
+                      << "Falling back to EGRID: " << egrid_path << "\n";
+            Opm::EclipseGrid eclipse_grid(egrid_path.string());
+            cpgrid.processEclipseFormat(&eclipse_grid, nullptr, false);
+        }
+
+        writeGridFromCpGrid(cpgrid, output_file);
+
+        std::cout << "Wrote grid: " << output_file << "\n"
+                  << "  source             : " << (built_from_data ? "DATA" : "EGRID fallback") << "\n"
+                  << "  cells/faces/vertices/cellFaces = "
+                  << cpgrid.numCells() << " / "
+                  << cpgrid.numFaces() << " / "
+                  << cpgrid.numVertices() << " / "
+                  << cpgrid.numCellFaces() << "\n";
+    } catch (const std::exception& e) {
+        std::cerr << "Failed to export grid from DATA: " << e.what() << std::endl;
+        return 3;
+    }
+
+    return 0;
+#endif
+}

--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -58,6 +58,8 @@
 
 #include <set>
 
+struct UnstructuredGrid;
+
 namespace Opm
 {
 struct NNCdata;
@@ -225,6 +227,20 @@ namespace Dune
         CpGrid();
 
         explicit CpGrid(MPIHelper::MPICommunicator comm);
+
+        /// Construct grid from serialized UnstructuredGrid file.
+        explicit CpGrid(const std::string& filename);
+
+        /// Read a serialized UnstructuredGrid file into an already-constructed grid.
+        ///
+        /// In an MPI run this method must be called on all ranks.  Only rank 0
+        /// actually reads the file and calls processUnstructuredGrid(); the other
+        /// ranks keep an empty global-view grid ready for scatterGrid / loadBalance.
+        /// After this call the logical_cartesian_size is broadcast to all ranks so
+        /// every rank knows the total cell count.
+        ///
+        /// \param filename  Path to the Sintef legacy unstructured-grid file.
+        void readUnstructuredGridFile(const std::string& filename);
 
 #if HAVE_OPM_COMMON
         /// Read the Eclipse grid format ('grdecl').

--- a/opm/grid/cpgrid/CpGrid.cpp
+++ b/opm/grid/cpgrid/CpGrid.cpp
@@ -48,6 +48,8 @@
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #endif
 
+#include <opm/grid/UnstructuredGrid.h>
+
 #include "../CpGrid.hpp"
 #include "LgrHelpers.hpp"
 #include "ParentToChildrenCellGlobalIdHandle.hpp"
@@ -183,6 +185,48 @@ CpGrid::CpGrid(MPIHelper::MPICommunicator comm)
     data_.push_back(std::make_shared<cpgrid::CpGridData>(comm, data_));
     current_data_ = &data_;
     global_id_set_ptr_ = std::make_shared<cpgrid::GlobalIdSet>(*(current_data_->back()));
+}
+
+CpGrid::CpGrid(const std::string& filename)
+    : distributed_data_(),
+      cell_scatter_gather_interfaces_(new InterfaceMap, FreeInterfaces{}),
+      point_scatter_gather_interfaces_(new InterfaceMap, FreeInterfaces{}),
+      global_id_set_ptr_()
+{
+    data_.push_back(std::make_shared<cpgrid::CpGridData>(data_));
+    current_data_ = &data_;
+    global_id_set_ptr_ = std::make_shared<cpgrid::GlobalIdSet>(*(current_data_->back()));
+
+    using GridPtr = std::unique_ptr<UnstructuredGrid, decltype(&destroy_grid)>;
+    GridPtr input_grid(read_grid(filename.c_str()), &destroy_grid);
+    if (!input_grid) {
+        OPM_THROW(std::runtime_error,
+                  "Failed to read UnstructuredGrid from file: " + filename);
+    }
+
+    current_data_->back()->processUnstructuredGrid(*input_grid);
+}
+
+void CpGrid::readUnstructuredGridFile(const std::string& filename)
+{
+    // Only the root rank reads and processes the file; all other ranks keep
+    // an empty global-view grid, which is correct for a subsequent
+    // scatterGrid / loadBalance call.
+    if (current_data_->back()->ccobj_.rank() == 0) {
+        using GridPtr = std::unique_ptr<UnstructuredGrid, decltype(&destroy_grid)>;
+        GridPtr input_grid(read_grid(filename.c_str()), &destroy_grid);
+        if (!input_grid) {
+            OPM_THROW(std::runtime_error,
+                      "Failed to read UnstructuredGrid from file: " + filename);
+        }
+        current_data_->back()->processUnstructuredGrid(*input_grid);
+    }
+
+    // Broadcast the logical Cartesian size so every rank knows the total
+    // cell count (mirrors what processEclipseFormat does).
+    current_data_->back()->ccobj_.broadcast(
+        current_data_->back()->logical_cartesian_size_.data(),
+        current_data_->back()->logical_cartesian_size_.size(), 0);
 }
 
 std::vector<int>

--- a/opm/grid/cpgrid/CpGridData.cpp
+++ b/opm/grid/cpgrid/CpGridData.cpp
@@ -25,6 +25,7 @@
 
 #include <opm/grid/utility/platform_dependent/reenable_warnings.h>
 #include <opm/grid/CpGrid.hpp>
+#include <opm/grid/UnstructuredGrid.h>
 
 namespace Dune
 {
@@ -144,6 +145,196 @@ void CpGridData::computeUniqueBoundaryIds()
     std::cout << "computeUniqueBoundaryIds() gave all boundary intersections\n"
               << "unique boundaryId()s ranging from 1 to " << count << std::endl;
 #endif
+}
+
+void CpGridData::processUnstructuredGrid(const UnstructuredGrid& input_grid)
+{
+    if (input_grid.dimensions != 3) {
+        OPM_THROW(std::runtime_error,
+                  "CpGrid::processUnstructuredGrid() currently requires a 3D grid.");
+    }
+    if (!input_grid.cell_facetag) {
+        OPM_THROW(std::runtime_error,
+                  "CpGrid::processUnstructuredGrid() requires cell facetags for Phase 1.");
+    }
+
+    const int num_cells = input_grid.number_of_cells;
+    const int num_faces = input_grid.number_of_faces;
+    const int num_nodes = input_grid.number_of_nodes;
+
+    face_to_cell_.clear();
+    face_to_point_.clear();
+    cell_to_face_.clear();
+    cell_to_point_.clear();
+    aquifer_cells_.clear();
+    zcorn.clear();
+
+    std::vector<int> face_axis_tag(num_faces, -1);
+
+    for (int cell = 0; cell < num_cells; ++cell) {
+        const auto begin = input_grid.cell_facepos[cell];
+        const auto end = input_grid.cell_facepos[cell + 1];
+        for (auto pos = begin; pos < end; ++pos) {
+            const int face = input_grid.cell_faces[pos];
+            const int facetag = input_grid.cell_facetag[pos];
+            const int axis = facetag / 2;
+            if (axis < 0 || axis > 2) {
+                OPM_THROW(std::runtime_error,
+                          "CpGrid::processUnstructuredGrid() found invalid face tag.");
+            }
+            if (face_axis_tag[face] == -1) {
+                face_axis_tag[face] = axis;
+            } else if (face_axis_tag[face] != axis) {
+                OPM_THROW(std::runtime_error,
+                          "CpGrid::processUnstructuredGrid() found inconsistent facetags for a face.");
+            }
+        }
+    }
+
+    for (int face = 0; face < num_faces; ++face) {
+        cpgrid::EntityRep<0> cells[2];
+        int cell_count = 0;
+
+        const int c0 = input_grid.face_cells[2 * face];
+        const int c1 = input_grid.face_cells[2 * face + 1];
+
+        if (c0 != -1) {
+            cells[cell_count++].setValue(c0, true);
+        }
+        if (c1 != -1) {
+            cells[cell_count++].setValue(c1, false);
+        }
+
+        if (cell_count > 0) {
+            std::sort(cells, cells + cell_count);
+            face_to_cell_.appendRow(cells, cells + cell_count);
+        }
+
+        const auto fn_begin = input_grid.face_nodepos[face];
+        const auto fn_end = input_grid.face_nodepos[face + 1];
+        face_to_point_.appendRow(input_grid.face_nodes + fn_begin,
+                                 input_grid.face_nodes + fn_end);
+    }
+
+    face_to_cell_.makeInverseRelation(cell_to_face_);
+
+    cell_to_point_.reserve(num_cells);
+    for (int cell = 0; cell < num_cells; ++cell) {
+        int bot_face = -1;
+        int top_face = -1;
+
+        const auto begin = input_grid.cell_facepos[cell];
+        const auto end = input_grid.cell_facepos[cell + 1];
+
+        for (auto pos = begin; pos < end; ++pos) {
+            const int face = input_grid.cell_faces[pos];
+            const int facetag = input_grid.cell_facetag[pos];
+            if (facetag == 4) {
+                bot_face = face;
+            } else if (facetag == 5) {
+                top_face = face;
+            }
+        }
+
+        if (bot_face < 0 || top_face < 0) {
+            OPM_THROW(std::runtime_error,
+                      "CpGrid::processUnstructuredGrid() requires K-/K+ tagged faces for each cell.");
+        }
+
+        const auto bfbegin = input_grid.face_nodepos[bot_face];
+        const auto bfend = input_grid.face_nodepos[bot_face + 1];
+        const auto tfbegin = input_grid.face_nodepos[top_face];
+        const auto tfend = input_grid.face_nodepos[top_face + 1];
+
+        if ((bfend - bfbegin) != 4 || (tfend - tfbegin) != 4) {
+            OPM_THROW(std::runtime_error,
+                      "CpGrid::processUnstructuredGrid() requires quadrilateral K-faces.");
+        }
+
+        std::array<int, 8> corners = {{ input_grid.face_nodes[bfbegin],
+                                        input_grid.face_nodes[bfbegin + 1],
+                                        input_grid.face_nodes[bfbegin + 3],
+                                        input_grid.face_nodes[bfbegin + 2],
+                                        input_grid.face_nodes[tfbegin],
+                                        input_grid.face_nodes[tfbegin + 1],
+                                        input_grid.face_nodes[tfbegin + 3],
+                                        input_grid.face_nodes[tfbegin + 2] }};
+
+        //std::array<int, 8> sorted_corners = corners;
+        //std::sort(sorted_corners.begin(), sorted_corners.end());
+        //const auto unique_end = std::unique(sorted_corners.begin(), sorted_corners.end());
+        //if (std::distance(sorted_corners.begin(), unique_end) != 8) {
+        //    OPM_THROW(std::runtime_error,
+        //              "CpGrid::processUnstructuredGrid() requires cells with exactly eight unique corners.");
+        //}
+
+        cell_to_point_.push_back(corners);
+    }
+
+    global_cell_.resize(num_cells);
+    if (input_grid.global_cell) {
+        std::copy_n(input_grid.global_cell, num_cells, global_cell_.begin());
+    } else {
+        std::iota(global_cell_.begin(), global_cell_.end(), 0);
+    }
+
+    std::copy_n(input_grid.cartdims, 3, logical_cartesian_size_.begin());
+
+    auto point_geom = geometry_.geomVector(std::integral_constant<int, 3>());
+    auto face_geom = geometry_.geomVector(std::integral_constant<int, 1>());
+    auto cell_geom = geometry_.geomVector(std::integral_constant<int, 0>());
+
+    point_geom->resize(num_nodes);
+    face_geom->resize(num_faces);
+    cell_geom->resize(num_cells);
+    face_normals_.resize(num_faces);
+
+    for (int node = 0; node < num_nodes; ++node) {
+        Geometry<0, 3>::GlobalCoordinate pos;
+        for (int d = 0; d < 3; ++d) {
+            pos[d] = input_grid.node_coordinates[3 * node + d];
+        }
+        (*point_geom)[cpgrid::EntityRep<3>(node, true)] = Geometry<0, 3>(pos);
+    }
+
+    for (int face = 0; face < num_faces; ++face) {
+        Geometry<2, 3>::GlobalCoordinate center;
+        for (int d = 0; d < 3; ++d) {
+            center[d] = input_grid.face_centroids[3 * face + d];
+            face_normals_.get(face)[d] = input_grid.face_normals[3 * face + d];
+        }
+        (*face_geom)[cpgrid::EntityRep<1>(face, true)] = Geometry<2, 3>(center, input_grid.face_areas[face]);
+
+        if (face_axis_tag[face] == -1) {
+            OPM_THROW(std::runtime_error,
+                      "CpGrid::processUnstructuredGrid() found a face not connected to any cell.");
+        }
+    }
+
+    std::vector<enum face_tag> tags(num_faces, NNC_FACE);
+    for (int face = 0; face < num_faces; ++face) {
+        tags[face] = static_cast<enum face_tag>(face_axis_tag[face]);
+    }
+    face_tag_.assign(tags.begin(), tags.end());
+
+    for (int cell = 0; cell < num_cells; ++cell) {
+        Geometry<3, 3>::GlobalCoordinate center;
+        for (int d = 0; d < 3; ++d) {
+            center[d] = input_grid.cell_centroids[3 * cell + d];
+        }
+        (*cell_geom)[cpgrid::EntityRep<0>(cell, true)] = Geometry<3, 3>(center,
+                                                                         input_grid.cell_volumes[cell],
+                                                                         point_geom,
+                                                                         cell_to_point_[cell].data());
+    }
+
+    computeUniqueBoundaryIds();
+
+    if (ccobj_.size() > 1) {
+        populateGlobalCellIndexSet();
+    }
+
+    index_set_ = std::make_unique<IndexSet>(cell_to_face_.size(), geomVector<3>().size());
 }
 
 int CpGridData::size(int codim) const

--- a/opm/grid/cpgrid/CpGridData.hpp
+++ b/opm/grid/cpgrid/CpGridData.hpp
@@ -80,6 +80,9 @@ namespace Opm
 {
 class EclipseState;
 }
+
+struct UnstructuredGrid;
+
 namespace Dune
 {
 class CpGrid;
@@ -312,6 +315,11 @@ public:
                               bool pinchActive,
                               double tolerance_unique_points,
                               bool edge_conformal);
+
+    /// Read serialized UnstructuredGrid data.
+    ///
+    /// Phase 1 scope: requires hexahedral cells with exactly eight corners.
+    void processUnstructuredGrid(const UnstructuredGrid& input_grid);
 
     /// @brief
     ///    Extract Cartesian index triplet (i,j,k) of an active cell.

--- a/opm/grid/polyhedralgrid/cartesianindexmapper.hh
+++ b/opm/grid/polyhedralgrid/cartesianindexmapper.hh
@@ -46,6 +46,9 @@ namespace Dune
 
         int cartesianIndex( const int compressedElementIndex ) const
         {
+            // For grids without globalCell we return the compressedIndex
+            if (grid_.globalCellPtr() == 0)
+                return compressedElementIndex;
             assert( compressedElementIndex >= 0 && compressedElementIndex < compressedSize() );
             return grid_.globalCell()[ compressedElementIndex ];
         }

--- a/opm/grid/polyhedralgrid/grid.hh
+++ b/opm/grid/polyhedralgrid/grid.hh
@@ -394,6 +394,21 @@ namespace Dune
       init();
     }
 
+        /** \brief constructor
+     *
+     *  \param[in]  filename  path to a serialized UnstructuredGrid file
+     */
+    explicit PolyhedralGrid(const std::string& filename)
+    : gridPtr_(createGrid(filename)),
+      grid_(*gridPtr_),
+      comm_(MPIHelper::getCommunicator()),
+      leafIndexSet_(*this),
+      globalIdSet_(*this),
+      localIdSet_(*this),
+      nBndSegments_(0)
+    {
+      init();
+    }
     /** \} */
 
     /** \name Casting operators
@@ -947,6 +962,16 @@ namespace Dune
       return cgrid;
     }
 #endif
+
+    UnstructuredGridType* createGrid(const std::string& filename) const
+    {
+      UnstructuredGridType* cgrid = read_grid(filename.c_str());
+      if (!cgrid) {
+        OPM_THROW(std::runtime_error,
+                  "Failed to read UnstructuredGrid from file: " + filename);
+      }
+      return cgrid;
+    }
 
     UnstructuredGridType* createGrid( const std::vector< int >& n, const std::vector< double >& dx ) const
     {

--- a/tests/test_cpgrid.cpp
+++ b/tests/test_cpgrid.cpp
@@ -5,6 +5,8 @@
 
 #include <dune/common/unused.hh>
 #include <opm/grid/CpGrid.hpp>
+#include <opm/grid/UnstructuredGrid.h>
+#include <opm/grid/cornerpoint_grid.h>
 #include <opm/grid/cpgrid/GridHelpers.hpp>
 
 #include <dune/grid/io/file/vtk/vtkwriter.hh>
@@ -24,7 +26,233 @@ using Dune::referenceElement; //grid check assume usage of Dune::Geometry
 // Re-enable warnings.
 #include <opm/grid/utility/platform_dependent/reenable_warnings.h>
 
+#include <cstdio>
+#include <cstdint>
+#include <fstream>
 #include <iostream>
+#include <sstream>
+#include <unordered_map>
+
+namespace {
+
+void serializeUnstructuredGridToFile(const UnstructuredGrid& grid, const std::string& filename)
+{
+    std::ofstream out(filename);
+    if (!out) {
+        throw std::runtime_error("Failed to open output file for serialized UnstructuredGrid: " + filename);
+    }
+
+    const int ndims = grid.dimensions;
+    const int ncells = grid.number_of_cells;
+    const int nfaces = grid.number_of_faces;
+    const int nnodes = grid.number_of_nodes;
+    const int nfacenodes = grid.face_nodepos[nfaces];
+    const int ncellfaces = grid.cell_facepos[ncells];
+    const int has_tag = (grid.cell_facetag != nullptr) ? 1 : 0;
+    const int has_indexmap = (grid.global_cell != nullptr) ? 1 : 0;
+
+    out << ndims << ' ' << ncells << ' ' << nfaces << ' ' << nnodes << ' '
+        << nfacenodes << ' ' << ncellfaces << ' ' << has_tag << ' ' << has_indexmap << '\n';
+
+    for (int d = 0; d < ndims; ++d) {
+        out << grid.cartdims[d] << (d + 1 == ndims ? '\n' : ' ');
+    }
+
+    for (int i = 0; i < nnodes * ndims; ++i) {
+        out << grid.node_coordinates[i] << (i + 1 == nnodes * ndims ? '\n' : ' ');
+    }
+
+    for (int i = 0; i < nfaces + 1; ++i) {
+        out << grid.face_nodepos[i] << (i + 1 == nfaces + 1 ? '\n' : ' ');
+    }
+    for (int i = 0; i < nfacenodes; ++i) {
+        out << grid.face_nodes[i] << (i + 1 == nfacenodes ? '\n' : ' ');
+    }
+    for (int i = 0; i < 2 * nfaces; ++i) {
+        out << grid.face_cells[i] << (i + 1 == 2 * nfaces ? '\n' : ' ');
+    }
+    for (int i = 0; i < nfaces; ++i) {
+        out << grid.face_areas[i] << (i + 1 == nfaces ? '\n' : ' ');
+    }
+    for (int i = 0; i < nfaces * ndims; ++i) {
+        out << grid.face_centroids[i] << (i + 1 == nfaces * ndims ? '\n' : ' ');
+    }
+    for (int i = 0; i < nfaces * ndims; ++i) {
+        out << grid.face_normals[i] << (i + 1 == nfaces * ndims ? '\n' : ' ');
+    }
+
+    for (int i = 0; i < ncells + 1; ++i) {
+        out << grid.cell_facepos[i] << (i + 1 == ncells + 1 ? '\n' : ' ');
+    }
+
+    for (int i = 0; i < ncellfaces; ++i) {
+        if (has_tag) {
+            out << grid.cell_faces[i] << ' ' << grid.cell_facetag[i];
+        } else {
+            out << grid.cell_faces[i];
+        }
+        out << (i + 1 == ncellfaces ? '\n' : ' ');
+    }
+
+    if (has_indexmap) {
+        for (int i = 0; i < ncells; ++i) {
+            out << grid.global_cell[i] << (i + 1 == ncells ? '\n' : ' ');
+        }
+    }
+
+    for (int i = 0; i < ncells; ++i) {
+        out << grid.cell_volumes[i] << (i + 1 == ncells ? '\n' : ' ');
+    }
+    for (int i = 0; i < ncells * ndims; ++i) {
+        out << grid.cell_centroids[i] << (i + 1 == ncells * ndims ? '\n' : ' ');
+    }
+}
+
+void compareCpGridCellsByGlobalId(const Dune::CpGrid& lhs,
+                                  const Dune::CpGrid& rhs,
+                                  const double tol = 1e-12)
+{
+    // Compare top-level observable grid metadata.
+    assert(lhs.logicalCartesianSize() == rhs.logicalCartesianSize());
+    assert(lhs.numCells() == rhs.numCells());
+    assert(lhs.numFaces() == rhs.numFaces());
+    assert(lhs.numVertices() == rhs.numVertices());
+    assert(lhs.numCellFaces() == rhs.numCellFaces());
+    assert(lhs.globalCell() == rhs.globalCell());
+    assert(lhs.uniqueBoundaryIds() == rhs.uniqueBoundaryIds());
+    assert(lhs.numBoundarySegments() == rhs.numBoundarySegments());
+
+    // NOTE: zcornData is not part of the serialized UnstructuredGrid file format,
+    // so we cannot require exact equivalence for this member here.
+
+    // Vertex geometry.
+    for (int v = 0; v < lhs.numVertices(); ++v) {
+        const auto& lp = lhs.vertexPosition(v);
+        const auto& rp = rhs.vertexPosition(v);
+        for (int d = 0; d < 3; ++d) {
+            assert(std::abs(lp[d] - rp[d]) < tol);
+        }
+    }
+
+    // Face topology and geometry.
+    for (int f = 0; f < lhs.numFaces(); ++f) {
+        assert(lhs.numFaceVertices(f) == rhs.numFaceVertices(f));
+        for (int lv = 0; lv < lhs.numFaceVertices(f); ++lv) {
+            assert(lhs.faceVertex(f, lv) == rhs.faceVertex(f, lv));
+        }
+
+        assert(lhs.faceCell(f, 0) == rhs.faceCell(f, 0));
+        assert(lhs.faceCell(f, 1) == rhs.faceCell(f, 1));
+        assert(std::abs(lhs.faceArea(f) - rhs.faceArea(f)) < tol);
+
+        const auto& lfc = lhs.faceCentroid(f);
+        const auto& rfc = rhs.faceCentroid(f);
+        const auto& lfn = lhs.faceNormal(f);
+        const auto& rfn = rhs.faceNormal(f);
+        for (int d = 0; d < 3; ++d) {
+            assert(std::abs(lfc[d] - rfc[d]) < tol);
+            assert(std::abs(lfn[d] - rfn[d]) < tol);
+        }
+        assert(lhs.boundaryId(f) == rhs.boundaryId(f));
+    }
+
+    // Cell topology and geometry.
+    for (int c = 0; c < lhs.numCells(); ++c) {
+        assert(lhs.numCellFaces(c) == rhs.numCellFaces(c));
+        for (int lf = 0; lf < lhs.numCellFaces(c); ++lf) {
+            assert(lhs.cellFace(c, lf) == rhs.cellFace(c, lf));
+        }
+
+        assert(std::abs(lhs.cellVolume(c) - rhs.cellVolume(c)) < tol);
+        assert(std::abs(lhs.cellCenterDepth(c) - rhs.cellCenterDepth(c)) < tol);
+
+        const auto& lcc = lhs.cellCentroid(c);
+        const auto& rcc = rhs.cellCentroid(c);
+        for (int d = 0; d < 3; ++d) {
+            assert(std::abs(lcc[d] - rcc[d]) < tol);
+        }
+
+        std::array<int, 3> lijk{};
+        std::array<int, 3> rijk{};
+        lhs.getIJK(c, lijk);
+        rhs.getIJK(c, rijk);
+        assert(lijk == rijk);
+
+        const auto lecl = lhs.getEclCentroid(c);
+        const auto recl = rhs.getEclCentroid(c);
+        for (int d = 0; d < 3; ++d) {
+            assert(std::abs(lecl[d] - recl[d]) < tol);
+        }
+    }
+
+    // Compare Dune ids for codim 0 and 3 (supported codims).
+    const auto& lhsGlobalIdSet = lhs.globalIdSet();
+    const auto& rhsGlobalIdSet = rhs.globalIdSet();
+    const auto lhsLeaf = lhs.leafGridView();
+    const auto rhsLeaf = rhs.leafGridView();
+
+    std::unordered_map<int, std::size_t> rhsCellIdByIndex;
+    std::unordered_map<int, std::size_t> rhsVertexIdByIndex;
+    rhsCellIdByIndex.reserve(static_cast<std::size_t>(rhs.numCells()));
+    rhsVertexIdByIndex.reserve(static_cast<std::size_t>(rhs.numVertices()));
+
+    for (const auto& elem : Dune::elements(rhsLeaf)) {
+        rhsCellIdByIndex.emplace(elem.index(), rhsGlobalIdSet.id(elem));
+    }
+    for (const auto& vertex : Dune::vertices(rhsLeaf)) {
+        rhsVertexIdByIndex.emplace(vertex.index(), rhsGlobalIdSet.id(vertex));
+    }
+
+    for (const auto& elem : Dune::elements(lhsLeaf)) {
+        const auto it = rhsCellIdByIndex.find(elem.index());
+        assert(it != rhsCellIdByIndex.end());
+        assert(static_cast<std::int64_t>(lhsGlobalIdSet.id(elem)) == static_cast<std::int64_t>(it->second));
+    }
+    for (const auto& vertex : Dune::vertices(lhsLeaf)) {
+        const auto it = rhsVertexIdByIndex.find(vertex.index());
+        assert(it != rhsVertexIdByIndex.end());
+        assert(static_cast<std::int64_t>(lhsGlobalIdSet.id(vertex)) == static_cast<std::int64_t>(it->second));
+    }
+
+    const auto& lhsGlobal = lhs.globalCell();
+    const auto& rhsGlobal = rhs.globalCell();
+    assert(lhsGlobal.size() == rhsGlobal.size());
+
+    std::unordered_map<int, int> lhsG2L;
+    std::unordered_map<int, int> rhsG2L;
+    lhsG2L.reserve(lhsGlobal.size());
+    rhsG2L.reserve(rhsGlobal.size());
+
+    for (int i = 0; i < static_cast<int>(lhsGlobal.size()); ++i) {
+        lhsG2L[lhsGlobal[i]] = i;
+    }
+    for (int i = 0; i < static_cast<int>(rhsGlobal.size()); ++i) {
+        rhsG2L[rhsGlobal[i]] = i;
+    }
+
+    for (const auto& gidLocal : lhsG2L) {
+        const int gid = gidLocal.first;
+        const int li = gidLocal.second;
+        const auto riIt = rhsG2L.find(gid);
+        assert(riIt != rhsG2L.end());
+        const int ri = riIt->second;
+
+        assert(std::abs(lhs.cellVolume(li) - rhs.cellVolume(ri)) < tol);
+        const auto& lc = lhs.cellCentroid(li);
+        const auto& rc = rhs.cellCentroid(ri);
+        for (int d = 0; d < 3; ++d) {
+            assert(std::abs(lc[d] - rc[d]) < tol);
+        }
+
+        const auto lecl = lhs.getEclCentroid(li);
+        const auto recl = rhs.getEclCentroid(ri);
+        for (int d = 0; d < 3; ++d) {
+            assert(std::abs(lecl[d] - recl[d]) < tol);
+        }
+    }
+}
+
+} // namespace
 
 template <class GridView>
 void testGridIteration( const GridView& gridView, const int nElem )
@@ -184,6 +412,34 @@ int main(int argc, char** argv )
         std::cout << " " << '\n';
     }
 
+    {
+        // Roundtrip: cornerpoint -> UnstructuredGrid file -> CpGrid,
+        // and compare with direct CpGrid cornerpoint construction.
+        std::vector<double> coord = ecl_grid.getCOORD();
+        std::vector<double> zcorn = ecl_grid.getZCORN();
+        std::vector<int> actnum = ecl_grid.getACTNUM();
+
+        grdecl g{};
+        g.dims[0] = static_cast<int>(ecl_grid.getNX());
+        g.dims[1] = static_cast<int>(ecl_grid.getNY());
+        g.dims[2] = static_cast<int>(ecl_grid.getNZ());
+        g.coord = coord.data();
+        g.zcorn = zcorn.data();
+        g.actnum = actnum.empty() ? nullptr : actnum.data();
+
+        std::unique_ptr<UnstructuredGrid, decltype(&destroy_grid)> ug(
+            create_grid_cornerpoint(&g, 0.0, 0),
+            &destroy_grid);
+        assert(ug);
+
+        const std::string roundtripFile = "cpgrid_cornerpoint_roundtrip.txt";
+        serializeUnstructuredGridToFile(*ug, roundtripFile);
+
+        Grid roundtripGrid(roundtripFile);
+        compareCpGridCellsByGlobalId(grid, roundtripGrid);
+
+        std::remove(roundtripFile.c_str());
+    }
 
 #endif
 
@@ -198,6 +454,58 @@ int main(int argc, char** argv )
 
     Dune::GridPtr< Grid > gridPtr( dgfFile );
     testGrid( *gridPtr, "CpGrid_dgf", 64, 125 );
+
+    {
+        // Test unstructured grid read from file, constructed from filename.
+        const std::string gridFileName = "cpgrid_test_from_filename.txt";
+        std::stringstream gridFile;
+        std::ofstream out(gridFileName);
+
+        // UnstructuredGrid file format:
+        // ndims ncells nfaces nnodes nfacenodes ncellfaces has_tag has_indexmap
+        gridFile << "3 1 6 8 24 6 1 1" << std::endl;
+        gridFile << "1 1 1" << std::endl;
+
+        // node coordinates (8 * 3)
+        gridFile << "0 0 0  1 0 0  0 1 0  1 1 0  0 0 1  1 0 1  0 1 1  1 1 1" << std::endl;
+
+        // face_nodepos (nfaces + 1)
+        gridFile << "0 4 8 12 16 20 24" << std::endl;
+        // face_nodes (6 faces * 4 nodes)
+        gridFile << "0 2 6 4  1 5 7 3  0 4 5 1  2 3 7 6  0 1 3 2  4 6 7 5" << std::endl;
+
+        // face_cells (2 * nfaces)
+        gridFile << "0 -1  0 -1  0 -1  0 -1  0 -1  0 -1" << std::endl;
+
+        // face_areas (nfaces)
+        gridFile << "1 1 1 1 1 1" << std::endl;
+        // face_centroids (nfaces * 3)
+        gridFile << "0 0.5 0.5  1 0.5 0.5  0.5 0 0.5  0.5 1 0.5  0.5 0.5 0  0.5 0.5 1" << std::endl;
+        // face_normals (nfaces * 3)
+        gridFile << "-1 0 0  1 0 0  0 -1 0  0 1 0  0 0 -1  0 0 1" << std::endl;
+
+        // cell_facepos (ncells + 1)
+        gridFile << "0 6" << std::endl;
+        // cell_faces + facetags (ncellfaces pairs)
+        // facetags: 0/1 I-/I+, 2/3 J-/J+, 4/5 K-/K+
+        gridFile << "0 0  1 1  2 2  3 3  4 4  5 5" << std::endl;
+
+        // global_cell map (ncells)
+        gridFile << "0" << std::endl;
+        // cell_volumes (ncells)
+        gridFile << "1" << std::endl;
+        // cell_centroids (ncells * 3)
+        gridFile << "0.5 0.5 0.5" << std::endl;
+
+        out << gridFile.str();
+        out.close();
+
+        Grid fileGrid(gridFileName);
+        assert(fileGrid.size(0) == 1);
+        assert(fileGrid.size(3) == 8);
+
+        std::remove(gridFileName.c_str());
+    }
 
     return 0;
 }

--- a/tests/test_polyhedralgrid.cpp
+++ b/tests/test_polyhedralgrid.cpp
@@ -455,5 +455,35 @@ int main(int argc, char** argv )
         gridcheck( *gridPtr );
     }
 
+    {
+        // Test 2D grid embedded in a 3D domain, constructed from filename.
+        const std::string gridFileName = "polyhedral_grid_test_from_filename.txt";
+        std::stringstream gridFile;
+        std::ofstream out(gridFileName);
+
+        gridFile << "3 1 3 3 6 3 0 0" << std::endl;
+        gridFile << "0 0 0" << std::endl;
+        gridFile << "0.0 0.0 1.0 0.0 1.0 0.0 0.0 1.0 1.0" << std::endl;
+        gridFile << "0 2 4 6" << std::endl;
+        gridFile << "0 1 0 2 1 2" << std::endl;
+        gridFile << "0 -1 0 -1 0 -1" << std::endl;
+        gridFile << "1.4142135623730951 1.0 1.0" << std::endl;
+        gridFile << "0.0 0.5 0.5 0.0 0.5 1.0 0.0 1.0 0.5" << std::endl;
+        gridFile << "-1.1102230246251565e-16 -1.0 -1.0 1.1102230246251565e-16 0.0 1.0 0.0 1.0 0.0" << std::endl;
+        gridFile << "0 3" << std::endl;
+        gridFile << "0 1 2" << std::endl;
+        gridFile << "0.5" << std::endl;
+        gridFile << "0.0 0.6666666666666666 0.6666666666666666" << std::endl;
+
+        out << gridFile.str();
+        out.close();
+
+        typedef Dune::PolyhedralGrid<2, 3, float> Grid;
+        Grid grid(gridFileName);     // <- constructor using filename/read_grid()
+        gridcheck(grid);
+
+        std::remove(gridFileName.c_str());
+    }
+
     return 0;
 }


### PR DESCRIPTION
Enable loading Sintef legacy unstructured-grid files into CpGrid via:
- CpGrid(filename) constructor for direct file loading
- readUnstructuredGridFile() method for MPI-aware loading
- CpGridData::processUnstructuredGrid() for format conversion

Add export utility (export_grid) to convert CpGrid back to unstructured format.

Support includes:
- MPI-parallel file reading (rank 0 reads and broadcasts)
- Full grid topology conversion (cells, faces, vertices, adjacency)
- Face axis tagging for K-direction identification
- Validation of 3D grids, face tags, and cell structure
- Comprehensive test coverage for both CpGrid and PolyhedralGrid

New files:
- examples/export_grid.cpp: CpGrid → unstructured format converter
- Complete test cases for unstructured grid operations