### PR TITLE
WellConnections: bound the Cartesian->compressed lookup

### DIFF
--- a/opm/grid/common/WellConnections.cpp
+++ b/opm/grid/common/WellConnections.cpp
@@ -115,6 +115,22 @@ void WellConnections::init([[maybe_unused]] const std::vector<OpmWellType>& well
 #if HAVE_OPM_COMMON
     well_indices_.resize(wells.size());
 
+    // Both loops below index cartesian_to_compressed with a position derived
+    // from the connection, and neither checked that the position is actually
+    // inside the map.  Bound the lookup against the container that is being
+    // indexed, so that a position which is not a level-zero Cartesian index
+    // cannot read past the end of it.
+    const auto lookup = [&cartesian_to_compressed](const int cart_grid_idx)
+    {
+        if ((cart_grid_idx < 0) ||
+            (static_cast<std::size_t>(cart_grid_idx) >= cartesian_to_compressed.size()))
+        {
+            return -1;
+        }
+
+        return cartesian_to_compressed[cart_grid_idx];
+    };
+
     // We assume that we know all the wells.
     int index=0;
     for (const auto& well : wells) {
@@ -126,7 +142,7 @@ void WellConnections::init([[maybe_unused]] const std::vector<OpmWellType>& well
             int j = connection.getJ();
             int k = connection.getK();
             int cart_grid_idx = i + cartesianSize[0]*(j + cartesianSize[1]*k);
-            int compressed_idx = cartesian_to_compressed[cart_grid_idx];
+            int compressed_idx = lookup(cart_grid_idx);
             if ( compressed_idx >= 0 ) // Ignore connections in inactive cells.
             {
                 well_indices.insert(compressed_idx);
@@ -135,7 +151,7 @@ void WellConnections::init([[maybe_unused]] const std::vector<OpmWellType>& well
         const auto possibleFutureConnectionSetIt = possibleFutureConnections.find(well.name());
         if (possibleFutureConnectionSetIt != possibleFutureConnections.end()) {
             for (auto& cart_grid_idx : possibleFutureConnectionSetIt->second) {
-                int compressed_idx = cartesian_to_compressed[cart_grid_idx];
+                int compressed_idx = lookup(cart_grid_idx);
                 if ( compressed_idx >= 0 ) // Ignore connections in inactive cells.
                 {
                     well_indices.insert(compressed_idx);


### PR DESCRIPTION
Narrowed after review — this is now only the out-of-bounds read. The LGR-specific handling and its test have been dropped; see the discussion below.

## What

`WellConnections::init` translates each connection into a compressed cell index:

```cpp
cart_grid_idx = i + nx*(j + ny*k);
compressed_idx = cartesian_to_compressed[cart_grid_idx];
```

and does the same for `possibleFutureConnections`. Neither lookup checks that the computed position is inside `cartesian_to_compressed` before indexing it.

The map is sized by the level-zero Cartesian grid, and a connection is not obliged to carry a position in that grid. When the position lands past the end, that is an out-of-bounds read during load balancing.

## The change

Both lookups go through a helper that returns −1 for a position outside the map. −1 then flows into the **existing** "ignore connections in inactive cells" test — no new control flow, and no new notion of a skipped connection: out-of-map is handled exactly as inactive already is.

The bound is `cartesian_to_compressed.size()`, i.e. the container actually being indexed, rather than the product of `cartesianSize`. The two agree in the `CpGrid` constructor, but the four-argument constructor takes them independently, so bounding against the container is the honest check.

Nothing changes for a position that was already in range, so grids whose connections all address level zero are unaffected.

## On the review comments

> it is 10 steps ahead of our schedule and we should first make the simple cases work

Understood, and dropped accordingly. The previous version also skipped connections by refinement level, which is a modelling decision about what belongs in the level-zero well graph. That is the part that was ahead of schedule, and it is gone — nothing here depends on refinement any more.

> Some of this code is more dangerous than before

Fair on the earlier version: it introduced a second, silent reason for a connection to disappear from the well graph, including for ordinary level-zero connections, with no diagnostic. This version does not add a skip path at all — it reuses the inactive-cell one — so the only behavioural difference is that a read which was undefined now returns −1.

## Testing

`test_graphofgrid` and the zoltan/partition tests pass. Built against opm-common master.

No unit test is included: the defect is an out-of-bounds read, and the value it returns is unspecified, so an assertion on the result is not decisive. It is visible under a sanitizer build. Happy to add an ASan-guarded case if you would like one.

## Not needed by anything in flight

For scheduling: none of the opm-common or opm-simulators PRs currently open depend on this. Pending it costs nothing on my side — say the word and I will close it and carry the fix locally.
