### PR TITLE
MinpvProcessor: opt-in thin-cell handling

### DIFF
--- a/opm/grid/MinpvProcessor.cpp
+++ b/opm/grid/MinpvProcessor.cpp
@@ -77,7 +77,8 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                         bool pinchOption4ALL,
                         const std::vector<double>& permz,
                         const std::function<double(int)>& multz,
-                        const double tolerance_unique_points) const
+                        const double tolerance_unique_points,
+                        const bool thin_cells_as_minpv) const
 {
     // Algorithm:
     // 1. Process each column of cells (with same i and j
@@ -132,7 +133,7 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                 bool c_active = actnum.empty() || actnum[c];
                 bool c_thin = (thickness[c] <= z_tolerance);
                 bool c_thin_inactive = !c_active && c_thin;
-                bool c_low_pv_active = pv[c] < minpvv[c] && c_active;
+                bool c_low_pv_active = (pv[c] < minpvv[c] && c_active) || (thin_cells_as_minpv && c_thin && c_active);
 
                 if (c_low_pv_active || c_thin_inactive) {
                     std::array<double, 8> cz = getCellZcorn(ii, jj, kk, zcorn);
@@ -175,7 +176,7 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                     bool active = actnum.empty() || actnum[c_below];
                     bool thin = (thickness[c_below] <= z_tolerance);
                     bool thin_inactive = !active && thin;
-                    bool low_pv_active = pv[c_below] < minpvv[c_below] && active;
+                    bool low_pv_active = ((pv[c_below] < minpvv[c_below]) && active) || (thin_cells_as_minpv && thin && active);
 
 
                     while ( (thin_inactive || low_pv_active) && kk_iter < dims_[2] )
@@ -232,7 +233,7 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                         active = actnum.empty() || actnum[c_below];
                         thin = (thickness[c_below] <= z_tolerance);
                         thin_inactive = (!actnum.empty() && !actnum[c_below]) && thin;
-                        low_pv_active = pv[c_below] < minpvv[c_below] && active;
+                        low_pv_active = ((pv[c_below] < minpvv[c_below]) && active) || (thin_cells_as_minpv && thin && active);
                     }
 
                     // The column ran off the grid bottom: the loop above left the last
@@ -246,7 +247,10 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                     }
 
                     // create nnc if false or merge the cells if true
