### PR TITLE
SparseTable initializer_list constructor

### DIFF
--- a/opm/grid/utility/SparseTable.hpp
+++ b/opm/grid/utility/SparseTable.hpp
@@ -44,6 +44,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <initializer_list>
 #include <numeric>
 #include <ostream>
 #include <type_traits>
@@ -147,6 +148,16 @@ private:
             }
         }
 
+
+        /// Initializer list constructor for easy construction of small SparseTables.
+        SparseTable(std::initializer_list<std::initializer_list<T>> initlist) requires (std::is_same_v<Storage<T>, std::vector<T>>)
+        {
+            row_start_.push_back(0);
+            for (const auto& row : initlist) {
+                data_.insert(data_.end(), row);
+                row_start_.push_back(data_.size());
+            }
+        }
 
         /// Sets the table to contain the given data, organized into
         /// rows as indicated by the given row sizes.

--- a/opm/grid/utility/SparseTable.hpp
+++ b/opm/grid/utility/SparseTable.hpp
@@ -53,7 +53,7 @@ namespace Opm
 {
 
 
-    template<class>
+template<class>
 inline constexpr bool always_false_v = false;
 
 // Poison iterator is a helper class that will allow for compilation only when it is not used.
@@ -132,10 +132,10 @@ private:
                     IntegerIter rowsize_beg, IntegerIter rowsize_end)
             : data_(data_beg, data_end)
         {
-	    setRowStartsFromSizes(rowsize_beg, rowsize_end);
+            setRowStartsFromSizes(rowsize_beg, rowsize_end);
         }
 
-        SparseTable (Storage<T>&& data, Storage<int>&& row_starts)
+        SparseTable(Storage<T>&& data, Storage<int>&& row_starts)
             : data_(std::move(data))
             , row_start_(std::move(row_starts))
         {
@@ -149,7 +149,7 @@ private:
 
 
         /// Sets the table to contain the given data, organized into
-	/// rows as indicated by the given row sizes.
+        /// rows as indicated by the given row sizes.
         /// \param data_beg The start of the table data.
         /// \param data_end One-beyond-end of the table data.
         /// \param rowsize_beg The start of the row length data.
@@ -158,8 +158,8 @@ private:
         void assign(DataIter data_beg, DataIter data_end,
                     IntegerIter rowsize_beg, IntegerIter rowsize_end)
         {
-	    data_.assign(data_beg, data_end);
-	    setRowStartsFromSizes(rowsize_beg, rowsize_end);
+            data_.assign(data_beg, data_end);
+            setRowStartsFromSizes(rowsize_beg, rowsize_end);
         }
 
 

--- a/tests/test_sparsetable.cpp
+++ b/tests/test_sparsetable.cpp
@@ -108,6 +108,10 @@ BOOST_AUTO_TEST_CASE(construction_and_queries)
     }
     BOOST_CHECK(st2 == st2_allocate);
 
+    // Test initializer_list constructor.
+    const SparseTable<int> st2_initlist = { {0}, {}, {1, 2}, {3, 4, 5, 6}, {7, 8, 9} };
+    BOOST_CHECK(st2 == st2_initlist);
+
     // One element too few.
     BOOST_CHECK_THROW(const SparseTable<int> st3(elem, elem + num_elem - 1, rowsizes, rowsizes + num_rows), std::exception);
 


### PR DESCRIPTION
Makes it easier to make quick tables for tests etc.

Also: fixing some weird indentation errors in SparseTable.hpp (separate commit).