### PR TITLE
Fixing warnings

### DIFF
--- a/tests/cpgrid/lgr/lgrIJK_test.cpp
+++ b/tests/cpgrid/lgr/lgrIJK_test.cpp
@@ -353,8 +353,8 @@ SCHEDULE
     BOOST_TEST(lgr1IJK[52][2] == 2);
 
     // Accessing inactive (non-existing) cells
-    BOOST_CHECK_THROW(lgrCartesianIdxToCellIdx.at(70), std::out_of_range);
-    BOOST_CHECK_THROW(lgrCartesianIdxToCellIdx.at(170), std::out_of_range);
+    BOOST_CHECK_THROW(static_cast<void>(lgrCartesianIdxToCellIdx.at(70)), std::out_of_range);
+    BOOST_CHECK_THROW(static_cast<void>(lgrCartesianIdxToCellIdx.at(170)), std::out_of_range);
 }
 
 BOOST_AUTO_TEST_CASE(fullInactiveParentCellsBlock_lgrCOORD_throws, *boost::unit_test::disabled())
@@ -433,5 +433,5 @@ SCHEDULE
                       lgr1IJK.size());
 
     // Accessing inactive (non-existing) cell
-    BOOST_CHECK_THROW(lgrCartesianIdxToCellIdx.at(0), std::out_of_range);
+    BOOST_CHECK_THROW(static_cast<void>(lgrCartesianIdxToCellIdx.at(0)), std::out_of_range);
 }

--- a/tests/cpgrid/lgr/lgr_cartesian_idx_test.cpp
+++ b/tests/cpgrid/lgr/lgr_cartesian_idx_test.cpp
@@ -106,7 +106,7 @@ void checkGlobalCellLgr(Dune::CpGrid& grid)
                 BOOST_CHECK_EQUAL( leafIdx_to_localCartesianIdxSets[leaf_idx][1], global_cell_level);
             }
             else {
-                BOOST_CHECK_THROW( localCartesianIdxSets_to_leafIdx[element.level()].at(global_cell_level), std::out_of_range);
+                BOOST_CHECK_THROW( static_cast<void>(localCartesianIdxSets_to_leafIdx[element.level()].at(global_cell_level)), std::out_of_range);
             }
         }
     }

--- a/tests/test_compressed_cartesian_mapping.cpp
+++ b/tests/test_compressed_cartesian_mapping.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(mapping)
     BOOST_CHECK_EQUAL(cartesian_to_compressed.at(9), 7);
 
     const int non_existing_index = 1829;
-    BOOST_CHECK_THROW(cartesian_to_compressed.at(non_existing_index), std::out_of_range);
+    BOOST_CHECK_THROW(static_cast<void>(cartesian_to_compressed.at(non_existing_index)), std::out_of_range);
 
     const std::vector<int> compressed_to_cartesian = Opm::compressedToCartesian(num_cells,  global_cell.data());
 

--- a/tests/test_graphofgrid.cpp
+++ b/tests/test_graphofgrid.cpp
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(SimpleGraph)
     BOOST_REQUIRE(edgeL[0]==1.);
     BOOST_REQUIRE(edgeL[3]==1.);
     BOOST_REQUIRE(edgeL[6]==1.);
-    BOOST_REQUIRE_THROW(edgeL.at(4),std::out_of_range); // not a neighbor
+    BOOST_REQUIRE_THROW(static_cast<void>(edgeL.at(4)),std::out_of_range); // not a neighbor
 
     BOOST_REQUIRE_THROW(gog.edgeList(10),std::logic_error); // vertex 10 is not in the graph
 }
@@ -83,17 +83,17 @@ BOOST_AUTO_TEST_CASE(SimpleGraphWithVertexContraction)
 
     auto edgeL = gog.edgeList(3); // std::map<int,float>(gID,edgeWeight)
     BOOST_REQUIRE(edgeL[1]==1);
-    BOOST_REQUIRE_THROW(edgeL.at(0),std::out_of_range);
+    BOOST_REQUIRE_THROW(static_cast<void>(edgeL.at(0)),std::out_of_range);
     gog.contractVertices(0,1);
     BOOST_REQUIRE(gog.size()==7);
     edgeL = gog.edgeList(3);
-    BOOST_REQUIRE_THROW(edgeL.at(1),std::out_of_range);
+    BOOST_REQUIRE_THROW(static_cast<void>(edgeL.at(1)),std::out_of_range);
     BOOST_REQUIRE(edgeL[0]==1);
     edgeL = gog.edgeList(0);
     BOOST_REQUIRE(edgeL.size()==4);
     BOOST_REQUIRE(edgeL[2]==1); // neighbor of 0
     BOOST_REQUIRE(edgeL[3]==1); // neighbor of 1
-    BOOST_REQUIRE_THROW(edgeL.at(1),std::out_of_range); // removed vertex, former neighbor of 0
+    BOOST_REQUIRE_THROW(static_cast<void>(edgeL.at(1)),std::out_of_range); // removed vertex, former neighbor of 0
 
     gog.contractVertices(0,2);
     BOOST_REQUIRE(gog.size()==6);


### PR DESCRIPTION
Fixing warnings of the type:
```bash
opm/opm-grid/tests/test_graphofgrid.cpp:68:25: warning: ignoring return value of function declared with
      'nodiscard' attribute [-Wunused-result]
   68 |     BOOST_REQUIRE_THROW(edgeL.at(4),std::out_of_range);
```