### PR TITLE
MinpvProcessor: guard merge branch against out-of-bounds zcorn access

### DIFF
--- a/opm/grid/MinpvProcessor.cpp
+++ b/opm/grid/MinpvProcessor.cpp
@@ -228,16 +228,18 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                         low_pv_active = pv[c_below] < minpvv[c_below] && active;
                     }
 
+                    // The column ran off the grid bottom: the loop above left the last
+                    // cell via the kk_iter == dims_[2] break, and that break only exits
+                    // the inner while, not this column's for-loop.  There is no cell
+                    // below to receive the void or to connect by an NNC, and c_below
+                    // is stale, so neither branch can proceed.  Without this guard the
+                    // merge branch reads and writes 8 doubles past the end of zcorn.
+                    if (kk_iter == dims_[2]) {
+                        break;
+                    }
+
                     // create nnc if false or merge the cells if true
                     if (mergeMinPVCells && c_low_pv_active) {
-                        // Column ran off the grid bottom: no cell below to receive
-                        // the void.  Without this guard the zcorn access at
-                        // kk_iter == dims_[2] reads and writes 8 doubles past the
-                        // end of the zcorn array.
-                        if (kk_iter == dims_[2]) {
-                            break;
-                        }
-
                         // Bottom cell inactive: leave the geometry untouched, no merge.
                         if (!actnum.empty() && !actnum[c_below]) {
                             kk = kk_iter;
@@ -256,8 +258,9 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                     else
                     {
 
-                        // No top or bottom cell, so no nnc is created.
-                        if (kk == 0 || kk_iter == dims_[2]) {
+                        // No top cell, so no nnc is created.  (The no-bottom-cell case,
+                        // kk_iter == dims_[2], is handled by the guard above.)
+                        if (kk == 0) {
                             kk = kk_iter;
                             continue;
                         }

--- a/opm/grid/MinpvProcessor.cpp
+++ b/opm/grid/MinpvProcessor.cpp
@@ -235,8 +235,7 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                         // kk_iter == dims_[2] reads and writes 8 doubles past the
                         // end of the zcorn array.
                         if (kk_iter == dims_[2]) {
-                            kk = kk_iter;
-                            continue;
+                            break;
                         }
 
                         // Bottom cell inactive: leave the geometry untouched, no merge.

--- a/opm/grid/MinpvProcessor.cpp
+++ b/opm/grid/MinpvProcessor.cpp
@@ -230,6 +230,21 @@ MinpvProcessor::process(const std::vector<double>& thickness,
 
                     // create nnc if false or merge the cells if true
                     if (mergeMinPVCells && c_low_pv_active) {
+                        // Column ran off the grid bottom: no cell below to receive
+                        // the void.  Without this guard the zcorn access at
+                        // kk_iter == dims_[2] reads and writes 8 doubles past the
+                        // end of the zcorn array.
+                        if (kk_iter == dims_[2]) {
+                            kk = kk_iter;
+                            continue;
+                        }
+
+                        // Bottom cell inactive: leave the geometry untouched, no merge.
+                        if (!actnum.empty() && !actnum[c_below]) {
+                            kk = kk_iter;
+                            continue;
+                        }
+
                         // Set lower k coordinates of cell below to upper cells's coordinates.
                         // i.e fill the void using the cell below
                         std::array<double, 8> cz_below = getCellZcorn(ii, jj, kk_iter, zcorn);

--- a/tests/test_minpvprocessor.cpp
+++ b/tests/test_minpvprocessor.cpp
@@ -388,3 +388,45 @@ BOOST_AUTO_TEST_CASE(Processing)
     BOOST_CHECK_EQUAL(minpv_result7.nnc.size(), 1);
     BOOST_CHECK_EQUAL_COLLECTIONS(z7.begin(), z7.end(), zcorn7after.begin(), zcorn7after.end());
 }
+
+BOOST_AUTO_TEST_CASE(MergeColumnRunsOffGridBottom)
+{
+    // Regression test: with mergeMinPVCells == true and a column whose
+    // low-pore-volume cells extend all the way to the grid bottom, the
+    // inner column walk exits with kk_iter == dims[2].  The merge branch
+    // then accessed getCellZcorn(ii, jj, kk_iter, ...) which reads -- and
+    // via setCellZcorn writes -- 8 doubles past the end of the zcorn
+    // array.  Detect the out-of-bounds write with sentinel padding placed
+    // directly behind the grid's zcorn data.
+    //
+    // 1x1x3 column, every cell active but below the pore volume limit.
+    std::vector<double> zcorn = { 0, 0, 0, 0,
+                                  1, 1, 1, 1,
+                                  1, 1, 1, 1,
+                                  2, 2, 2, 2,
+                                  2, 2, 2, 2,
+                                  3, 3, 3, 3 };
+    const std::size_t ncorn = zcorn.size();
+    const double sentinel = -999.25;
+    std::vector<double> padded = zcorn;
+    padded.resize(ncorn + 8, sentinel); // guard region behind zcorn
+
+    std::vector<double> pv = { 0.1, 0.1, 0.1 };
+    std::vector<double> minpvv(3, 0.5);
+    std::vector<int> actnum = { 1, 1, 1 };
+    std::vector<double> thickness = { 1, 1, 1 };
+    const double z_threshold = 0.0;
+    const bool mergeMinPVCells = true;
+
+    Opm::MinpvProcessor mp(1, 1, 3);
+    const auto result = mp.process(thickness, z_threshold, 1e20, pv, minpvv, actnum,
+                                   mergeMinPVCells, padded.data());
+
+    // All three cells are below the pore volume limit and must be removed.
+    BOOST_CHECK_EQUAL(result.removed_cells.size(), 3);
+
+    // The guard region must be untouched: no out-of-bounds zcorn access.
+    for (std::size_t i = ncorn; i < padded.size(); ++i) {
+        BOOST_CHECK_EQUAL(padded[i], sentinel);
+    }
+}

--- a/tests/test_minpvprocessor.cpp
+++ b/tests/test_minpvprocessor.cpp
@@ -27,6 +27,8 @@
 
 #include <opm/grid/MinpvProcessor.hpp>
 
+#include <algorithm>
+
 
 BOOST_AUTO_TEST_CASE(GAP_MAXGAP)
 {
@@ -389,6 +391,38 @@ BOOST_AUTO_TEST_CASE(Processing)
     BOOST_CHECK_EQUAL_COLLECTIONS(z7.begin(), z7.end(), zcorn7after.begin(), zcorn7after.end());
 }
 
+namespace {
+
+    /// 1x1xN column of unit cells, with 8 doubles of sentinel padding behind
+    /// the zcorn data so an out-of-bounds write is caught deterministically.
+    struct PaddedColumn
+    {
+        explicit PaddedColumn(const int nz)
+        {
+            for (int k = 0; k < nz; ++k) {
+                const double top = k, bot = k + 1;
+                for (int i = 0; i < 4; ++i) { padded.push_back(top); }
+                for (int i = 0; i < 4; ++i) { padded.push_back(bot); }
+            }
+
+            ncorn = padded.size();
+            padded.resize(ncorn + 8, sentinel);
+        }
+
+        void checkGuardIntact() const
+        {
+            for (std::size_t i = ncorn; i < padded.size(); ++i) {
+                BOOST_CHECK_EQUAL(padded[i], sentinel);
+            }
+        }
+
+        static constexpr double sentinel = -999.25;
+        std::vector<double> padded{};
+        std::size_t ncorn{};
+    };
+
+} // Anonymous namespace
+
 BOOST_AUTO_TEST_CASE(MergeColumnRunsOffGridBottom)
 {
     // Regression test: with mergeMinPVCells == true and a column whose
@@ -400,33 +434,70 @@ BOOST_AUTO_TEST_CASE(MergeColumnRunsOffGridBottom)
     // directly behind the grid's zcorn data.
     //
     // 1x1x3 column, every cell active but below the pore volume limit.
-    std::vector<double> zcorn = { 0, 0, 0, 0,
-                                  1, 1, 1, 1,
-                                  1, 1, 1, 1,
-                                  2, 2, 2, 2,
-                                  2, 2, 2, 2,
-                                  3, 3, 3, 3 };
-    const std::size_t ncorn = zcorn.size();
-    const double sentinel = -999.25;
-    std::vector<double> padded = zcorn;
-    padded.resize(ncorn + 8, sentinel); // guard region behind zcorn
+    PaddedColumn col{3};
 
-    std::vector<double> pv = { 0.1, 0.1, 0.1 };
-    std::vector<double> minpvv(3, 0.5);
-    std::vector<int> actnum = { 1, 1, 1 };
-    std::vector<double> thickness = { 1, 1, 1 };
-    const double z_threshold = 0.0;
-    const bool mergeMinPVCells = true;
+    const std::vector<double> pv = { 0.1, 0.1, 0.1 };
+    const std::vector<double> minpvv(3, 0.5);
+    const std::vector<int> actnum = { 1, 1, 1 };
+    const std::vector<double> thickness = { 1, 1, 1 };
 
     Opm::MinpvProcessor mp(1, 1, 3);
-    const auto result = mp.process(thickness, z_threshold, 1e20, pv, minpvv, actnum,
-                                   mergeMinPVCells, padded.data());
+    const auto result = mp.process(thickness, /*z_threshold =*/ 0.0, 1e20,
+                                   pv, minpvv, actnum,
+                                   /*mergeMinPVCells =*/ true, col.padded.data());
 
     // All three cells are below the pore volume limit and must be removed.
     BOOST_CHECK_EQUAL(result.removed_cells.size(), 3);
 
-    // The guard region must be untouched: no out-of-bounds zcorn access.
-    for (std::size_t i = ncorn; i < padded.size(); ++i) {
-        BOOST_CHECK_EQUAL(padded[i], sentinel);
-    }
+    col.checkGuardIntact();
+}
+
+
+BOOST_AUTO_TEST_CASE(MergeRunsOffBottomFirstCellStays)
+{
+    // As MergeColumnRunsOffGridBottom, but the topmost cell is above the pore
+    // volume limit.  The column walk still runs off the grid bottom, starting
+    // one cell lower.  The retained cell must survive and the guard region
+    // must be untouched.
+    PaddedColumn col{4};
+
+    const std::vector<double> pv = { 1.0, 0.1, 0.1, 0.1 };
+    const std::vector<double> minpvv(4, 0.5);
+    const std::vector<int> actnum = { 1, 1, 1, 1 };
+    const std::vector<double> thickness = { 1, 1, 1, 1 };
+
+    Opm::MinpvProcessor mp(1, 1, 4);
+    const auto result = mp.process(thickness, /*z_threshold =*/ 0.0, 1e20,
+                                   pv, minpvv, actnum,
+                                   /*mergeMinPVCells =*/ true, col.padded.data());
+
+    const auto& removed = result.removed_cells;
+    BOOST_CHECK(std::find(removed.begin(), removed.end(), 0) == removed.end());
+    BOOST_CHECK_EQUAL(removed.size(), 3);
+
+    col.checkGuardIntact();
+}
+
+BOOST_AUTO_TEST_CASE(MergeRunsOffBottomSecondCellStays)
+{
+    // The retained cell is in the middle of the column: cell 0 is below the
+    // limit and merges into cell 1, then cells 2 and 3 are below the limit and
+    // their walk runs off the grid bottom.
+    PaddedColumn col{4};
+
+    const std::vector<double> pv = { 0.1, 1.0, 0.1, 0.1 };
+    const std::vector<double> minpvv(4, 0.5);
+    const std::vector<int> actnum = { 1, 1, 1, 1 };
+    const std::vector<double> thickness = { 1, 1, 1, 1 };
+
+    Opm::MinpvProcessor mp(1, 1, 4);
+    const auto result = mp.process(thickness, /*z_threshold =*/ 0.0, 1e20,
+                                   pv, minpvv, actnum,
+                                   /*mergeMinPVCells =*/ true, col.padded.data());
+
+    const auto& removed = result.removed_cells;
+    BOOST_CHECK(std::find(removed.begin(), removed.end(), 1) == removed.end());
+    BOOST_CHECK_EQUAL(removed.size(), 3);
+
+    col.checkGuardIntact();
 }


### PR DESCRIPTION
Bug. In MinpvProcessor::process, the mergeMinPVCells branch reads and writes getCellZcorn(ii, jj, kk_iter, ...) without the bottom-of-grid guard that the NNC branch already has. When a column of low-pore-volume cells runs off the grid bottom, the inner column walk exits with kk_iter == dims_[2] and the void-fill then accesses 8 doubles past the end of the zcorn array — both a read and a write. The merge is also performed when the receiving bottom cell is inactive.

Fix. Two early-outs mirroring the NNC branch: skip when the column ran off the bottom, and skip when the receiving cell is inactive.

Test. MergeColumnRunsOffGridBottom in tests/test_minpvprocessor.cpp places sentinel padding directly behind the zcorn data and asserts it is untouched, so the out-of-bounds write is detected deterministically rather than relying on a crash.

Verified on this branch: with the fix reverted the new case produces 5 failures (wrong removed_cells count plus 4 clobbered sentinels) while all 5 pre-existing cases still pass; with the fix, all 6 pass.