-                    if (mergeMinPVCells && c_low_pv_active) {
+                    // For edge-conformal grids (thin_cells_as_minpv) merge whenever
+                    // requested so the grid stays topologically connected; otherwise
+                    // keep the historic behavior of merging only low-pv cells.
+                    if (mergeMinPVCells && (c_low_pv_active || thin_cells_as_minpv)) {
                         // Bottom cell inactive: leave the geometry untouched, no merge.
                         if (!actnum.empty() && !actnum[c_below]) {
                             kk = kk_iter;
@@ -271,6 +275,7 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                             kk = kk_iter;
                             continue;
                         }
+
                         // bottom cell not active, hence no nnc is created
                         if (!actnum.empty() && !actnum[c_below]) {
                             kk = kk_iter;
@@ -284,7 +289,7 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                         auto above_active = actnum.empty() || actnum[c_above];
                         auto above_inactive = !actnum.empty() && !actnum[c_above];
                         auto above_thin = thickness[c_above] < z_tolerance;
-                        auto above_small_pv = pv[c_above] < minpvv[c_above];
+                        auto above_small_pv = (pv[c_above] < minpvv[c_above]) || (thin_cells_as_minpv && above_thin);
 
                         if ((above_inactive && above_thin) || (above_active && above_small_pv
                                                                && (!pinchNOGAP || above_thin) ) ) {
@@ -292,7 +297,7 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                                 c_above = ii + dims_[0] * (jj + dims_[1] * (k_above));
                                 above_active = actnum.empty() || actnum[c_above];
                                 above_inactive = !actnum.empty() && !actnum[c_above];
-                                auto above_significant_pv = pv[c_above] > minpvv[c_above];
+                                auto above_significant_pv = !((pv[c_above] < minpvv[c_above]) || (thin_cells_as_minpv && thickness[c_above] < z_tolerance));
                                 auto above_broad = thickness[c_above] > z_tolerance;
 
                                 // \todo if condition seems wrong and should be the negation of above?
@@ -317,12 +322,19 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                         option4ALLZero = option4ALLZero || (!permz.empty() && permz[c_above] == 0.0) || multz(c_above) == 0.0;
                         nnc_allowed = nnc_allowed && (computeGap(cz_above, cz_below) < max_gap) && (!pinchOption4ALL || !option4ALLZero) ;
 
+                        // With thin_cells_as_minpv a thin cell counts as low-pv here
+                        // too; with it off these reduce to the plain pv comparison.
+                        const bool above_holds_volume = (pv[c_above] > minpvv[c_above])
+                            && !(thin_cells_as_minpv && thickness[c_above] < z_tolerance);
+                        const bool below_holds_volume = (pv[c_below] > minpvv[c_below])
+                            && !(thin_cells_as_minpv && thickness[c_below] < z_tolerance);
+
                         // Note that collapsed cells become inactive in preprocess.c
                         // We treat them as a barrier preventing NNCs here.
                         if ( nnc_allowed &&
                              (actnum.empty() || (actnum[c_above] && actnum[c_below])) &&
                              !isCollapsed(cz_below) && !isCollapsed(cz_above) &&
-                             pv[c_above] > minpvv[c_above] && pv[c_below] > minpvv[c_below]) {
+                             above_holds_volume && below_holds_volume) {
                             result.add_nnc(c_above, c_below);
                         }
                         kk = kk_iter;
@@ -330,7 +342,7 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                 }
                 else
                 {
-                    if (kk < dims_[2] - 1 && (actnum.empty() || actnum[c]) && pv[c] > minpvv[c] &&
+                    if (kk < dims_[2] - 1 && (actnum.empty() || actnum[c]) && !((pv[c] < minpvv[c]) || (thin_cells_as_minpv && thickness[c] < z_tolerance)) &&
                         multz(c) != 0.0)
                     {
                         // Check whether there is a gap to the neighbor below whose thickness is less
@@ -338,7 +350,7 @@ MinpvProcessor::process(const std::vector<double>& thickness,
                         int kk_below = kk + 1;
                         int c_below = ii + dims_[0] * (jj + dims_[1] * kk_below);
 
-                        if ((actnum.empty() || actnum[c_below]) && pv[c_below] > minpvv[c_below])
+                        if ((actnum.empty() || actnum[c_below]) && !((pv[c_below] < minpvv[c_below]) || (thin_cells_as_minpv && thickness[c_below] < z_tolerance)))
                         {
                             // Check MAX_GAP threshold
                             std::array<double, 8> cz = getCellZcorn(ii, jj, kk, zcorn);

--- a/opm/grid/MinpvProcessor.hpp
+++ b/opm/grid/MinpvProcessor.hpp
@@ -69,6 +69,9 @@ namespace Opm
         /// cell below will be changed to include the deleted volume if mergeMinPCCells is true
         /// els the volume will be lost
         /// \param[in]       tolerance_unique_points Tolerance used to identify points based on their cooridinates.
+        /// \param[in]       thin_cells_as_minpv If true, active cells thinner than z_tolerance are
+        ///                  treated like low-pore-volume cells (removed/merged).  Used for
+        ///                  edge-conformal grids, which must stay topologically connected.
         Result process(const std::vector<double>& thickness,
                        const double z_tolerance,
                        const double max_gap,
@@ -81,7 +84,8 @@ namespace Opm
                        const bool pinchOption4ALL = false,
                        const std::vector<double>& permz = {},
                        const std::function<double(int)>& multZ = [](int){ return 0;},
-                       const double tolerance_unique_points = 0) const;
+                       const double tolerance_unique_points = 0,
+                       const bool thin_cells_as_minpv = false) const;
     private:
         double computeGap(const std::array<double,8>& coord_above, const std::array<double,8>& coord_below) const;
         std::array<int,8> cornerIndices(const int i, const int j, const int k) const;

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -205,8 +205,11 @@ namespace cpgrid
                     return transMult.getMultiplier(cartindex, ::Opm::FaceDir::ZPlus) *
                         transMult.getMultiplier(cartindex, ::Opm::FaceDir::ZMinus);
                 };
+                // Edge-conformal grids must stay topologically connected: merge removed
+                // cells geometrically instead of bridging them with NNCs.
+                const bool mergeMinPVCells = edge_conformal;
                 minpv_result = mp.process(thickness, z_tolerance, ecl_grid.getPinchMaxEmptyGap(),
-                                          poreVolume, ecl_grid.getMinpvVector(), actnumData, false,
+                                          poreVolume, ecl_grid.getMinpvVector(), actnumData, mergeMinPVCells,
                                           zcornData.data(), nogap, pinchOptionALL,
                                           permZ, multZ, tolerance_unique_points);
                 if (!minpv_result.nnc.empty()) {
@@ -224,6 +227,11 @@ namespace cpgrid
 
             // Add PINCH NNCs.
             std::vector<Opm::NNCdata> pinchedNNCs;
+            if (edge_conformal) {
+                // Merged (not bridged) cells: an edge-conformal grid must not
+                // produce artificial faces via MINPV NNCs.
+                assert(minpv_result.nnc.empty());
+            }
 
             for (const auto& [cell1, cell2] : minpv_result.nnc) {
                 nnc_cells[PinchNNC].insert({cell1, cell2});
@@ -416,12 +424,21 @@ namespace cpgrid
         }
         else {
             // Make the grid.
+            auto pinchActive_copy = pinchActive;
+            if (edge_conformal) {
+                // Edge-conformal grids merged all removed cells geometrically;
+                // there must be no NNC bridging, and pinch handling must treat
+                // the merged columns as active gaps.
+                pinchActive_copy = true;
+                assert(nnc_cells[PinchNNC].empty());
+                assert(nnc_cells[ExplicitNNC].empty());
+            }
             this->processEclipseFormat(g,
                                        ecl_state,
                                        nnc_cells,
                                        false,
                                        turn_normals,
-                                       pinchActive,
+                                       pinchActive_copy,
                                        tolerance_unique_points,
                                        edge_conformal);
         }

--- a/opm/grid/cpgrid/processEclipseFormat.cpp
+++ b/opm/grid/cpgrid/processEclipseFormat.cpp
@@ -211,7 +211,8 @@ namespace cpgrid
                 minpv_result = mp.process(thickness, z_tolerance, ecl_grid.getPinchMaxEmptyGap(),
                                           poreVolume, ecl_grid.getMinpvVector(), actnumData, mergeMinPVCells,
                                           zcornData.data(), nogap, pinchOptionALL,
-                                          permZ, multZ, tolerance_unique_points);
+                                          permZ, multZ, tolerance_unique_points,
+                                          /* thin_cells_as_minpv = */ edge_conformal);
                 if (!minpv_result.nnc.empty()) {
                     this->zcorn = zcornData;
                 }


### PR DESCRIPTION
New defaulted parameter `thin_cells_as_minpv` (default `false`, behaviour unchanged). When enabled, active cells thinner than `z_tolerance` are treated like low-pore-volume cells throughout — removal, the column walk, NNC suppression and the gap check — and the merge branch runs for all removed cells, not only low-pv ones.

Every new condition reduces to the plain pore-volume comparison when the option is off, so the default path is unchanged rather than merely equivalent-looking.

`processEclipseFormat` wires it to `edge_conformal`. The requirement comes from the geomech/thermal stack: vertex-based discretizations need a conforming, connected grid.

**Stacked on OPM/opm-grid#1064**, which carries the `processEclipseFormat` half. That part is independent, needed for ordinary edge-conformal grids, and can be reviewed without this one. Until it merges the diff here includes it.
